### PR TITLE
(fits) File list downloader 

### DIFF
--- a/astroquery/utils/__init__.py
+++ b/astroquery/utils/__init__.py
@@ -1,6 +1,8 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
-
-# This sub-module is destined for common non-package specific utility
-# functions that will ultimately be merged into `astropy.utils`
+"""
+This sub-module is destined for common non-package specific utility
+functions that will ultimately be merged into `astropy.utils`
+"""
 
 from .progressbar import *
+from .download_file_list import *

--- a/astroquery/utils/download_file_list.py
+++ b/astroquery/utils/download_file_list.py
@@ -1,10 +1,12 @@
 import StringIO
-import astropy.io.fits as fits
 import re
 import string
-import astropy.coordinates as coord
-import astropy.utils.data as aud
 import os
+import gzip
+import astropy.io.fits as fits
+import astropy.utils.data as aud
+
+__all__ = ['download_list_of_fitsfiles']
 
 whitespace_re = re.compile("\s")
 valid_chars = "-_.()%s%s" % (string.ascii_letters, string.digits)


### PR DESCRIPTION
Both UKIDSS and FermiLAT return lists of matching FITS files, and I think in many cases IRSA does the same.  So, it makes sense to abstract out that step.

This downloader simply gets the URLs (using `get_readable_fileobj`) and opens them as `fits` objects, with an option of saving the file in an optional directory with a lot of optional file name arguments.  The intent is to make it easy to create files of the form:

`UKIDSS_G043.17+0.01_H2_GPS_12312012.fits`

or something along that line, rather than the cryptic form like:

`L130413170713F15B52BC06_PH01.fits`

(but still make it possible to keep that cryptic form in the filename)
