### PR TITLE
Fixed typo on astropy.coordinates.SphericalCoordinatesBase class import.

### DIFF
--- a/astroquery/utils/commons.py
+++ b/astroquery/utils/commons.py
@@ -28,13 +28,13 @@ try:
     ICRSCoord = coord.SkyCoord
     CoordClasses = (coord.SkyCoord, BaseCoordinateFrame)
 except ImportError:
-    from astropy.coordinates import SphericalCoordinateBase as BaseCoordinateFrame
+    from astropy.coordinates import SphericalCoordinatesBase as BaseCoordinateFrame
     ICRSCoordGenerator = lambda *args, **kwargs: coord.ICRS(*args, **kwargs)
     GalacticCoordGenerator = lambda *args, **kwargs: coord.Galactic(*args, **kwargs)
     FK5CoordGenerator = lambda *args, **kwargs: coord.FK5(*args, **kwargs)
     FK4CoordGenerator = lambda *args, **kwargs: coord.FK4(*args, **kwargs)
     ICRSCoord = coord.ICRS
-    CoordClasses = (coord.SphericalCoordinateBase,)
+    CoordClasses = (coord.SphericalCoordinatesBase,)
 
 from ..exceptions import TimeoutError
 from .. import version


### PR DESCRIPTION
Found a mistyping when importing: from astroquery.vizier import Vizier
The correct name of the class on astropy is SphericalCoordinatesBase not SphericalCoordinateBase.

```
In [1]: from astroquery.vizier import Vizier
WARNING: ConfigurationDefaultMissingWarning: Requested default configuration file astroquery/astroquery.cfg is not a file. Cannot install default profile. If you are importing from source, this is expected. [astroquery._astropy_init]
ERROR: AttributeError: 'module' object has no attribute 'SphericalCoordinateBase' [IPython.core.interactiveshell]
---------------------------------------------------------------------------
AttributeError                            Traceback (most recent call last)
<ipython-input-1-b30b3faacb69> in <module>()
----> 1 from astroquery.vizier import Vizier

/Users/william/workspace/astroquery/astroquery/vizier/__init__.py in <module>()
     29 ROW_LIMIT = ConfigurationItem('row_limit', 50, 'maximum number of rows that will be fetched from the result (set to -1 for unlimited).')
     30 
---> 31 from .core import Vizier,VizierClass
     32 
     33 __all__ = ['Vizier','VizierClass']

/Users/william/workspace/astroquery/astroquery/vizier/core.py in <module>()
     17 
     18 from ..query import BaseQuery
---> 19 from ..utils import commons
     20 from ..utils import async_to_sync
     21 from ..utils import schema

/Users/william/workspace/astroquery/astroquery/utils/__init__.py in <module>()
      6 
      7 from .progressbar import *
----> 8 from .download_file_list import *
      9 from .class_or_instance import *
     10 from .commons import *

/Users/william/workspace/astroquery/astroquery/utils/download_file_list.py in <module>()
      7 from astropy.extern.six import StringIO
      8 import astropy.io.fits as fits
----> 9 from .commons import get_readable_fileobj
     10 
     11 __all__ = ['download_list_of_fitsfiles']

/Users/william/workspace/astroquery/astroquery/utils/commons.py in <module>()
     35     FK4CoordGenerator = lambda *args, **kwargs: coord.FK4(*args, **kwargs)
     36     ICRSCoord = coord.ICRS
---> 37     CoordClasses = (coord.SphericalCoordinateBase,)
     38 
     39 from ..exceptions import TimeoutError

AttributeError: 'module' object has no attribute 'SphericalCoordinateBase'
```
