### PR TITLE
Get Simbad magnitudes for a source

### DIFF
--- a/astroquery/simbad/core.py
+++ b/astroquery/simbad/core.py
@@ -161,10 +161,15 @@ class SimbadClass(BaseQuery):
                                           (os.path.join('data',
                                                         'votable_fields_table.txt')),
                                          format='ascii')
-        print (votable_fields_table)
+        print("Available VOTABLE fields: ")
+        print(votable_fields_table)
 
         print("\nFor more information on a field :\nSimbad.get_field_description "
               "('field_name')")
+
+        print()
+        print("Currently active VOTABLE fields:")
+        print(self._VOTABLE_FIELDS)
 
     def get_field_description(self, field_name):
         """


### PR DESCRIPTION
I need to access the magnitudes in various filters for some sources, but am not sure how to do this. Simbad.list_votable_fields() includes an entry called 'flux(filtername)', but it is not clear how to use that. I have tried the following combinations, which all say there is no such field.
- Simbad.set_votable_fields('flux(V)') 
- Simbad.set_votable_fields('flux(v)')
- Simbad.set_votable_fields('fluxV')
- Simbad.set_votable_fields('V')
- Simbad.set_votable_fields('Vmag')

This is likely more of a documentation issue than needing to add the feature to the code, but can someone let me know how to get at least the V magnitude of a source?

Thanks!
