### PR TITLE
LAMDA: Add a utility for computing the critical density

### DIFF
--- a/astroquery/lamda/__init__.py
+++ b/astroquery/lamda/__init__.py
@@ -16,6 +16,3 @@ Note:
   data are encouraged.
 """
 from .core import Lamda
-
-import warnings
-warnings.warn("LAMDA has not yet been refactored to have its API match the rest of astroquery.")

--- a/astroquery/lamda/__init__.py
+++ b/astroquery/lamda/__init__.py
@@ -15,7 +15,7 @@ Note:
   references to the original papers providing the spectroscopic and collisional
   data are encouraged.
 """
-from .core import *
+from .core import Lamda
 
 import warnings
-warnings.warn("Experimental: LAMDA has not yet been refactored to have its API match the rest of astroquery.")
+warnings.warn("LAMDA has not yet been refactored to have its API match the rest of astroquery.")

--- a/astroquery/lamda/core.py
+++ b/astroquery/lamda/core.py
@@ -50,7 +50,8 @@ class LamdaClass(BaseQuery):
         if mol not in self.molecule_dict:
             raise InvalidQueryError("Molecule {0} is not in the valid "
                                     "molecule list.  See Lamda.molecule_dict")
-        response = self._request('GET', self.url.format(mol), cache=cache)
+        response = self._request('GET', self.url.format(mol), timeout=timeout,
+                                 cache=cache)
         response.raise_for_status()
         return response
 
@@ -63,7 +64,7 @@ class LamdaClass(BaseQuery):
         with open(outfilename,'w') as f:
             f.write(molreq.text)
 
-    def query(self, mol, return_datafile=False, cache=True):
+    def query(self, mol, return_datafile=False, cache=True, timeout=None):
         """
         Query the LAMDA database.
 
@@ -97,7 +98,8 @@ class LamdaClass(BaseQuery):
         """
         # Send HTTP request to open URL
         datafile = [s.strip() for s in
-                    self._get_molfile(mol, cache=cache).text.splitlines()]
+                    self._get_molfile(mol, timeout=timeout,
+                                      cache=cache).text.splitlines()]
         if return_datafile:
             return datafile
         # Parse datafile string list and return a table

--- a/astroquery/lamda/core.py
+++ b/astroquery/lamda/core.py
@@ -17,7 +17,7 @@ from ..query import BaseQuery
 __all__ = ['Lamda']
 
 # should skip only if remote_data = False
