### PR TITLE
Expand SDSS query

### DIFF
--- a/astroquery/sdss/core.py
+++ b/astroquery/sdss/core.py
@@ -571,8 +571,7 @@ class SDSSClass(BaseQuery):
         bytecontent = (response.content.encode('ascii')
                        if hasattr(response.content,'encode')
                        else response.content)
-        if 'error_message' in response.content:
-            #print(response.content.encode('ascii'))
+        if 'error_message' in io.BytesIO(bytecontent):
             raise RemoteServiceError(response.content)
         arr = np.atleast_1d(np.genfromtxt(io.BytesIO(bytecontent),
                             names=True, dtype=None, delimiter=b',',


### PR DESCRIPTION
Expanded the SDSS by adding photoobj_fields and specobj_fields to
query_region_async and _args_to_payload parameters so that the user can
retrieve any field from the PhotoObjAll object (see
http://cas.sdss.org/dr4/en/help/browser/description.asp?n=PhotoObjAll&t=
U)
