### PR TITLE
Use BytesIO/StringIO instead of temporary files

### DIFF
--- a/astroquery/irsa/core.py
+++ b/astroquery/irsa/core.py
@@ -91,7 +91,6 @@ If onlist=0, the following parameters are required:
 from __future__ import print_function, division
 
 import warnings
-import tempfile
 import xml.etree.ElementTree as tree
 
 from astropy.extern import six
@@ -351,14 +350,10 @@ class IrsaClass(BaseQuery):
         if len(content) == 0:
             raise Exception("The IRSA server sent back an empty reply")
 
-        # Write table to temporary file
-        output = tempfile.NamedTemporaryFile()
-        output.write(response.content)
-        output.flush()
-
         # Read it in using the astropy VO table reader
         try:
-            first_table = votable.parse(output.name, pedantic=False).get_first_table()
+            first_table = votable.parse(six.BytesIO(response.content),
+                                        pedantic=False).get_first_table()
         except Exception as ex:
             self.response = response
             self.table_parse_error = ex

--- a/astroquery/ned/core.py
+++ b/astroquery/ned/core.py
@@ -1,7 +1,6 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 from __future__ import print_function
 
-import tempfile
 import re
 from collections import namedtuple
 from xml.dom.minidom import parseString
@@ -616,10 +615,8 @@ class NedClass(BaseQuery):
         if not verbose:
             commons.suppress_vo_warnings()
         try:
-            tf = tempfile.NamedTemporaryFile()
-            tf.write(response.content)
-            tf.file.flush()
-            first_table = votable.parse(tf.name, pedantic=False).get_first_table()
+            tf = six.BytesIO(response.content)
+            first_table = votable.parse(tf, pedantic=False).get_first_table()
             # For astropy version < 0.3 returns tables that have field ids as col names
             if ASTROPY_VERSION < '0.3':
                 table = first_table.to_table()

--- a/astroquery/nrao/core.py
+++ b/astroquery/nrao/core.py
@@ -2,13 +2,13 @@
 from __future__ import print_function
 
 import re
-import tempfile
 import warnings
 import functools
 
 import astropy.units as u
 import astropy.io.votable as votable
 from astropy import coordinates
+from astropy.extern import six
 
 from ..query import BaseQuery
 from ..utils import commons, async_to_sync
@@ -241,10 +241,8 @@ class NraoClass(BaseQuery):
         new_content = degrees_re.sub(r'unit="degrees"  datatype="char" arraysize="*"', new_content)
 
         try:
-            tf = tempfile.NamedTemporaryFile()
-            tf.write(new_content.encode('utf-8'))
-            tf.flush()
-            first_table = votable.parse(tf.name, pedantic=False).get_first_table()
+            tf = six.BytesIO(new_content.encode())
+            first_table = votable.parse(tf, pedantic=False).get_first_table()
             try:
                 table = first_table.to_table(use_names_over_ids=True)
             except TypeError:

--- a/astroquery/simbad/core.py
+++ b/astroquery/simbad/core.py
@@ -8,13 +8,13 @@ import re
 import json
 import os
 from collections import namedtuple
-import tempfile
 import warnings
 import astropy.units as u
 from astropy.utils.data import get_pkg_data_filename
 import astropy.coordinates as coord
 from astropy.table import Table
 import astropy.io.votable as votable
+from astropy.extern.six import BytesIO
 from ..query import BaseQuery
 from ..utils import commons
 from ..exceptions import TableParseError
@@ -884,7 +884,6 @@ class SimbadVOTableResult(SimbadResult):
     def __init__(self, txt, verbose=False, pedantic=False):
         SimbadResult.__init__(self, txt, verbose=verbose)
         self.__pedantic = pedantic
-        self.__file = None
         self.__table = None
         if not self.verbose:
             commons.suppress_vo_warnings()
@@ -892,11 +891,8 @@ class SimbadVOTableResult(SimbadResult):
 
     @property
     def table(self):
-        if self.__file is None:
-            self.__file = tempfile.NamedTemporaryFile()
-            self.__file.write(self.data.encode('utf-8'))
-            self.__file.flush()
-            self.__table = votable.parse_single_table(self.__file, pedantic=False).to_table()
+        if self.__table is None:
+            self.__table = votable.parse_single_table(BytesIO(self.data.encode('utf8')), pedantic=False).to_table()
         return self.__table
 
 bibcode_regex = re.compile(r'query\s+bibcode\s+(wildcard)?\s+([\w]*)')

--- a/astroquery/vizier/core.py
+++ b/astroquery/vizier/core.py
@@ -4,7 +4,6 @@ from __future__ import print_function
 import os
 import warnings
 import json
-import tempfile
 
 from astropy.extern import six
 import astropy.units as u
@@ -537,9 +536,7 @@ class VizierClass(BaseQuery):
         if not verbose:
             commons.suppress_vo_warnings()
         try:
-            tf = tempfile.NamedTemporaryFile()
-            tf.write(response.content)
-            tf.file.flush()
+            tf = six.BytesIO(response.content)
 
             if invalid == 'mask':
                 vo_tree = votable.parse(tf, pedantic=False, invalid='mask')

--- a/astroquery/xmatch/core.py
+++ b/astroquery/xmatch/core.py
@@ -1,5 +1,4 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
-import tempfile
 
 from astropy.extern import six
 from astropy.io import ascii
@@ -92,8 +91,9 @@ class XMatchClass(BaseQuery):
             # write the Table's content into a new, temporary CSV-file
             # so that it can be pointed to via the `files` option
             # file will be closed when garbage-collected
-            fp = tempfile.NamedTemporaryFile()
-            cat1.write(fp.name, format='ascii.csv')
+            fp = six.StringIO()
+            cat1.write(fp, format='ascii.csv')
+            fp.seek(0)
             kwargs['files'] = {'cat1': fp}
         else:
             # assume it's a file-like object, support duck-typing
@@ -112,8 +112,9 @@ class XMatchClass(BaseQuery):
             # write the Table's content into a new, temporary CSV-file
             # so that it can be pointed to via the `files` option
             # file will be closed when garbage-collected
-            fp = tempfile.NamedTemporaryFile()
-            cat1.write(fp.name, format='ascii.csv')
+            fp = six.StringIO()
+            cat1.write(fp, format='ascii.csv')
+            fp.seek(0)
             kwargs['files'] = {'cat1': fp}
         else:
             # assume it's a file-like object, support duck-typing


### PR DESCRIPTION
Okay, sorry for all the little pull requests. There's a few places where votables are created by writing to a temp file, and then passing the filename to `votable.parse`. There's one comment saying these files are closed on garbage collection, but that's only an implementation detail of cpython, not really a valid assumption for python in general. Pretty much any API accepting files will be fine with file-like objects instead of real filenames anyways.

With this, all the errors from running tests with `open_files=True` in python2 and python3 are gone.
