### PR TITLE
Handle radio button case in Eso form activation

### DIFF
--- a/astroquery/eso/core.py
+++ b/astroquery/eso/core.py
@@ -88,7 +88,7 @@ class EsoClass(QueryWithLogin):
             if tag_name == 'input':
                 is_file = (form_elem.get('type') == 'file')
                 value = form_elem.get('value')
-                if form_elem.get('type') == 'checkbox':
+                if form_elem.get('type') in ['checkbox','radio']:
                     if form_elem.has_attr('checked'):
                         if not value:
                             value = 'on'


### PR DESCRIPTION
Getting datasets out of the ESO archived had stopped working. This was traced down to mis-handled radio buttons that are now in use in the request confirmation process.