### PR TITLE
Fermi fix for python3.

### DIFF
--- a/astroquery/fermi/lat_data.py
+++ b/astroquery/fermi/lat_data.py
@@ -53,7 +53,7 @@ class FermiLAT_QueryClass(object):
                    'spacecraft':'on' if spacecraftdata else 'off'}
 
         result = requests.post(self.request_url, data=payload)
-        re_result = self.result_url_re.findall(result.content)
+        re_result = self.result_url_re.findall(result.text)
 
         if len(re_result) == 0:
             raise ValueError("Results did not contain a result url... something went awry (that hasn't been tested yet)")


### PR DESCRIPTION
Work with the response content (.text) of requests, rather than the binary response content (.content). Should fix the fermi test for python3.
