### PR TITLE
Fixed up email job alerting system. Texting only works with Verizon.

### DIFF
--- a/astroquery/cosmosim/__init__.py
+++ b/astroquery/cosmosim/__init__.py
@@ -32,6 +32,6 @@ class Conf(_config.ConfigNamespace):
     
 conf = Conf()
 
-from .core import CosmoSim
+from .core import CosmoSim,CosmoSimClass
 
-__all__ = ['CosmoSim', 'Conf', 'conf']
+__all__ = ['CosmoSim', 'CosmoSimClass', 'Conf', 'conf']

--- a/astroquery/cosmosim/core.py
+++ b/astroquery/cosmosim/core.py
@@ -1215,7 +1215,7 @@ class AlertThread(object):
     def __init__(self, jobid, queue='short'):
         """ 
         Parameters
-        __________
+        ----------
         jobid : string
             The jobid of the sql query.
         queue : string


### PR DESCRIPTION
Email alerting was a bit buggy; seems to be working now for a wide range of email types (.com,.edu). Texting works for Verizon numbers only. Need to think about how to implement this for any arbitrary number in any country for any provider.
