### PR TITLE
Adding astroquery version number to testing header

### DIFF
--- a/astroquery/conftest.py
+++ b/astroquery/conftest.py
@@ -1,13 +1,24 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 from __future__ import print_function
-from astropy.tests.helper import pytest, remote_data
+import os
+
 from .utils import turn_off_internet
+
+# This is to figure out the astroquery version, rather than using Astropy's
+from . import version
+
 
 # this contains imports plugins that configure py.test for astropy tests.
 # by importing them here in conftest.py they are discoverable by py.test
 # no matter how it is invoked within the source tree.
 
 from astropy.tests.pytest_plugins import *
+
+try:
+    packagename = os.path.basename(os.path.dirname(__file__))
+    TESTED_VERSIONS[packagename] = version.version
+except NameError:
+    pass
 
 
 # pytest magic:


### PR DESCRIPTION
This is a follow-up on astropy/astropy#3543.