### PR TITLE
Fix six imports

### DIFF
--- a/astroquery/utils/url_helpers.py
+++ b/astroquery/utils/url_helpers.py
@@ -1,5 +1,8 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
-from astropy.extern import six
+try:
+    from astropy.extern.six.moves.urllib_parse import SplitResult,urlsplit
+except ImportError:
+    from six.moves.urllib_parse import SplitResult,urlsplit
 import os.path
 
 
@@ -25,10 +28,9 @@ def urljoin_keep_path(url, path):
     """
     # urlparse.SplitResult doesn't allow overriding attribute values,
     # so ``splitted_url.path = ...`` is not possible here, unfortunately.
-    splitted_url = six.moves.urllib_parse.urlsplit(url)
-    return six.moves.urllib_parse.SplitResult(
-        splitted_url.scheme,
-        splitted_url.netloc,
-        os.path.join(splitted_url.path, path),
-        splitted_url.query,
-        splitted_url.fragment).geturl()
+    splitted_url = urlsplit(url)
+    return SplitResult(splitted_url.scheme,
+                       splitted_url.netloc,
+                       os.path.join(splitted_url.path, path),
+                       splitted_url.query,
+                       splitted_url.fragment).geturl()


### PR DESCRIPTION
Astroquery requires six > 1.7ish.  Astropy bundles 1.5.  See:
https://github.com/astropy/astropy/issues/2840
https://github.com/astropy/astropy/issues/2814
