### PR TITLE
Include config file in source repo

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,7 +12,6 @@ __pycache__
 # Other generated files
 */version.py
 */cython_version.py
-astroquery/astroquery.cfg
 
 htmlcov
 .coverage

--- a/astroquery/astroquery.cfg
+++ b/astroquery/astroquery.cfg
@@ -1,0 +1,197 @@
+[besancon]
+
+# Besancon download URL.  Changed to modele2003 in 2013.
+# Options: ftp://sasftp.obs-besancon.fr/modele/modele2003/, ftp://sasftp.obs-besancon.fr/modele/
+#besancon_download_url = ftp://sasftp.obs-besancon.fr/modele/modele2003/
+
+# Besancon model form URL
+# Options: http://model.obs-besancon.fr/modele_form.php
+#besancon_model_Form = http://model.obs-besancon.fr/modele_form.php
+
+# Amount of time before pinging the Besancon server to see if the file is
+# ready.  Minimum 30s.
+#besancon_ping_delay = 30.0
+
+# Timeout for Besancon query
+#besancon_timeout = 30.0
+
+[eso]
+
+# maximum number of rows returned (set to -1 for unlimited).
+#row_limit = 50
+
+[fermi]
+
+# Fermi query URL
+# Options: http://fermi.gsfc.nasa.gov/cgi-bin/ssc/LAT/LATDataQuery.cgi
+#fermi_url = http://fermi.gsfc.nasa.gov/cgi-bin/ssc/LAT/LATDataQuery.cgi
+
+# time limit for connecting to FERMI server
+#timeout = 60
+
+# time limit for retrieving a data file once it has been located
+#retrieval_timeout = 120
+
+[irsa]
+
+# Name of the IRSA mirror to use.
+# Options: http://irsa.ipac.caltech.edu/cgi-bin/Gator/nph-query
+#irsa_server = http://irsa.ipac.caltech.edu/cgi-bin/Gator/nph-query
+
+# URL from which to list all the public catalogs in IRSA.
+# Options: http://irsa.ipac.caltech.edu/cgi-bin/Gator/nph-scan
+#gator_list_catalogs = http://irsa.ipac.caltech.edu/cgi-bin/Gator/nph-scan
+
+# maximum number of rows to retrieve in result
+#row_limit = 500
+
+# time limit for connecting to the IRSA server
+#timeout = 60
+
+[irsa_dust]
+
+# Name of the irsa_dust server to use
+# Options: http://irsa.ipac.caltech.edu/cgi-bin/DUST/nph-dust
+#irsa_dust_server = http://irsa.ipac.caltech.edu/cgi-bin/DUST/nph-dust
+
+# default timeout for connecting to server
+#timeout = 30
+
+[magpis]
+
+# Name of the MAGPIS server.
+# Options: http://third.ucllnl.org/cgi-bin/gpscutout
+#magpis_server = http://third.ucllnl.org/cgi-bin/gpscutout
+
+# time limit for connecting to MAGPIS server
+#timeout = 60
+
+[ned]
+
+# Name of the NED mirror to use.
+# Options: http://ned.ipac.caltech.edu/cgi-bin/
+#ned_server = http://ned.ipac.caltech.edu/cgi-bin/
+
+# time limit for connecting to NED server
+#timeout = 60
+
+# value of the Hubble Constant for many NED queries.
+# Options: 73, 70.5
+#hubble_constant = 73
+
+# the correct redshift for NED queries, see comments above.
+# Options: 1, 2, 3, 4
+#correct_redshift = 1
+
+# Frame in which to display the coordinates in the output.
+# Options: Equatorial, Ecliptic, Galactic, SuperGalactic
+#output_coordinate_frame = Equatorial
+
+# Equinox for the output coordinates.
+# Options: J2000.0, B1950.0
+#output_equinox = J2000.0
+
+# display output sorted by this criteria.
+# Options: RA or Longitude, DEC or Latitude, GLON, GLAT, Redshift - ascending, Redshift - descending
+#sort_output_by = RA or Longitude
+
+[nist]
+
+# Name of the NIST URL to query.
+# Options: http://physics.nist.gov/cgi-bin/ASD/lines1.pl
+#nist_server = http://physics.nist.gov/cgi-bin/ASD/lines1.pl
+
+# time limit for connecting to NIST server
+#timeout = 30
+
+[nrao]
+
+# Name of the NRAO mirror to use.
+# Options: https://archive.nrao.edu/archive/ArchiveQuery
+#nrao_server = https://archive.nrao.edu/archive/ArchiveQuery
+
+# time limit for connecting to NRAO server
+#timeout = 60
+
+[nvas]
+
+# Name of the NVAS mirror to use.
+# Options: https://webtest.aoc.nrao.edu/cgi-bin/lsjouwer/archive-pos.pl
+#nvas_server = https://webtest.aoc.nrao.edu/cgi-bin/lsjouwer/archive-pos.pl
+
+# time limit for connecting to NVAS server
+#timeout = 60
+
+[ogle]
+
+# Name of the OGLE mirror to use.
+# Options: http://ogle.astrouw.edu.pl/cgi-ogle/getext.py
+#ogle_server = http://ogle.astrouw.edu.pl/cgi-ogle/getext.py
+
+# Time limit for connecting to the OGLE server.
+#timeout = 60
+
+[sdss]
+
+# Link to SDSS website.
+#sdss_server = http://data.sdss3.org/sas/dr10
+
+# Max number of queries allowed per second
+#maxqueries = 1
+
+# Default timeout for connecting to server
+#timeout = 30
+
+[simbad]
+
+# Name of the SIMBAD mirror to use.
+# Options: simbad.u-strasbg.fr, simbad.harvard.edu
+#simbad_server = simbad.u-strasbg.fr
+
+# time limit for connecting to Simbad server
+#timeout = 60
+
+# maximum number of rows that will be fetched from the result.
+#row_limit = 0
+
+[splatalogue]
+
+#Splatalogue SLAP interface URL (not used). = http://find.nrao.edu/splata-slap/slap
+
+#Splatalogue web interface URL. = http://www.cv.nrao.edu/php/splat/c_export.php
+
+# default timeout for connecting to server
+#timeout = 60
+
+#Limit to number of lines exported = 10000
+
+[template_module]
+
+# put a brief description of the item here
+# Options: http://dummy_server_mirror_1, http://dummy_server_mirror_2, http://dummy_server_mirror_n
+#server = http://dummy_server_mirror_1
+
+# default timeout for connecting to server
+#timeout = 30
+
+[ukidss]
+
+# Name of the UKIDSS mirror to use.
+# Options: http://surveys.roe.ac.uk:8080/wsa/
+#ukidss_server = http://surveys.roe.ac.uk:8080/wsa/
+
+# time limit for connecting to UKIDSS server
+#timeout = 60
+
+[vizier]
+
+# Name of the VizieR mirror to use.
+# Options: vizier.u-strasbg.fr, vizier.nao.ac.jp, vizier.hia.nrc.ca, vizier.ast.cam.ac.uk, vizier.cfa.harvard.edu, www.ukirt.jach.hawaii.edu, vizier.iucaa.ernet.in, vizier.china-vo.org
+#vizier_server = vizier.u-strasbg.fr
+
+# default timeout for connecting to server
+#timeout = 60
+
+# maximum number of rows that will be fetched from the result (set to -1 for
+# unlimited).
+#row_limit = 50

--- a/astroquery/setup_package.py
+++ b/astroquery/setup_package.py
@@ -1,0 +1,4 @@
+# Licensed under a 3-clause BSD style license - see LICENSE.rst
+
+def get_package_data():
+    return {'astroquery': ['astroquery.cfg']}


### PR DESCRIPTION
It turns out most of #501 is unnecessary -- astroquery was already on the "new" config API and basically all we were seeing was the result of a recent breakage in astropy (that only affected affiliated packages).

This is basically #501 boiled down to only the necessary bit, which is to include a copy of the config file in the source tree since it is no longer generated in the new config scheme.