### PR TITLE
Make TableList more convenient to work with

### DIFF
--- a/astroquery/utils/commons.py
+++ b/astroquery/utils/commons.py
@@ -146,7 +146,9 @@ class TableList(OrderedDict):
     for an OrderedDict of `astropy.table.Table` objects.
 
     HINT: To access the tables by # instead of by table ID:
-    >>> TableList.items()[1]
+    >>> t = TableList(a=1,b=2)
+    >>> t.items()[1]
+    ('b', 2)
     """
 
     def __repr__(self):
@@ -182,7 +184,7 @@ class TableList(OrderedDict):
         return "\n".join([header_str, body_str])
 
     def print_table_list(self):
-        print(self.format_table_list)
+        print(self.format_table_list())
 
 
 def suppress_vo_warnings():

--- a/astroquery/utils/tests/test_utils.py
+++ b/astroquery/utils/tests/test_utils.py
@@ -110,16 +110,18 @@ def test_TableDict():
     in_list  = create_in_list([t1, t2, t3])
     table_list = commons.TableList(in_list)
     repr_str = table_list.__repr__()
-    assert repr_str == '<TableList with 3 table(s) and 7 total row(s)>'
+    assert repr_str == ("TableList with 3 tables:\n\t'0:t1' with 3 column(s) and 1 row(s)"
+                   " \n\t'1:t2' with 1 column(s) and 3 row(s)"
+                   " \n\t'2:t3' with 3 column(s) and 3 row(s) ")
 
 def test_TableDict_print_table_list(capsys):
     in_list  = create_in_list([t1, t2, t3])
     table_list = commons.TableList(in_list)
     table_list.print_table_list()
     out, err = capsys.readouterr()
-    assert out == ("<TableList with 3 tables:\n\t't1' with 3 column(s) and 1 row(s)"
-                   " \n\t't2' with 1 column(s) and 3 row(s)"
-                   " \n\t't3' with 3 column(s) and 3 row(s) \n>\n")
+    assert out == ("TableList with 3 tables:\n\t'0:t1' with 3 column(s) and 1 row(s)"
+                   " \n\t'1:t2' with 1 column(s) and 3 row(s)"
+                   " \n\t'2:t3' with 3 column(s) and 3 row(s) \n")
 
 
 


### PR DESCRIPTION
A few small tweaks to TableList to make it easier to work with; the `__repr__` now prints out all of the tables along with their ordered number, so you can access them like:

```
t = TableList(a=1,b=2,c=3)
t.items()[1]
```

(though this example would crash if you tried to `__repr__` since a table list has to contain Tables)
