### PR TITLE
add input column to Simbad result, relates to issue #473

### DIFF
--- a/astroquery/simbad/core.py
+++ b/astroquery/simbad/core.py
@@ -565,7 +565,7 @@ class SimbadClass(BaseQuery):
             Query results table
         """
         result = self.query_object('\n'.join(object_names), wildcard=wildcard,
-                                 get_query_payload=get_query_payload)
+                                   get_query_payload=get_query_payload)
 
         if keep_input:
             return self.add_input_column_to_simbad_result(object_names)
@@ -599,7 +599,6 @@ class SimbadClass(BaseQuery):
         self.last_parsed_result.table["INPUT"] = successes
 
         return self.last_parsed_result.table
-
 
     def query_objects_async(self, object_names, wildcard=False, cache=True,
                             get_query_payload=False):


### PR DESCRIPTION
This pull request relates to issue #473.  It adds a column "INPUT" to the result of a Simbad query.  This column is useful when one runs query_objects() with many identifiers, some of which are not recognized by Simbad.  

This PR also adds a flag to query_objects.

I did not make a test for this yet, but I figured I would at least get the ball rolling before I forgot about it, and maybe get some feedback about whether this approach seems OK.  Specifically, we might want to leave it out of query_objects for now, since it is an experimental feature.

As for the test, any advice on where to start is appreciated.  

Once again, any constructive critique is appreciated, this is my first time attempting a PR.