-__doctest_skip__ = ['query']
+__doctest_skip__ = ['LamdaClass.query']
 
 # query_types and collider_ids are potentially useful but not used.
 query_types = {

--- a/astroquery/lamda/core.py
+++ b/astroquery/lamda/core.py
@@ -74,7 +74,9 @@ def print_mols():
         print(mols[mol_family], '\n')
 
 def get_molfile(mol):
-    return requests.get(url.format(mol))
+    response = requests.get(url.format(mol))
+    response.raise_for_status()
+    return response
 
 def download_molfile(mol, outfilename):
     molreq = get_molfile(mol)

--- a/astroquery/lamda/core.py
+++ b/astroquery/lamda/core.py
@@ -44,14 +44,14 @@ class LamdaClass(BaseQuery):
         self._moldict_path = os.path.join(self.cache_location,
                                           "molecules.json")
 
-    def _get_molfile(self, mol, cache=True):
+    def _get_molfile(self, mol, cache=True, timeout=None):
         """
         """
         if mol not in self.molecule_dict:
             raise InvalidQueryError("Molecule {0} is not in the valid "
                                     "molecule list.  See Lamda.molecule_dict")
-        response = self._request('GET', self.url.format(mol), timeout=timeout,
-                                 cache=cache)
+        response = self._request('GET', self.molecule_dict[mol],
+                                 timeout=timeout, cache=cache)
         response.raise_for_status()
         return response
 

--- a/astroquery/lamda/core.py
+++ b/astroquery/lamda/core.py
@@ -5,50 +5,13 @@ import numpy as np
 from astropy.table import Table
 from astropy import table
 from astropy import log
+from ..query import Query
 
-__all__ = ['query', 'print_mols', 'parse_lamda_datafile']
+__all__ = ['Lamda']
 
 # should skip only if remote_data = False
 __doctest_skip__ = ['query']
 
-url = "http://home.strw.leidenuniv.nl/~moldata/datafiles/{0}.dat"
-mols = {
-    # Atoms
-    'C': ['catom'],
-    'C+': ['c+', 'c+@uv'],
-    'O': ['oatom'],
-    # Molecules
-    'CO': ['co', '13co', 'c17o', 'c18o', 'co@neufeld'],
-    'CS': ['cs@xpol', '13cs@xpol', 'c34s@xpol'],
-    'HCl': ['hcl', 'hcl@hfs'],
-    'OCS': ['ocs@xpol'],
-    'SO': ['so'],
-    'SO2': ['so2@xpol'],
-    'SiO': ['sio', '29sio'],
-    'SiS': ['sis@xpol'],
-    'SiC2': ['o-sic2'],
-    'HCO+': ['hco+@xpol', 'h13co+@xpol', 'hc17o+@xpol', 'hc18o+@xpol',
-             'dco+@xpol'],
-    'N2H+': ['n2h+@xpol', 'n2h+_hfs'],
-    'HCS+': ['hcs+@xpol'],
-    'HC3N': ['hc3n'],
-    'HCN': ['hcn', 'hcn@xpol', 'hcn@hfs', 'h13cn@xpol', 'hc15n@xpol'],
-    'HNC': ['hnc'],
-    'C3H2': ['p-c3h2', 'o-c3h2'],
-    'H2O': ['ph2o@daniel', 'oh2o@daniel', 'ph2o@rovib', 'oh2o@rovib'],
-    'H2CO': ['p-h2co', 'o-h2co'],
-    'OH': ['oh', 'oh@hfs'],
-    'CH3OH': ['e-ch3oh', 'a-ch3oh'],
-    'NH3': ['p-nh3', 'o-nh3'],
-    'HDO': ['hdo'],
-    'H3O+': ['p-h3o+', 'o-h3o+'],
-    'HNCO': ['hnco'],
-    'NO': ['no'],
-    'CN': ['cn'],
-    'CH3CN': ['ch3cn'],
-    'O2': ['o2'],
-    'HF': ['hf']
-}
 query_types = {
     'erg_levels': '!NUMBER OF ENERGY LEVELS',
     'rad_trans': '!NUMBER OF RADIATIVE TRANSITIONS',
@@ -64,71 +27,106 @@ collider_ids = {'H2': 1,
                 'H+': 7}
 collider_ids.update({v:k for k,v in list(collider_ids.items())})
 
+class LamdaClass(Query):
 
-def print_mols():
-    """
-    Print molecule names available for query.
-    """
-    for mol_family in mols.keys():
-        print('-- {0} :'.format(mol_family))
-        print(mols[mol_family], '\n')
+    url = "http://home.strw.leidenuniv.nl/~moldata/datafiles/{0}.dat"
 
-def get_molfile(mol):
-    response = requests.get(url.format(mol))
+    def _get_molfile(self, mol):
+        """
+        """
+        response = requests.get(self.url.format(mol))
+        response.raise_for_status()
+        return response
+
+    def download_molfile(self, mol, outfilename):
+        """
+        Download a particular molecular data file `mol` to output file
+        `outfilename`
+        """
+        molreq = self._get_molfile(mol)
+        with open(outfilename,'w') as f:
+            f.write(molreq.text)
+
+    def query(self, mol, query_type=None, coll_partner_index=0,
+              return_datafile=False):
+        """
+        Query the LAMDA database.
+
+        Parameters
+        ----------
+        mol : string
+            Molecule or atom designation. For a list of valid designations see
+            the :meth:`print_mols` method.
+
+        Returns
+        -------
+        Tuple of tables: ({rateid: Table, },
+                          Table,
+                          Table)
+
+        Examples
+        --------
+        >>> from astroquery import lamda
+        >>> collrates,radtransitions,enlevels = lamda.query(mol='co')
+        >>> enlevels.pprint()
+        LEVEL ENERGIES(cm^-1) WEIGHT  J
+        ----- --------------- ------ ---
+            2     3.845033413    3.0   1
+            3    11.534919938    5.0   2
+          ...             ...    ... ...
+        >>> collrates['H2'].pprint(max_width=60)
+        Transition Upper Lower ... C_ij(T=325) C_ij(T=375)
+        ---------- ----- ----- ... ----------- -----------
+                 1     2     1 ...     2.8e-11       3e-11
+                 2     3     1 ...     1.8e-11     1.9e-11
+        """
+        # Send HTTP request to open URL
+        datafile = [s.strip() for s in
+                    self._get_molfile(mol).text.splitlines()]
+        if return_datafile:
+            return datafile
+        # Parse datafile string list and return a table
+        tables = parse_lamda_lines(datafile)
+        return tables
+
+    def get_molecule_list(self, cache=True):
+        """
+        Scrape the list of valid molecules
+        """
+        if cache and hasattr(self, '_molecule_dict'):
+            return self._molecule_dict
+
+        url = 'http://home.strw.leidenuniv.nl/~moldata/'
+        response = requests.get(url)
+        response.raise_for_status()
+
+        soup = BeautifulSoup(response.content)
+
+        links = soup.find_all('a', href=True)
+        datfile_urls = [url
+                        for link in links
+                        for url in _find_datfiles(link['href'])]
+
+        molecule_re = re.compile(r'http://[a-zA-Z0-9.]*/~moldata/datafiles/([A-Z0-9a-z_-]*).dat')
+        molecule_dict = {molecule_re.search(url).groups()[0]:
+                         url
+                         for url in datfile_urls}
+        self._molecule_dict = molecule_dict
+
+        return molecule_dict
+
+
+def _find_datfiles(url):
+    response = requests.get(url)
     response.raise_for_status()
-    return response
 
-def download_molfile(mol, outfilename):
-    molreq = get_molfile(mol)
-    with open(outfilename,'w') as f:
-        f.write(molreq.text)
+    soup = BeautifulSoup(response.content)
 
-def query(mol, query_type=None, coll_partner_index=0, return_datafile=False):
-    """
-    Query the LAMDA database.
+    links = soup.find_all('a', href=True)
 
-    Parameters
-    ----------
-    mol : string
-        Molecule or atom designation. For a list of valid designations see
-        the :meth:`print_mols` method.
+    urls = [link['href'] for link in links if '.dat' in link['href']]
 
-    Returns
-    -------
-    Tuple of tables: ({rateid: Table, },
-                      Table,
-                      Table)
-
-    Examples
-    --------
-    >>> from astroquery import lamda
-    >>> collrates,radtransitions,enlevels = lamda.query(mol='co')
-    >>> enlevels.pprint()
-    LEVEL ENERGIES(cm^-1) WEIGHT  J
-    ----- --------------- ------ ---
-        2     3.845033413    3.0   1
-        3    11.534919938    5.0   2
-      ...             ...    ... ...
-    >>> collrates['H2'].pprint(max_width=60)
-    Transition Upper Lower ... C_ij(T=325) C_ij(T=375)
-    ---------- ----- ----- ... ----------- -----------
-             1     2     1 ...     2.8e-11       3e-11
-             2     3     1 ...     1.8e-11     1.9e-11
-    """
-    # Send HTTP request to open URL
-    datafile = [s.strip() for s in get_molfile(mol).text.splitlines()]
-    if return_datafile:
-        return datafile
-    # Parse datafile string list and return a table
-    tables = parse_lamda_lines(datafile)
-    return tables
-
-
-def _cln(s):
-    """
-    Clean a string of comments, newlines
-    """
-    return s.split("!")[0].strip()
+    return urls
 
 def parse_lamda_datafile(filename):
     with open(filename) as f:
@@ -244,6 +242,10 @@ def parse_lamda_lines(data):
 
     return coll_tables,rad_table,mol_table
 
+def _cln(s):
+    """
+    Clean a string of comments, newlines
+    """
+    return s.split("!")[0].strip()
 
-if __name__ == "__main__":
-    pass
+Lamda = LamdaClass()

--- a/astroquery/lamda/tests/test_lamda.py
+++ b/astroquery/lamda/tests/test_lamda.py
@@ -1,48 +1,16 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 import os
-import requests
-from astropy.tests.helper import pytest
-from ... import lamda
+from ...lamda import Lamda,core
 from ...utils.testing_tools import MockResponse
 
 DATA_FILES = {'co': 'co.txt'}
-
 
 def data_path(filename):
     data_dir = os.path.join(os.path.dirname(__file__), 'data')
     return os.path.join(data_dir, filename)
 
-
-def get_mockreturn(url, params=None, timeout=10, **kwargs):
-    filename = data_path(DATA_FILES['co'])
-    content = open(filename, 'rb').read()
-    return MockResponse(content, **kwargs)
-
-
-@pytest.fixture
-def patch_get(request):
-    mp = request.getfuncargvalue("monkeypatch")
-    mp.setattr(requests, 'get', get_mockreturn)
-    return mp
-
-
-def test_print_query():
-    lamda.print_mols()
-
-
-def test_query_levels(patch_get):
-    lamda.query(mol='co', query_type='erg_levels')
-
-
-def test_query_radtrans(patch_get):
-    lamda.query(mol='co', query_type='rad_trans')
-
-
-def test_query_collrates(patch_get):
-    lamda.query(mol='co', query_type='coll_rates', coll_partner_index=1)
-
 def test_parser():
-    collrates,radtransitions,enlevels = lamda.core.parse_lamda_datafile(data_path('co.txt'))
+    collrates,radtransitions,enlevels = core.parse_lamda_datafile(data_path('co.txt'))
 
     assert set(collrates.keys()) == set(['PH2', 'OH2'])
     assert len(enlevels) == 41

--- a/astroquery/lamda/tests/test_lamda_remote.py
+++ b/astroquery/lamda/tests/test_lamda_remote.py
@@ -8,7 +8,7 @@ imp.reload(requests)
 
 @remote_data
 def test_query():
-    result = lamda.query(mol='co', query_type='erg_levels')
+    result = lamda.Lamda.query(mol='co')
     assert [len(r) for r in result] == [2, 40, 41]
     collider_dict = result[0]
     assert collider_dict.keys() == ['PH2', 'OH2']

--- a/astroquery/lamda/utils.py
+++ b/astroquery/lamda/utils.py
@@ -4,7 +4,7 @@ from astropy import constants
 from astropy import units as u
 
 def ncrit(lamda_tables, transition_upper, transition_lower, temperature, OPR=3,
-          partners=['H2', 'oH2', 'pH2']):
+          partners=['H2', 'OH2', 'PH2']):
     """
     Compute the critical density for a transition given its temperature.
 

--- a/astroquery/lamda/utils.py
+++ b/astroquery/lamda/utils.py
@@ -1,0 +1,70 @@
+import numpy as np
+import re
+from astropy import constants
+from astropy import units as u
+
+def ncrit(lamda_tables, transition_upper, transition_lower, temperature, OPR=3,):
+    """
+
+    """
+    
+    fortho = (OPR)/(OPR-1)
+
+    crates = lamda_tables[0]
+    avals = lamda_tables[1]
+    enlevs = lamda_tables[2]
+
+    aval = avals[(avals['Upper']==transition_upper) &
+                 (avals['Lower']==transition_lower)]['EinsteinA'][0]
+
+    temperature_re = re.compile("C_ij\(T=([0-9]*)\)")
+    crate_temperatures = np.array([int(temperature_re.search(cn).groups()[0])
+                                   for cn in crates[crates.keys()[0]].keys()
+                                   if temperature_re.search(cn)
+                         ])
+    if temperature < crate_temperatures.min():
+        crates_ji_all = {coll: cr['C_ij(T={0})'.format(crate_temperatures.min())]
+                         for coll,cr in crates.items()}
+    elif temperature > crate_temperatures.max():
+        crates_ji_all = {coll: cr['C_ij(T={0})'.format(crate_temperatures.max())]
+                         for coll,cr in crates.items()}
+    elif temperature in crate_temperatures:
+        crates_ji_all = {coll: cr['C_ij(T={0})'.format(temperature)]
+                         for coll,cr in crates.items()}
+    else: # interpolate
+        nearest = np.argmin(np.abs(temperature-crate_temperatures))
+        if crate_temperatures[nearest] < temperature:
+            low, high = crate_temperatures[nearest], crate_temperatures[nearest+1]
+        else:
+            low, high = crate_temperatures[nearest-1], crate_temperatures[nearest]
+        crates_ji_all = {coll: 
+                              (cr['C_ij(T={0})'.format(high)]-cr['C_ij(T={0})'.format(low)])*(temperature-low)/(high-low)
+                               +cr['C_ij(T={0})'.format(low)]
+                         for coll,cr in crates.items()}
+
+    transition_indices_ji = {coll: np.nonzero(cr['Upper']==transition_upper)[0] for coll,cr in crates.items()}
+    crates_ji = {coll: crates_ji_all[coll][transition_indices_ji[coll]]
+                 for coll in crates}
+
+
+    # i > j: collisions from higher levels
+    transition_indices_ij = {coll: np.nonzero(cr['Lower']==transition_upper)[0] for coll,cr in crates.items()}
+    coll = crates.keys()[0]
+    degeneracies_i = enlevs['Weight'][crates[coll][transition_indices_ij[coll]]['Upper']-1]
+    degeneracies_j = enlevs['Weight'][crates[coll][transition_indices_ij[coll]]['Lower']-1]
+    energy_i = enlevs['Energy'][crates[coll][transition_indices_ij[coll]]['Upper']-1] *u.cm**-1
+    energy_j = enlevs['Energy'][crates[coll][transition_indices_ij[coll]]['Lower']-1] *u.cm**-1
+    # Shirley 2015 eqn 4:
+    crates_ij = {coll: (crates_ji_all[coll][transition_indices_ij[coll]] * degeneracies_i/degeneracies_j.astype('float')
+                       * np.exp((-energy_i-energy_j).to(u.erg, u.spectral())/(constants.k_B * temperature * u.K)))
+                 for coll in crates}
+
+    crates_tot_percollider = {coll: (np.sum(crates_ij[coll]) + np.sum(crates_ji[coll])) * u.cm**3/u.s
+                              for coll in crates}
+    if 'OH2' in crates:
+        crates_tot = fortho*crates_tot_percollider['OH2'] + (1-fortho)*crates_tot_percollider['PH2']
+    elif 'H2' in crates:
+        crates_tot = crates_tot_percollider['H2']
+
+
+    return ((aval*u.s**-1) / crates_tot).to(u.cm**-3)

--- a/astroquery/lamda/utils.py
+++ b/astroquery/lamda/utils.py
@@ -74,15 +74,15 @@ def ncrit(lamda_tables, transition_upper, transition_lower, temperature, OPR=3,)
 
     # i > j: collisions from higher levels
     transition_indices_ij = {coll: np.nonzero(cr['Lower']==transition_upper)[0] for coll,cr in crates.items()}
-    coll = crates.keys()[0]
-    degeneracies_i = enlevs['Weight'][crates[coll][transition_indices_ij[coll]]['Upper']-1]
-    degeneracies_j = enlevs['Weight'][crates[coll][transition_indices_ij[coll]]['Lower']-1]
-    energy_i = enlevs['Energy'][crates[coll][transition_indices_ij[coll]]['Upper']-1] *u.cm**-1
-    energy_j = enlevs['Energy'][crates[coll][transition_indices_ij[coll]]['Lower']-1] *u.cm**-1
-    # Shirley 2015 eqn 4:
-    crates_ij = {coll: (crates_ji_all[coll][transition_indices_ij[coll]] * degeneracies_i/degeneracies_j.astype('float')
-                       * np.exp((-energy_i-energy_j).to(u.erg, u.spectral())/(constants.k_B * temperature * u.K)))
-                 for coll in crates}
+    crates_ij = {}
+    for coll in crates.keys():
+        degeneracies_i = enlevs['Weight'][crates[coll][transition_indices_ij[coll]]['Upper']-1]
+        degeneracies_j = enlevs['Weight'][crates[coll][transition_indices_ij[coll]]['Lower']-1]
+        energy_i = enlevs['Energy'][crates[coll][transition_indices_ij[coll]]['Upper']-1] *u.cm**-1
+        energy_j = enlevs['Energy'][crates[coll][transition_indices_ij[coll]]['Lower']-1] *u.cm**-1
+        # Shirley 2015 eqn 4:
+        crates_ij[coll] = (crates_ji_all[coll][transition_indices_ij[coll]] * degeneracies_i/degeneracies_j.astype('float')
+                           * np.exp((-energy_i-energy_j).to(u.erg, u.spectral())/(constants.k_B * temperature * u.K)))
 
     crates_tot_percollider = {coll: (np.sum(crates_ij[coll]) + np.sum(crates_ji[coll])) * u.cm**3/u.s
                               for coll in crates}

--- a/astroquery/lamda/utils.py
+++ b/astroquery/lamda/utils.py
@@ -94,6 +94,8 @@ def ncrit(lamda_tables, transition_upper, transition_lower, temperature, OPR=3,
                               for coll in crates}
     if 'OH2' in crates:
         crates_tot = fortho*crates_tot_percollider['OH2'] + (1-fortho)*crates_tot_percollider['PH2']
+    elif 'PH2' in crates:
+        crates_tot = crates_tot_percollider['PH2']
     elif 'H2' in crates:
         crates_tot = crates_tot_percollider['H2']
 

--- a/astroquery/lamda/utils.py
+++ b/astroquery/lamda/utils.py
@@ -5,7 +5,32 @@ from astropy import units as u
 
 def ncrit(lamda_tables, transition_upper, transition_lower, temperature, OPR=3,):
     """
+    Compute the critical density for a transition given its temperature.
 
+    The critical density is defined as the Einstein A value divided by the sum
+    of the collision rates into the state minus the collision rates out of that
+    state.  See Shirley et al 2015, eqn 4
+    (http://esoads.eso.org/cgi-bin/bib_query?arXiv:1501.01629)    
+
+    Parameters
+    ----------
+    lamda_tables : list
+        The list of LAMDA tables returned from a Lamda.query operation.  Should be
+        [ collision_rates_dict, Avals/Freqs, Energy Levels ]
+    transition_upper : int
+        The upper transition number as indexed in the lamda catalog
+    transition_lower: int
+        The lower transition number as indexed in the lamda catalog
+    temperature : float
+        Kinetic temperature in Kelvin.  Will be interpolated as appropriate.
+        Extrapolation uses nearest value
+    OPR : float
+        ortho/para ratio of h2 if para/ortho h2 are included as colliders
+
+    Returns
+    -------
+    ncrit : astropy.units.Quantity
+        A quantity with units cm^-3
     """
     
     fortho = (OPR)/(OPR-1)

--- a/astroquery/lamda/utils.py
+++ b/astroquery/lamda/utils.py
@@ -3,7 +3,8 @@ import re
 from astropy import constants
 from astropy import units as u
 
-def ncrit(lamda_tables, transition_upper, transition_lower, temperature, OPR=3,):
+def ncrit(lamda_tables, transition_upper, transition_lower, temperature, OPR=3,
+          partners=['H2', 'oH2', 'pH2']):
     """
     Compute the critical density for a transition given its temperature.
 
@@ -26,6 +27,9 @@ def ncrit(lamda_tables, transition_upper, transition_lower, temperature, OPR=3,)
         Extrapolation uses nearest value
     OPR : float
         ortho/para ratio of h2 if para/ortho h2 are included as colliders
+    partners : list
+        A list of valid partners.  It probably does not make sense to include
+        both electrons and H2 because they'll have different densities.
 
     Returns
     -------
@@ -35,7 +39,9 @@ def ncrit(lamda_tables, transition_upper, transition_lower, temperature, OPR=3,)
     
     fortho = (OPR)/(OPR-1)
 
-    crates = lamda_tables[0]
+    # exclude partners that are explicitly excluded
+    crates = {coll: val for coll, val in lamda_tables[0].items()
+              if coll in partners}
     avals = lamda_tables[1]
     enlevs = lamda_tables[2]
 


### PR DESCRIPTION
The critical density for an n>2 level system requires full knowledge of the collision rate network.  It's not trivial to compute, so I've added a utility for it.  Also, a minor bugfix to raise a useful error when LAMDA fails.

The critical density tool needs tests and docs prior to merging.