### PR TITLE
Make FileContainer accept the same args as get_readable_fileobj

### DIFF
--- a/astroquery/utils/commons.py
+++ b/astroquery/utils/commons.py
@@ -325,10 +325,10 @@ class FileContainer(object):
     files.
     """
 
-    def __init__(self, target, cache=True):
-
+    def __init__(self, target, **kwargs):
+        kwargs.setdefault('cache', True)
         self._target = target
-        self._readable_object = aud.get_readable_fileobj(target, cache=cache)
+        self._readable_object = aud.get_readable_fileobj(target, **kwargs)
 
     def get_fits(self):
         """


### PR DESCRIPTION
Since `FileContainer` is mostly a wrapper around `astropy.utils.data.get_readable_fileobj`, it is useful to be able to pass the arguments the later accepts to the former's constructor.

Among other things, this change allows functions that make use of `FileContainer` to download FITS files to specify a value for the `remote_timeout`.
