### PR TITLE
Allow users to query a list of coordinates for SDSS query

### DIFF
--- a/astroquery/sdss/core.py
+++ b/astroquery/sdss/core.py
@@ -681,7 +681,7 @@ class SDSSClass(BaseQuery):
         if coordinates is not None:
             if (not isinstance(coordinates, list) and
                 not (isinstance(coordinates, commons.CoordClasses) and
-                isinstance(coordinates.data.lat.value, np.ndarray))
+                not coordinates.isscalar)
             ):
                 coordinates = [coordinates]
             for n, target in enumerate(coordinates):


### PR DESCRIPTION
Due to restrictions by the SDSS server it can be useful to query a list
of coordinates in a single query. The result can then be matched with
the original list by using:

```
dr = coords.Angle(radius).to('degree').value
obj_coords = coords.SkyCoord(result['ra'], result['dec'], frame='icrs', unit='deg')
matches, d2d, d3d = obj_coords.match_to_catalog_sky(coordinates)
result = result.group_by(matches)
```

where the group keys are the indices to the coordinates sent to the
query.

A future modification of astroquery can do the above procedure
automatically.
