### PR TITLE
all services: use ConfigItem instead of deprecated ConfigurationItem

### DIFF
--- a/astroquery/alfalfa/__init__.py
+++ b/astroquery/alfalfa/__init__.py
@@ -9,7 +9,7 @@ This package is for querying the ALFALFA data repository hosted at
 http://arecibo.tc.cornell.edu/hiarchive/alfalfa/
 """
 
-from .core import Alfalfa,AlfalfaClass
+from .core import Alfalfa, AlfalfaClass
 
 import warnings
 warnings.warn("Experimental: ALFALFA has not yet been refactored to have its API match the rest of astroquery.")

--- a/astroquery/besancon/__init__.py
+++ b/astroquery/besancon/__init__.py
@@ -7,26 +7,39 @@ http://model.obs-besancon.fr/
 
 :Author: Adam Ginsburg (adam.g.ginsburg@gmail.com)
 """
-from astropy.config import ConfigurationItem
-# maintain a list of URLs in case the user wants to append a mirror
-BESANCON_DOWNLOAD_URL = ConfigurationItem('besancon_download_url',[
-                                    'ftp://sasftp.obs-besancon.fr/modele/modele2003/',
-                                    'ftp://sasftp.obs-besancon.fr/modele/',
-                                    ],
-    'Besancon download URL.  Changed to modele2003 in 2013.')
+from astropy import config as _config
 
-BESANCON_MODEL_FORM = ConfigurationItem('besancon_model_Form',
-                            ["http://model.obs-besancon.fr/modele_form.php"],
-                            "Besancon model form URL")
 
-BESANCON_PING_DELAY = ConfigurationItem('besancon_ping_delay', 30.0,
-                                        "Amount of time before pinging the Besancon server to see if the file is ready.  Minimum 30s.",
-                                        cfgtype="float(min=30.0)")
+class Conf(_config.ConfigNamespace):
+    """
+    Configuration parameters for `astroquery.besancon`.
+    """
 
-BESANCON_TIMEOUT = ConfigurationItem('besancon_timeout', 30.0,
-                                        "Timeout for Besancon query")
+    download_url = _config.ConfigItem(
+        ['ftp://sasftp.obs-besancon.fr/modele/modele2003/',
+         'ftp://sasftp.obs-besancon.fr/modele/',
+         ],
+        'Besancon download URL.  Changed to modele2003 in 2013.'
+        )
+    model_form = _config.ConfigItem(
+        ['http://model.obs-besancon.fr/modele_form.php'],
+        'Besancon model form URL'
+        )
+    ping_delay = _config.ConfigItem(
+        30.0,
+        'Amount of time before pinging the Besancon server to see if the file is ready.  Minimum 30s.'
+        )
+    timeout = _config.ConfigItem(
+        30.0,
+        'Timeout for Besancon query'
+        )
 
-from .core import Besancon,BesanconClass
-from .reader import BesanconFixed,BesanconFixedWidthHeader,BesanconFixedWidthData
+conf = Conf()
 
-__all__ = ['Besancon','BesanconClass','BesanconFixed','BesanconFixedWidthHeader','BesanconFixedWidthData']
+from .core import Besancon, BesanconClass
+from .reader import BesanconFixed, BesanconFixedWidthHeader, BesanconFixedWidthData
+
+__all__ = ['Besancon', 'BesanconClass', 'BesanconFixed',
+           'BesanconFixedWidthHeader', 'BesanconFixedWidthData',
+           'Conf', 'conf',
+           ]

--- a/astroquery/besancon/core.py
+++ b/astroquery/besancon/core.py
@@ -7,7 +7,6 @@ import sys
 import re
 import os
 from astropy.io import ascii
-from . import BESANCON_DOWNLOAD_URL, BESANCON_MODEL_FORM, BESANCON_PING_DELAY, BESANCON_TIMEOUT
 from astropy.extern.six.moves.urllib_error import URLError
 from astropy.extern.six import StringIO
 
@@ -15,6 +14,7 @@ from ..query import BaseQuery
 from ..utils import commons
 from ..utils import prepend_docstr_noreturns
 from ..utils import async_to_sync
+from . import conf
 
 __all__ = ['Besancon','BesanconClass','parse_besancon_model_string']
 
@@ -77,10 +77,10 @@ class BesanconClass(BaseQuery):
     # to refactor this whole project to be class-based, so they should be
     # set for class instances.
 
-    url_download = BESANCON_DOWNLOAD_URL()
-    QUERY_URL = BESANCON_MODEL_FORM()
-    ping_delay = BESANCON_PING_DELAY()
-    TIMEOUT = BESANCON_TIMEOUT()
+    url_download = conf.download_url
+    QUERY_URL = conf.model_form
+    ping_delay = conf.ping_delay
+    TIMEOUT = conf.timeout
     # sample file name:  1340900648.230224.resu
     result_re = re.compile("[0-9]{10}\.[0-9]{6}\.resu")
 

--- a/astroquery/eso/__init__.py
+++ b/astroquery/eso/__init__.py
@@ -1,7 +1,24 @@
-from astropy.config import ConfigurationItem
+# Licensed under a 3-clause BSD style license - see LICENSE.rst
+"""
+ESO service.
+"""
+from astropy import config as _config
 
-ROW_LIMIT = ConfigurationItem('row_limit', 50, 'maximum number of rows returned (set to -1 for unlimited).')
+
+class Conf(_config.ConfigNamespace):
+    """
+    Configuration parameters for `astroquery.eso`.
+    """
+
+    row_limit = _config.ConfigItem(
+        50,
+        'Maximum number of rows returned (set to -1 for unlimited).'
+        )
+
+conf = Conf()
 
 from .core import Eso, EsoClass
 
-__all__ = ['Eso', 'EsoClass']
+__all__ = ['Eso', 'EsoClass',
+           'Conf', 'conf',
+           ]

--- a/astroquery/eso/core.py
+++ b/astroquery/eso/core.py
@@ -16,7 +16,7 @@ from astropy import log
 from ..exceptions import LoginError, RemoteServiceError
 from ..utils import schema, system_tools
 from ..query import QueryWithLogin, suspend_cache
-from . import ROW_LIMIT
+from . import conf
 
 def _check_response(content):
     """
@@ -32,7 +32,7 @@ def _check_response(content):
 
 class EsoClass(QueryWithLogin):
 
-    ROW_LIMIT = ROW_LIMIT()
+    ROW_LIMIT = conf.row_limit
 
     def __init__(self):
         super(EsoClass, self).__init__()

--- a/astroquery/fermi/__init__.py
+++ b/astroquery/fermi/__init__.py
@@ -5,18 +5,35 @@ Access to Fermi Gamma-ray Space Telescope data.
 http://fermi.gsfc.nasa.gov
 http://fermi.gsfc.nasa.gov/ssc/data/
 """
-from astropy.config import ConfigurationItem
+from astropy import config as _config
 
-FERMI_URL = ConfigurationItem('fermi_url',
-                              ['http://fermi.gsfc.nasa.gov/cgi-bin/ssc/LAT/LATDataQuery.cgi'],
-                              "Fermi query URL")
-FERMI_TIMEOUT = ConfigurationItem('timeout', 60, 'time limit for connecting to FERMI server')
-FERMI_RETRIEVAL_TIMEOUT = ConfigurationItem('retrieval_timeout', 120, 'time limit for retrieving a data file once it has been located')
 
-from .core import FermiLAT, FermiLATClass, GetFermilatDatafile, get_fermilat_datafile
+class Conf(_config.ConfigNamespace):
+    """
+    Configuration parameters for `astroquery.fermi`.
+    """
+
+    url = _config.ConfigItem(
+        'http://fermi.gsfc.nasa.gov/cgi-bin/ssc/LAT/LATDataQuery.cgi',
+        'Fermi query URL.'
+        )
+    timeout = _config.ConfigItem(
+        60,
+        'Time limit for connecting to Fermi server.'
+        )
+    retrieval_timeout = _config.ConfigItem(
+        120,
+        'Time limit for retrieving a data file once it has been located.'
+        )
+
+conf = Conf()
+
+from .core import *
+
+__all__ = ['FermiLAT', 'FermiLATClass',
+           'GetFermilatDatafile', 'get_fermilat_datafile',
+           'Conf', 'conf',
+           ]
 
 import warnings
 warnings.warn("Experimental: Fermi-LAT has not yet been refactored to have its API match the rest of astroquery.")
