### PR TITLE
Adding absolute_import to all setup_package

### DIFF
--- a/astroquery/alfalfa/tests/setup_package.py
+++ b/astroquery/alfalfa/tests/setup_package.py
@@ -1,4 +1,6 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
+from __future__ import absolute_import
+
 import os
 
 

--- a/astroquery/alma/setup_package.py
+++ b/astroquery/alma/setup_package.py
@@ -1,4 +1,6 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
+from __future__ import absolute_import
+
 import os
 
 

--- a/astroquery/alma/tests/setup_package.py
+++ b/astroquery/alma/tests/setup_package.py
@@ -1,4 +1,6 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
+from __future__ import absolute_import
+
 import os
 
 

--- a/astroquery/atomic/setup_package.py
+++ b/astroquery/atomic/setup_package.py
@@ -1,3 +1,5 @@
+from __future__ import absolute_import
+
 import os.path
 
 

--- a/astroquery/besancon/tests/setup_package.py
+++ b/astroquery/besancon/tests/setup_package.py
@@ -1,4 +1,6 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
+from __future__ import absolute_import
+
 import os
 
 

--- a/astroquery/eso/tests/setup_package.py
+++ b/astroquery/eso/tests/setup_package.py
@@ -1,4 +1,6 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
+from __future__ import absolute_import
+
 import os
 
 

--- a/astroquery/fermi/setup_package.py
+++ b/astroquery/fermi/setup_package.py
@@ -1,4 +1,6 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
+from __future__ import absolute_import
+
 import os
 
 

--- a/astroquery/gama/tests/setup_package.py
+++ b/astroquery/gama/tests/setup_package.py
@@ -1,4 +1,6 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
+from __future__ import absolute_import
+
 import os
 
 

--- a/astroquery/heasarc/tests/setup_package.py
+++ b/astroquery/heasarc/tests/setup_package.py
@@ -1,4 +1,6 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
+from __future__ import absolute_import
+
 import os
 
 

--- a/astroquery/irsa/tests/setup_package.py
+++ b/astroquery/irsa/tests/setup_package.py
@@ -1,4 +1,6 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
+from __future__ import absolute_import
+
 import os
 
 

--- a/astroquery/irsa_dust/tests/setup_package.py
+++ b/astroquery/irsa_dust/tests/setup_package.py
@@ -1,4 +1,6 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
+from __future__ import absolute_import
+
 import os
 
 

--- a/astroquery/lamda/tests/setup_package.py
+++ b/astroquery/lamda/tests/setup_package.py
@@ -1,4 +1,6 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
+from __future__ import absolute_import
+
 import os
 
 

--- a/astroquery/lcogt/tests/setup_package.py
+++ b/astroquery/lcogt/tests/setup_package.py
@@ -1,4 +1,6 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
+from __future__ import absolute_import
+
 import os
 
 

--- a/astroquery/magpis/tests/setup_package.py
+++ b/astroquery/magpis/tests/setup_package.py
@@ -1,4 +1,6 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
+from __future__ import absolute_import
+
 import os
 
 

--- a/astroquery/ned/setup_package.py
+++ b/astroquery/ned/setup_package.py
@@ -1,4 +1,6 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
+from __future__ import absolute_import
+
 import os
 
 

--- a/astroquery/nist/tests/setup_package.py
+++ b/astroquery/nist/tests/setup_package.py
@@ -1,4 +1,6 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
+from __future__ import absolute_import
+
 import os
 
 

--- a/astroquery/nrao/tests/setup_package.py
+++ b/astroquery/nrao/tests/setup_package.py
@@ -1,4 +1,6 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
+from __future__ import absolute_import
+
 import os
 
 

--- a/astroquery/nvas/tests/setup_package.py
+++ b/astroquery/nvas/tests/setup_package.py
@@ -1,4 +1,6 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
+from __future__ import absolute_import
+
 import os
 
 

--- a/astroquery/ogle/tests/setup_package.py
+++ b/astroquery/ogle/tests/setup_package.py
@@ -1,4 +1,6 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
+from __future__ import absolute_import
+
 import os
 
 

--- a/astroquery/open_exoplanet_catalogue/tests/setup_package.py
+++ b/astroquery/open_exoplanet_catalogue/tests/setup_package.py
@@ -1,4 +1,6 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
+from __future__ import absolute_import
+
 import os
 
 

--- a/astroquery/sdss/tests/setup_package.py
+++ b/astroquery/sdss/tests/setup_package.py
@@ -1,4 +1,6 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
+from __future__ import absolute_import
+
 import os
 
 

--- a/astroquery/setup_package.py
+++ b/astroquery/setup_package.py
@@ -1,4 +1,6 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
+from __future__ import absolute_import
+
 
 def get_package_data():
     return {'astroquery': ['astroquery.cfg']}

--- a/astroquery/sha/tests/setup_package.py
+++ b/astroquery/sha/tests/setup_package.py
@@ -1,4 +1,6 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
+from __future__ import absolute_import
+
 import os
 
 

--- a/astroquery/simbad/setup_package.py
+++ b/astroquery/simbad/setup_package.py
@@ -1,4 +1,6 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
+from __future__ import absolute_import
+
 import os
 
 

--- a/astroquery/skyview/setup_package.py
+++ b/astroquery/skyview/setup_package.py
@@ -1,4 +1,6 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
+from __future__ import absolute_import
+
 import os
 
 

--- a/astroquery/splatalogue/setup_package.py
+++ b/astroquery/splatalogue/setup_package.py
@@ -1,4 +1,6 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
+from __future__ import absolute_import
+
 import os
 
 

--- a/astroquery/template_module/tests/setup_package.py
+++ b/astroquery/template_module/tests/setup_package.py
@@ -1,4 +1,6 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
+from __future__ import absolute_import
+
 import os
 
 

--- a/astroquery/tests/setup_package.py
+++ b/astroquery/tests/setup_package.py
@@ -1,4 +1,5 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
+from __future__ import absolute_import
 
 
 def get_package_data():

--- a/astroquery/ukidss/tests/setup_package.py
+++ b/astroquery/ukidss/tests/setup_package.py
@@ -1,4 +1,6 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
+from __future__ import absolute_import
+
 import os
 
 

--- a/astroquery/vizier/setup_package.py
+++ b/astroquery/vizier/setup_package.py
@@ -1,4 +1,6 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
+from __future__ import absolute_import
+
 import os
 
 

--- a/astroquery/xmatch/setup_package.py
+++ b/astroquery/xmatch/setup_package.py
@@ -1,4 +1,6 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
+from __future__ import absolute_import
+
 import os
 
 


### PR DESCRIPTION
There are many RuntimeWarning due to absolute imports. Those are fixed in the PR by adding 
```
from __future__ import absolute_import
```
to the ``setup_package.py`` files.

The same issue was solved in astropy in: https://github.com/astropy/astropy/pull/3215