### PR TITLE
Rebuild LAMDA parser

### DIFF
--- a/astroquery/lamda/tests/test_lamda.py
+++ b/astroquery/lamda/tests/test_lamda.py
@@ -42,9 +42,8 @@ def test_query_collrates(patch_get):
     lamda.query(mol='co', query_type='coll_rates', coll_partner_index=1)
 
 def test_parser():
-    tabledict = lamda.core.parse_lamda_datafile(data_path('co.txt'))
+    collrates,radtransitions,enlevels = lamda.core.parse_lamda_datafile(data_path('co.txt'))
 
-    assert set(tabledict.keys()) == set(['erg_levels', 'rad_trans', 'coll_rates'])
-    assert set(tabledict['coll_rates'].keys()) == set(['pH2', 'oH2'])
-    assert len(tabledict['erg_levels']) == 41
-    assert len(tabledict['rad_trans']) == 40
+    assert set(collrates.keys()) == set(['PH2', 'OH2'])
+    assert len(enlevels) == 41
+    assert len(radtransitions) == 40


### PR DESCRIPTION
The LAMDA parser previously relied on the existence of comments, which are inconsistent across the board and not used by RADEX or other fortran programs.  The new parser, while hideous, encodes the same logic used by the RADEX parser.
