### PR TITLE
File objects downloaded as 'closed' by default

### DIFF
--- a/astroquery/nvas/core.py
+++ b/astroquery/nvas/core.py
@@ -77,8 +77,12 @@ class Nvas(BaseQuery):
         if get_query_payload:
             return readable_objs
 
-        return [fits.open(obj.__enter__(), ignore_missing_end=True) for obj in readable_objs]
+        filelist = []
+        for obj in readable_objs:
+            with obj as f:
+                filelist.append(fits.open(f,ignore_missing_end=True))
 
+        return filelist
 
     @class_or_instance
     def get_images_async(self, coordinates, radius=0.25 * u.arcmin, max_rms=10000,


### PR DESCRIPTION
In the current API, we return a list of fits objects with `get_images`, e.g.:

```
>>> images = Nvas.get_images('AFGL 4029')
11 images found.
Downloading http://www.vla.nrao.edu/astro/archive/pipeline/position/J030129.0+602912/14.9I1.37_AS683_2000MAY05_1_220.U1.43M.imfits
|==========================================================================================================================| 768k/768k (100.00%)        01s
Downloading http://www.vla.nrao.edu/astro/archive/pipeline/position/J030129.0+602912/22.4I0.93_AS683_2000MAY05_1_184.U55.7S.imfits
|==========================================================================================================================| 794k/794k (100.00%)        02s
Downloading http://www.vla.nrao.edu/astro/archive/pipeline/position/J030131.4+602917/14.9I0.46_AH0128_1984FEB12_1_139.U1.43M.imfits
|==========================================================================================================================|  11M/ 11M (100.00%)        16s
Downloading http://www.vla.nrao.edu/astro/archive/pipeline/position/J030131.4+602917/14.9I0.42_AH0128_1984FEB12_1_234.U1.43M.imfits
|==========================================================================================================================|  11M/ 11M (100.00%)        16s
Downloading http://www.vla.nrao.edu/astro/archive/pipeline/position/J030132.3+602911/4.89I13.0_AS0341_1988AUG02_1_197.U4.56M.imfits
|==========================================================================================================================|  72k/ 72k (100.00%)        00s
Downloading http://www.vla.nrao.edu/astro/archive/pipeline/position/J030132.3+602911/8.46I0.70_AC0240_1989MAR19_1_86.1U2.59M.imfits
|==========================================================================================================================|  11M/ 11M (100.00%)        19s
Downloading http://www.vla.nrao.edu/astro/archive/pipeline/position/J030132.3+602911/8.46I9.32_AK0386_1995MAR23_1_158.U2.60M.imfits
|==========================================================================================================================|  69k/ 69k (100.00%)        00s
Downloading http://www.vla.nrao.edu/astro/archive/pipeline/position/J030132.3+602911/14.9I0.39_AC0240_1989MAR19_1_333.U1.43M.imfits
|==========================================================================================================================|  11M/ 11M (100.00%)        16s
Downloading http://www.vla.nrao.edu/astro/archive/pipeline/position/J030132.3+602911/14.9I4.99_AK0386_1995MAR23_1_338.U1.44M.imfits
|==========================================================================================================================|  69k/ 69k (100.00%)        00s
Downloading http://www.vla.nrao.edu/astro/archive/pipeline/position/J030135.7+602907/1.51I14.7_AS0192_1984APR13_1_249.U10.5M.imfits
|==========================================================================================================================| 406k/406k (100.00%)        00s
^@Downloading http://www.vla.nrao.edu/astro/archive/pipeline/position/J030200.0+602615/1.51I14.6_AS0192_1984APR13_1_231.U10.5M.imfits
|==========================================================================================================================| 406k/406k (100.00%)        00s
```

However, these are all "Closed" I/O objects:

```
>>> images[0][0].data
ERROR: ValueError: I/O operation on closed file [numpy.core.memmap]
Traceback (most recent call last):
  File "<ipython-input-17-9831a49b93c0>", line 1, in <module>
    images[0][0].data
  File "astropy/utils/misc.py", line 258, in __get__
    val = self._fget(obj)
  File "astropy/io/fits/hdu/image.py", line 197, in data
    data = self._get_scaled_image_data(self._data_offset, self.shape)
  File "astropy/io/fits/hdu/image.py", line 517, in _get_scaled_image_data
    raw_data = self._get_raw_data(shape, code, offset)
  File "astropy/io/fits/hdu/base.py", line 416, in _get_raw_data
    return self._file.readarray(offset=offset, dtype=code, shape=shape)
  File "astropy/io/fits/file.py", line 206, in readarray
    shape=shape).view(np.ndarray)
  File "/Users/adam/virtual-python/lib/python2.7/site-packages/numpy/core/memmap.py", line 217, in __new__
    fid.seek(0, 2)
ValueError: I/O operation on closed file
```

They ought to be kept open.
