### PR TITLE
pass data by file

### DIFF
--- a/astroquery/sdss/core.py
+++ b/astroquery/sdss/core.py
@@ -149,7 +149,8 @@ class SDSSClass(BaseQuery):
                              for i in range(len(coordinates))])
 
         # firstcol is hardwired, as obj_names is always passed
-        request_payload = dict(uquery=sql_query, paste=data,
+        files = {'upload': ('astroquery', data)}
+        request_payload = dict(uquery=sql_query,
                                firstcol=1,
                                format='csv', photoScope='nearPrim',
                                radius=radius,
@@ -159,6 +160,7 @@ class SDSSClass(BaseQuery):
             return request_payload
         url = self._get_crossid_url(dr)
         response = self._request("POST", url, params=request_payload,
+                                 files=files,
                                  timeout=timeout, cache=cache)
         return response
 


### PR DESCRIPTION
I don't know whether this is universal or not. When I tries to do cross_id for a larger list of coordinates (~400, which is not that large really), it fails and gives such message:

```
Your_browser_sent_an_invalid_request
------------------------------------
                      </body></html>
```

Without digging into the details, I suspect this is due to some limitation in requests library (?)

Instead of passing the data via `paste` field, now the data is passed as a file. At least this now works for me.
