### PR TITLE
Vizier queries seem slow

### DIFF
--- a/astroquery/vizier/core.py
+++ b/astroquery/vizier/core.py
@@ -212,7 +212,7 @@ class VizierClass(BaseQuery):
         return response
 
     def query_object_async(self, object_name, catalog=None, radius=None,
-                           coordinate_frame=None):
+                           coordinate_frame=None, get_query_payload=False):
         """
         Serves the same purpose as `query_object` but only
         returns the HTTP response rather than the parsed result.
@@ -252,6 +252,8 @@ class VizierClass(BaseQuery):
         data_payload = self._args_to_payload(
             center=center,
             catalog=catalog)
+        if get_query_payload:
+            return data_payload
         response = self._request(method='POST',
                                  url=self._server_to_url(),
                                  data=data_payload,

--- a/astroquery/vizier/core.py
+++ b/astroquery/vizier/core.py
@@ -130,7 +130,7 @@ class VizierClass(BaseQuery):
         self._keywords = None
 
     def find_catalogs(self, keywords, include_obsolete=False, verbose=False,
-                      max_catalogs=None):
+                      max_catalogs=None, return_type='votable'):
         """
         Search Vizier for catalogs based on a set of keywords, e.g. author name
 
@@ -172,7 +172,7 @@ class VizierClass(BaseQuery):
         if max_catalogs is not None:
             data_payload['-meta.max'] = max_catalogs
         response = self._request(method='POST',
-                                 url=self._server_to_url(),
+                                 url=self._server_to_url(return_type=return_type),
                                  data=data_payload,
                                  timeout=self.TIMEOUT)
         if 'STOP, Max. number of RESOURCE reached' in response.text:
@@ -190,7 +190,7 @@ class VizierClass(BaseQuery):
 
         return result
 
-    def get_catalogs_async(self, catalog, verbose=False):
+    def get_catalogs_async(self, catalog, verbose=False, return_type='votable'):
         """
         Query the Vizier service for a specific catalog
 
@@ -207,13 +207,14 @@ class VizierClass(BaseQuery):
 
         data_payload = self._args_to_payload(catalog=catalog)
         response = self._request(method='POST',
-                                 url=self._server_to_url(),
+                                 url=self._server_to_url(return_type=return_type),
                                  data=data_payload,
                                  timeout=self.TIMEOUT)
         return response
 
     def query_object_async(self, object_name, catalog=None, radius=None,
-                           coordinate_frame=None, get_query_payload=False):
+                           coordinate_frame=None, get_query_payload=False,
+                           return_type='votable', cache=True):
         """
         Serves the same purpose as `query_object` but only
         returns the HTTP response rather than the parsed result.
@@ -256,14 +257,15 @@ class VizierClass(BaseQuery):
         if get_query_payload:
             return data_payload
         response = self._request(method='POST',
-                                 url=self._server_to_url(),
+                                 url=self._server_to_url(return_type=return_type),
                                  data=data_payload,
-                                 timeout=self.TIMEOUT)
+                                 timeout=self.TIMEOUT,
+                                 cache=cache)
         return response
 
     def query_region_async(self, coordinates, radius=None, inner_radius=None,
                            width=None, height=None, catalog=None,
-                           get_query_payload=False):
+                           get_query_payload=False, cache=True):
         """
         Serves the same purpose as `query_region` but only
         returns the HTTP response rather than the parsed result.
@@ -381,12 +383,15 @@ class VizierClass(BaseQuery):
             return data_payload
 
         response = self._request(method='POST',
-                                 url=self._server_to_url(),
+                                 url=self._server_to_url(return_type=return_type),
                                  data=data_payload,
-                                 timeout=self.TIMEOUT)
+                                 timeout=self.TIMEOUT,
+                                 cache=cache)
         return response
 
-    def query_constraints_async(self, catalog=None, **kwargs):
+    def query_constraints_async(self, catalog=None, return_type='votable',
+                                cache=True,
+                                **kwargs):
         """
         Send a query to Vizier in which you specify constraints with keyword/value
         pairs.
@@ -444,9 +449,10 @@ class VizierClass(BaseQuery):
             column_filters=kwargs,
             center={'-c.rd': 180})
         response = self._request(method='POST',
-                                 url=self._server_to_url(),
+                                 url=self._server_to_url(return_type=return_type),
                                  data=data_payload,
-                                 timeout=self.TIMEOUT)
+                                 timeout=self.TIMEOUT,
+                                 cache=cache)
         return response
 
     def _args_to_payload(self, *args, **kwargs):

