### PR TITLE
Validation in schema should use six.string_types

### DIFF
--- a/astroquery/vizier/core.py
+++ b/astroquery/vizier/core.py
@@ -35,8 +35,10 @@ class VizierClass(BaseQuery):
 
     _str_schema = schema.Or(*six.string_types)
     _schema_columns = schema.Schema([_str_schema], error="columns must be a list of strings")
-    _schema_column_filters = schema.Schema({schema.Optional(_str_schema):_str_schema}, error="column_filters must be a dictionary where both keys and values are strings")
-    _schema_catalog = schema.Schema(schema.Or([_str_schema],_str_schema,None), error="catalog must be a list of strings or a single string")
+    _schema_column_filters = schema.Schema({schema.Optional(_str_schema):_str_schema},
+                                           error="column_filters must be a dictionary where both keys and values are strings")
+    _schema_catalog = schema.Schema(schema.Or([_str_schema],_str_schema,None),
+                                    error="catalog must be a list of strings or a single string")
 
     def __init__(self, columns=["*"], column_filters={}, catalog=None, keywords=None):
         self.columns = VizierClass._schema_columns.validate(columns)

--- a/astroquery/vizier/tests/test_vizier.py
+++ b/astroquery/vizier/tests/test_vizier.py
@@ -174,3 +174,11 @@ class TestVizierClass:
     def test_columns_unicode(self):
         v = vizier.core.Vizier(columns=[u'Vmag', u'B-V', u'_RAJ2000', u'_DEJ2000'])
         assert len(v.columns) == 4
+
+    def test_column_filters(self):
+        v = vizier.core.Vizier(column_filters={'Vmag':'>10'})
+        assert len(v.column_filters) == 1
+
+    def test_column_filters_unicode(self):
+        v = vizier.core.Vizier(column_filters={u'Vmag':u'>10'})
+        assert len(v.column_filters) == 1


### PR DESCRIPTION
Else, unicode will fail in py2.7 where it should be accepted.
