### PR TITLE
Fix use of kwargs in Eso.query_instrument()

### DIFF
--- a/astroquery/eso/core.py
+++ b/astroquery/eso/core.py
@@ -287,6 +287,7 @@ class EsoClass(QueryWithLogin):
             instrument_form = self.request("GET", url)
             query_dict = {}
             query_dict.update(column_filters)
+            query_dict.update(kwargs)
             query_dict["wdbo"] = "csv/download"
             for k in columns:
                 query_dict["tab_"+k] = True


### PR DESCRIPTION
`kwargs` needed to be added to the `query_dict` dictionary.
