### PR TITLE
Add support for HTTP GET requests in astroquery.utils.commons.send_request

### DIFF
--- a/astroquery/utils/commons.py
+++ b/astroquery/utils/commons.py
@@ -39,8 +39,11 @@ def send_request(url, data, timeout, request_type='POST'):
         if request_type == 'GET':
             response = requests.get(url, params=data, timeout=timeout)
             return response
-        response = requests.post(url, data=data, timeout=timeout)
-        return response
+        elif request_type == 'POST':
+            response = requests.post(url, data=data, timeout=timeout)
+            return response
+        else:
+            raise ValueError("request_type must be either 'GET' or 'POST'.")
     except requests.exceptions.Timeout:
             raise TimeoutError("Query timed out, time elapsed {time}s".
                                format(time=timeout))

--- a/astroquery/utils/tests/test_utils.py
+++ b/astroquery/utils/tests/test_utils.py
@@ -87,3 +87,8 @@ def test_send_request_get(monkeypatch):
     response = commons.send_request('https://github.com/astropy/astroquery',
                                     dict(a='b'), 60, request_type='GET')
     assert response.url == 'https://github.com/astropy/astroquery?a=b'
+
+def test_send_request_err():
+    with pytest.raises(ValueError):
+        commons.send_request('https://github.com/astropy/astroquery',
+                     dict(a='b'), 60, request_type='PUT')


### PR DESCRIPTION
This PR updates `send_request` so that it can also make `HTTP GET` requests. This is essential for some services like `ned` where the url of the `cgi-bin` is directly used and so parameters cannot be posted but rather must be sent as a part of the query url itself
