### PR TITLE
Web page example uses hrs for dec

### DIFF
--- a/docs/gallery.rst
+++ b/docs/gallery.rst
@@ -80,7 +80,7 @@ Example 4
     >>> customSimbad.add_votable_fields('ra(d)','dec(d)')
     >>> customSimbad.remove_votable_fields('coordinates')
     >>> from astropy import coordinates
-    >>> C = coordinates.SkyFrame(0,0,unit=('deg','deg'), frame='icrs')
+    >>> C = coordinates.SkyCoord(0,0,unit=('deg','deg'), frame='icrs')
     >>> result = S.query_region(C, radius='2 degrees')
     >>> result[:5].pprint()
         MAIN_ID        RA_d       DEC_d

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -74,7 +74,7 @@ All query tools allow coordinate-based queries:
     >>> from astropy import coordinates
     >>> import astropy.units as u
     >>> # works only for ICRS coordinates:
-    >>> c = coordinate.SkyFrame("05h35m17.3s -05d23m28s", frame='icrs')
+    >>> c = coordinate.SkyCoord("05h35m17.3s -05d23m28s", frame='icrs')
     >>> r = 5 * u.arcminute
     >>> result_table = Simbad.query_region(c, radius=r)
     >>> result_table.pprint(show_unit=True)

--- a/docs/irsa/irsa.rst
+++ b/docs/irsa/irsa.rst
@@ -106,7 +106,7 @@ a string, as specified by `astropy.coordinates`:
 
     >>> from astroquery.irsa import Irsa
     >>> import astropy.coordinates as coord
-    >>> table = Irsa.query_region(coord.SkyFrame(121.1743,
+    >>> table = Irsa.query_region(coord.SkyCoord(121.1743,
     ...                           -21.5733, unit=(u.deg,u.deg),
     ...                           frame='galactic'),
     ...                           catalog='fp_psc', radius='0d2m0s')

--- a/docs/nrao/nrao.rst
+++ b/docs/nrao/nrao.rst
@@ -76,7 +76,7 @@ Here's an example with all these optional parameters.
    >>> from astroquery.nrao import Nrao
    >>> import astropy.units as u
    >>> import astropy.coordinates as coord
-   >>> result_table = Nrao.query_region(coord.SkyFrame(68.29625,
+   >>> result_table = Nrao.query_region(coord.SkyCoord(68.29625,
    ... 5.35431,  unit=(u.deg, u.deg), frame='icrs'), radius=2*u.arcmin,
    ... telescope='historical_vla', start_date='1985-06-30 18:16:49',
    ... end_date='1985-06-30 18:20:19', freq_low=1600*u.MHz, freq_up=1700*u.MHz,

--- a/docs/nvas/nvas.rst
+++ b/docs/nvas/nvas.rst
@@ -52,7 +52,7 @@ centre.
     >>> from astroquery.nvas import Nvas
     >>> import astropy.coordinates as coord
     >>> import astropy.units as u
-    >>> images = Nvas.get_images(coord.SkyFrame(49.489, -0.37,
+    >>> images = Nvas.get_images(coord.SkyCoord(49.489, -0.37,
     ...                          unit=(u.deg, u.deg), frame='galactic'),
     ...                          band="K")
 

--- a/docs/ogle/ogle.rst
+++ b/docs/ogle/ogle.rst
@@ -20,7 +20,7 @@ using an `astropy.coordinates` instance use:
     >>> from astropy import coordinates
     >>> from astropy imoprt units as u
     >>> from astroquery import ogle
-    >>> co = coordinates.SkyFrame(0*u.deg, 3*u.deg, frame='galactic')
+    >>> co = coordinates.SkyCoord(0*u.deg, 3*u.deg, frame='galactic')
     >>> t = ogle.query(coord=co)
 
 Arguments can be passed to choose the interpolation algorithm, quality factor,

--- a/docs/simbad/simbad.rst
+++ b/docs/simbad/simbad.rst
@@ -168,7 +168,7 @@ For other coordinate systems, use the appropriate `astropy.coordinates` object:
     >>> from astroquery.simbad import Simbad
     >>> import astropy.coordinates as coord
     >>> import astropy.units as u
-    >>> result_table = Simbad.query_region(coord.SkyFrame(31.0087, 14.0627,
+    >>> result_table = Simbad.query_region(coord.SkyCoord(31.0087, 14.0627,
     ...                                    unit=(u.deg, u.deg), frame='galactic'),
     ...                                    radius='0d0m2s')
     >>> print(result_table)

--- a/docs/ukidss/ukidss.rst
+++ b/docs/ukidss/ukidss.rst
@@ -149,7 +149,7 @@ parameters will no longer be effective.
     >>> from astroquery.ukidss import Ukidss
     >>> import astropy.units as u
     >>> import astropy.coordinates as coord
-    >>> images = Ukidss.get_images(coord.SkyFrame(49.489, -0.27,
+    >>> images = Ukidss.get_images(coord.SkyCoord(49.489, -0.27,
     ...                                           unit=(u.deg, u.deg),
     ...                                           frame='galactic'),
     ...                            image_width=5 * u.arcmin)
@@ -197,7 +197,7 @@ parameters. Let us now see a complete example to illustrate these points.
     >>> from astroquery.ukidss import Ukidss
     >>> import astropy.units as u
     >>> import astropy.coordinates as coord 
-    >>> image_urls = Ukidss.get_image_list(coord.SkyFrame(ra=83.633083,
+    >>> image_urls = Ukidss.get_image_list(coord.SkyCoord(ra=83.633083,
     ...          dec=22.0145, unit=(u.deg, u.deg), frame='icrs'),
     ...          frame_type='interleave',
     ...          programme_id="GCS", waveband="K", radius=20*u.arcmin)
@@ -227,7 +227,7 @@ results are returned in a `~astropy.table.Table`.
     >>> from astroquery.ukidss import Ukidss
     >>> import astropy.coordinates as coord
     >>> import astropy.units as u
-    >>> table = Ukidss.query_region(coord.SkyFrame(10.625, -0.38,
+    >>> table = Ukidss.query_region(coord.SkyCoord(10.625, -0.38,
     ...                                            unit=(u.deg, u.deg),
     ...                                            frame='galactic'),
     ...                             radius=6 * u.arcsec)

--- a/docs/vizier/vizier.rst
+++ b/docs/vizier/vizier.rst
@@ -161,7 +161,7 @@ dimension.
     >>> from astroquery.vizier import Vizier
     >>> import astropy.units as u
     >>> import astropy.coordinates as coord
-    >>> result = Vizier.query_region(coord.SkyFrame(ra=299.590, dec=35.201,
+    >>> result = Vizier.query_region(coord.SkyCoord(ra=299.590, dec=35.201,
     ...                                             unit=(u.deg, u.deg),
     ...                                             frame='icrs'),
     ...                         width="30m",


### PR DESCRIPTION
The coordinate example on the astroquery web page uses hours for DEC

   c = coord.ICRS("05h35m17.3s -05h23m28s")

It's possible this is intentional, but it seems unlikely, especially since if that h is replaced with a d those are the coordinates of M42.
