### PR TITLE
automodapi doesn't include classes

### DIFF
--- a/astroquery/alfalfa/__init__.py
+++ b/astroquery/alfalfa/__init__.py
@@ -9,7 +9,7 @@ This package is for querying the ALFALFA data repository hosted at
 http://arecibo.tc.cornell.edu/hiarchive/alfalfa/
 """
 
-from .core import Alfalfa
+from .core import Alfalfa,AlfalfaClass
 
 import warnings
 warnings.warn("Experimental: ALFALFA has not yet been refactored to have its API match the rest of astroquery.")

--- a/astroquery/besancon/__init__.py
+++ b/astroquery/besancon/__init__.py
@@ -26,7 +26,7 @@ BESANCON_PING_DELAY = ConfigurationItem('besancon_ping_delay', 30.0,
 BESANCON_TIMEOUT = ConfigurationItem('besancon_timeout', 30.0,
                                         "Timeout for Besancon query")
 
-from .core import Besancon
+from .core import Besancon,BesanconClass
 from .reader import BesanconFixed,BesanconFixedWidthHeader,BesanconFixedWidthData
 
-__all__ = ['Besancon','BesanconFixed','BesanconFixedWidthHeader','BesanconFixedWidthData']
+__all__ = ['Besancon','BesanconClass','BesanconFixed','BesanconFixedWidthHeader','BesanconFixedWidthData']

--- a/astroquery/fermi/__init__.py
+++ b/astroquery/fermi/__init__.py
@@ -13,7 +13,7 @@ FERMI_URL = ConfigurationItem('fermi_url',
 FERMI_TIMEOUT = ConfigurationItem('timeout', 60, 'time limit for connecting to FERMI server')
 FERMI_RETRIEVAL_TIMEOUT = ConfigurationItem('retrieval_timeout', 120, 'time limit for retrieving a data file once it has been located')
 
-from .core import FermiLAT, GetFermilatDatafile, get_fermilat_datafile
+from .core import FermiLAT, FermiLATClass, GetFermilatDatafile, get_fermilat_datafile
 
 import warnings
 warnings.warn("Experimental: Fermi-LAT has not yet been refactored to have its API match the rest of astroquery.")

--- a/astroquery/gama/__init__.py
+++ b/astroquery/gama/__init__.py
@@ -7,4 +7,4 @@ http://www.gama-survey.org/dr2/query/
 :author: James T. Allen <james.thomas.allen@gmail.com>
 """
 
-from .core import GAMA
+from .core import GAMA,GAMAClass

