### PR TITLE
Inject custom configurations in tests

### DIFF
--- a/astroquery/_astropy_init.py
+++ b/astroquery/_astropy_init.py
@@ -30,7 +30,7 @@ def _get_test_runner():
 
 def test(package=None, test_path=None, args=None, plugins=None,
          verbose=False, pastebin=None, remote_data=False, pep8=False,
-         pdb=False, coverage=False, open_files=False, **kwargs):
+         pdb=False, coverage=False, open_files=False, config=None, **kwargs):
     """
     Run the tests using `py.test <http://pytest.org/latest>`__. A proper set
     of arguments is constructed and passed to `pytest.main`_.
@@ -108,7 +108,7 @@ def test(package=None, test_path=None, args=None, plugins=None,
         package=package, test_path=test_path, args=args,
         plugins=plugins, verbose=verbose, pastebin=pastebin,
         remote_data=remote_data, pep8=pep8, pdb=pdb,
-        coverage=coverage, open_files=open_files, **kwargs)
+        coverage=coverage, open_files=open_files, config=config, **kwargs)
 
 if not _ASTROPY_SETUP_:
     import os

--- a/astroquery/eso/tests/test_eso_remote.py
+++ b/astroquery/eso/tests/test_eso_remote.py
@@ -51,6 +51,7 @@ class TestEso:
         assert 'Object' in result_s.colnames
         assert 'b333' in result_s['Object']
 
+    @pytest.mark.skipif('Eso.USERNAME')
     def test_nologin(self):
         # WARNING: this test will fail if you haven't cleared your cache and
         # you have downloaded this file!


### PR DESCRIPTION
This is an attempt to inject non default configuration items to the test suite of astroquery.
This PR is paired with https://github.com/astropy/astropy/pull/2955
To test use you would need to issue:

```
>>> import astroquery
>>> astroquery.test(package='eso', remote_data=True, config={'astroquery.eso.username':'ICONDOR'})
```

NB: Replace `ICONDOR` by your own username...
