### PR TITLE
Label un-refactored packages with `Experimental` warning

### DIFF
--- a/astroquery/alfalfa/__init__.py
+++ b/astroquery/alfalfa/__init__.py
@@ -8,3 +8,5 @@ ALFALFA Spectra Archive Query Tool
 
 from .core import ALFALFA
 
+import warnings
+warnings.warn("Experimental: ALFALFA has not yet been refactored to have its API match the rest of astroquery.")

--- a/astroquery/fermi/__init__.py
+++ b/astroquery/fermi/__init__.py
@@ -12,3 +12,6 @@ FERMI_URL = ConfigurationItem('fermi_url',
                               "Fermi query URL")
 
 from .core import FermiLAT, GetFermilatDatafile, get_fermilat_datafile
+
+import warnings
+warnings.warn("Experimental: Fermi-LAT has not yet been refactored to have its API match the rest of astroquery.")

--- a/astroquery/lamda/__init__.py
+++ b/astroquery/lamda/__init__.py
@@ -16,3 +16,6 @@ Note:
   data are encouraged.
 """
 from .core import *
+
+import warnings
+warnings.warn("Experimental: LAMDA has not yet been refactored to have its API match the rest of astroquery.")

--- a/astroquery/ogle/__init__.py
+++ b/astroquery/ogle/__init__.py
@@ -25,3 +25,6 @@ OGLE_TIMEOUT = ConfigurationItem('timeout', 60,
 from .core import Ogle
 
 __all__ = ['Ogle']
+
+import warnings
+warnings.warn("Experimental: OGLE has not yet been refactored to have its API match the rest of astroquery.")

--- a/astroquery/sdss/__init__.py
+++ b/astroquery/sdss/__init__.py
@@ -14,3 +14,6 @@ SDSS_SERVER = ConfigurationItem('sdss_server', 'http://das.sdss.org',
 SDSS_MAXQUERY = ConfigurationItem('maxqueries', 1, 'Max number of queries allowed per second')
 
 from .core import SDSS
+
+import warnings
+warnings.warn("Experimental: SDSS has not yet been refactored to have its API match the rest of astroquery (but it's nearly there).")

--- a/astroquery/sha/__init__.py
+++ b/astroquery/sha/__init__.py
@@ -9,3 +9,6 @@ This package is for querying the Spitzer Heritage Archive (SHA)
 found at: http://sha.ipac.caltech.edu/applications/Spitzer/SHA.
 """
 from .core import *
+
+import warnings
+warnings.warn("Experimental: SHA has not yet been refactored to have its API match the rest of astroquery.")


### PR DESCRIPTION
Planning for a 0.1 release towards the end of the summer, we don't expect to have all of the modules completely refactored yet, so we need some way to indicate which modules are not yet refactored.  All modules not refactored should print an `Experimental:` warning, indicating that the API does not yet match that specified in the documentation.
