### PR TITLE
Adding support for Column of coordinates in SDSS

### DIFF
--- a/astroquery/sdss/core.py
+++ b/astroquery/sdss/core.py
@@ -14,7 +14,7 @@ import io
 import numpy as np
 from astropy import units as u
 import astropy.coordinates as coord
-from astropy.table import Table
+from astropy.table import Table, Column
 from ..query import BaseQuery
 from . import conf
 from ..utils import commons, async_to_sync
@@ -66,7 +66,8 @@ class SDSSClass(BaseQuery):
 
         Parameters
         ----------
-        coordinates : str or `astropy.coordinates` object or list of coordinates
+        coordinates : str or `astropy.coordinates` object or list of \
+        coordinates or `~astropy.table.Column` of coordinates
             The target(s) around which to search. It may be specified as a string
             in which case it is resolved using online services or as the
             appropriate `astropy.coordinates` object. ICRS coordinates may also
@@ -736,9 +737,9 @@ class SDSSClass(BaseQuery):
         q_where = 'WHERE '
         if coordinates is not None:
             if (not isinstance(coordinates, list) and
+                not isinstance(coordinates, Column) and
                 not (isinstance(coordinates, commons.CoordClasses) and
-                not coordinates.isscalar)
-            ):
+                     not coordinates.isscalar)):
                 coordinates = [coordinates]
             for n, target in enumerate(coordinates):
                 # Query for a region
@@ -750,8 +751,8 @@ class SDSSClass(BaseQuery):
                 if n > 0:
                     q_where += ' or '
                 q_where += ('((p.ra between %g and %g) and '
-                           '(p.dec between %g and %g))'
-                           % (ra - dr, ra + dr, dec - dr, dec + dr))
+                            '(p.dec between %g and %g))'
+                            % (ra - dr, ra + dr, dec - dr, dec + dr))
         elif spectro:
             # Spectra: query for specified plate, mjd, fiberid
             s_fields = ['s.%s=%d' % (key, val) for (key, val) in

--- a/astroquery/sdss/tests/test_sdss.py
+++ b/astroquery/sdss/tests/test_sdss.py
@@ -5,6 +5,7 @@ import os
 import socket
 from astropy.extern.six.moves.urllib_error import URLError
 from astropy.tests.helper import pytest
+from astropy.table import Column
 from ... import sdss
 from ...utils.testing_tools import MockResponse
 from ...exceptions import TimeoutError
@@ -83,6 +84,11 @@ def data_path(filename):
 # Test Case: A Seyfert 1 galaxy
 coords = commons.ICRSCoordGenerator('0h8m05.63s +14d50m23.3s')
 
+# Test Case: list of coordinates
+coords_list = [coords, coords]
+
+# Test Case: Column of coordinates
+coords_column = Column(coords_list, name='coordinates')
 
 def test_sdss_spectrum(patch_get, patch_get_readable_fileobj, coords=coords):
     xid = sdss.core.SDSS.query_region(coords, spectro=True)
@@ -150,3 +156,11 @@ def test_spectra_timeout(patch_get, patch_get_readable_fileobj_slow):
 def test_images_timeout(patch_get, patch_get_readable_fileobj_slow):
     with pytest.raises(TimeoutError):
         img = sdss.core.SDSS.get_images(run=1904, camcol=3, field=164)
+
+
+def test_list_coordinates(patch_get, patch_get_readable_fileobj_slow):
+    xid = sdss.core.SDSS.query_region(coords_list)
+
+
+def test_column_coordinates(patch_get, patch_get_readable_fileobj_slow):
+    xid = sdss.core.SDSS.query_region(coords_column)


### PR DESCRIPTION
As SDSS.query_region() accepts a list of coordinates it may/should accept a Column of coordinates, too. (It originally worked if the Column is a mixin SkyCoord, but not when it has separate SkyCoord objects).

@keflavich - I think I'll have a few other similar minor commits. Do you prefer to have them separately or everything in one PR?