### PR TITLE
Remove empty scripts folder

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -45,3 +45,6 @@ distribute-*.tar.gz
 .settings
 .project
 .pydevproject
+
+# Pycharm
+.idea

--- a/scripts/README.rst
+++ b/scripts/README.rst
@@ -1,5 +1,0 @@
-Scripts
-=======
-
-This directory contains command-line scripts for the affiliated package.
-


### PR DESCRIPTION
@keflavich This removes the empty scripts folder.

It's a stupid, trivial change, but I'm going through the affiliated packages to check https://github.com/astropy/package-template/pull/116 and thought it might be better to remove it now in case astroquery grows some scripts in the future ... 