### PR TITLE
MAGPIS returns invalid FITS data

### DIFF
--- a/astroquery/magpis/core.py
+++ b/astroquery/magpis/core.py
@@ -12,7 +12,7 @@ from ..utils.class_or_instance import class_or_instance
 from ..utils.docstr_chompers import prepend_docstr_noreturns
 from ..utils import commons
 from . import MAGPIS_SERVER, MAGPIS_TIMEOUT
-from ...exceptions import InvalidQueryError
+from ..exceptions import InvalidQueryError
 
 __all__ = ['Magpis']
 
@@ -20,22 +20,27 @@ __all__ = ['Magpis']
 class Magpis(BaseQuery):
     URL = MAGPIS_SERVER()
     TIMEOUT = MAGPIS_TIMEOUT()
-    surveys = ["gps6epoch3",
-    "gps6epoch4",
-    "gps20",
-    "gps20new",
-    "gps90",
-    "gpsmsx",
-    "gpsmsx2",
-    "gpsglimpse36",
-    "gpsglimpse45",
-    "gpsglimpse58",
-    "gpsglimpse80",
-    "mipsgal",
-    "bolocam"]
+    surveys = ["gps6",
+               "gps6epoch2",
+               "gps6epoch3",
+               "gps6epoch4",
+               "gps20",
+               "gps20new",
+               "gps90",
+               "gpsmsx",
+               "gpsmsx2",
+               "gpsglimpse36",
+               "gpsglimpse45",
+               "gpsglimpse58",
+               "gpsglimpse80",
+               "mipsgal",
+               "atlasgal",
+               "bolocam"]
+    maximsize = 1024
 
     @class_or_instance
-    def _args_to_payload(self, coordinates, image_size=1*u.arcmin, survey='bolocam'):
+    def _args_to_payload(self, coordinates, image_size=1*u.arcmin, survey='bolocam',
+                         maximsize=None):
         """
         Fetches image cutouts from MAGPIS surveys.
 
@@ -54,6 +59,9 @@ class Magpis(BaseQuery):
             The MAGPIS survey you want to cut out. Defaults to 'bolocam'. The other
             surveys that can be used can be listed via
             :meth:`~astroquery.core.Magpis.list_surveys`.
+        maximsize : int, optional
+            Specify the maximum image size (in pixels on each dimension) that
+            will be returned.  Max is 2048.
         """
         request_payload = {}
         request_payload["Survey"] = survey
@@ -63,6 +71,7 @@ class Magpis(BaseQuery):
         request_payload["Equinox"] = "Galactic"
         request_payload["ImageSize"] = commons.radius_to_unit(image_size,'arcmin')
         request_payload["ImageType"] = "FITS File"
+        request_payload["MaxImSize"] = self.maximsize if maximsize is None else maximsize
         return request_payload
 
     @class_or_instance
@@ -85,7 +94,7 @@ class Magpis(BaseQuery):
             return response
         S = BytesIO(response.content)
         try:
-            fits.open(S, ignore_missing_end=True)
+            return fits.open(S, ignore_missing_end=True)
         except IOError:
             raise InvalidQueryError(response.content) 
 
