### PR TITLE
Eso/alma minor test clean

### DIFF
--- a/astroquery/alma/tests/test_alma_remote.py
+++ b/astroquery/alma/tests/test_alma_remote.py
@@ -1,15 +1,25 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
-import os
 import tempfile
 import shutil
 import numpy as np
 from astropy.tests.helper import pytest, remote_data
 from astropy import coordinates
 from astropy import units as u
-from .. import Alma
-from ...exceptions import LoginError
+
+# keyring is an optional dependency required by the alma module.
+try:
+    import keyring
+    HAS_KEYRING = True
+except ImportError:
+    HAS_KEYRING = False
+
+if HAS_KEYRING:
+    from .. import Alma
+
+SKIP_TESTS = not HAS_KEYRING
 
 
+@pytest.mark.skipif('SKIP_TESTS')
 @remote_data
 class TestAlma:
 
@@ -19,6 +29,7 @@ class TestAlma:
     @pytest.fixture()
     def temp_dir(self, request):
         my_temp_dir = tempfile.mkdtemp()
+
         def fin():
             shutil.rmtree(my_temp_dir)
         request.addfinalizer(fin)
@@ -97,7 +108,7 @@ class TestAlma:
 
         target = 'NGC4945'
         project_code = '2012.1.00912.S'
-        
+
         payload = {'project_code':project_code,
                    'source_name_alma':target,}
         result = alma.query(payload=payload)
@@ -130,7 +141,7 @@ class TestAlma:
 
         target = 'NGC4945'
         project_code = '2011.0.00121.S'
-        
+
         payload = {'project_code':project_code,
                    'source_name_alma':target,}
         result = alma.query(payload=payload)
@@ -155,7 +166,7 @@ class TestAlma:
         assert len(data) == 8
 
     def test_help(self):
-        
+
         help_list = Alma._get_help_page()
         assert help_list[0][0] == u'Position'
         assert help_list[1][0] == u'Energy'

--- a/astroquery/cosmosim/tests/test_cosmosim_remote.py
+++ b/astroquery/cosmosim/tests/test_cosmosim_remote.py
@@ -3,22 +3,21 @@ import os
 import tempfile
 import shutil
 from astropy.tests.helper import pytest, remote_data
+from ...exceptions import LoginError
+
 try:
     import keyring
     HAS_KEYRING = True
 except ImportError:
     HAS_KEYRING = False
-try:
-    from ...cosmosim import CosmoSim
-    COSMOSIM_IMPORTED = True
-except ImportError:
-    COSMOSIM_IMPORTED = False
-from ...exceptions import LoginError
 
-SKIP_TESTS = not(HAS_KEYRING and COSMOSIM_IMPORTED)
+if HAS_KEYRING:
+    from ...cosmosim import CosmoSim
+
+SKIP_TESTS = not HAS_KEYRING
 
 #@pytest.mark.skipif('SKIP_TESTS')
 #@remote_data
 #class TestEso:
 #    def __init__():
-        
+

--- a/astroquery/eso/tests/test_eso.py
+++ b/astroquery/eso/tests/test_eso.py
@@ -1,16 +1,19 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 import os
-from distutils.version import LooseVersion
-import astropy
-try:
-    from ...eso import Eso
-    ESO_IMPORTED = True
-except ImportError:
-    ESO_IMPORTED = False
 from astropy.tests.helper import pytest
 from ...utils.testing_tools import MockResponse
 
-SKIP_TESTS = not ESO_IMPORTED
+# keyring is an optional dependency required by the eso module.
+try:
+    import keyring
+    HAS_KEYRING = True
+except ImportError:
+    HAS_KEYRING = False
+
+if HAS_KEYRING:
+    from ...eso import Eso
+
+SKIP_TESTS = not HAS_KEYRING
 
 DATA_DIR = os.path.join(os.path.dirname(__file__), 'data')
 
@@ -22,12 +25,12 @@ DATA_FILES = {'GET': {'http://archive.eso.org/wdb/wdb/eso/amber/form':
                       'amber_form.html',
                       'http://archive.eso.org/wdb/wdb/adp/phase3_main/form':
                       'vvv_sgra_form.html',
-                     },
+                      },
               'POST': {'http://archive.eso.org/wdb/wdb/eso/amber/query':
                        'amber_sgra_query.tbl',
                        'http://archive.eso.org/wdb/wdb/adp/phase3_main/query':
                        'vvv_sgra_survey_response.tbl',
-                      }
+                       }
               }
 
 
@@ -63,6 +66,7 @@ def test_SgrAstar(monkeypatch):
     # test that max_results = 50
     assert len(result) == 50
     assert 'GC_IRS7' in result['Object']
+
 
 @pytest.mark.skipif('SKIP_TESTS')
 def test_vvv(monkeypatch):

--- a/astroquery/eso/tests/test_eso_remote.py
+++ b/astroquery/eso/tests/test_eso_remote.py
@@ -2,19 +2,19 @@
 import tempfile
 import shutil
 from astropy.tests.helper import pytest, remote_data
+from ...exceptions import LoginError
+
+# keyring is an optional dependency required by the eso module.
 try:
     import keyring
     HAS_KEYRING = True
 except ImportError:
     HAS_KEYRING = False
-try:
-    from ...eso import Eso
-    ESO_IMPORTED = True
-except ImportError:
-    ESO_IMPORTED = False
-from ...exceptions import LoginError
 
-SKIP_TESTS = not(HAS_KEYRING and ESO_IMPORTED)
+if HAS_KEYRING:
+    from ...eso import Eso
+
+SKIP_TESTS = not HAS_KEYRING
 
 instrument_list = [u'fors1', u'fors2', u'sphere', u'vimos', u'omegacam',
                    u'hawki', u'isaac', u'naco', u'visir', u'vircam', u'apex',


### PR DESCRIPTION
As mentioned in #551, only keyring import should be in a try...except and not the eso module import. This PR fixes that.

Also does the same for the alma module, as it requires keyring, too.