### PR TITLE
Changing deprecated coordinates.ICRS() calls to coordinates.SkyCoord()

### DIFF
--- a/astroquery/alfalfa/core.py
+++ b/astroquery/alfalfa/core.py
@@ -119,7 +119,7 @@ class AlfalfaClass(BaseQuery):
         --------
         >>> from astroquery.alfalfa import Alfalfa
         >>> from astropy import coordinates as coords
-        >>> C = coords.ICRS('0h8m05.63s +14d50m23.3s')
+        >>> C = coords.SkyCoord('0h8m05.63s +14d50m23.3s')
         >>> agc = Alfalfa.query_region(C,'3 arcmin')
 
         Returns

--- a/astroquery/alfalfa/tests/test_alfalfa.py
+++ b/astroquery/alfalfa/tests/test_alfalfa.py
@@ -54,7 +54,7 @@ def data_path(filename):
     return os.path.join(data_dir, filename)
 
 # Test Case: A Seyfert 1 galaxy
-coords = coordinates.ICRS('0h8m05.63s +14d50m23.3s')
+coords = coordinates.SkyCoord('0h8m05.63s +14d50m23.3s')
 
 ALFALFA = alfalfa.core.Alfalfa()
 

--- a/astroquery/fermi/tests/test_fermi.py
+++ b/astroquery/fermi/tests/test_fermi.py
@@ -33,7 +33,7 @@ def post_mockreturn(url, data=None, timeout=50, **kwargs):
             response = MockResponse(r.read(), **kwargs)
     return response
 
-FK5_COORDINATES = coord.ICRS(10.68471, 41.26875, unit=('deg', 'deg'))
+FK5_COORDINATES = coord.SkyCoord(10.68471, 41.26875, unit=('deg', 'deg'))
 
 # disable waiting so tests run fast
 fermi.core.get_fermilat_datafile.TIMEOUT = 1

--- a/astroquery/irsa/tests/test_irsa.py
+++ b/astroquery/irsa/tests/test_irsa.py
@@ -110,9 +110,9 @@ def test_query_region_box(coordinates, patch_get):
                                          width=2 * u.arcmin)
     assert isinstance(result, Table)
 
-poly1 = [coord.ICRS(ra=10.1, dec=10.1, unit=(u.deg, u.deg)),
-        coord.ICRS(ra=10.0, dec=10.1, unit=(u.deg, u.deg)),
-        coord.ICRS(ra=10.0, dec=10.0, unit=(u.deg, u.deg))]
+poly1 = [coord.SkyCoord(ra=10.1, dec=10.1, unit=(u.deg, u.deg)),
+        coord.SkyCoord(ra=10.0, dec=10.1, unit=(u.deg, u.deg)),
+        coord.SkyCoord(ra=10.0, dec=10.0, unit=(u.deg, u.deg))]
 poly2 = [(10.1 * u.deg, 10.1 * u.deg), (10.0 * u.deg, 10.1 * u.deg), (10.0 * u.deg, 10.0 * u.deg)]
 
 

--- a/astroquery/irsa/tests/test_irsa_remote.py
+++ b/astroquery/irsa/tests/test_irsa_remote.py
@@ -39,9 +39,9 @@ class TestIrsa:
         assert isinstance(result, Table)
 
     def test_query_region_async_polygon(self):
-        polygon = [coord.ICRS(ra=10.1, dec=10.1, unit=(u.deg, u.deg)),
-                   coord.ICRS(ra=10.0, dec=10.1, unit=(u.deg, u.deg)),
-                   coord.ICRS(ra=10.0, dec=10.0, unit=(u.deg, u.deg))]
+        polygon = [coord.SkyCoord(ra=10.1, dec=10.1, unit=(u.deg, u.deg)),
+                   coord.SkyCoord(ra=10.0, dec=10.1, unit=(u.deg, u.deg)),
+                   coord.SkyCoord(ra=10.0, dec=10.0, unit=(u.deg, u.deg))]
         response = irsa.core.Irsa.query_region_async("m31", catalog="fp_psc", spatial="Polygon",
                                                  polygon=polygon)
         assert response is not None