@@ -103,14 +112,16 @@ class Magpis(BaseQuery):
         response : `requests.Response`
             The HTTP response returned from the service
         """
+        if survey not in self.surveys:
+            raise InvalidQueryError("Survey must be one of "+(",".join(self.list_surveys())))
         request_payload = self._args_to_payload(coordinates, image_size=image_size,
                                                 survey=survey)
         if get_query_payload:
             return request_payload
-        response = commons.send_request(Magpis.URL, request_payload, Magpis.TIMEOUT)
+        response = commons.send_request(self.URL, request_payload, self.TIMEOUT)
         return response
 
     @class_or_instance
     def list_surveys(self):
         """Return a list of surveys for MAGPIS"""
-        return Magpis.surveys
+        return self.surveys

--- a/astroquery/magpis/tests/test_magpis.py
+++ b/astroquery/magpis/tests/test_magpis.py
@@ -50,10 +50,10 @@ def test_list_surveys():
 
 def test_get_images_async(patch_post, patch_parse_coordinates):
     response = magpis.core.Magpis.get_images_async(coord.GalacticCoordinates(10.5, 0.0, unit=(u.deg, u.deg)),
-                                                   image_size=2 * u.deg, survey="gps6",
+                                                   image_size=2 * u.deg, survey="gps6epoch3",
                                                    get_query_payload=True)
     npt.assert_approx_equal(response['ImageSize'], 120, significant=3)
-    assert response['Survey'] == 'gps6'
+    assert response['Survey'] == 'gps6epoch3'
     response = magpis.core.Magpis.get_images_async(coord.GalacticCoordinates(10.5, 0.0, unit=(u.deg, u.deg)))
     assert response is not None
 
@@ -61,4 +61,9 @@ def test_get_images_async(patch_post, patch_parse_coordinates):
 def test_get_images(patch_post, patch_parse_coordinates):
     image = magpis.core.Magpis.get_images(coord.GalacticCoordinates(10.5, 0.0, unit=(u.deg, u.deg)))
     assert image is not None
+
+@pytest.mark.xfail
+def test_get_images_fail(patch_post, patch_parse_coordinates):
+    image = magpis.core.Magpis.get_images(coord.GalacticCoordinates(10.5, 0.0, unit=(u.deg, u.deg)),
+                                          survey='Not a survey')
 

--- a/astroquery/magpis/tests/test_magpis_remote.py
+++ b/astroquery/magpis/tests/test_magpis_remote.py
@@ -14,9 +14,14 @@ from ... import magpis
 class TestMagpis:
 
     def test_get_images_async(self):
-        response = magpis.core.Magpis.get_images_async(coord.GalacticCoordinates(10.5, 0.0, unit=(u.deg, u.deg)))
+        response = magpis.core.Magpis.get_images_async(
+                        coord.GalacticCoordinates(10.5, 0.0, unit=(u.deg, u.deg)),
+                        image_size='1 arcmin')
         assert response is not None
 
     def test_get_images(self):
-        image = magpis.core.Magpis.get_images(coord.GalacticCoordinates(10.5, 0.0, unit=(u.deg, u.deg)))
+        image = magpis.core.Magpis.get_images(
+                coord.GalacticCoordinates(10.5, 0.0, unit=(u.deg, u.deg)),
+                image_size='1 arcmin')
         assert image is not None
+        assert image[0].data.shape == (8,8)


### PR DESCRIPTION
Example:

```
>>> from astropy import magpis
>>> img = magpis.Magpis.get_images('19h23m02.7s +14d28m48.09s','1 arcmin',survey='gps6epoch3')

WARNING: Coordinate string is being interpreted as an ICRS coordinate. [astroquery.utils.commons]
WARNING: VerifyWarning: Error validating header for HDU #0 (note: PyFITS uses zero-based indexing).
    Header size is not multiple of 2880: 316
There may be extra bytes after the last HDU or the file is corrupted. [astropy.io.fits.hdu.hdulist]
ERROR: IOError: Empty or corrupt FITS file [astropy.io.fits.hdu.hdulist]
Traceback (most recent call last):
  File "<ipython-input-182-9713ed3e273d>", line 1, in <module>
    img = magpis.Magpis.get_images('19h23m02.7s +14d28m48.09s','1 arcmin',survey='gps6epoch3')
  File "/Users/adam/repos/astroquery/astroquery/utils/class_or_instance.py", line 25, in <lambda>
    f = lambda *args, **kwds: self.fn(cls, *args, **kwds)
  File "/Users/adam/repos/astroquery/astroquery/magpis/core.py", line 86, in get_images
    return fits.open(S, ignore_missing_end=True)
  File "/Users/adam/repos/astropy/astropy/io/fits/hdu/hdulist.py", line 117, in fitsopen
    return HDUList.fromfile(name, mode, memmap, save_backup, **kwargs)
  File "/Users/adam/repos/astropy/astropy/io/fits/hdu/hdulist.py", line 249, in fromfile
    save_backup=save_backup, **kwargs)
  File "/Users/adam/repos/astropy/astropy/io/fits/hdu/hdulist.py", line 836, in _readfrom
    raise IOError('Empty or corrupt FITS file')
IOError: Empty or corrupt FITS file

> /Users/adam/repos/astropy/astropy/io/fits/hdu/hdulist.py(843)_readfrom()
    842         finally:
--> 843             compressed.COMPRESSION_ENABLED = saved_compression_enabled
    844
```
