### PR TITLE
renamed method BaseQuery.request to BaseQuery._request

### DIFF
--- a/astroquery/eso/tests/test_eso.py
+++ b/astroquery/eso/tests/test_eso.py
@@ -41,7 +41,7 @@ def test_SgrAstar(monkeypatch):
     eso = Eso()
 
     # monkeypatch instructions from https://pytest.org/latest/monkeypatch.html
-    monkeypatch.setattr(eso, 'request', eso_request)
+    monkeypatch.setattr(eso, '_request', eso_request)
     # set up local cache path to prevent remote query
     eso.cache_location = DATA_DIR
 

--- a/astroquery/query.py
+++ b/astroquery/query.py
@@ -123,7 +123,7 @@ class BaseQuery(object):
         """ init a fresh copy of self """
         return self.__class__(*args, **kwargs)
     
-    def request(self, method, url, params=None, data=None, headers=None,
+    def _request(self, method, url, params=None, data=None, headers=None,
                 files=None, save=False, savedir='', timeout=None):
         """
         A generic HTTP request method, similar to `requests.Session.request` but
@@ -155,7 +155,7 @@ class BaseQuery(object):
             local_filepath = os.path.join(self.cache_location or savedir or '.', local_filename)
             print("Downloading {0}...".format(local_filename))
             with suspend_cache(self): #Never cache file downloads: they are already saved on disk
-                r = self.request(method, url, save=False, params=params,
+                r = self._request(method, url, save=False, params=params,
                                  headers=headers, data=data, files=files,
                                  timeout=timeout)
                 with open(local_filepath, 'wb') as f:

--- a/astroquery/vizier/core.py
+++ b/astroquery/vizier/core.py
@@ -160,7 +160,7 @@ class VizierClass(BaseQuery):
             keywords = " ".join(keywords)
 
         data_payload = {'-words':keywords, '-meta.all':1}
-        response = self.request(method='POST',
+        response = self._request(method='POST',
                                 url=self._server_to_url(),
                                 data=data_payload,
                                 timeout=self.TIMEOUT)
@@ -191,7 +191,7 @@ class VizierClass(BaseQuery):
         """
 
         data_payload = self._args_to_payload(catalog=catalog)
-        response = self.request(method='POST',
+        response = self._request(method='POST',
                                 url=self._server_to_url(),
                                 data=data_payload,
                                 timeout=self.TIMEOUT)
@@ -237,7 +237,7 @@ class VizierClass(BaseQuery):
         data_payload = self._args_to_payload(
             center=center,
             catalog=catalog)
-        response = self.request(method='POST',
+        response = self._request(method='POST',
                                 url=self._server_to_url(),
                                 data=data_payload,
                                 timeout=self.TIMEOUT)
@@ -361,7 +361,7 @@ class VizierClass(BaseQuery):
         if get_query_payload:
             return data_payload
 
-        response = self.request(method='POST',
+        response = self._request(method='POST',
                                 url=self._server_to_url(),
                                 data=data_payload,
                                 timeout=self.TIMEOUT)
@@ -424,7 +424,7 @@ class VizierClass(BaseQuery):
             catalog=catalog,
             column_filters=kwargs,
             center={'-c.rd':180})
-        response = self.request(method='POST',
+        response = self._request(method='POST',
                                 url=self._server_to_url(),
                                 data=data_payload,
                                 timeout=self.TIMEOUT)


### PR DESCRIPTION
This fixes issue #350. New services that are in open PRs might need to be updated; I know that my PR for the xMatch service requires adjustments after this PR has been merged so that the tests keep passing.