--- a/astroquery/nrao/tests/test_nrao_remote.py
+++ b/astroquery/nrao/tests/test_nrao_remote.py
@@ -15,9 +15,9 @@ from ... import nrao
 class TestNrao:
 
     def test_query_region_async(self):
-        response = nrao.core.Nrao.query_region_async(coord.ICRS("04h33m11.1s 05d21m15.5s"))
+        response = nrao.core.Nrao.query_region_async(coord.SkyCoord("04h33m11.1s 05d21m15.5s"))
         assert response is not None
 
     def test_query_region(self):
-        result = nrao.core.Nrao.query_region(coord.ICRS("04h33m11.1s 05d21m15.5s"))
+        result = nrao.core.Nrao.query_region(coord.SkyCoord("04h33m11.1s 05d21m15.5s"))
         assert isinstance(result, Table)

--- a/astroquery/sdss/core.py
+++ b/astroquery/sdss/core.py
@@ -104,7 +104,7 @@ class SDSSClass(BaseQuery):
         --------
         >>> from astroquery.sdss import SDSS
         >>> from astropy import coordinates as coords
-        >>> co = coords.ICRS('0h8m05.63s +14d50m23.3s')
+        >>> co = coords.SkyCoord('0h8m05.63s +14d50m23.3s')
         >>> result = SDSS.query_region(co)
         >>> print(result[:5])
               ra           dec             objid        run  rerun camcol field
@@ -359,7 +359,7 @@ class SDSSClass(BaseQuery):
 
         >>> from astropy import coordinates as coords
         >>> from astroquery.sdss import SDSS
-        >>> co = coords.ICRS('0h8m05.63s +14d50m23.3s')
+        >>> co = coords.SkyCoord('0h8m05.63s +14d50m23.3s')
         >>> result = SDSS.query_region(co, spectro=True)
         >>> spec = SDSS.get_spectra(matches=result)
 
@@ -483,7 +483,7 @@ class SDSSClass(BaseQuery):
 
         >>> from astropy import coordinates as coords
         >>> from astroquery.sdss import SDSS
-        >>> co = coords.ICRS('0h8m05.63s +14d50m23.3s')
+        >>> co = coords.SkyCoord('0h8m05.63s +14d50m23.3s')
         >>> result = SDSS.query_region(co)
         >>> imgs = SDSS.get_images(matches=result)
 

--- a/astroquery/sdss/tests/test_sdss_remote.py
+++ b/astroquery/sdss/tests/test_sdss_remote.py
@@ -15,7 +15,7 @@ def test_images_timeout():
     An independent timeout test to verify that test_images_timeout in the
     TestSDSSRemote class should be working.  Consider this a regression test.
     """
-    coords = coordinates.ICRS('0h8m05.63s +14d50m23.3s')
+    coords = coordinates.SkyCoord('0h8m05.63s +14d50m23.3s')
     xid = sdss.core.SDSS.query_region(coords)
     assert len(xid) == 18
     with pytest.raises(TimeoutError):
@@ -25,7 +25,7 @@ def test_images_timeout():
 @remote_data
 class TestSDSSRemote:
     # Test Case: A Seyfert 1 galaxy
-    coords = coordinates.ICRS('0h8m05.63s +14d50m23.3s')
+    coords = coordinates.SkyCoord('0h8m05.63s +14d50m23.3s')
     mintimeout = 1e-6
 
 

--- a/astroquery/simbad/tests/test_simbad_remote.py
+++ b/astroquery/simbad/tests/test_simbad_remote.py
@@ -12,7 +12,7 @@ import imp
 imp.reload(requests)
 
 # M42 coordinates
-ICRS_COORDS = coord.ICRS("05h35m17.3s -05h23m28s")
+ICRS_COORDS = coord.SkyCoord("05h35m17.3s -05h23m28s", frame='icrs')
 
 
 @remote_data
@@ -122,19 +122,19 @@ class TestSimbad(object):
 
     # Special case of null test: zero-sized region
     def test_query_region_null(self):
-        result = simbad.core.Simbad.query_region(coord.ICRS("00h00m0.0s 00h00m0.0s"), radius="0d",
+        result = simbad.core.Simbad.query_region(coord.SkyCoord("00h00m0.0s 00h00m0.0s"), radius="0d",
                                                  equinox=2000.0, epoch='J2000')
         assert result is None
 
     # Special case of null test: very small region
     def test_query_small_region_null(self):
-        result = simbad.core.Simbad.query_region(coord.ICRS("00h00m0.0s 00h00m0.0s"), radius=1.0 * u.marcsec,
+        result = simbad.core.Simbad.query_region(coord.SkyCoord("00h00m0.0s 00h00m0.0s"), radius=1.0 * u.marcsec,
                                                  equinox=2000.0, epoch='J2000')
         assert result is None
 
     # Special case : zero-sized region with one object
     def test_query_zero_sized_region(self):
-        result = simbad.core.Simbad.query_region(coord.ICRS("20h54m05.6889s 37d01m17.380s"), radius="0d",
+        result = simbad.core.Simbad.query_region(coord.SkyCoord("20h54m05.6889s 37d01m17.380s"), radius="0d",
                                                  equinox=2000.0, epoch='J2000')
         # This should find a single star, BD+36 4308
         assert len(result) == 1

--- a/astroquery/utils/commons.py
+++ b/astroquery/utils/commons.py
@@ -159,7 +159,7 @@ def radius_to_unit(radius, unit='degree'):
 def parse_coordinates(coordinates):
     """
     Takes a string or astropy.coordinates object. Checks if the