--- a/astroquery/vizier/core.py
+++ b/astroquery/vizier/core.py
@@ -110,6 +110,10 @@ class VizierClass(BaseQuery):
         FITS binary table: asu-binfits
         plain text: asu-txt
         """
+        # Only votable is supported now, but in case we try to support
+        # something in the future we should disallow invalid ones.
+        assert return_type in ('votable', 'asu-tsv', 'asu-fits',
+                               'asu-binfits', 'asu-txt')
         return "http://" + self.VIZIER_SERVER + "/viz-bin/" + return_type
 
     @property

--- a/astroquery/vizier/core.py
+++ b/astroquery/vizier/core.py
@@ -617,7 +617,7 @@ class VizierClass(BaseQuery):
         table_list : `astroquery.utils.TableList` or str
             If there are errors in the parsing, then returns the raw results as a string.
         """
-        if response.content[:5] == '<?xml':
+        if response.content[:5] == b'<?xml':
             try:
                 return parse_vizier_votable(response.content, verbose=verbose,
                                             invalid=invalid,
@@ -629,9 +629,9 @@ class VizierClass(BaseQuery):
                                       "in self.response, and the error in self.table_parse_error."
                                       "  The attempted parsed result is in self.parsed_result.\n"
                                       "Exception: " + str(self.table_parse_error))
-        elif response.content[:5] == '#\n#  ':
+        elif response.content[:5] == b'#\n#  ':
             return parse_vizier_tsvfile(data, verbose=verbose)
-        elif response.content[:6] == 'SIMPLE':
+        elif response.content[:6] == b'SIMPLE':
             return fits.open(BytesIO(response.content), ignore_missing_end=True)
 
     @property

--- a/astroquery/vizier/core.py
+++ b/astroquery/vizier/core.py
@@ -176,8 +176,9 @@ class VizierClass(BaseQuery):
                                  data=data_payload,
                                  timeout=self.TIMEOUT)
         if 'STOP, Max. number of RESOURCE reached' in response.text:
-            raise ValueError("Maximum number of catalogs exceeded.  Try setting max_catalogs "
-                             "to a large number and try again")
+            raise ValueError("Maximum number of catalogs exceeded.  Try "
+                             "setting max_catalogs to a large number and"
+                             " try again")
         result = self._parse_result(response, verbose=verbose, get_catalog_names=True)
 
         # Filter out the obsolete catalogs, unless requested
@@ -536,7 +537,8 @@ class VizierClass(BaseQuery):
             script += "\n" + str(self.keywords)
         return script
 
-    def _parse_result(self, response, get_catalog_names=False, verbose=False, invalid='warn'):
+    def _parse_result(self, response, get_catalog_names=False, verbose=False,
+                      invalid='warn'):
         """
         Parses the HTTP response to create a `~astropy.table.Table`.
 

--- a/astroquery/vizier/core.py
+++ b/astroquery/vizier/core.py
@@ -8,6 +8,7 @@ import copy
 import re
 
 from astropy.extern import six
+from astropy.extern.six import BytesIO
 import astropy.units as u
 import astropy.coordinates as coord
 import astropy.table as tbl
@@ -311,7 +312,8 @@ class VizierClass(BaseQuery):
 
     def query_region_async(self, coordinates, radius=None, inner_radius=None,
                            width=None, height=None, catalog=None,
-                           get_query_payload=False, cache=True):
+                           get_query_payload=False, cache=True,
+                           return_type='votable'):
         """
         Serves the same purpose as `query_region` but only
         returns the HTTP response rather than the parsed result.


### PR DESCRIPTION
Hello, 

I use the Vizier module to query SDSS and it seems slow. My general query is,

```
Vizier.ROW_LIMIT = -1 # Removes row limit on output table
result = Vizier.query_region(<galaxy>, width=1.0*u.deg,
                                 height=1.0*u.deg, catalog='SDSS')
```

Where <galaxy> can be something like 'NGC3377'. It takes about a minute and a half to run and return results.

I'm not sure if this is something that can be improved but I think it's worth looking into.

Alexa