### PR TITLE
Fermi docs example broken

### DIFF
--- a/docs/fermi.rst
+++ b/docs/fermi.rst
@@ -13,10 +13,13 @@ centered on M 31 for the energy range 1 to 100 GeV for the first day in 2013.
 .. code-block:: python
 
     >>> from astroquery import fermi
-    >>> query = fermi.FermiLAT_Query()
-    >>> URL = query('M31', energyrange_MeV='1000, 100000', obsdates='2013-01-01 00:00:00, 2013-01-02 00:00:00')
-    >>> print URL
-    'http://fermi.gsfc.nasa.gov/cgi-bin/ssc/LAT/QueryResults.cgi?id=L1304140823265C26556A17'
+    >>> result = fermi.FermiLAT.query_object('M31', energyrange_MeV='1000, 100000', obsdates='2013-01-01 00:00:00, 2013-01-02 00:00:00')
+    >>> print result
+    ['http://fermi.gsfc.nasa.gov/FTP/fermi/data/lat/queries/L1309041729388EB8D2B447_SC00.fits',
+     'http://fermi.gsfc.nasa.gov/FTP/fermi/data/lat/queries/L1309041729388EB8D2B447_PH00.fits']
+    >>> from astropy.io import fits
+    >>> sc = fits.open('http://fermi.gsfc.nasa.gov/FTP/fermi/data/lat/queries/L1309041729388EB8D2B447_SC00.fits')
+    
 
 Reference/API
 =============


### PR DESCRIPTION
The example in the [Fermi tutorial](http://astroquery.readthedocs.org/en/latest/fermi.html#getting-started) doesn't work:

```
In [22]: from astroquery import fermi

In [23]: query = fermi.FermiLAT_Query()
ERROR: TypeError: __call__() takes at least 2 arguments (1 given) [IPython.core.interactiveshell]
---------------------------------------------------------------------------
TypeError                                 Traceback (most recent call last)
<ipython-input-23-6470dbf3fa96> in <module>()
----> 1 query = fermi.FermiLAT_Query()

TypeError: __call__() takes at least 2 arguments (1 given)
```

@jdnc Can you re-factor Fermi soon (see #112)?
If not I might have time to do it next week.