-
-# clean up namespace - prevents doc warnings.  Unecessary if an `__all__` is added
-del ConfigurationItem

--- a/astroquery/fermi/core.py
+++ b/astroquery/fermi/core.py
@@ -7,9 +7,11 @@ from ..query import BaseQuery
 from ..utils import commons, async_to_sync
 import astropy.units as u
 
-from . import FERMI_URL,FERMI_TIMEOUT,FERMI_RETRIEVAL_TIMEOUT
+from . import conf
 
-__all__ = ['FermiLAT', 'FermiLATClass', 'GetFermilatDatafile','get_fermilat_datafile']
+__all__ = ['FermiLAT', 'FermiLATClass',
+           'GetFermilatDatafile', 'get_fermilat_datafile',
+           ]
 
 @async_to_sync
 class FermiLATClass(BaseQuery):
@@ -17,9 +19,9 @@ class FermiLATClass(BaseQuery):
     TODO: document
     """
 
-    request_url = FERMI_URL()
+    request_url = conf.url
     result_url_re = re.compile('The results of your query may be found at <a href="(http://fermi.gsfc.nasa.gov/.*?)"')
-    TIMEOUT = FERMI_TIMEOUT()
+    TIMEOUT = conf.timeout
 
     def query_object_async(self, *args, **kwargs):
         """
@@ -117,7 +119,7 @@ class GetFermilatDatafile(object):
 
     fitsfile_re = re.compile('<a href="(.*?)">Available</a>')
 
-    TIMEOUT = FERMI_RETRIEVAL_TIMEOUT()
+    TIMEOUT = conf.retrieval_timeout
 
     check_frequency = 1  # minutes
 

--- a/astroquery/gama/__init__.py
+++ b/astroquery/gama/__init__.py
@@ -1,3 +1,4 @@
+# Licensed under a 3-clause BSD style license - see LICENSE.rst
 """
 gama
 ----
@@ -7,4 +8,4 @@ http://www.gama-survey.org/dr2/query/
 :author: James T. Allen <james.thomas.allen@gmail.com>
 """
 
-from .core import GAMA,GAMAClass
+from .core import GAMA, GAMAClass

--- a/astroquery/gama/core.py
+++ b/astroquery/gama/core.py
@@ -1,3 +1,4 @@
+# Licensed under a 3-clause BSD style license - see LICENSE.rst
 """Download GAMA data"""
 import re
 import os
@@ -6,7 +7,8 @@ from astropy.table import Table
 from ..query import BaseQuery
 from ..utils import commons, async_to_sync
 
-__all__ = ['GAMA','GAMAClass']
+__all__ = ['GAMA', 'GAMAClass']
+
 
 @async_to_sync
 class GAMAClass(BaseQuery):

--- a/astroquery/gama/tests/test_gama.py
+++ b/astroquery/gama/tests/test_gama.py
@@ -1,3 +1,4 @@
+# Licensed under a 3-clause BSD style license - see LICENSE.rst
 from astropy.table import Table
 from ... import gama
 from astropy.tests.helper import remote_data

--- a/astroquery/irsa/__init__.py
+++ b/astroquery/irsa/__init__.py
@@ -3,17 +3,39 @@
 IRSA Query Tool
 ===============
 
-This module contains various methods for querying the IRSA Catalog Query Service(CatQuery)
+This module contains various methods for querying the
+IRSA Catalog Query Service(CatQuery).
 """
-from astropy.config import ConfigurationItem
+from astropy import config as _config
 
-IRSA_SERVER = ConfigurationItem('irsa_server', ['http://irsa.ipac.caltech.edu/cgi-bin/Gator/nph-query'],
-                               'Name of the IRSA mirror to use.')
-GATOR_LIST_CATALOGS = ConfigurationItem('gator_list_catalogs', ['http://irsa.ipac.caltech.edu/cgi-bin/Gator/nph-scan'],
-                                        'URL from which to list all the public catalogs in IRSA.')
-ROW_LIMIT = ConfigurationItem('row_limit', 500, 'maximum number of rows to retrieve in result')
-TIMEOUT = ConfigurationItem('timeout', 60, 'time limit for connecting to the IRSA server')
 
-from .core import Irsa,IrsaClass
+class Conf(_config.ConfigNamespace):
+    """
+    Configuration parameters for `astroquery.irsa`.
+    """
 
-__all__ = ['Irsa','IrsaClass']
+    server = _config.ConfigItem(
+        'http://irsa.ipac.caltech.edu/cgi-bin/Gator/nph-query',
+        'Name of the IRSA mirror to use.'
+        )
+    gator_list_catalogs = _config.ConfigItem(
+        'http://irsa.ipac.caltech.edu/cgi-bin/Gator/nph-scan',
+        'URL from which to list all the public catalogs in IRSA.'
+        )
+    row_limit = _config.ConfigItem(
+        500,
+        'Maximum number of rows to retrieve in result'
+        )
+    timeout = _config.ConfigItem(
+        60,
+        'Time limit for connecting to the IRSA server.'
+        )
+
+conf = Conf()
+
+
+from .core import Irsa, IrsaClass
+
+__all__ = ['Irsa', 'IrsaClass',
+           'Conf', 'conf',
+           ]

--- a/astroquery/irsa/core.py
+++ b/astroquery/irsa/core.py
@@ -101,20 +101,17 @@ import astropy.io.votable as votable
 
 from ..query import BaseQuery
 from ..utils import commons
-from . import (IRSA_SERVER,
-               GATOR_LIST_CATALOGS,
-               ROW_LIMIT,
-               TIMEOUT)
+from . import conf
 from ..exceptions import TableParseError
 
 __all__ = ['Irsa', 'IrsaClass']
 
 
 class IrsaClass(BaseQuery):
-    IRSA_URL = IRSA_SERVER()
-    GATOR_LIST_URL = GATOR_LIST_CATALOGS()
-    TIMEOUT = TIMEOUT()
-    ROW_LIMIT = ROW_LIMIT()
+    IRSA_URL = conf.server
+    GATOR_LIST_URL = conf.gator_list_catalogs
+    TIMEOUT = conf.timeout
+    ROW_LIMIT = conf.row_limit
 
     def query_region(self, coordinates=None, catalog=None, spatial='Cone',
                      radius=10 * u.arcsec, width=None, polygon=None,

--- a/astroquery/irsa/tests/test_irsa.py
+++ b/astroquery/irsa/tests/test_irsa.py
@@ -13,7 +13,7 @@ import numpy as np
 from ...utils.testing_tools import MockResponse
 from ...utils import commons
 from ... import irsa
-from ...irsa import ROW_LIMIT
+from ...irsa import conf
 
 DATA_FILES = {'Cone': 'Cone.xml',
               'Box': 'Box.xml',
@@ -73,7 +73,7 @@ def test_parse_coordinates(coordinates, expected):
 
 def test_args_to_payload():
     out = irsa.core.Irsa._args_to_payload("fp_psc")
-    assert out == dict(catalog='fp_psc', outfmt=3, outrows=ROW_LIMIT())
+    assert out == dict(catalog='fp_psc', outfmt=3, outrows=conf.row_limit)
 
 
 @pytest.mark.parametrize(("coordinates"), OBJ_LIST)

--- a/astroquery/irsa_dust/__init__.py
+++ b/astroquery/irsa_dust/__init__.py
@@ -9,14 +9,28 @@ IRSA Galactic Dust Reddening and Extinction Query Tool
 
     :Originally contributed by: David Shiga (dshiga.dev@gmail.com)
 """
-from astropy.config import ConfigurationItem
-# maintain a list of URLs in case the user wants to append a mirror
-IRSA_DUST_SERVER = ConfigurationItem('irsa_dust_server',[
-                                    'http://irsa.ipac.caltech.edu/cgi-bin/DUST/nph-dust'],
-    'Name of the irsa_dust server to use')
+from astropy import config as _config
 
-IRSA_DUST_TIMEOUT = ConfigurationItem('timeout', 30, 'default timeout for connecting to server')
 
