### PR TITLE
Adding SDSS query_crossid() to use  the crossid api

### DIFF
--- a/astroquery/sdss/core.py
+++ b/astroquery/sdss/core.py
@@ -96,6 +96,12 @@ class SDSSClass(BaseQuery):
             It generates unique object names by default.
         """
 
+        if (not isinstance(coordinates, list) and
+                not isinstance(coordinates, Column) and
+                not (isinstance(coordinates, commons.CoordClasses) and
+                     not coordinates.isscalar)):
+                coordinates = [coordinates]
+
         if obj_names is None:
             obj_names = ['obj_{0}'.format(i) for i in range(len(coordinates))]
         elif len(obj_names) != len(coordinates):

--- a/astroquery/sdss/core.py
+++ b/astroquery/sdss/core.py
@@ -59,9 +59,41 @@ class SDSSClass(BaseQuery):
     def query_crossid_async(self, coordinates, obj_names=None,
                             photoobj_fields=None, specobj_fields=None,
                             get_query_payload=False, timeout=TIMEOUT,
-                            radius=5. * u.arcsec, output_format='csv'):
+                            radius=5. * u.arcsec):
         """
-        Query using the cross-identification API.
+        Query using the cross-identification web interface.
+
+        Parameters
+        ----------
+        coordinates : str or `astropy.coordinates` object or list of
+            coordinates or `~astropy.table.Column` of coordinates The
+            target(s) around which to search. It may be specified as a
+            string in which case it is resolved using online services or as
+            the appropriate `astropy.coordinates` object. ICRS coordinates
+            may also be entered as strings as specified in the
+            `astropy.coordinates` module.
+
+            Example:
+            ra = np.array([220.064728084,220.064728467,220.06473483])
+            dec = np.array([0.870131920218,0.87013210119,0.870138329659])
+            coordinates = SkyCoord(ra, dec, frame='icrs', unit='deg')
+        radius : str or `~astropy.units.Quantity` object, optional The
+            string must be parsable by `~astropy.coordinates.Angle`. The
+            appropriate `~astropy.units.Quantity` object from
+            `astropy.units` may also be used. Defaults to 2 arcsec.
+        timeout : float, optional
+            Time limit (in seconds) for establishing successful connection with
+            remote server.  Defaults to `SDSSClass.TIMEOUT`.
+        photoobj_fields : float, optional
+            PhotoObj quantities to return. If photoobj_fields is None and
+            specobj_fields is None then the value of fields is used
+        specobj_fields : float, optional
+            SpecObj quantities to return. If photoobj_fields is None and
+            specobj_fields is None then the value of fields is used
+        obj_names : str, or list or `~astropy.table.Column`, optional
+            Target names. If given, every coordinate should have a
+            corresponding name, and it gets repeated in the query result.
+            It generates unique object names by default.
         """
 
         if obj_names is None:
@@ -100,7 +132,7 @@ class SDSSClass(BaseQuery):
 
         sql_query += ',dbo.fPhotoTypeN(p.type) as type \
                       FROM #upload u JOIN #x x ON x.up_id = u.up_id \
-                      JOIN PhotoTag p ON p.objID = x.objID ORDER BY x.up_id'
+                      JOIN PhotoObjAll p ON p.objID = x.objID ORDER BY x.up_id'
 
         data = "obj_id ra dec \n"
         data += " \n ".join(['{0} {1} {2}'.format(obj_names[i],
@@ -111,7 +143,7 @@ class SDSSClass(BaseQuery):
         # firstcol is hardwired, as obj_names is always passed
         request_payload = dict(uquery=sql_query, paste=data,
                                firstcol=1,
-                               format=output_format, photoScope='nearPrim',
+                               format='csv', photoScope='nearPrim',
                                radius=radius,
                                photoUpType='ra-dec', searchType='photo')
 

--- a/astroquery/sdss/core.py
+++ b/astroquery/sdss/core.py
@@ -25,10 +25,8 @@ __all__ = ['SDSS', 'SDSSClass']
 
 __doctest_skip__ = ['SDSSClass.*']
 
-from .field_names import photoobj_defs, specobj_defs, photoobj_all, specobj_all
-
-crossid_defs = ['ra', 'dec', 'modelMag_u', 'modelMag_g',
-                'modelMag_r', 'modelMag_i', 'modelMag_z']
+from .field_names import (photoobj_defs, specobj_defs, photoobj_all,
+                          specobj_all, crossid_defs)
 
 # Cross-correlation templates from DR-7
 spec_templates = {'star_O': 0, 'star_OB': 1, 'star_B': 2, 'star_A': [3, 4],

--- a/astroquery/sdss/core.py
+++ b/astroquery/sdss/core.py
@@ -59,7 +59,7 @@ class SDSSClass(BaseQuery):
     def query_crossid_async(self, coordinates, obj_names=None,
                             photoobj_fields=None, specobj_fields=None,
                             get_query_payload=False, timeout=TIMEOUT,
-                            radius=u.degree / 1800, output_format='csv'):
+                            radius=5. * u.arcsec, output_format='csv'):
         """
         Query using the cross-identification API.
         """
@@ -122,7 +122,7 @@ class SDSSClass(BaseQuery):
 
         return r
 
-    def query_region_async(self, coordinates, radius=u.degree / 1800.,
+    def query_region_async(self, coordinates, radius=2. * u.arcsec,
                            fields=None, spectro=False, timeout=TIMEOUT,
                            get_query_payload=False, photoobj_fields=None,
                            specobj_fields=None, field_help=False,
@@ -397,7 +397,7 @@ class SDSSClass(BaseQuery):
                                  request_type='GET')
         return r
 
-    def get_spectra_async(self, coordinates=None, radius=u.degree / 1800.,
+    def get_spectra_async(self, coordinates=None, radius=2. * u.arcsec,
                           matches=None, plate=None, fiberID=None, mjd=None,
                           timeout=TIMEOUT, get_query_payload=False):
         """
