### PR TITLE
Fix alfalfa example in docstring

### DIFF
--- a/astroquery/alfalfa/core.py
+++ b/astroquery/alfalfa/core.py
@@ -122,8 +122,8 @@ class ALFALFA(BaseQuery):
         Examples
         --------
         >>> agc = alfalfa.crossID(ra='0h8m05.63s', dec='14d50m23.3s', dr)
-        >>> for match in xid:
-        >>>     print match['ra'], match['dec'], match['objid']
+        >>> for match in agc:
+        ...     print(match['ra'], match['dec'], match['objid'])
 
         Returns
         -------


### PR DESCRIPTION
Is this fix correct (looping over `agc` instead of `xid`)?

This was the only remaining error for `python3.3 setup.py build` in `astroquery`, i.e. now it's possible to run `python3.3 setup.py test -P service` for the services that already work with Python 3.

Note that with `python3.2 setup.py build` there are two `SyntaxError`s in `progressbar.py` that could be easily fixed by using [six.u](http://pythonhosted.org/six/#six.u) ... but I guess there's probably going to be zero Python 3.2 astroquery users ... if someone uses Python 3 they'll use Python 3.3 or later versions.

```
  File "/Users/deil/code/astroquery/astroquery/utils/progressbar.py", line 23
    sys.stdout.write(u"Downloaded %12.2g of %12.2g Mb (%6.2f%%)\r" %
                                                                 ^
SyntaxError: invalid syntax
```
