### PR TITLE
Run doctests as part of `python setup.py test`

### DIFF
--- a/astroquery/conftest.py
+++ b/astroquery/conftest.py
@@ -19,3 +19,7 @@ def pytest_configure(config):
         #turn_on_internet(verbose=config.option.verbose)
     else:
         turn_off_internet(verbose=config.option.verbose)
+
+    from astropy.tests.pytest_plugins import pytest_configure
+
+    pytest_configure(config)

--- a/setup.cfg
+++ b/setup.cfg
@@ -10,3 +10,4 @@ show-response = 1
 [pytest]
 minversion = 2.2
 norecursedirs = build docs/_build
+doctest_plus = enabled


### PR DESCRIPTION
In an online discussion with @keflavich, we discovered that doctests were not running as part of `python setup.py test` in astroquery.

This resolves that by

1) turning on the doctest_plus plugin in `setup.cfg`

2) delegating from the `pytest_configure` function in astroquery to the one in astropy, which sets up all the doctest magic.

@embray: Is the `setup.cfg` requirement documented somewhere?  Should it be, and if so where?

@astrofrog: Does this have any impact on the package template?
