### PR TITLE
Allow Eso.retrieve_data to support *.fits.fz files

### DIFF
--- a/astroquery/eso/core.py
+++ b/astroquery/eso/core.py
@@ -498,6 +498,9 @@ class EsoClass(QueryWithLogin):
             elif os.path.exists(local_filename + ".Z"):
                 log.info("Found {0}.fits.Z...".format(dataset))
                 files.append(local_filename + ".Z")
+            elif os.path.exists(local_filename + ".fz"):  # RICE-compressed
+                log.info("Found {0}.fits.fz...".format(dataset))
+                files.append(local_filename + ".fz")
             else:
                 datasets_to_download.append(dataset)
 

--- a/astroquery/utils/system_tools.py
+++ b/astroquery/utils/system_tools.py
@@ -35,7 +35,7 @@ def gunzip(filename):
     filename : str
         Name of the decompressed file (or input filname if gzip is not available).
     """
-    if __is_gzip_found:
+    if __is_gzip_found and not filename.endswith('.fz'):  # ".fz" denotes RICE rather than gzip compression
         subprocess.call(["gzip", "-d", "{0}".format(filename)], stdout=DEVNULL, stderr=DEVNULL)
         return filename.rsplit(".", 1)[0]
     else:


### PR DESCRIPTION
The current implementation of `Eso.retrieve_data` appears to assume that a file retrieved from the ESO archive always has the extension `.fits` or `fits.Z`.  The ESO archive also contains RICE-compressed files with extension `fits.fz` however (coming from the omegacam instrument).

For example:
```Python
In [4]: tbl = eso.query_instrument('omegacam', column_filters={'night': '2015 01 01'}) 
In [5]: tbl['DP.ID'][0]
Out[5]: 'OMEGA.2015-01-01T23:48:55.388'
In [6]: filename = eso.retrieve_data(tbl['DP.ID'][0])
INFO: Staging request... [astroquery.eso.core]
INFO: Staging form is at http://dataportal.eso.org/rh/requests/gba/150281 [astroquery.eso.core]
INFO: Downloading files... [astroquery.eso.core]
INFO: Downloading OMEGA.2015-01-01T23:48:55.388.fits.fz... [astroquery.query]
|======================================================| 276M/276M (100.00%)      5m10sINFO: Done! [astroquery.eso.core]
```

Downloading the file works fine, but the filename returned by `retrieve_data` is incorrect:
```Python
In [7]: filename
Out[7]: u'/home/gb/.astropy/cache/astroquery/Eso/OMEGA.2015-01-01T23:48:55.388.fits'
In [19]: os.path.exists(filename)
Out[19]: False
In [20]: os.path.exists(filename + '.fz')
Out[20]: True
```

In addition, the caching mechanism is broken because it only looks for previously-downloaded `.fits` and `.fits.Z` files.

I believe that this PR fixes both these problems.

(PS: I didn't add a regression test because the omegacam files are really rather big?)