### PR TITLE
Bugfix - payload keyword 'version' should be 'data_version'. 

### DIFF
--- a/astroquery/splatalogue/core.py
+++ b/astroquery/splatalogue/core.py
@@ -27,7 +27,7 @@ class SplatalogueClass(BaseQuery):
     QUERY_URL = conf.query_url
     TIMEOUT = conf.timeout
     LINES_LIMIT = conf.lines_limit
-    versions = ('v1.0', 'v2.0')
+    versions = ('v1.0', 'v2.0', 'vall')
     # global constant, not user-configurable
     ALL_LINE_LISTS = ('Lovas', 'SLAIM', 'JPL', 'CDMS', 'ToyoMA', 'OSU',
                       'Recomb', 'Lisa', 'RFI')
@@ -170,7 +170,7 @@ class SplatalogueClass(BaseQuery):
             The type of intensity on which to place a lower limit
         transition : str
             e.g. 1-0
-        version : ``'v1.0'`` or ``'v2.0'``
+        version : ``'v1.0'`` or ``'v2.0'`` or ``'vall'``
             Data version
         exclude : list
             Types of lines to exclude.  Default is:
@@ -274,7 +274,7 @@ class SplatalogueClass(BaseQuery):
             payload['tran'] = transition
 
         if version in self.versions:
-            payload['version'] = version
+            payload['data_version'] = version
         elif version is not None:
             raise ValueError("Invalid version specified.  Allowed versions are {vers}".format(vers=str(self.versions)))
 

--- a/astroquery/splatalogue/tests/test_splatalogue.py
+++ b/astroquery/splatalogue/tests/test_splatalogue.py
@@ -2,7 +2,7 @@
 from ... import splatalogue
 from ...utils.testing_tools import MockResponse
 from astropy import units as u
-from astropy.tests.helper import pytest
+from astropy.tests.helper import pytest, remote_data
 import requests
 import os
 
@@ -101,6 +101,7 @@ def test_band_crashorno():
 
 
 # regression test : version selection should work
+@remote_data
 def test_version_selection():
     results = splatalogue.Splatalogue.query_lines(
     min_frequency= 703*u.GHz,

--- a/astroquery/splatalogue/tests/test_splatalogue.py
+++ b/astroquery/splatalogue/tests/test_splatalogue.py
@@ -61,6 +61,7 @@ def test_get_payload():
                                                        get_query_payload=True)
     assert '__utma' in q
 
+
 # regression test: line lists should ask for only one line list, not all
 def test_line_lists():
     q = splatalogue.core.Splatalogue.query_lines_async(1 * u.GHz, 10 * u.GHz,
@@ -97,3 +98,14 @@ def test_band_crashorno():
         splatalogue.core.Splatalogue.query_lines_async(band='invalid',
                                                        get_query_payload=True)
     assert exc.value.args[0] == "Invalid frequency band."
+
+
+# regression test : version selection should work
+def test_version_selection():
+    results = splatalogue.Splatalogue.query_lines(
+    min_frequency= 703*u.GHz,
+    max_frequency=706*u.GHz,
+    chemical_name='Acetaldehyde',
+    version='v1.0'
+    )
+    assert len(results)==1


### PR DESCRIPTION
The payload keyword ['version'] should be ['data_version'], don't know if Splatalogue changed this recently or if we had it wrong previously.
I also added the 'vall' option to the version selection (i.e. both v1.0 and v2.0).

To reproduce this in the unfixed version: 
```python
from astroquery import splatalogue
import astropy.units as u
results = splatalogue.Splatalogue.query_lines(
    min_frequency= 703*u.GHz,
    max_frequency=706*u.GHz,
    chemical_name='Acetaldehyde',
    version='v1.0'
    )
len(results)
```
This is equivalent to this (except the filter for vt=0) URL:
http://www.cv.nrao.edu/php/splat/c.php?submit=submit&sid[]=393&chemical_name=Acetaldehyde%20(CH3CHO%20vt=0)&el4=el4&ls1=ls1&displayRecomb=displayRecomb&displayLovas=displayLovas&displaySLAIM=displaySLAIM&displayJPL=displayJPL&displayCDMS=displayCDMS&displayToyaMA=displayToyaMA&displayOSU=displayOSU&displayLisa=displayLisa&displayRFI=displayRFI&data_version=v1.0&no_atmospheric=no_atmospheric&from=703&to=706&frequency_units=GHz&show_unres_qn=show_unres_qn&show_upper_degeneracy=show_upper_degeneracy&submit=1

with the fix the length is just 1, without it, it is 144. 
