### PR TITLE
SDSS docfixes

### DIFF
--- a/astroquery/sdss/core.py
+++ b/astroquery/sdss/core.py
@@ -20,6 +20,8 @@ from astropy import coordinates as coord
 import requests
 import io
 
+__all__ = ['crossID','get_image','get_spectral_template']
+
 # Default photometric and spectroscopic quantities to retrieve.
 photoobj_defs = ['ra', 'dec', 'objid', 'run', 'rerun', 'camcol', 'field']
 specobj_defs = ['z', 'plate', 'mjd', 'fiberID', 'specobjid', 'specClass']
@@ -255,7 +257,8 @@ def get_spectral_template(kind='qso'):
                 
     return spectra
     
-class Spectrum:
+class Spectrum(object):
+    """ TODO: document """
     def __init__(self, hdulist):
         self.hdulist = hdulist
         
@@ -290,7 +293,8 @@ class Spectrum:
             self._err = self.hdulist[0].data[2]
         return self._err     
     
-class Image:
+class Image(object):
+    """ TODO: document """
     def __init__(self, hdulist):
         self.hdulist = hdulist
         self.w = wcs.WCS(self.header)


### PR DESCRIPTION
SDSS caused the sphinx builds to crash with errors like this:

```
ERROR: TypeError: cannot concatenate 'str' and 'type' objects [astropy.utils.misc]
Traceback (most recent call last):
  File "<stdin>", line 29, in <module>
  File "/Users/adam/virtual-python/lib/python2.7/site-packages/sphinx/application.py", line 200, in build
    self.builder.build_all()
  File "/Users/adam/virtual-python/lib/python2.7/site-packages/sphinx/builders/__init__.py", line 159, in build_all
    self.build(None, summary='all source files', method='all')
  File "/Users/adam/virtual-python/lib/python2.7/site-packages/sphinx/builders/__init__.py", line 216, in build
    purple, length):
  File "/Users/adam/virtual-python/lib/python2.7/site-packages/sphinx/builders/__init__.py", line 120, in status_iterator
    for item in iterable:
  File "/Users/adam/virtual-python/lib/python2.7/site-packages/sphinx/environment.py", line 613, in update_generator
    self.read_doc(docname, app=app)
  File "/Users/adam/virtual-python/lib/python2.7/site-packages/sphinx/environment.py", line 761, in read_doc
    pub.publish()
  File "/Users/adam/virtual-python/lib/python2.7/site-packages/docutils/core.py", line 217, in publish
    self.settings)
  File "/Users/adam/virtual-python/lib/python2.7/site-packages/docutils/readers/__init__.py", line 71, in read
    self.input = self.source.read()
  File "/Users/adam/virtual-python/lib/python2.7/site-packages/sphinx/environment.py", line 743, in read
    app.emit('source-read', docname, arg)
  File "/Users/adam/virtual-python/lib/python2.7/site-packages/sphinx/application.py", line 314, in emit
    results.append(callback(self, *args))
  File "/Volumes/disk5/Users/adam/repos/astropy/astropy/sphinx/ext/automodapi.py", line 262, in process_automodapi
    source[0] = automodapi_replace(source[0], app, True, docname)
  File "/Volumes/disk5/Users/adam/repos/astropy/astropy/sphinx/ext/automodapi.py", line 197, in automodapi_replace
    ispkg, hascls, hasfuncs = _mod_info(modnm, toskip)
  File "/Volumes/disk5/Users/adam/repos/astropy/astropy/sphinx/ext/automodapi.py", line 247, in _mod_info
    for localnm, fqnm, obj in zip(*find_mod_objs(modname, onlylocals=True)):
  File "/Volumes/disk5/Users/adam/repos/astropy/astropy/utils/misc.py", line 188, in find_mod_objs
    fqnames.append(obj.__module__ + '.' + obj.__name__)
TypeError: cannot concatenate 'str' and 'type' objects
Sphinx Documentation subprocess failed with return code 1
```

I think this comes from not specifying `__all__` in the `core.py` file, so autodoc ended up looking for the wrong things....
