### PR TITLE
Update SDSS DR version and template URL

### DIFF
--- a/astroquery/sdss/__init__.py
+++ b/astroquery/sdss/__init__.py
@@ -13,7 +13,7 @@ class Conf(_config.ConfigNamespace):
     Configuration parameters for `astroquery.sdss`.
     """
     server = _config.ConfigItem(
-        ['http://data.sdss3.org/sas/dr10'],
+        ['http://data.sdss3.org/sas/dr12'],
         'Link to SDSS website.'
         )
     timeout = _config.ConfigItem(

--- a/astroquery/sdss/core.py
+++ b/astroquery/sdss/core.py
@@ -50,7 +50,7 @@ class SDSSClass(BaseQuery):
     BASE_URL = conf.server
     SPECTRO_OPTICAL = BASE_URL
     IMAGING = BASE_URL + '/boss/photoObj/frames'
-    TEMPLATES = 'http://www.sdss.org/dr7/algorithms/spectemplates/spDR2'
+    TEMPLATES = 'http://classic.sdss.org/dr7/algorithms/spectemplates/spDR2'
     MAXQUERIES = conf.maxqueries
     AVAILABLE_TEMPLATES = spec_templates
     TIMEOUT = conf.timeout


### PR DESCRIPTION
The ``get_spectral_template()`` function was broken with the old link (``remote_data`` test failed, too), and I guess we can upgrade from DR10 to DR12.