-from .core import IrsaDust,IrsaDustClass
+class Conf(_config.ConfigNamespace):
+    """
+    Configuration parameters for `astroquery.irsa_dust`.
+    """
+    # maintain a list of URLs in case the user wants to append a mirror
+    server = _config.ConfigItem(
+        ['http://irsa.ipac.caltech.edu/cgi-bin/DUST/nph-dust'],
+        'Name of the irsa_dust server to use.'
+        )
+    timeout = _config.ConfigItem(
+        30,
+        'Default timeout for connecting to server.'
+        )
 
-__all__ = ['IrsaDust','IrsaDustClass']
+conf = Conf()
+
+
+from .core import IrsaDust, IrsaDustClass
+
+__all__ = ['IrsaDust', 'IrsaDustClass',
+           'Conf', 'conf',
+           ]

--- a/astroquery/irsa_dust/core.py
+++ b/astroquery/irsa_dust/core.py
@@ -3,7 +3,7 @@ from astropy.table import Table, Column
 import astropy.units as u
 import astropy.coordinates as coord
 from . import utils
-from . import IRSA_DUST_SERVER, IRSA_DUST_TIMEOUT
+from . import conf
 from ..utils import commons
 from ..query import BaseQuery
 
@@ -37,8 +37,8 @@ DATA_TABLE = "./data/table"
 
 class IrsaDustClass(BaseQuery):
 
