### PR TITLE
Template Module fixes

### DIFF
--- a/astroquery/template_module/core.py
+++ b/astroquery/template_module/core.py
@@ -61,7 +61,8 @@ class TemplateClass(BaseQuery):
         return result
     """
 
-    def query_object_async(self, object_name, get_query_payload=False):
+    def query_object_async(self, object_name, get_query_payload=False,
+                           cache=True):
         """
         This method is for services that can parse object names. Otherwise
         use :meth:`astroquery.template_module.TemplateClass.query_region`.
@@ -198,6 +199,8 @@ class TemplateClass(BaseQuery):
             # catch common errors here
             # return raw result/ handle in some way
             pass
+
+        return Table()
 
     # Image queries do not use the async_to_sync approach: the "synchronous"
     # version must be defined explicitly.  The example below therefore presents

--- a/astroquery/template_module/tests/test_module_remote.py
+++ b/astroquery/template_module/tests/test_module_remote.py
@@ -10,6 +10,7 @@ from astropy.tests.helper import remote_data, pytest
 
 
 @remote_data
-class TestDummyClass:
+class TestTemplateClass:
     # now write tests for each method here
-    pass
+    def test_this(self):
+        pass


### PR DESCRIPTION
A few big fixes.  Thanks @cdeil 

 1. Run the template module tests (using `__init__.py`)
 2. Use a more up-to-date approach for monkeypatching
 3. fix some minor bugs in the templates