### PR TITLE
Preserve the argspec of decorated functions in order to make docs/help look nicer

### DIFF
--- a/astroquery/utils/class_or_instance.py
+++ b/astroquery/utils/class_or_instance.py
@@ -12,28 +12,6 @@ class class_or_instance(object):
 
     def __init__(self, fn):
         self.fn = fn
-        argspec = inspect.getargspec(fn)
-        if argspec.args[0] != 'self':
-            raise ValueError('Method created with "self" not the first argument')
-        else:
-            # in the "fake" definition, we leave out "self"
-            args = argspec.args[1:]
-
-        # Some "default args" have repr's that are *not* evaluatable
-        # These must be replaced with strings
-        if argspec.defaults is not None:
-            defaults = []
-            for ii,default in enumerate(argspec.defaults):
-                try:
-                    eval("%s" % repr(default))
-                    defaults.append(default)
-                except SyntaxError:
-                    defaults.append('%s' % repr(default))
-        else:
-            defaults = None
-
-        self.argspec_d = dict(args=args, varargs=argspec.varargs,
-                              varkw=argspec.keywords, defaults=defaults)
 
         if hasattr(fn,'__doc__'):
             self.__doc__ = fn.__doc__
@@ -55,7 +33,8 @@ class class_or_instance(object):
             slf = obj
         else:
             slf = cls
-        argspec[0].remove('self')
+        if argspec[0][0] == 'self':
+            argspec[0].remove('self')
         tgt_func = src_func
         signature = inspect.formatargspec(formatvalue=lambda val: "",
                                           *argspec


### PR DESCRIPTION
This updates `class_or_instance` to preserve the callspec of the function that is decorated.

It works great for docs!

```
>>> ALFALFA.query_region?
Type:       function
String Form:<function query_region at 0x10545b488>
File:       Dynamically generated function. No source code available.
Definition: ALFALFA.query_region(coordinates, radius='<Quantity 3.0 arcmin>', optical_counterpart=False)
Docstring:
Perform object cross-ID in ALFALFA.
```

It works badly for the code, though:

```
>>> ALFALFA.query_region('M31')
ERROR: ValueError: Invalid character at col 0 in angle u'<Quantity 3.0 arcmin>' [astropy.coordinates.angle_utilities]
```

The problem is that the argspec is actually used to define the function, so `radius='<Quantity 3.0 arcmin>'` is actually being passed to the function, which obviously won't work.  I need some help figuring out a workaround that will allow the "observed" argspec to change, but preserve the original/real argspec - i.e., change the argspec, but not use it when calling the decorated function...
