### PR TITLE
ESO tests should be skipped if bs4 is not available

### DIFF
--- a/astroquery/eso/tests/test_eso.py
+++ b/astroquery/eso/tests/test_eso.py
@@ -1,8 +1,14 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 import os
-from ...eso import Eso
+try:
+    from ...eso import Eso
+    ESO_IMPORTED = True
+except ImportError:
+    ESO_IMPORTED = False
 from astropy.tests.helper import pytest
 from ...utils.testing_tools import MockResponse
+
+SKIP_TESTS = not ESO_IMPORTED
 
 DATA_DIR = os.path.join(os.path.dirname(__file__), 'data')
 
@@ -35,6 +41,7 @@ def eso_request(request_type, url, **kwargs):
 # This test should attempt to access the internet and therefore should fail
 # (_activate_form always connects to the internet)
 #@pytest.mark.xfail
+@pytest.mark.skipif('SKIP_TESTS')
 def test_SgrAstar(monkeypatch):
     # Local caching prevents a remote query here
 

--- a/astroquery/eso/tests/test_eso_remote.py
+++ b/astroquery/eso/tests/test_eso_remote.py
@@ -1,7 +1,11 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 import os
 from astropy.tests.helper import pytest, remote_data
-from ...eso import Eso
+try:
+    from ...eso import Eso
+    ESO_IMPORTED = True
+except ImportError:
+    ESO_IMPORTED = False
 from ...exceptions import LoginError
 
 CACHE_PATH = os.path.join(os.path.dirname(__file__), 'data')
@@ -12,8 +16,9 @@ try:
 except ImportError:
     HAS_KEYRING = False
 
+SKIP_TESTS = not(HAS_KEYRING and ESO_IMPORTED)
 
-@pytest.mark.skipif('not HAS_KEYRING')
+@pytest.mark.skipif('SKIP_TESTS')
 @remote_data
 class TestEso:
     def test_SgrAstar(self):


### PR DESCRIPTION
Currently the `astroquery.eso` tests fail if `bs4` is not installed:
https://gist.github.com/cdeil/9f1ab9be1129737ded77

Instead the tests should be skipped.