--- a/astroquery/irsa/__init__.py
+++ b/astroquery/irsa/__init__.py
@@ -11,6 +11,6 @@ GATOR_LIST_CATALOGS = ConfigurationItem('gator_list_catalogs', ['http://irsa.ipa
 ROW_LIMIT = ConfigurationItem('row_limit', 500, 'maximum number of rows to retrieve in result')
 TIMEOUT = ConfigurationItem('timeout', 60, 'time limit for connecting to the IRSA server')
 
-from .core import Irsa
+from .core import Irsa,IrsaClass
 
-__all__ = ['Irsa']
+__all__ = ['Irsa','IrsaClass']

--- a/astroquery/irsa_dust/__init__.py
+++ b/astroquery/irsa_dust/__init__.py
@@ -16,6 +16,6 @@ IRSA_DUST_SERVER = ConfigurationItem('irsa_dust_server',[
 
 IRSA_DUST_TIMEOUT = ConfigurationItem('timeout', 30, 'default timeout for connecting to server')
 
-from .core import IrsaDust
+from .core import IrsaDust,IrsaDustClass
 
-__all__ = ['IrsaDust']
+__all__ = ['IrsaDust','IrsaDustClass']

--- a/astroquery/magpis/__init__.py
+++ b/astroquery/magpis/__init__.py
@@ -17,6 +17,6 @@ MAGPIS_SERVER = ConfigurationItem('magpis_server', ["http://third.ucllnl.org/cgi
                                'Name of the MAGPIS server.')
 MAGPIS_TIMEOUT = ConfigurationItem('timeout', 60, 'time limit for connecting to MAGPIS server')
 
-from .core import Magpis
+from .core import Magpis,MagpisClass
 
-__all__ = ['Magpis']
+__all__ = ['Magpis','MagpisClass']

--- a/astroquery/ned/__init__.py
+++ b/astroquery/ned/__init__.py
@@ -56,6 +56,6 @@ SORT_OUTPUT_BY = ConfigurationItem('sort_output_by',
                                     "Redshift - ascending",
                                     "Redshift - descending"], 'display output sorted by this criteria.')
 
-from .core import Ned
+from .core import Ned,NedClass
 
-__all__ = ['Ned']
+__all__ = ['Ned','NedClass']

--- a/astroquery/nist/__init__.py
+++ b/astroquery/nist/__init__.py
@@ -8,6 +8,6 @@ NIST_SERVER = ConfigurationItem('nist_server', ["http://physics.nist.gov/cgi-bin
 
 NIST_TIMEOUT = ConfigurationItem('timeout', 30, 'time limit for connecting to NIST server')
 
-from .core import Nist
+from .core import Nist,NistClass
 
-__all__ = ['Nist']
+__all__ = ['Nist','NistClass']

--- a/astroquery/nrao/__init__.py
+++ b/astroquery/nrao/__init__.py
@@ -9,6 +9,6 @@ NRAO_SERVER = ConfigurationItem('nrao_server', ['https://archive.nrao.edu/archiv
 NRAO_TIMEOUT = ConfigurationItem('timeout', 60, 'time limit for connecting to NRAO server')
 
 
-from .core import Nrao
+from .core import Nrao,NraoClass
 
-__all__ = ['Nrao']
+__all__ = ['Nrao','NraoClass']

--- a/astroquery/nvas/__init__.py
+++ b/astroquery/nvas/__init__.py
@@ -15,6 +15,6 @@ NVAS_SERVER = ConfigurationItem('nvas_server', ["https://webtest.aoc.nrao.edu/cg
                                'Name of the NVAS mirror to use.')
 NVAS_TIMEOUT = ConfigurationItem('timeout', 60, 'time limit for connecting to NVAS server')
 
-from .core import Nvas
+from .core import Nvas,NvasClass
 
-__all__ = ['Nvas']
+__all__ = ['Nvas','NvasClass']

--- a/astroquery/ogle/__init__.py
+++ b/astroquery/ogle/__init__.py
@@ -22,9 +22,9 @@ OGLE_TIMEOUT = ConfigurationItem('timeout', 60,
                                  'Time limit for connecting to the OGLE server.')
 
 
-from .core import Ogle
+from .core import Ogle,OgleClass
 
-__all__ = ['Ogle']
+__all__ = ['Ogle','OgleClass']
 
 import warnings
 warnings.warn("Experimental: OGLE has not yet been refactored to have its API match the rest of astroquery.")

--- a/astroquery/sdss/__init__.py
+++ b/astroquery/sdss/__init__.py
@@ -16,7 +16,7 @@ SDSS_MAXQUERY = ConfigurationItem('maxqueries', 1, 'Max number of queries allowe
 SDSS_TIMEOUT = ConfigurationItem('timeout', 30,
                                  'Default timeout for connecting to server')
 
-from .core import SDSS
+from .core import SDSS,SDSSClass
 
 import warnings
 warnings.warn("Experimental: SDSS has not yet been refactored to have its API match the rest of astroquery (but it's nearly there).")

--- a/astroquery/simbad/__init__.py
+++ b/astroquery/simbad/__init__.py
@@ -15,6 +15,6 @@ SIMBAD_TIMEOUT = ConfigurationItem('timeout', 60, 'time limit for connecting to 
 # O defaults to the maximum limit
 ROW_LIMIT = ConfigurationItem('row_limit', 0, 'maximum number of rows that will be fetched from the result.')
 
-from .core import Simbad
+from .core import Simbad,SimbadClass
 
-__all__ = ['Simbad']
+__all__ = ['Simbad','SimbadClass']

--- a/astroquery/splatalogue/__init__.py
+++ b/astroquery/splatalogue/__init__.py
@@ -17,6 +17,6 @@ LINES_LIMIT = ConfigurationItem('Limit to number of lines exported', 10000)
 
 import load_species_table
 
-from .core import Splatalogue
+from .core import Splatalogue,SplatalogueClass
 
-__all__ = ['Splatalogue']
+__all__ = ['Splatalogue','SplatalogueClass']

--- a/astroquery/template_module/__init__.py
+++ b/astroquery/template_module/__init__.py
@@ -27,6 +27,6 @@ TIMEOUT = ConfigurationItem('timeout', 30, 'default timeout for connecting to se
 # Now import your public class
 # Should probably have the same name as your module
 
-from .core import DummyClass
+from .core import Dummy,DummyClass
 
-__all__ = ['DummyClass']
+__all__ = ['Dummy','DummyClass']

--- a/astroquery/template_module/core.py
+++ b/astroquery/template_module/core.py
@@ -21,7 +21,7 @@ from . import SERVER, TIMEOUT # import configurable items declared in __init__.p
 
 
 # export all the public classes and methods
-__all__ = ['DummyClass']
+__all__ = ['Dummy','DummyClass']
 
 # declare global variables and constants if any
 
@@ -345,6 +345,9 @@ class DummyClass(BaseQuery):
         # do something with regex on the HTML
         # return the list of image URLs
         pass
+
+# the default tool for users to interact with is an instance of the Class
+Dummy = DummyClass()
 
 # once your class is done, tests should be written
 # See ./tests for examples on this

--- a/astroquery/ukidss/__init__.py
+++ b/astroquery/ukidss/__init__.py
@@ -18,6 +18,6 @@ UKIDSS_SERVER = ConfigurationItem('ukidss_server', ["http://surveys.roe.ac.uk:80
                                   'Name of the UKIDSS mirror to use.')
 UKIDSS_TIMEOUT = ConfigurationItem('timeout', 60, 'time limit for connecting to UKIDSS server')
 
-from .core import Ukidss,clean_catalog
+from .core import Ukidss,UkidssClass,clean_catalog
 
-__all__ = ['Ukidss','clean_catalog']
+__all__ = ['Ukidss','UkidssClass','clean_catalog']

--- a/astroquery/vizier/__init__.py
+++ b/astroquery/vizier/__init__.py
@@ -28,4 +28,6 @@ VIZIER_TIMEOUT = ConfigurationItem('timeout', 60, 'default timeout for connectin
 
 ROW_LIMIT = ConfigurationItem('row_limit', 50, 'maximum number of rows that will be fetched from the result (set to -1 for unlimited).')
 
-from .core import Vizier
+from .core import Vizier,VizierClass
+
+__all__ = ['Vizier','VizierClass']


### PR DESCRIPTION
automodapi isn't showing the API for classes:
http://astroquery.readthedocs.org/en/latest/vizier.html

but it seems to work fine for functions:
http://astroquery.readthedocs.org/en/latest/sha.html

@astrofrog - any idea who knows more about this?
