### PR TITLE
Add support for GROND to ESO query_instrument

### DIFF
--- a/astroquery/eso/core.py
+++ b/astroquery/eso/core.py
@@ -321,6 +321,8 @@ class EsoClass(QueryWithLogin):
 
         if instrument in ('feros','harps'):
             url = 'http://archive.eso.org/wdb/wdb/eso/repro/form'
+        elif instrument == 'grond':
+            url = 'http://archive.eso.org/wdb/wdb/eso/eso_archive_main/form'
         else:
             url = "http://archive.eso.org/wdb/wdb/eso/{0}/form".format(instrument)
         table = None
@@ -340,6 +342,9 @@ class EsoClass(QueryWithLogin):
             query_dict['tab_dp_id'] = (kwargs.pop('tab_dp_id')
                                        if 'tab_db_id' in kwargs
                                        else 'on')
+
+            if instrument == 'grond':
+                query_dict['instrument'] = "GROND"
 
             for k in columns:
                 query_dict["tab_" + k] = True


### PR DESCRIPTION
GROND doesn't have it's own instrument-specific page in the ESO archive, so you have to query the generic archive page.
Perhaps this applies to some other instruments as well?