### PR TITLE
Eso.retrieve_data : 'Session' object has no attribute 'redirect_cache'

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -100,7 +100,7 @@ for root, dirs, files in os.walk(PACKAGENAME):
                     os.path.relpath(root, PACKAGENAME), filename))
 package_info['package_data'][PACKAGENAME].extend(c_files)
 
-required_packages = ['astropy>=0.4.1', 'requests', 'keyring', 'beautifulsoup4',
+required_packages = ['astropy>=0.4.1', 'requests>=2.4.1', 'keyring', 'beautifulsoup4',
                      'html5lib']
 
 setup(name=PACKAGENAME,


### PR DESCRIPTION
Using the latest master, I bumped into the following error when trying to retrieve the data. It seems like that it might have been introduced in #435.

cc: @jwoillez 

```
In [126]: aaa=eso.Eso.retrieve_data('UVES.2009-03-07T05:17:07.882')
INFO: Found UVES.2009-03-07T05:17:07.882.fits... [astroquery.eso.core]
---------------------------------------------------------------------------
AttributeError                            Traceback (most recent call last)
<ipython-input-126-d2eff617f66d> in <module>()
----> 1 aaa=eso.Eso.retrieve_data('UVES.2009-03-07T05:17:07.882')

/Users/bsipocz/munka/devel/astroquery/astroquery/eso/core.pyc in retrieve_data(self, datasets, cache)
    550                 filename = self._request("GET", fileLink, save=True)
    551                 files.append(system_tools.gunzip(filename))
--> 552         self._session.redirect_cache.clear() # EMpty the redirect cache of this request session
    553         log.info("Done!")
    554         if (not return_list) and (len(files)==1):

AttributeError: 'Session' object has no attribute 'redirect_cache'

...

In [129]: astroquery.__version__
Out[129]: u'0.3.dev9894'
```
