### PR TITLE
Added query.py for BaseQuery class

### DIFF
--- a/astroquery/query.py
+++ b/astroquery/query.py
@@ -12,7 +12,12 @@ class BaseQuery(object):
 
     __metaclass__ = abc.ABCMeta
 
-    # would it really be necessary for every class to override this?
+
+class QueryWithLogin(BaseQuery):
+    """
+    This is the base class for all the query classes which are required to
+    have a login to access the data.
+    """
     @abc.abstractmethod
     def login(self, **kwargs):
         """
@@ -22,10 +27,5 @@ class BaseQuery(object):
         ----------
         Keyword arguments that can be used to create
         the data payload(dict) sent via `requests.post`
-
         """
-        pass
-
-    @abc.abstractmethod
-    def __call__(self):
         pass


### PR DESCRIPTION
This PR adds a `query.py` module in astroquery for factoring out common functions of different query classes to `BaseQuery` as discussed in #110
