### PR TITLE
HTTP user-agent should be astroquery

### DIFF
--- a/astroquery/query.py
+++ b/astroquery/query.py
@@ -97,6 +97,11 @@ class BaseQuery(object):
 
     def __init__(self):
         self._session = requests.session()
+        self._session.headers['User-Agent'] = ('astropy:astroquery.{vers} '
+                                               '{olduseragent}'
+                                               .format(vers=version.version,
+                                                       olduseragent=
+                                                       self._session.headers['User-Agent']))
         self.cache_location = os.path.join(paths.get_cache_dir(), 'astroquery',
                                            self.__class__.__name__.split("Class")[0])
         if not os.path.exists(self.cache_location):

--- a/astroquery/query.py
+++ b/astroquery/query.py
@@ -99,7 +99,7 @@ class BaseQuery(object):
 
     def __init__(self):
         self._session = requests.session()
-        self._session.headers['User-Agent'] = ('astropy:astroquery.{vers} '
+        self._session.headers['User-Agent'] = ('astroquery.{vers} '
                                                '{olduseragent}'
                                                .format(vers=version.version,
                                                        olduseragent=

--- a/astroquery/query.py
+++ b/astroquery/query.py
@@ -98,12 +98,10 @@ class BaseQuery(object):
     """
 
     def __init__(self):
-        self._session = requests.session()
-        self._session.headers['User-Agent'] = ('astroquery/{vers} '
-                                               '{olduseragent}'
-                                               .format(vers=version.version,
-                                                       olduseragent=
-                                                       self._session.headers['User-Agent']))
+        S = self._session = requests.session()
+        S.headers['User-Agent'] = ('astroquery/{vers} {olduseragent}'
+                                   .format(vers=version.version,
+                                           olduseragent=S.headers['User-Agent']))
         self.cache_location = os.path.join(paths.get_cache_dir(), 'astroquery',
                                            self.__class__.__name__.split("Class")[0])
         if not os.path.exists(self.cache_location):

--- a/astroquery/query.py
+++ b/astroquery/query.py
@@ -99,7 +99,7 @@ class BaseQuery(object):
 
     def __init__(self):
         self._session = requests.session()
-        self._session.headers['User-Agent'] = ('astroquery.{vers} '
+        self._session.headers['User-Agent'] = ('astroquery/{vers} '
                                                '{olduseragent}'
                                                .format(vers=version.version,
                                                        olduseragent=

--- a/astroquery/query.py
+++ b/astroquery/query.py
@@ -14,6 +14,8 @@ from astropy import log
 from astropy.utils.console import ProgressBar
 import astropy.utils.data
 
+from . import version
+
 __all__ = ['BaseQuery', 'QueryWithLogin']
 
 

--- a/astroquery/simbad/core.py
+++ b/astroquery/simbad/core.py
@@ -115,6 +115,7 @@ class SimbadClass(BaseQuery):
     _VOTABLE_FIELDS = ['main_id', 'coordinates']
 
     def __init__(self):
+        super(SimbadClass, self).__init__()
         self._VOTABLE_FIELDS = copy.copy(self._VOTABLE_FIELDS)
 
     def list_wildcards(self):

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -181,7 +181,7 @@ class Mock(object):
         else:
             return Mock()
 
-MOCK_MODULES = ['atpy', 'beautifulsoup4', 'vo', 'requests', 'lxml', 'keyring', 'bs4']
+MOCK_MODULES = ['atpy', 'beautifulsoup4', 'vo', 'lxml', 'keyring', 'bs4']
 for mod_name in MOCK_MODULES:
     sys.modules[mod_name] = Mock()
 


### PR DESCRIPTION
In the old request approach, the user agent was set to be astroquery (in `commons.py`) but we've lost this with the new interface, which is very bad.