### PR TITLE
Cache timeout functionality

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,7 +11,6 @@ __pycache__
 
 # Other generated files
 */version.py
-astroquery/astroquery.cfg
 
 htmlcov
 .coverage

--- a/astroquery/__init__.py
+++ b/astroquery/__init__.py
@@ -15,3 +15,14 @@ from ._astropy_init import *
 # For egg_info test builds to pass, put package imports here.
 #if not _ASTROPY_SETUP_:
 #    from astroquery import *
+
+from astropy import config as _config
+
+class Conf(_config.ConfigNamespace):
+    
+    default_cache_timeout = _config.ConfigItem(
+          60.0*60.0*24.0,
+          'Astroquery-wide default cache timeout (seconds).'
+          )
+
+conf = Conf()

--- a/astroquery/__init__.py
+++ b/astroquery/__init__.py
@@ -13,16 +13,15 @@ from ._astropy_init import *
 # ----------------------------------------------------------------------------
 
 # For egg_info test builds to pass, put package imports here.
-#if not _ASTROPY_SETUP_:
-#    from astroquery import *
+if not _ASTROPY_SETUP_:
 
-from astropy import config as _config
+    from astropy import config as _config
 
-class Conf(_config.ConfigNamespace):
-    
-    default_cache_timeout = _config.ConfigItem(
-          60.0*60.0*24.0,
-          'Astroquery-wide default cache timeout (seconds).'
-          )
+    class Conf(_config.ConfigNamespace):
 
-conf = Conf()
+        default_cache_timeout = _config.ConfigItem(
+              60.0*60.0*24.0,
+              'Astroquery-wide default cache timeout (seconds).'
+              )
+
+    conf = Conf()

--- a/astroquery/astroquery.cfg
+++ b/astroquery/astroquery.cfg
@@ -1,0 +1,11 @@
+
+## Astroquery-wide default cache timeout (seconds).
+#default_cache_timeout = 86400
+
+[eso]
+## Maximum number of rows returned (set to -1 for unlimited).
+#row_limit = 50
+
+## Optional default username for ESO archive.
+#username = ''
+

--- a/astroquery/setup_package.py
+++ b/astroquery/setup_package.py
@@ -1,0 +1,4 @@
+# Licensed under a 3-clause BSD style license - see LICENSE.rst
+
+def get_package_data():
+    return {'astroquery': ['astroquery.cfg']}


### PR DESCRIPTION
Currently configured by default to 24 hours (24*3600 seconds).
