### PR TITLE
Python 3 fix in Vizier.find_catalogs

### DIFF
--- a/astroquery/vizier/core.py
+++ b/astroquery/vizier/core.py
@@ -171,15 +171,15 @@ class VizierClass(BaseQuery):
                                  url=self._server_to_url(),
                                  data=data_payload,
                                  timeout=self.TIMEOUT)
-        if 'STOP, Max. number of RESOURCE reached' in response.content:
+        if 'STOP, Max. number of RESOURCE reached' in response.text:
             raise ValueError("Maximum number of catalogs exceeded.  Try setting max_catalogs "
                              "to a large number and try again")
         result = self._parse_result(response, verbose=verbose, get_catalog_names=True)
 
         # Filter out the obsolete catalogs, unless requested
         if include_obsolete is False:
-            for (key, resource) in result.items():
-                for info in resource.infos:
+            for key in list(result):
+                for info in result[key].infos:
                     if (info.name == 'status') and (info.value == 'obsolete'):
                         del result[key]
 


### PR DESCRIPTION
`Vizier.find_catalogs` is currently broken in Python 3.

This PR makes the necessary compatibility fixes. It enables `test_vizier_remote.py` to pass in both Python 2.7 and 3.4 on my machine (whereas it is failing in 3.4 at present).

If this gets merged, #477 can be closed.