-    DUST_SERVICE_URL = IRSA_DUST_SERVER()
-    TIMEOUT = IRSA_DUST_TIMEOUT()
+    DUST_SERVICE_URL = conf.server
+    TIMEOUT = conf.timeout
     image_type_to_section = {
         'temperature': 't',
         'ebv': 'r',

--- a/astroquery/magpis/__init__.py
+++ b/astroquery/magpis/__init__.py
@@ -11,12 +11,26 @@ MAGPIS Image and Catalog Query Tool
         Adam Ginsburg (adam.g.ginsburg@gmail.com)
 
 """
-from astropy.config import ConfigurationItem
+from astropy import config as _config
 
-MAGPIS_SERVER = ConfigurationItem('magpis_server', ["http://third.ucllnl.org/cgi-bin/gpscutout"],
-                               'Name of the MAGPIS server.')
-MAGPIS_TIMEOUT = ConfigurationItem('timeout', 60, 'time limit for connecting to MAGPIS server')
 
-from .core import Magpis,MagpisClass
+class Conf(_config.ConfigNamespace):
+    """
+    Configuration parameters for `astroquery.magpis`.
+    """
+    server = _config.ConfigItem(
+        ['http://third.ucllnl.org/cgi-bin/gpscutout'],
+        'Name of the MAGPIS server.'
+        )
+    timeout = _config.ConfigItem(
+        60,
+        'Time limit for connecting to MAGPIS server.'
+        )
 
-__all__ = ['Magpis','MagpisClass']
+conf = Conf()
+
+from .core import Magpis, MagpisClass
+
+__all__ = ['Magpis', 'MagpisClass',
+           'Conf', 'conf',
+           ]

--- a/astroquery/magpis/core.py
+++ b/astroquery/magpis/core.py
@@ -11,15 +11,15 @@ from astropy.io import fits
 from ..query import BaseQuery
 from ..utils.docstr_chompers import prepend_docstr_noreturns
 from ..utils import commons
-from . import MAGPIS_SERVER, MAGPIS_TIMEOUT
+from . import conf
 from ..exceptions import InvalidQueryError
 
-__all__ = ['Magpis','MagpisClass']
+__all__ = ['Magpis', 'MagpisClass']
 
 
 class MagpisClass(BaseQuery):
-    URL = MAGPIS_SERVER()
-    TIMEOUT = MAGPIS_TIMEOUT()
+    URL = conf.server
+    TIMEOUT = conf.timeout
     surveys = ["gps6",
                "gps6epoch2",
                "gps6epoch3",

--- a/astroquery/ned/__init__.py
+++ b/astroquery/ned/__init__.py
@@ -23,42 +23,68 @@ Module containing a series of functions that execute queries to the NASA Extraga
         ASP Conference Series, Vol. 382., p.165
 
 """
-
-from astropy.config import ConfigurationItem
-NED_SERVER = ConfigurationItem('ned_server', ['http://ned.ipac.caltech.edu/cgi-bin/'],
-                               'Name of the NED mirror to use.')
-
-NED_TIMEOUT = ConfigurationItem('timeout', 60, 'time limit for connecting to NED server')
+from astropy import config as _config
 
 
-# Set input parameters of choice
-HUBBLE_CONSTANT = ConfigurationItem('hubble_constant', [73, 70.5], 'value of the Hubble Constant for many NED queries.')
+class Conf(_config.ConfigNamespace):
+    """
+    Configuration parameters for `astroquery.ned`.
+    """
+    server = _config.ConfigItem(
+        ['http://ned.ipac.caltech.edu/cgi-bin/'],
+        'Name of the NED server to use.'
+        )
+    timeout = _config.ConfigItem(
+        60,
+        'Time limit for connecting to NED server.'
+        )
 
-"""
-The correct redshift for NED queries may be chosen by specifying numbers 1, 2, 3 and 4, having the following meanings
-(1) To the Reference Frame defined by the 3K CMB
-(2) To the Reference Frame defined by the Virgo Infall only
-(3) To the Reference Frame defined by the (Virgo + GA) only
-(4) To the Reference Frame defined by the (Virgo + GA + Shapley)
-"""
-CORRECT_REDSHIFT = ConfigurationItem('correct_redshift', [1, 2, 3, 4], 'the correct redshift for NED queries, see comments above.')
+    # Set input parameters of choice
 
-# Set output parameters of choice
-OUTPUT_COORDINATE_FRAME = ConfigurationItem('output_coordinate_frame',
-                                            ['Equatorial',
-                                             'Ecliptic',
-                                             'Galactic',
-                                             'SuperGalactic'], 'Frame in which to display the coordinates in the output.')
+    hubble_constant = _config.ConfigItem(
+        [73, 70.5],
+        'Value of the Hubble Constant for many NED queries.'
+        )
 
-OUTPUT_EQUINOX = ConfigurationItem('output_equinox', ['J2000.0', 'B1950.0'], 'Equinox for the output coordinates.')
-SORT_OUTPUT_BY = ConfigurationItem('sort_output_by',
-                                   ["RA or Longitude",
-                                    "DEC or Latitude",
-                                    "GLON",
-                                    "GLAT",
-                                    "Redshift - ascending",
-                                    "Redshift - descending"], 'display output sorted by this criteria.')
+    """
+    The correct redshift for NED queries may be chosen by specifying numbers
+    1, 2, 3 and 4, having the following meanings:
+    (1) To the Reference Frame defined by the 3K CMB
+    (2) To the Reference Frame defined by the Virgo Infall only
+    (3) To the Reference Frame defined by the (Virgo + GA) only
+    (4) To the Reference Frame defined by the (Virgo + GA + Shapley)
+    """
+    correct_redshift = _config.ConfigItem(
+        [1, 2, 3, 4],
+        'The correct redshift for NED queries, see comments above..'
+        )
 
-from .core import Ned,NedClass
+    # Set output parameters of choice
+    output_coordinate_frame = _config.ConfigItem(
+        ['Equatorial',
+         'Ecliptic',
+         'Galactic',
+         'SuperGalactic'],
+        'Frame in which to display the coordinates in the output.'
+        )
+    output_equinox = _config.ConfigItem(
+        ['J2000.0', 'B1950.0'],
+        'Equinox for the output coordinates.'
+        )
+    sort_output_by = _config.ConfigItem(
+        ["RA or Longitude",
+         "DEC or Latitude",
+         "GLON",
+         "GLAT",
+         "Redshift - ascending",
+         "Redshift - descending"],
+        'Display output sorted by this criteria.'
+        )
 
-__all__ = ['Ned','NedClass']
+conf = Conf()
+
+from .core import Ned, NedClass
+
+__all__ = ['Ned', 'NedClass',
+           'Conf', 'conf',
+           ]

--- a/astroquery/ned/core.py
+++ b/astroquery/ned/core.py
@@ -15,15 +15,10 @@ from astropy import __version__ as ASTROPY_VERSION
 
 from ..query import BaseQuery
 from ..utils import commons
-from . import (HUBBLE_CONSTANT,
-               CORRECT_REDSHIFT,
-               OUTPUT_COORDINATE_FRAME,
-               OUTPUT_EQUINOX,
-               SORT_OUTPUT_BY)
-from . import NED_SERVER, NED_TIMEOUT
-from ..exceptions import TableParseError,RemoteServiceError
+from . import conf
+from ..exceptions import TableParseError, RemoteServiceError
 
-__all__ = ["Ned","NedClass"]
+__all__ = ["Ned", "NedClass"]
 
 
 class NedClass(BaseQuery):
@@ -33,13 +28,13 @@ class NedClass(BaseQuery):
     http://ned.ipac.caltech.edu/
     """
     # make configurable
-    BASE_URL = NED_SERVER()
+    BASE_URL = conf.server
     OBJ_SEARCH_URL = BASE_URL + 'nph-objsearch'
     ALL_SKY_URL = BASE_URL + 'nph-allsky'
     DATA_SEARCH_URL = BASE_URL + 'nph-datasearch'
     IMG_DATA_URL = BASE_URL + 'imgdata'
     SPECTRA_URL = BASE_URL + 'NEDspectra'
-    TIMEOUT = NED_TIMEOUT()
+    TIMEOUT = conf.timeout
     Options = namedtuple('Options', ('display_name', 'cgi_name'))
 
     PHOTOMETRY_OUT = {1: Options('Data as Published and Homogenized (mJy)', 'bot'),
@@ -588,10 +583,10 @@ class NedClass(BaseQuery):
         ----------
         request_payload : dict
         """
-        request_payload['hconst'] = HUBBLE_CONSTANT()
+        request_payload['hconst'] = conf.hubble_constant
         request_payload['omegam'] = 0.27
         request_payload['omegav'] = 0.73
-        request_payload['corr_z'] = CORRECT_REDSHIFT()
+        request_payload['corr_z'] = conf.correct_redshift
 
     def _set_output_options(self, request_payload):
         """
@@ -601,9 +596,9 @@ class NedClass(BaseQuery):
         ----------
         request_payload : dict
         """
-        request_payload['out_csys'] = OUTPUT_COORDINATE_FRAME()
-        request_payload['out_equinox'] = OUTPUT_EQUINOX()
-        request_payload['obj_sort'] = SORT_OUTPUT_BY()
+        request_payload['out_csys'] = conf.output_coordinate_frame
+        request_payload['out_equinox'] = conf.output_equinox
+        request_payload['obj_sort'] = conf.sort_output_by
 
     def _parse_result(self, response, verbose=False):
         """
@@ -660,6 +655,7 @@ class NedClass(BaseQuery):
 
 Ned = NedClass()
 
+
 def _parse_radius(radius):
     """
     Parses the radius and returns it in the format expected by NED.
@@ -674,7 +670,6 @@ def _parse_radius(radius):
         The value of the radius in arcminutes.
     """
     return coord.Angle(radius).to('arcmin').value
-
 
 
 def _check_ned_valid(string):

--- a/astroquery/ned/tests/test_ned.py
+++ b/astroquery/ned/tests/test_ned.py
@@ -4,7 +4,6 @@ from __future__ import print_function
 import os
 import requests
 
-
 from numpy import testing as npt
 from astropy.tests.helper import pytest
 from astropy.table import Table
@@ -15,12 +14,7 @@ from ...utils.testing_tools import MockResponse
 
 from ... import ned
 from ...utils import commons
-from ...ned import (HUBBLE_CONSTANT,
-               CORRECT_REDSHIFT,
-               OUTPUT_COORDINATE_FRAME,
-               OUTPUT_EQUINOX,
-               SORT_OUTPUT_BY)
-
+from ...ned import conf
 
 DATA_FILES = {
     'object': 'query_object.xml',
@@ -175,13 +169,13 @@ def test_query_refcode_async(patch_get):
     response = ned.core.Ned.query_refcode_async('1997A&A...323...31K', True)
     assert response == {'search_type': 'Search',
                         'refcode': '1997A&A...323...31K',
-                        'hconst': HUBBLE_CONSTANT(),
+                        'hconst': conf.hubble_constant,
                         'omegam': 0.27,
                         'omegav': 0.73,
-                        'corr_z': CORRECT_REDSHIFT(),
-                        'out_csys': OUTPUT_COORDINATE_FRAME(),
-                        'out_equinox': OUTPUT_EQUINOX(),
-                        'obj_sort': SORT_OUTPUT_BY(),
+                        'corr_z': conf.correct_redshift,
+                        'out_csys': conf.output_coordinate_frame,
+                        'out_equinox': conf.output_equinox,
+                        'obj_sort': conf.sort_output_by,
                         'extend': 'no',
                         'img_stamp': 'NO',
                         'list_limit': 0,

--- a/astroquery/nist/__init__.py
+++ b/astroquery/nist/__init__.py
@@ -2,12 +2,26 @@
 """
 Fetches line spectra from the NIST Atomic Spectra Database.
 """
-from astropy.config import ConfigurationItem
-NIST_SERVER = ConfigurationItem('nist_server', ["http://physics.nist.gov/cgi-bin/ASD/lines1.pl"],
-                               'Name of the NIST URL to query.')
+from astropy import config as _config
 
-NIST_TIMEOUT = ConfigurationItem('timeout', 30, 'time limit for connecting to NIST server')
 
-from .core import Nist,NistClass
+class Conf(_config.ConfigNamespace):
+    """
+    Configuration parameters for `astroquery.nist`.
+    """
+    server = _config.ConfigItem(
+        ['http://physics.nist.gov/cgi-bin/ASD/lines1.pl'],
+        'Name of the NIST URL to query.'
+        )
+    timeout = _config.ConfigItem(
+        30,
+        'Time limit for connecting to NIST server.'
+        )
 
-__all__ = ['Nist','NistClass']
+conf = Conf()
+
+from .core import Nist, NistClass
+
+__all__ = ['Nist', 'NistClass',
+           'Conf', 'conf',
+           ]

--- a/astroquery/nist/core.py
+++ b/astroquery/nist/core.py
@@ -7,12 +7,12 @@ import astropy.units as u
 import astropy.io.ascii as asciitable
 
 from ..query import BaseQuery
-from ..utils import commons,async_to_sync
+from ..utils import commons, async_to_sync
 from ..utils.docstr_chompers import prepend_docstr_noreturns
-from . import NIST_SERVER, NIST_TIMEOUT
+from . import conf
 from ..exceptions import TableParseError
 
-__all__ = ['Nist','NistClass']
+__all__ = ['Nist', 'NistClass']
 
 
 def _strip_blanks(table):
@@ -38,8 +38,8 @@ def _strip_blanks(table):
 
 @async_to_sync
 class NistClass(BaseQuery):
-    URL = NIST_SERVER()
-    TIMEOUT = NIST_TIMEOUT()
+    URL = conf.server
+    TIMEOUT = conf.timeout
     unit_code = {'Angstrom':0,
                  'nm': 1,
                  'um': 2}

--- a/astroquery/nrao/__init__.py
+++ b/astroquery/nrao/__init__.py
@@ -2,13 +2,26 @@
 """
 Module to query the NRAO Data Archive for observation summaries.
 """
-from astropy.config import ConfigurationItem
-
-NRAO_SERVER = ConfigurationItem('nrao_server', ['https://archive.nrao.edu/archive/ArchiveQuery'],
-                               'Name of the NRAO mirror to use.')
-NRAO_TIMEOUT = ConfigurationItem('timeout', 60, 'time limit for connecting to NRAO server')
+from astropy import config as _config
 
 
-from .core import Nrao,NraoClass
+class Conf(_config.ConfigNamespace):
+    """
+    Configuration parameters for `astroquery.nrao`.
+    """
+    server = _config.ConfigItem(
+        ['https://archive.nrao.edu/archive/ArchiveQuery'],
+        'Name of the NRAO mirror to use.'
+        )
+    timeout = _config.ConfigItem(
+        60,
+        'Time limit for connecting to NRAO server.'
+        )
 
-__all__ = ['Nrao','NraoClass']
+conf = Conf()
+
+from .core import Nrao, NraoClass
+
+__all__ = ['Nrao', 'NraoClass',
+           'Conf', 'conf',
+           ]

--- a/astroquery/nrao/core.py
+++ b/astroquery/nrao/core.py
@@ -15,9 +15,9 @@ from ..utils import commons, async_to_sync
 from ..utils.docstr_chompers import prepend_docstr_noreturns
 from ..exceptions import TableParseError
 
-from . import NRAO_SERVER, NRAO_TIMEOUT
+from . import conf
 
-__all__ = ["Nrao","NraoClass"]
+__all__ = ["Nrao", "NraoClass"]
 
 
 def _validate_params(func):
@@ -42,8 +42,8 @@ def _validate_params(func):
 @async_to_sync
 class NraoClass(BaseQuery):
 
-    DATA_URL = NRAO_SERVER()
-    TIMEOUT = NRAO_TIMEOUT()
+    DATA_URL = conf.server
+    TIMEOUT = conf.timeout
 
     # dicts and lists for data archive queries
     telescope_code = {
@@ -238,7 +238,7 @@ class NraoClass(BaseQuery):
         new_content = days_re.sub(r'unit="days"  datatype="char" arraysize="*"', new_content)
         degrees_re = re.compile(r'unit="degrees"  datatype="double"')
         new_content = degrees_re.sub(r'unit="degrees"  datatype="char" arraysize="*"', new_content)
-                
+
         try:
             tf = tempfile.NamedTemporaryFile()
             tf.write(new_content.encode('utf-8'))

--- a/astroquery/nvas/__init__.py
+++ b/astroquery/nvas/__init__.py
@@ -8,13 +8,26 @@
 
         Adam Ginsburg (adam.g.ginsburg@gmail.com)
 """
+from astropy import config as _config
 
-from astropy.config import ConfigurationItem
 
-NVAS_SERVER = ConfigurationItem('nvas_server', ["https://webtest.aoc.nrao.edu/cgi-bin/lsjouwer/archive-pos.pl"],
-                               'Name of the NVAS mirror to use.')
-NVAS_TIMEOUT = ConfigurationItem('timeout', 60, 'time limit for connecting to NVAS server')
+class Conf(_config.ConfigNamespace):
+    """
+    Configuration parameters for `astroquery.nvas`.
+    """
+    server = _config.ConfigItem(
+        ['https://webtest.aoc.nrao.edu/cgi-bin/lsjouwer/archive-pos.pl'],
+        'Name of the NVAS mirror to use.'
+        )
+    timeout = _config.ConfigItem(
+        60,
+        'Time limit for connecting to NVAS server.'
+        )
 
-from .core import Nvas,NvasClass
+conf = Conf()
 
-__all__ = ['Nvas','NvasClass']
+from .core import Nvas, NvasClass
+
+__all__ = ['Nvas', 'NvasClass',
+           'Conf', 'conf',
+           ]

--- a/astroquery/nvas/core.py
+++ b/astroquery/nvas/core.py
@@ -8,14 +8,14 @@ from astropy import coordinates as coord
 
 from ..query import BaseQuery
 from ..utils import commons
-from . import NVAS_SERVER, NVAS_TIMEOUT
+from . import conf
 
-__all__ = ["Nvas","NvasClass"]
+__all__ = ["Nvas", "NvasClass"]
 
 
 class NvasClass(BaseQuery):
-    URL = NVAS_SERVER()
-    TIMEOUT = NVAS_TIMEOUT()
+    URL = conf.server
+    TIMEOUT = conf.timeout
     valid_bands = ["all","L","C","X","U","K","Q"]
 
     band_freqs = {

--- a/astroquery/ogle/__init__.py
+++ b/astroquery/ogle/__init__.py
@@ -13,18 +13,29 @@ Note:
   If you use the data from OGLE please refer to the publication by Nataf et al.
   (2012).
 """
-from astropy.config import ConfigurationItem
-
-OGLE_SERVER = ConfigurationItem('ogle_server',
-                                ['http://ogle.astrouw.edu.pl/cgi-ogle/getext.py'],
-                                'Name of the OGLE mirror to use.')
-OGLE_TIMEOUT = ConfigurationItem('timeout', 60,
-                                 'Time limit for connecting to the OGLE server.')
+from astropy import config as _config
 
 
-from .core import Ogle,OgleClass
+class Conf(_config.ConfigNamespace):
+    """
+    Configuration parameters for `astroquery.ogle`.
+    """
+    server = _config.ConfigItem(
+        ['http://ogle.astrouw.edu.pl/cgi-ogle/getext.py'],
+        'Name of the OGLE mirror to use.'
+        )
+    timeout = _config.ConfigItem(
+        60,
+        'Time limit for connecting to OGLE server.'
+        )
 
-__all__ = ['Ogle','OgleClass']
+conf = Conf()
+
+from .core import Ogle, OgleClass
+
+__all__ = ['Ogle', 'OgleClass',
+           'Conf', 'conf',
+           ]
 
 import warnings
 warnings.warn("Experimental: OGLE has not yet been refactored to have its API match the rest of astroquery.")

--- a/astroquery/ogle/core.py
+++ b/astroquery/ogle/core.py
@@ -10,7 +10,7 @@ from ..query import BaseQuery
 from ..utils import commons, async_to_sync
 from ..utils.docstr_chompers import prepend_docstr_noreturns
 
-from . import OGLE_SERVER, OGLE_TIMEOUT
+from . import conf
 
 __all__ = ['Ogle', 'OgleClass']
 
@@ -46,8 +46,8 @@ class CoordParseError(ValueError):
 @async_to_sync
 class OgleClass(BaseQuery):
 
-    DATA_URL = OGLE_SERVER()
-    TIMEOUT = OGLE_TIMEOUT()
+    DATA_URL = conf.server
+    TIMEOUT = conf.timeout
 
     algorithms = ['NG', 'NN']
     quality_codes = ['GOOD', 'ALL']

--- a/astroquery/open_exoplanet_catalogue/__init__.py
+++ b/astroquery/open_exoplanet_catalogue/__init__.py
@@ -7,5 +7,4 @@ https://github.com/hannorein/open_exoplanet_catalogue
 https://github.com/hannorein/oec_meta
 http://openexoplanetcatalogue.com
 """
-from astropy.config import ConfigurationItem
 from .oec_query import *

--- a/astroquery/open_exoplanet_catalogue/oec_query.py
+++ b/astroquery/open_exoplanet_catalogue/oec_query.py
@@ -1,8 +1,7 @@
-#!/usr/bin/python
+# Licensed under a 3-clause BSD style license - see LICENSE.rst
 import xml.etree.ElementTree as ET
 import gzip
 import io
-import os
 from .utils import Number
 
 oec_server_url = "https://github.com/OpenExoplanetCatalogue/oec_gzip/raw/master/systems.xml.gz"

--- a/astroquery/open_exoplanet_catalogue/utils.py
+++ b/astroquery/open_exoplanet_catalogue/utils.py
@@ -1,3 +1,4 @@
+# Licensed under a 3-clause BSD style license - see LICENSE.rst
 
 class Number(object):
     """ Number class for values containing errors. Math operations use 

--- a/astroquery/sdss/__init__.py
+++ b/astroquery/sdss/__init__.py
@@ -5,21 +5,30 @@ SDSS Spectra/Image/SpectralTemplate Archive Query Tool
 
 :Author: Jordan Mirocha (mirochaj@gmail.com)
 """
+from astropy import config as _config
 
-from astropy.config import ConfigurationItem
 
-SDSS_SERVER = ConfigurationItem('sdss_server', 'http://data.sdss3.org/sas/dr10',
-                                'Link to SDSS website.')
+class Conf(_config.ConfigNamespace):
+    """
+    Configuration parameters for `astroquery.sdss`.
+    """
+    server = _config.ConfigItem(
+        ['http://data.sdss3.org/sas/dr10'],
+        'Link to SDSS website.'
+        )
+    timeout = _config.ConfigItem(
+        60,
+        'Time limit for connecting to SDSS server.'
+        )
+    maxqueries = _config.ConfigItem(
+        1,
+        'Max number of queries allowed per second.'
+        )
 
-SDSS_MAXQUERY = ConfigurationItem('maxqueries', 1, 'Max number of queries allowed per second')
-
-SDSS_TIMEOUT = ConfigurationItem('timeout', 30,
-                                 'Default timeout for connecting to server')
+conf = Conf()
 
 from .core import SDSS, SDSSClass
 
 import warnings
-warnings.warn("Experimental: SDSS has not yet been refactored to have its API match the rest of astroquery (but it's nearly there).")
-
-# clean up namespace - prevents doc warnings.  Unecessary if an `__all__` is added
-del ConfigurationItem
+warnings.warn("Experimental: SDSS has not yet been refactored to have its API "
+              "match the rest of astroquery (but it's nearly there).")

--- a/astroquery/sdss/core.py
+++ b/astroquery/sdss/core.py
@@ -17,7 +17,7 @@ import astropy.coordinates as coord
 from astropy.table import Table
 import io
 from ..query import BaseQuery
-from . import SDSS_SERVER, SDSS_MAXQUERY, SDSS_TIMEOUT
+from . import conf
 from ..utils import commons, async_to_sync
 from ..utils.docstr_chompers import prepend_docstr_noreturns
 from ..exceptions import RemoteServiceError
@@ -48,13 +48,13 @@ sdss_arcsec_per_pixel = 0.396
 @async_to_sync
 class SDSSClass(BaseQuery):
 
-    BASE_URL = SDSS_SERVER()
+    BASE_URL = conf.server
     SPECTRO_OPTICAL = BASE_URL
     IMAGING = BASE_URL + '/boss/photoObj/frames'
     TEMPLATES = 'http://www.sdss.org/dr7/algorithms/spectemplates/spDR2'
-    MAXQUERIES = SDSS_MAXQUERY()
+    MAXQUERIES = conf.maxqueries
     AVAILABLE_TEMPLATES = spec_templates
-    TIMEOUT = SDSS_TIMEOUT()
+    TIMEOUT = conf.timeout
 
     QUERY_URL = 'http://skyserver.sdss3.org/public/en/tools/search/x_sql.aspx'
 

--- a/astroquery/simbad/__init__.py
+++ b/astroquery/simbad/__init__.py
@@ -8,16 +8,31 @@ The SIMBAD query tool creates a `script query
 data that is then parsed into a SimbadResult object.
 This object then parses the data and returns a table parsed with `astropy.io.votable.parse`.
 """
-from astropy.config import ConfigurationItem
+from astropy import config as _config
 
-SIMBAD_SERVER = ConfigurationItem('simbad_server', ['simbad.u-strasbg.fr',
-                                                    'simbad.harvard.edu'], 'Name of the SIMBAD mirror to use.')
 
-SIMBAD_TIMEOUT = ConfigurationItem('timeout', 60, 'time limit for connecting to Simbad server')
+class Conf(_config.ConfigNamespace):
+    """
+    Configuration parameters for `astroquery.simbad`.
+    """
+    server = _config.ConfigItem(
+        ['simbad.u-strasbg.fr', 'simbad.harvard.edu'],
+        'Name of the SIMBAD mirror to use.'
+        )
+    timeout = _config.ConfigItem(
+        60,
+        'Time limit for connecting to Simbad server.'
+        )
+    row_limit = _config.ConfigItem(
+        # O defaults to the maximum limit
+        0,
+        'Maximum number of rows that will be fetched from the result.'
+        )
 
-# O defaults to the maximum limit
-ROW_LIMIT = ConfigurationItem('row_limit', 0, 'maximum number of rows that will be fetched from the result.')
+conf = Conf()
 
 from .core import Simbad, SimbadClass
 
-__all__ = ['Simbad', 'SimbadClass']
+__all__ = ['Simbad', 'SimbadClass',
+           'Conf', 'conf',
+           ]

--- a/astroquery/simbad/core.py
+++ b/astroquery/simbad/core.py
@@ -3,28 +3,24 @@
 Simbad query class for accessing the Simbad Service
 """
 from __future__ import print_function
+import copy
 import re
 import json
 import os
 from collections import namedtuple
 import tempfile
 import warnings
-from ..query import BaseQuery
-from ..utils import commons
 import astropy.units as u
 from astropy.utils.data import get_pkg_data_filename
 import astropy.coordinates as coord
 from astropy.table import Table
-from astropy.extern import six
-import copy
-try:
-    import astropy.io.vo.table as votable
-except ImportError:
-    import astropy.io.votable as votable
-from . import SIMBAD_SERVER, SIMBAD_TIMEOUT, ROW_LIMIT
+import astropy.io.votable as votable
+from ..query import BaseQuery
+from ..utils import commons
 from ..exceptions import TableParseError
+from . import conf
 
-__all__ = ['Simbad','SimbadClass']
+__all__ = ['Simbad', 'SimbadClass']
 
 
 def validate_epoch(func):
@@ -59,7 +55,8 @@ def validate_equinox(func):
                 raise ValueError("Equinox must be a number")
         return func(*args, **kwargs)
     return wrapper
-    
+
+
 def strip_field(f, keep_filters=False):
     """Helper tool: remove parameters from VOTABLE fields
     However, this should only be applied to a subset of VOTABLE fields:
@@ -82,12 +79,13 @@ def strip_field(f, keep_filters=False):
     # the overall else (default option)
     return f
 
+
 class SimbadClass(BaseQuery):
     """
     The class for querying the Simbad web service.
     """
-    SIMBAD_URL = 'http://' + SIMBAD_SERVER() + '/simbad/sim-script'
-    TIMEOUT = SIMBAD_TIMEOUT()
+    SIMBAD_URL = 'http://' + conf.server + '/simbad/sim-script'
+    TIMEOUT = conf.timeout
     WILDCARDS = {
                 '*': 'Any string of characters (including an empty one)',
                 '?': 'Any character (exactly one character)',
@@ -109,7 +107,7 @@ class SimbadClass(BaseQuery):
         'query_bibobj_async': 'query bibobj'
     }
 
-    ROW_LIMIT = ROW_LIMIT()
+    ROW_LIMIT = conf.row_limit
 
     # also find a way to fetch the votable fields table from <http://simbad.u-strasbg.fr/simbad/sim-help?Page=sim-fscript#VotableFields>
     # tried something for this in this ipython nb
@@ -703,7 +701,7 @@ class SimbadClass(BaseQuery):
             args_str = ' '.join([str(val) for val in args])
         kwargs_str = ' '.join("{key}={value}".format(key=key, value=kwargs[key]) for
                               key in present_keys)
-        
+
         # For the record, I feel dirty for writing this wildcard-case hack.
         # This entire function should be refactored when someone has time.
         allargs_str = ' '.join([" ", args_str, kwargs_str, "\n"])

--- a/astroquery/simbad/get_votable_fields.py
+++ b/astroquery/simbad/get_votable_fields.py
@@ -1,4 +1,5 @@
 # -*- coding: utf-8 -*-
+# Licensed under a 3-clause BSD style license - see LICENSE.rst
 from __future__ import print_function
 import astropy.utils.data as aud
 import re

--- a/astroquery/simbad/tests/test_simbad.py
+++ b/astroquery/simbad/tests/test_simbad.py
@@ -46,7 +46,6 @@ class MockResponseSimbad(MockResponse):
         if match:
             filename = DATA_FILES[match.group(1)]
             content = open(data_path(filename), "r").read()
-            print(filename)
             return content
 
 

--- a/astroquery/simbad/tests/test_simbad_remote.py
+++ b/astroquery/simbad/tests/test_simbad_remote.py
@@ -1,12 +1,10 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
-from ... import simbad
 from astropy.tests.helper import remote_data, pytest
 import astropy.coordinates as coord
 import astropy.units as u
 from astropy.table import Table
-import sys
 from ...utils.testing_tools import MockResponse
-is_python3 = (sys.version_info >= (3,))
+from ... import simbad
 
 # double-check super-undo monkeypatching...
 import requests

--- a/astroquery/skyview/__init__.py
+++ b/astroquery/skyview/__init__.py
@@ -1,3 +1,4 @@
+# Licensed under a 3-clause BSD style license - see LICENSE.rst
 from astropy import config as _config
 
 
@@ -14,4 +15,6 @@ conf = Conf()
 
 from .core import SkyView, SkyViewClass
 
-__all__ = ['SkyView', 'SkyViewClass', 'conf']
+__all__ = ['SkyView', 'SkyViewClass',
+           'Conf', 'conf',
+           ]

--- a/astroquery/skyview/core.py
+++ b/astroquery/skyview/core.py
@@ -1,3 +1,4 @@
+# Licensed under a 3-clause BSD style license - see LICENSE.rst
 from astropy.extern.six.moves.urllib import parse as urlparse
 from astropy.extern import six
 

--- a/astroquery/skyview/setup_package.py
+++ b/astroquery/skyview/setup_package.py
@@ -1,3 +1,4 @@
+# Licensed under a 3-clause BSD style license - see LICENSE.rst
 import os
 
 

--- a/astroquery/skyview/tests/test_skyview.py
+++ b/astroquery/skyview/tests/test_skyview.py
@@ -1,3 +1,4 @@
+# Licensed under a 3-clause BSD style license - see LICENSE.rst
 import os.path
 
 from ...utils.testing_tools import MockResponse

--- a/astroquery/skyview/tests/test_skyview_remote.py
+++ b/astroquery/skyview/tests/test_skyview_remote.py
@@ -1,3 +1,4 @@
+# Licensed under a 3-clause BSD style license - see LICENSE.rst
 from astropy.tests.helper import remote_data
 
 from ...skyview import SkyView

--- a/astroquery/splatalogue/__init__.py
+++ b/astroquery/splatalogue/__init__.py
@@ -9,14 +9,36 @@ Splatalogue Catalog Query Tool
 
      Magnus Vilehlm Persson (magnusp@vilhelm.nu)
 """
-from astropy.config import ConfigurationItem
-SLAP_URL = ConfigurationItem("Splatalogue SLAP interface URL (not used).",'http://find.nrao.edu/splata-slap/slap')
-QUERY_URL = ConfigurationItem("Splatalogue web interface URL.",'http://www.cv.nrao.edu/php/splat/c_export.php')
-SPLATALOGUE_TIMEOUT = ConfigurationItem('timeout', 60, 'default timeout for connecting to server')
-LINES_LIMIT = ConfigurationItem('Limit to number of lines exported', 10000)
+from astropy import config as _config
+
+
+class Conf(_config.ConfigNamespace):
+    """
+    Configuration parameters for `astroquery.splatalogue`.
+    """
+    slap_url = _config.ConfigItem(
+        'http://find.nrao.edu/splata-slap/slap',
+        'Splatalogue SLAP interface URL (not used).'
+        )
+    query_url = _config.ConfigItem(
+        'http://www.cv.nrao.edu/php/splat/c_export.php',
+        'SSplatalogue web interface URL.'
+        )
+    timeout = _config.ConfigItem(
+        60,
+        'Time limit for connecting to Splatalogue server.'
+        )
+    lines_limit = _config.ConfigItem(
+        1000,
+        'Limit to number of lines exported.'
+        )
+
+conf = Conf()
 
 from . import load_species_table
 from . import utils
-from .core import Splatalogue,SplatalogueClass
+from .core import Splatalogue, SplatalogueClass
 
-__all__ = ['Splatalogue','SplatalogueClass']
+__all__ = ['Splatalogue', 'SplatalogueClass',
+           'Conf', 'conf',
+           ]

--- a/astroquery/splatalogue/core.py
+++ b/astroquery/splatalogue/core.py
@@ -10,7 +10,7 @@ from ..query import BaseQuery
 from ..utils import commons, async_to_sync
 from ..utils.docstr_chompers import prepend_docstr_noreturns
 from astropy import units as u
-from . import SLAP_URL, QUERY_URL, SPLATALOGUE_TIMEOUT, LINES_LIMIT
+from . import conf
 from . import load_species_table
 import warnings
 
@@ -23,10 +23,10 @@ __all__ = ['Splatalogue', 'SplatalogueClass']
 @async_to_sync
 class SplatalogueClass(BaseQuery):
 
-    SLAP_URL = SLAP_URL()
-    QUERY_URL = QUERY_URL()
-    TIMEOUT = SPLATALOGUE_TIMEOUT()
-    LINES_LIMIT = LINES_LIMIT()
+    SLAP_URL = conf.slap_url
+    QUERY_URL = conf.query_url
+    TIMEOUT = conf.timeout
+    LINES_LIMIT = conf.lines_limit
     versions = ('v1.0', 'v2.0')
     # global constant, not user-configurable
     ALL_LINE_LISTS = ('Lovas', 'SLAIM', 'JPL', 'CDMS', 'ToyoMA', 'OSU',

--- a/astroquery/splatalogue/tests/test_splatalogue.py
+++ b/astroquery/splatalogue/tests/test_splatalogue.py
@@ -47,7 +47,7 @@ def test_load_species_table():
     CO = tbl.find(' CO ')
     assert len(CO) == 4
 
-# regression test: ConfigurationItems were in wrong order at one point
+# regression test: ConfigItems were in wrong order at one point
 def test_url():
     assert 'http://' in splatalogue.core.Splatalogue.QUERY_URL
     assert 'cv.nrao.edu' in splatalogue.core.Splatalogue.QUERY_URL

--- a/astroquery/template_module/__init__.py
+++ b/astroquery/template_module/__init__.py
@@ -11,22 +11,30 @@
 # See <http://docs.astropy.org/en/latest/config/index.html#developer-usage>
 # for docs and examples on how to do this
 # Below is a common use case
+from astropy import config as _config
 
-from astropy.config import ConfigurationItem
 
-# Set the server mirrors to query
-SERVER = ConfigurationItem('server',
-                           ['http://dummy_server_mirror_1',
-                            'http://dummy_server_mirror_2',
-                            'http://dummy_server_mirror_n'],
-                           'put a brief description of the item here')
+class Conf(_config.ConfigNamespace):
+    """
+    Configuration parameters for `astroquery.template_module`.
+    """
+    server = _config.ConfigItem(
+        ['http://dummy_server_mirror_1',
+         'http://dummy_server_mirror_2',
+         'http://dummy_server_mirror_n'],
+        'Name of the template_module server to use.'
+        )
+    timeout = _config.ConfigItem(
+        30,
+        'Time limit for connecting to template_module server.'
+        )
 
-# Set the timeout for connecting to the server in seconds, here we set it to 30s
-TIMEOUT = ConfigurationItem('timeout', 30, 'default timeout for connecting to server')
+conf = Conf()
 
 # Now import your public class
 # Should probably have the same name as your module
+from .core import Dummy, DummyClass
 
-from .core import Dummy,DummyClass
-
-__all__ = ['Dummy','DummyClass']
+__all__ = ['Dummy', 'DummyClass',
+           'Conf', 'conf',
+           ]

--- a/astroquery/template_module/core.py
+++ b/astroquery/template_module/core.py
@@ -17,11 +17,11 @@ from ..query import BaseQuery # all Query classes should inherit from this.
 from ..utils import commons # has common functions required by most modules
 from ..utils import prepend_docstr_noreturns # automatically generate docs for similar functions
 from ..utils import async_to_sync # all class methods must be callable as static as well as instance methods.
-from . import SERVER, TIMEOUT # import configurable items declared in __init__.py
+from . import conf # import configurable items declared in __init__.py
 
 
 # export all the public classes and methods
-__all__ = ['Dummy','DummyClass']
+__all__ = ['Dummy', 'DummyClass']
 
 # declare global variables and constants if any
 
@@ -35,8 +35,8 @@ class DummyClass(BaseQuery):
     Not all the methods below are necessary but these cover most of the common cases, new methods may be added if necessary, follow the guidelines at <http://astroquery.readthedocs.org/en/latest/api.html>
     """
     # use the Configuration Items imported from __init__.py to set the URL, TIMEOUT, etc.
-    URL = SERVER()
-    TIMEOUT = TIMEOUT()
+    URL = conf.server
+    TIMEOUT = conf.timeout
 
     def query_object(self, object_name, get_query_payload=False, verbose=False):
         """

--- a/astroquery/tests/setup_package.py
+++ b/astroquery/tests/setup_package.py
@@ -1,3 +1,6 @@
+# Licensed under a 3-clause BSD style license - see LICENSE.rst
+
+
 def get_package_data():
     return {
         _ASTROPY_PACKAGE_NAME_ + '.tests': ['coveragerc']}

--- a/astroquery/ukidss/__init__.py
+++ b/astroquery/ukidss/__init__.py
@@ -12,12 +12,26 @@ UKIDSS Image and Catalog Query Tool
 
         Adam Ginsburg (adam.g.ginsburg@gmail.com)
 """
-from astropy.config import ConfigurationItem
+from astropy import config as _config
 
-UKIDSS_SERVER = ConfigurationItem('ukidss_server', ["http://surveys.roe.ac.uk:8080/wsa/"],
-                                  'Name of the UKIDSS mirror to use.')
-UKIDSS_TIMEOUT = ConfigurationItem('timeout', 60, 'time limit for connecting to UKIDSS server')
 
-from .core import Ukidss,UkidssClass,clean_catalog
+class Conf(_config.ConfigNamespace):
+    """
+    Configuration parameters for `astroquery.ukidss`.
+    """
+    server = _config.ConfigItem(
+        ['http://surveys.roe.ac.uk:8080/wsa/'],
+        'Name of the UKIDSS mirror to use.'
+        )
+    timeout = _config.ConfigItem(
+        30,
+        'Time limit for connecting to UKIDSS server.'
+        )
 
-__all__ = ['Ukidss','UkidssClass','clean_catalog']
+conf = Conf()
+
+from .core import Ukidss, UkidssClass, clean_catalog
+
+__all__ = ['Ukidss', 'UkidssClass', 'clean_catalog',
+           'Conf', 'conf',
+           ]

--- a/astroquery/ukidss/core.py
+++ b/astroquery/ukidss/core.py
@@ -15,7 +15,7 @@ import astropy.io.votable as votable
 from ..query import QueryWithLogin
 from ..exceptions import InvalidQueryError, TimeoutError
 from ..utils import commons
-from . import UKIDSS_SERVER, UKIDSS_TIMEOUT
+from . import conf
 from ..exceptions import TableParseError
 
 __all__ = ['Ukidss', 'UkidssClass', 'clean_catalog']
@@ -48,12 +48,12 @@ class UkidssClass(QueryWithLogin):
     queries.  Allows registered users to login, but defaults to using the
     public UKIDSS data sets.
     """
-    BASE_URL = UKIDSS_SERVER()
+    BASE_URL = conf.server
     LOGIN_URL = BASE_URL + "DBLogin"
     IMAGE_URL = BASE_URL + "GetImage"
     ARCHIVE_URL = BASE_URL + "ImageList"
     REGION_URL = BASE_URL + "WSASQL"
-    TIMEOUT = UKIDSS_TIMEOUT()
+    TIMEOUT = conf.timeout
 
     filters = {'all': 'all', 'J': 3, 'H': 4, 'K': 5, 'Y': 2,
                'Z': 1, 'H2': 6, 'Br': 7}

--- a/astroquery/utils/__init__.py
+++ b/astroquery/utils/__init__.py
@@ -10,4 +10,4 @@ from .class_or_instance import *
 from .commons import *
 from .process_asyncs import async_to_sync
 from .docstr_chompers import prepend_docstr_noreturns
-from .testing_tools import turn_off_internet,turn_on_internet
+from .testing_tools import turn_off_internet, turn_on_internet

--- a/astroquery/vizier/__init__.py
+++ b/astroquery/vizier/__init__.py
@@ -13,21 +13,41 @@ acknowledgment would be appreciated::
   This research has made use of the VizieR catalogue access tool, CDS, Strasbourg, France.
   The original description of the VizieR service was published in A&AS 143, 23
 """
-from astropy.config import ConfigurationItem
+from astropy import config as _config
 
-VIZIER_SERVER = ConfigurationItem('vizier_server', ['vizier.u-strasbg.fr',
-                                                    'vizier.nao.ac.jp',
-                                                    'vizier.hia.nrc.ca',
-                                                    'vizier.ast.cam.ac.uk',
-                                                    'vizier.cfa.harvard.edu',
-                                                    'www.ukirt.jach.hawaii.edu',
-                                                    'vizier.iucaa.ernet.in',
-                                                    'vizier.china-vo.org'], 'Name of the VizieR mirror to use.')
 
-VIZIER_TIMEOUT = ConfigurationItem('timeout', 60, 'default timeout for connecting to server')
+class Conf(_config.ConfigNamespace):
+    """
+    Configuration parameters for `astroquery.vizier`.
+    """
 
-ROW_LIMIT = ConfigurationItem('row_limit', 50, 'maximum number of rows that will be fetched from the result (set to -1 for unlimited).')
+    server = _config.ConfigItem(
+        ['vizier.u-strasbg.fr',
+         'vizier.nao.ac.jp',
+         'vizier.hia.nrc.ca',
+         'vizier.ast.cam.ac.uk',
+         'vizier.cfa.harvard.edu',
+         'www.ukirt.jach.hawaii.edu',
+         'vizier.iucaa.ernet.in',
+         'vizier.china-vo.org',
+         ],
+        'Name of the VizieR mirror to use.'
+        )
+    timeout = _config.ConfigItem(
+        60,
+        'Default timeout for connecting to server',
+        aliases=['astropy.coordinates.name_resolve.name_resolve_timeout']
+        )
+    row_limit = _config.ConfigItem(
+        50,
+        'Maximum number of rows that will be fetched from the result '
+        '(set to -1 for unlimited).'
+        )
 
-from .core import Vizier,VizierClass
+conf = Conf()
 
-__all__ = ['Vizier','VizierClass']
+from .core import Vizier, VizierClass
+
+__all__ = ['Vizier', 'VizierClass',
+           'Conf', 'conf',
+           ]

--- a/astroquery/vizier/core.py
+++ b/astroquery/vizier/core.py
@@ -19,7 +19,7 @@ from ..query import BaseQuery
 from ..utils import commons
 from ..utils import async_to_sync
 from ..utils import schema
-from . import VIZIER_SERVER, VIZIER_TIMEOUT, ROW_LIMIT
+from . import conf
 from ..exceptions import TableParseError
 
 
@@ -39,8 +39,8 @@ class VizierClass(BaseQuery):
                                     error="catalog must be a list of strings or a single string")
 
     def __init__(self, columns=["*"], column_filters={}, catalog=None, keywords=None,
-                 ucd="", timeout=VIZIER_TIMEOUT(), vizier_server=VIZIER_SERVER(),
-                 row_limit=ROW_LIMIT()):
+                 ucd="", timeout=conf.timeout, vizier_server=conf.server,
+                 row_limit=conf.row_limit):
         super(VizierClass, self).__init__()
         self.columns = columns
         self.column_filters = column_filters

--- a/astroquery/xmatch/__init__.py
+++ b/astroquery/xmatch/__init__.py
@@ -1,3 +1,4 @@
+# Licensed under a 3-clause BSD style license - see LICENSE.rst
 from astropy import config as _config
 
 
@@ -7,10 +8,13 @@ class Conf(_config.ConfigNamespace):
     """
     url = _config.ConfigItem(
         'http://cdsxmatch.u-strasbg.fr/xmatch/api/v1/sync',
-        'xMatch URL')
+        'xMatch URL'
+        )
 
     timeout = _config.ConfigItem(
-        60, 'time limit for connecting to xMatch server')
+        60,
+        'time limit for connecting to xMatch server'
+        )
 
 
 conf = Conf()
@@ -18,4 +22,6 @@ conf = Conf()
 
 from .core import XMatch, XMatchClass
 
-__all__ = ['XMatch', 'XMatchClass', 'conf']
+__all__ = ['XMatch', 'XMatchClass',
+           'Conf', 'conf',
+           ]

--- a/astroquery/xmatch/core.py
+++ b/astroquery/xmatch/core.py
@@ -1,3 +1,4 @@
+# Licensed under a 3-clause BSD style license - see LICENSE.rst
 import tempfile
 
 import six

--- a/astroquery/xmatch/setup_package.py
+++ b/astroquery/xmatch/setup_package.py
@@ -1,3 +1,4 @@
+# Licensed under a 3-clause BSD style license - see LICENSE.rst
 import os
 
 

--- a/astroquery/xmatch/tests/test_xmatch.py
+++ b/astroquery/xmatch/tests/test_xmatch.py
@@ -1,3 +1,4 @@
+# Licensed under a 3-clause BSD style license - see LICENSE.rst
 import os.path
 
 import pytest

--- a/astroquery/xmatch/tests/test_xmatch_remote.py
+++ b/astroquery/xmatch/tests/test_xmatch_remote.py
@@ -1,3 +1,4 @@
+# Licensed under a 3-clause BSD style license - see LICENSE.rst
 import os.path
 
 import pytest


### PR DESCRIPTION
The class `ConfigurationItem` from AstroPy is deprecated and will be removed in version 1.0
