### PR TITLE
Don't use hardcoded temp file in test_utils

### DIFF
--- a/astroquery/utils/tests/test_utils.py
+++ b/astroquery/utils/tests/test_utils.py
@@ -18,6 +18,7 @@ import os
 from astropy.io import fits
 import astropy.utils.data as aud
 import astropy.version
+import tempfile
 
 
 class SimpleQueryClass(object):
@@ -401,8 +402,14 @@ def patch_getreadablefileobj(request):
 
 def test_filecontainer_save(patch_getreadablefileobj):
     ffile = commons.FileContainer(fitsfilepath, encoding='binary')
-    ffile.save_fits('/tmp/test_emptyfile.fits')
-    assert os.path.exists('/tmp/test_emptyfile.fits')
+    temp_dir = tempfile.mkdtemp()
+    empty_temp_file = temp_dir + os.sep + 'test_emptyfile.fits'
+    try:
+        ffile.save_fits(empty_temp_file)
+        assert os.path.exists(empty_temp_file)
+    finally:
+        os.remove(empty_temp_file)
+        os.rmdir(temp_dir)
 
 
 def test_filecontainer_get(patch_getreadablefileobj):


### PR DESCRIPTION
The hardcoded /tmp/test_emptyfile.fits in test_filecontainer_save in utils/tests/test_utils.py has a few problems:
1. The file is owned by the user who created it, meaning the test fails if another user writes it first
2. The file is left behind after the test. Insignificant, but not good practice
3. If tests are run in parrallel - say, by testing different versions at once - then asserting the file exists seems like a potential race condition
