### PR TITLE
Raise exception when radius=0 passed to Simbad query_region

### DIFF
--- a/astroquery/simbad/core.py
+++ b/astroquery/simbad/core.py
@@ -785,7 +785,11 @@ def _parse_radius(radius):
     try:
         angle = commons.parse_radius(radius)
         # find the most appropriate unit - d, m or s
-        index = min([i for (i, val) in enumerate(angle.dms) if int(val) > 0])
+        nonzero_indices = [i for (i, val) in enumerate(angle.dms) if int(val) > 0]
+        if len(nonzero_indices) > 0:
+            index = min(nonzero_indices)
+        else:
+            index = 2  # use arcseconds when radius smaller than 1 arcsecond
         unit = ('d', 'm', 's')[index]
         if unit == 'd':
             return str(int(angle.degree)) + unit

--- a/astroquery/simbad/tests/test_simbad.py
+++ b/astroquery/simbad/tests/test_simbad.py
@@ -262,6 +262,19 @@ def test_query_region_radius_error(patch_post, coordinates, radius, equinox, epo
                                                     equinox=equinox, epoch=epoch)
 
 
+@pytest.mark.parametrize(('coordinates', 'radius', 'equinox', 'epoch'),
+                         [(ICRS_COORDS, "0d", None, None),
+                          (GALACTIC_COORDS, 1.0 * u.marcsec, 2000.0, 'J2000')
+                          ])
+def test_query_region_small_radius(patch_post, coordinates, radius, equinox, epoch):
+    result1 = simbad.core.Simbad.query_region(coordinates, radius=radius,
+                                              equinox=equinox, epoch=epoch)
+    result2 = simbad.core.Simbad().query_region(coordinates, radius=radius,
+                                                equinox=equinox, epoch=epoch)
+    assert isinstance(result1, Table)
+    assert isinstance(result2, Table)
+
+
 @pytest.mark.parametrize(('object_name', 'wildcard'),
                          [("m1", None),
                          ("m [0-9]", True)

--- a/astroquery/simbad/tests/test_simbad_remote.py
+++ b/astroquery/simbad/tests/test_simbad_remote.py
@@ -122,8 +122,19 @@ class TestSimbad(object):
 
     # Special case of null test: zero-sized region
     def test_query_region_null(self):
-        # This test will fail if some object is discovered within 1 arcsec of the origin
-        # (Due to other bugs I could not set a smaller radius, or radius=0)
-        result = simbad.core.Simbad.query_region(coord.ICRS("00h00m0.0s 00h00m0.0s"), radius=1 * u.arcsec,
+        result = simbad.core.Simbad.query_region(coord.ICRS("00h00m0.0s 00h00m0.0s"), radius="0d",
                                                  equinox=2000.0, epoch='J2000')
         assert result is None
+
+    # Special case of null test: very small region
+    def test_query_small_region_null(self):
+        result = simbad.core.Simbad.query_region(coord.ICRS("00h00m0.0s 00h00m0.0s"), radius=1.0 * u.marcsec,
+                                                 equinox=2000.0, epoch='J2000')
+        assert result is None
+
+    # Special case : zero-sized region with one object
+    def test_query_zero_sized_region(self):
+        result = simbad.core.Simbad.query_region(coord.ICRS("20h54m05.6889s 37d01m17.380s"), radius="0d",
+                                                 equinox=2000.0, epoch='J2000')
+        # This should find a single star, BD+36 4308
+        assert len(result) == 1


### PR DESCRIPTION
This fixes #370 by validating any given value for `radius` except `None`.