@@ -496,7 +496,7 @@ class SDSSClass(BaseQuery):
         return results
 
     @prepend_docstr_noreturns(get_spectra_async.__doc__)
-    def get_spectra(self, coordinates=None, radius=u.degree / 1800.,
+    def get_spectra(self, coordinates=None, radius=2. * u.arcsec,
                     matches=None, plate=None, fiberID=None, mjd=None,
                     timeout=TIMEOUT):
         """
@@ -513,7 +513,7 @@ class SDSSClass(BaseQuery):
 
         return [obj.get_fits() for obj in readable_objs]
 
-    def get_images_async(self, coordinates=None, radius=u.degree / 1800.,
+    def get_images_async(self, coordinates=None, radius=2. * u.arcsec,
                          matches=None, run=None, rerun=301, camcol=None,
                          field=None, band='g', timeout=TIMEOUT,
                          get_query_payload=False, cache=True):
@@ -625,7 +625,7 @@ class SDSSClass(BaseQuery):
         return results
 
     @prepend_docstr_noreturns(get_images_async.__doc__)
-    def get_images(self, coordinates=None, radius=u.degree / 1800.,
+    def get_images(self, coordinates=None, radius=2. * u.arcsec,
                    matches=None, run=None, rerun=301, camcol=None, field=None,
                    band='g', timeout=TIMEOUT, cache=True):
         """
@@ -736,7 +736,7 @@ class SDSSClass(BaseQuery):
         else:
             return Table(arr)
 
-    def _args_to_payload(self, coordinates=None, radius=u.degree / 1800.,
+    def _args_to_payload(self, coordinates=None, radius=2. * u.arcsec,
                          fields=None, spectro=False,
                          plate=None, mjd=None, fiberID=None, run=None,
                          rerun=301, camcol=None, field=None,

--- a/astroquery/sdss/core.py
+++ b/astroquery/sdss/core.py
@@ -100,10 +100,10 @@ class SDSSClass(BaseQuery):
 
         sql_query += ', '.join(photobj_fields + specobj_fields)
 
-        sql_query += ',dbo.fPhotoTypeN(p.type) as type, FROM #upload u JOIN #x x ON x.up_id = u.up_id JOIN PhotoTag p ON p.objID = x.objID ORDER BY x.up_id'
+        sql_query += ',dbo.fPhotoTypeN(p.type) as type \
+                      FROM #upload u JOIN #x x ON x.up_id = u.up_id \
+                      JOIN PhotoTag p ON p.objID = x.objID ORDER BY x.up_id'
 
-        # still have to work on this
-        # data = "\n".join(zip(obj_names, coordinates)
         data = "obj_id ra dec \n"
         data += " \n ".join(['{0} {1} {2}'.format(obj_names[i],
                                                   coordinates[i].ra.deg,
@@ -208,7 +208,7 @@ class SDSSClass(BaseQuery):
         if get_query_payload or field_help:
             return request_payload
         r = commons.send_request(SDSS.QUERY_URL, request_payload, timeout,
-                                 request_type='POST')
+                                 request_type='GET')
 
         return r
 

--- a/astroquery/sdss/core.py
+++ b/astroquery/sdss/core.py
@@ -71,7 +71,7 @@ class SDSSClass(BaseQuery):
                              "be equal")
 
         if isinstance(radius, u.Quantity):
-            radius = radius.to(u.deg).value
+            radius = radius.to(u.arcmin).value
         else:
             try:
                 float(radius)

--- a/astroquery/sdss/field_names.py
+++ b/astroquery/sdss/field_names.py
@@ -3,6 +3,11 @@ photoobj_defs = ['ra', 'dec', 'objid', 'run', 'rerun', 'camcol', 'field']
 specobj_defs = ['z', 'plate', 'mjd', 'fiberID', 'specobjid', 'run2d',
                 'instrument']
 
+# Default fields for the crossid query
+crossid_defs = ['ra', 'dec', 'psfMag_u', 'psfMagerr_u', 'psfMag_g',
+                'psfMagerr_g', 'psfMag_r', 'psfMagerr_r', 'psfMag_i',
+                'psfMagerr_i', 'psfMag_z', 'psfMagerr_z']
+
 # All valid fields in PhotoObjAll and SpecObjAll
 photoobj_all = ['name', 'objid', 'up_id', 'up_name', 'up_ra', 'up_dec',
                 'up_id1', 'objid1', 'objid2', 'skyversion', 'run', 'rerun',

--- a/astroquery/sdss/tests/test_sdss_remote.py
+++ b/astroquery/sdss/tests/test_sdss_remote.py
@@ -142,3 +142,12 @@ class TestSDSSRemote:
 
         assert query1.colnames == ['r']
         assert query2.colnames == ['ra', 'dec', 'r']
+
+    def test_query_crossid(self):
+        query1 = sdss.core.SDSS.query_crossid(self.coords)
+        query2 = sdss.core.SDSS.query_crossid([self.coords, self.coords])
+        assert isinstance(query1, Table)
+        assert query1['objID'][0] == 1237652943176138868
+
+        assert isinstance(query2, Table)
+        assert query2['objID'][0] == query1['objID'][0] == query2['objID'][1]


### PR DESCRIPTION
This PR adds support for queries using the crossid API which are beyond to the limitations of the sql api (it cuts the query, thus doesn't work when a large number of coordinates are passed at the) same time. crossid api has the more generous limitations listed  [here](http://skyserver.sdss.org/dr12/en/help/docs/limits.aspx).

This works as is for thousands of coordinates and the default photobj fields, however more throughout testing and documentation is needed (e.g. haven't tested for specobj fields, most probably is not yet working).

Closes #492