### PR TITLE
astroquery.vizier not retrieving selected columns

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -72,7 +72,7 @@ install:
     - source activate test
 
     # CORE DEPENDENCIES
-    - if [[ $SETUP_CMD != egg_info ]]; then $CONDA_INSTALL numpy=$NUMPY_VERSION pytest pip Cython; fi
+    - if [[ $SETUP_CMD != egg_info ]]; then $CONDA_INSTALL numpy=$NUMPY_VERSION pytest pip Cython jinja2; fi
     - if [[ $SETUP_CMD != egg_info ]]; then $PIP_INSTALL pytest-xdist; fi
 
     # ASTROPY

--- a/astroquery/vizier/core.py
+++ b/astroquery/vizier/core.py
@@ -4,6 +4,7 @@ from __future__ import print_function
 import os
 import warnings
 import json
+import copy
 
 from astropy.extern import six
 import astropy.units as u
@@ -460,7 +461,7 @@ class VizierClass(BaseQuery):
         # process: columns
         columns = kwargs.get('columns')
         if columns is None:
-            columns = self.columns
+            columns = copy.copy(self.columns)
         else:
             columns = self.columns + columns
 

--- a/astroquery/vizier/core.py
+++ b/astroquery/vizier/core.py
@@ -56,7 +56,8 @@ class VizierClass(BaseQuery):
     def columns(self):
         """ Columns to include.  The special keyword 'all' will return ALL
         columns from ALL retrieved tables. """
-        return self._columns
+        # columns need to be immutable but still need to be a list
+        return list(tuple(self._columns))
 
     @columns.setter
     def columns(self, values):

--- a/astroquery/vizier/core.py
+++ b/astroquery/vizier/core.py
@@ -463,8 +463,12 @@ class VizierClass(BaseQuery):
         else:
             columns = self.columns + columns
 
-        if 'all' in columns:
-            columns.remove('all')
+        # keyword names that can mean 'all' need to be treated separately
+        alls = ['all','*']
+        if any(x in columns for x in alls):
+            for x in alls:
+                if x in columns:
+                    columns.remove(x)
             body['-out.all'] = 2
 
         # process: columns - always request computed positions in degrees
@@ -485,6 +489,7 @@ class VizierClass(BaseQuery):
             else:
                 columns_out += [column]
         body['-out.add'] = ','.join(columns_out)
+        body['-out'] = columns_out
         if len(sorts_out) > 0:
             body['-sort'] = ','.join(sorts_out)
         # process: maximum rows returned

--- a/astroquery/vizier/tests/test_vizier_remote.py
+++ b/astroquery/vizier/tests/test_vizier_remote.py
@@ -92,6 +92,9 @@ class TestVizierRemote(object):
         targets = commons.ICRSCoordGenerator(ra=[299.590, 299.90],
                                              dec=[35.201, 35.201],
                                              unit=(u.deg, u.deg))
+        # Regression test: the columns of the default should never
+        # be modified from default
+        assert vizier.core.Vizier.columns == ['*']
         result = vizier.core.Vizier.query_region(targets,
                                                  radius=10 * u.arcsec,
                                                  catalog=["HIP", "NOMAD", "UCAC"])

--- a/docs/vizier/vizier.rst
+++ b/docs/vizier/vizier.rst
@@ -207,23 +207,25 @@ this Vizier instance:
    
     >>> result = v.query_object("HD 226868", catalog=["NOMAD", "UCAC"])              
     >>> print(result)
-    TableList with 2 tables:
-       '0:I/289/out' with 3 column(s) and 18 row(s) 
-       '1:I/322A/out' with 4 column(s) and 10 row(s) 
-
+    TableList with 3 tables:
+        '0:I/297/out' with 3 column(s) and 50 row(s)
+        '1:I/289/out' with 3 column(s) and 18 row(s)
+        '2:I/322A/out' with 3 column(s) and 10 row(s)
+    
     >>> print(result['I/322A/out'])
-     _RAJ2000    DEJ2000    Vmag   _DEJ2000 
-    ---------- ----------- ------ ----------
-    299.572419  35.1942342 15.986  35.194234
-    299.580291  35.1768889 13.274  35.176889
-    299.582571  35.1852253 14.863  35.185225
-    299.594172  35.1799948 14.690  35.179995
-    299.601402  35.1981078 14.644  35.198108
-    299.617669  35.1869987 14.394  35.186999
-    299.561498  35.2016928 15.687  35.201693
-    299.570217  35.2256634 14.878  35.225663
-    299.601081  35.2333378 13.170  35.233338
-    299.617995  35.2058637 13.946  35.205864
+     _RAJ2000   _DEJ2000   Vmag
+       deg        deg      mag
+    ---------- ---------- ------
+    299.572419  35.194234 15.986
+    299.580291  35.176889 13.274
+    299.582571  35.185225 14.863
+    299.594172  35.179995 14.690
+    299.601402  35.198108 14.644
+    299.617669  35.186999 14.394
+    299.561498  35.201693 15.687
+    299.570217  35.225663 14.878
+    299.601081  35.233338 13.170
+    299.617995  35.205864 13.946
 
 When specifying the columns of the query, sorting of the returned table can be
 requested by adding ``+`` (or ``-`` for reverse sorting order) in front of the column


### PR DESCRIPTION
I discovered astroquery yesterday and I think it is a great tool for me. However, I failed to reproduce the example in the docs when selecting only certain columns from a catalog:
```python
>>> v = Vizier(columns=['_RAJ2000', '_DEJ2000','B-V', 'Vmag', 'Plx'], column_filters={"Vmag":">10"}, keywords=["optical"])

>>> result = v.query_object("HD 226868", catalog=["NOMAD", "UCAC"])

>>> print result
TableList with 3 tables:
        '0:I/297/out' with 21 column(s) and 50 row(s) 
        '1:I/289/out' with 16 column(s) and 18 row(s) 
        '2:I/322A/out' with 26 column(s) and 10 row(s)

>>> print result[2]
 _RAJ2000   _DEJ2000   Vmag    UCAC4      RAJ2000   ...  Z   B   L   N   S 
   deg        deg      mag                  deg     ...                    
---------- ---------- ------ ---------- ----------- ... --- --- --- --- ---
299.572419  35.194234 15.986 626-088995 299.5724189 ...   0   0   0   1   0
299.580291  35.176889 13.274 626-089002 299.5802912 ...   1   0   0   3   0
299.582571  35.185225 14.863 626-089007 299.5825712 ...   0   0   0   1   0
299.594172  35.179995 14.690 626-089015 299.5941718 ...   0   0   0   1   0
299.601402  35.198108 14.644 626-089019 299.6014021 ...   1   0   0   0   0
299.617669  35.186999 14.394 626-089038 299.6176686 ...   1   0   0   1   0
299.561498  35.201693 15.687 627-087872 299.5614977 ...   0   0   0   3   0
299.570217  35.225663 14.878 627-087887 299.5702165 ...   0   0   0   3   0
299.601081  35.233338 13.170 627-087924 299.6010806 ...   1   0   0   1   0
299.617995  35.205864 13.946 627-087944 299.6179950 ...   1   0   0   1   0
```
Is this a bug or am I doing something wrong?

Thanks in advance for your help!
