### PR TITLE
Add links to Github, astropy.vo and pyvo on the top-level docs page

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -3,6 +3,8 @@ AstroQuery
 
 This is the documentation for the AstroQuery affiliated package of astropy.
 
+Code and issue tracker are on `GitHub <https://github.com/astropy/astroquery>`_.
+
 Introduction
 ------------
 
@@ -11,6 +13,13 @@ AstroQuery is a set of tools for querying astronomical web forms and databases.
 The :doc:`api` is intended to be kept as consistent as possible, such
 that any web service can be used with a minimal learning curve imposed on the
 user.
+
+There are two other packages with complimentary functionality as AstroQuery:
+`astropy.vo <http://docs.astropy.org/en/latest/vo/index.html>`_ is in the Astropy core and
+`pyvo <https://pyvo.readthedocs.org/en/latest/>`_ is an Astropy affiliated package.
+They are more oriented to general `virtual observatory <http://www.virtualobservatory.org>`_
+discovery and queries, whereas Astroquery has web service specific interfaces.
+
 
 Installation
 ------------
@@ -76,8 +85,9 @@ All query tools allow coordinate-based queries:
 Table of Contents
 -----------------
 
-The modules and their maintainers are listed on the wiki:
-https://github.com/astropy/astroquery/wiki/Maintainers
+The modules and their maintainers are listed on the
+`Maintainers <https://github.com/astropy/astroquery/wiki/Maintainers>`_
+wiki page.
 
 The following modules have been completed using a common API:
 


### PR DESCRIPTION
I think it would make sense for `astropy.vo`, `astroquery` and `pyvo` to cross-link to each other.
So as a first step, let's link to the others from astroquery?

I tried to describe in one sentence how `astroquery` compares to `astropy.vo` and `pyvo`, which might be incorrect. @keflavich Please check.

And I've included a link back to github because I like it when it's easy to browse between the docs and code/issues.
