### PR TITLE
Check response status code and raise if it is an error

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,14 +1,15 @@
 0.3 (unreleased)
 ----------------
 
-- None yet
+- Bugfix for ``utils.commons.send_request()``: Raise exception if error status
+  is returned in the response. (#491)
 
 0.2.3 (2014-09-30)
 ------------------
 
 
 - AstroResponse has been removed, which means that all cached objects will have
-  new hashes.  You should clear your cache: for most users, that means 
+  new hashes.  You should clear your cache: for most users, that means
   ``rm -r ~/.astropy/cache/astroquery/`` (#418)
 - In ESO and ALMA, default to *not* storing your password.  New keyword
   ``store_password=False``.  (#415)

--- a/astroquery/utils/commons.py
+++ b/astroquery/utils/commons.py
@@ -90,10 +90,10 @@ def send_request(url, data, timeout, request_type='POST', headers={},
         else:
             raise ValueError("request_type must be either 'GET' or 'POST'.")
 
-        if response.status_code >= 400:
-            raise response.raise_for_status()
-        else:
-            return response
+        response.raise_for_status()
+
+        return response
+
     except requests.exceptions.Timeout:
             raise TimeoutError("Query timed out, time elapsed {time}s".
                                format(time=timeout))

--- a/astroquery/utils/commons.py
+++ b/astroquery/utils/commons.py
@@ -84,13 +84,16 @@ def send_request(url, data, timeout, request_type='POST', headers={},
         if request_type == 'GET':
             response = requests.get(url, params=data, timeout=timeout,
                                     headers=headers, **kwargs)
-            return response
         elif request_type == 'POST':
             response = requests.post(url, data=data, timeout=timeout,
                                      headers=headers, **kwargs)
-            return response
         else:
             raise ValueError("request_type must be either 'GET' or 'POST'.")
+
+        if response.status_code >= 400:
+            raise response.raise_for_status()
+        else:
+            return response
     except requests.exceptions.Timeout:
             raise TimeoutError("Query timed out, time elapsed {time}s".
                                format(time=timeout))

--- a/astroquery/utils/testing_tools.py
+++ b/astroquery/utils/testing_tools.py
@@ -33,15 +33,16 @@ class MockResponse(object):
     """
 
     def __init__(self, content=None, url=None, headers={},
-                 content_type=None, stream=False, auth=None):
+                 content_type=None, stream=False, auth=None, status_code=200):
         assert content is None or hasattr(content, 'decode')
         self.content = content
         self.raw = content
         self.headers = headers
         if content_type is not None:
-            self.headers.update({'Content-Type':content_type})
+            self.headers.update({'Content-Type': content_type})
         self.url = url
         self.auth = auth
+        self.status_code = status_code
 
     def iter_lines(self):
         c = self.content.split(b"\n")

--- a/astroquery/utils/tests/test_utils.py
+++ b/astroquery/utils/tests/test_utils.py
@@ -85,14 +85,16 @@ def test_parse_radius_2(radius):
 
 
 def test_send_request_post(monkeypatch):
-    def mock_post(url, data, timeout, headers={}):
+    def mock_post(url, data, timeout, headers={}, status_code=200):
         class SpecialMockResponse(object):
 
-            def __init__(self, url, data, headers):
+            def __init__(self, url, data, headers, status_code):
                 self.url = url
                 self.data = data
                 self.headers = headers
-        return SpecialMockResponse(url, data, headers=headers)
+                self.status_code = status_code
+        return SpecialMockResponse(url, data, headers=headers,
+                                   status_code=status_code)
     monkeypatch.setattr(requests, 'post', mock_post)
 
     response = commons.send_request('https://github.com/astropy/astroquery',
@@ -103,8 +105,9 @@ def test_send_request_post(monkeypatch):
 
 
 def test_send_request_get(monkeypatch):
-    def mock_get(url, params, timeout, headers={}):
+    def mock_get(url, params, timeout, headers={}, status_code=200):
         req = requests.Request('GET', url, params=params, headers=headers).prepare()
+        req.status_code = status_code
         return req
     monkeypatch.setattr(requests, 'get', mock_get)
     response = commons.send_request('https://github.com/astropy/astroquery',
@@ -113,8 +116,9 @@ def test_send_request_get(monkeypatch):
 
 
 def test_quantity_timeout(monkeypatch):
-    def mock_get(url, params, timeout, headers={}):
+    def mock_get(url, params, timeout, headers={}, status_code=200):
         req = requests.Request('GET', url, params=params, headers=headers).prepare()
+        req.status_code = status_code
         return req
     monkeypatch.setattr(requests, 'get', mock_get)
     response = commons.send_request('https://github.com/astropy/astroquery',

--- a/astroquery/utils/tests/test_utils.py
+++ b/astroquery/utils/tests/test_utils.py
@@ -93,6 +93,10 @@ def test_send_request_post(monkeypatch):
                 self.data = data
                 self.headers = headers
                 self.status_code = status_code
+
+            def raise_for_status(self):
+                pass
+
         return SpecialMockResponse(url, data, headers=headers,
                                    status_code=status_code)
     monkeypatch.setattr(requests, 'post', mock_post)
@@ -108,6 +112,7 @@ def test_send_request_get(monkeypatch):
     def mock_get(url, params, timeout, headers={}, status_code=200):
         req = requests.Request('GET', url, params=params, headers=headers).prepare()
         req.status_code = status_code
+        req.raise_for_status = lambda: None
         return req
     monkeypatch.setattr(requests, 'get', mock_get)
     response = commons.send_request('https://github.com/astropy/astroquery',
@@ -119,6 +124,7 @@ def test_quantity_timeout(monkeypatch):
     def mock_get(url, params, timeout, headers={}, status_code=200):
         req = requests.Request('GET', url, params=params, headers=headers).prepare()
         req.status_code = status_code
+        req.raise_for_status = lambda: None
         return req
     monkeypatch.setattr(requests, 'get', mock_get)
     response = commons.send_request('https://github.com/astropy/astroquery',


### PR DESCRIPTION
Would it make sense to check the response status for a query? If a client/server error is returned, it may be useful to raise an exception rather than return it as a valid result.

