### PR TITLE
Skip the second ESO test if the new ascii reader is being used.  See

### DIFF
--- a/astroquery/eso/tests/test_eso.py
+++ b/astroquery/eso/tests/test_eso.py
@@ -68,6 +68,9 @@ bad_ascii_reader = LooseVersion(astropy.__version__) > LooseVersion('1.0.dev9885
 
 @pytest.mark.skipif('SKIP_TESTS or bad_ascii_reader')
 def test_vvv(monkeypatch):
+    eso = Eso()
+    monkeypatch.setattr(eso, '_request', eso_request)
+    eso.cache_location = DATA_DIR
 
     result_s = eso.query_survey('VVV', coord1=266.41681662, coord2=-29.00782497)
     assert result_s is not None


### PR DESCRIPTION
See https://github.com/astropy/astropy/issues/2940

Travis tests failures are because the new ascii reader apparently has trouble with null unicode characters, and somehow the older reader managed to ignore them.  For now, we'll just skip the test so that development on astroquery can continue using travis, but a workaround or solution is needed.
