### PR TITLE
Small fix in Simbad test suite to make it pass with new astropy stable.

### DIFF
--- a/astroquery/simbad/tests/test_simbad.py
+++ b/astroquery/simbad/tests/test_simbad.py
@@ -80,7 +80,7 @@ def post_mockreturn(url, data, timeout, **kwargs):
 def test_parse_radius(radius, expected_radius):
     actual = simbad.core._parse_radius(radius)
     # bug in 1168: https://github.com/astropy/astropy/pull/1168
-    if (LooseVersion(astropy.version.version) <= LooseVersion('0.2.4')
+    if (LooseVersion(astropy.version.version) <= LooseVersion('0.2.5')
        and radius in ('5d',)):
         # error...
         pass


### PR DESCRIPTION
Angle('5d') is not fixed in astropy 0.2.5.
