### PR TITLE
need to check for ipynb more intelligently

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -4,6 +4,8 @@
 - Support direct transmission of SQL queries to the SDSS server (#410)
 - Added email/text job completion alert (#407) to the CosmoSim tool (#267).
 - ESO archive now supports HARPS/FEROS reprocessed data queries (#412)
+- IPython notebook checker in the ESO tool is now compatible with regular
+  python (#413)
 
 
 0.2 (2014-08-17)

--- a/astroquery/eso/core.py
+++ b/astroquery/eso/core.py
@@ -149,7 +149,7 @@ class EsoClass(QueryWithLogin):
         # Get password from keyring or prompt
         password_from_keyring = keyring.get_password("astroquery:www.eso.org", username)
         if password_from_keyring is None:
-            if __IPYTHON__:
+            if system_tools.in_ipynb():
                 log.warn("You may be using an ipython notebook:"
                          " the password form will appear in your terminal.")
             password = getpass.getpass("{0}, enter your ESO password:\n".format(username))

--- a/astroquery/utils/system_tools.py
+++ b/astroquery/utils/system_tools.py
@@ -40,3 +40,19 @@ def gunzip(filename):
         return filename.rsplit(".", 1)[0]
     else:
         return filename
+
+# If astropy#2793 is merged, this should be replaced with astropy.in_ipynb
+def in_ipynb():
+    try:
+        cfg = get_ipython().config 
+        app = cfg['IPKernelApp']
+        # ipython 1.0 console has no 'parent_appname',
+        # but ipynb does
+        if ('parent_appname' in app and
+            app['parent_appname'] == 'ipython-notebook'):
+            return True
+        else:
+            return False
+    except NameError:
+        # NameError will occur if this is called from python (not ipython)
+        return False


### PR DESCRIPTION
The `if __ipython__` check fails if you run astroquery from regular python