-    string is parsable as an astropy.coordinates.ICRS
+    string is parsable as an `astropy.coordinates`
     object or is a name that is resolvable. Otherwise asserts
     that the argument is an astropy.coordinates object.
 

--- a/astroquery/utils/download_file_list.py
+++ b/astroquery/utils/download_file_list.py
@@ -92,7 +92,7 @@ def download_list_of_fitsfiles(linklist, output_directory=None,
                 # this part will eventually be handled by astropy.coordinates directly
                 # ctype = h0['CTYPE1']
                 # if 'RA' in ctype:
-                #     coordinate = coord.ICRS(lon,lat,unit=('deg','deg'))
+                #     coordinate = coord.SkyCoord(lon,lat,unit=('deg','deg'))
                 # elif 'GLON' in ctype:
                 #     coordinate = coord.Galactic(lon,lat,unit=('deg','deg'))
                 # else:

--- a/astroquery/utils/tests/test_utils.py
+++ b/astroquery/utils/tests/test_utils.py
@@ -49,7 +49,7 @@ def test_class_or_instance():
 
 
 @pytest.mark.parametrize(('coordinates'),
-                         [coord.ICRS(ra=148, dec=69, unit=(u.deg, u.deg)),
+                         [coord.SkyCoord(ra=148, dec=69, unit=(u.deg, u.deg)),
                           ]
                          )
 def test_parse_coordinates_1(coordinates):

--- a/docs/alfalfa/alfalfa.rst
+++ b/docs/alfalfa/alfalfa.rst
@@ -16,7 +16,7 @@ used in the SDSS example).
 
     >>> from astroquery.alfalfa import Alfalfa
     >>> from astropy import coordinates as coords
-    >>> pos = coords.ICRS('0h8m05.63s +14d50m23.3s')
+    >>> pos = coords.SkyCoord('0h8m05.63s +14d50m23.3s')
     >>> agc = Alfalfa.query_region(pos, optical_counterpart=True)
 
 This retrieves the AGC number of the object closest to the supplied ra and dec
@@ -36,7 +36,7 @@ This returns a PyFITS HDUList object.  If we want to have a look at the entire A
 .. code-block:: python
 
     >>> cat = Alfalfa.get_catalog()
-    
+
 which returns a dictionary containing HI measurements for nearly 16,000
 objects.
 


### PR DESCRIPTION
Since ``astroquery`` requires astropy >v0.4.1, this is safe to do now to avoid the ``AstropyDeprecationWarning``.