### PR TITLE
Fix SkyView encoding bug for downloading images

### DIFF
--- a/astroquery/skyview/core.py
+++ b/astroquery/skyview/core.py
@@ -219,7 +219,7 @@ class SkyViewClass(BaseQuery):
                                          gridlabels, radius=radius,
                                          height=height, width=width,
                                          cache=cache)
-        return [commons.FileContainer(url) for url in image_urls]
+        return [commons.FileContainer(url, encoding='binary') for url in image_urls]
 
     @prepend_docstr_noreturns(get_images.__doc__)
     def get_image_list(self, position, survey, coordinates=None,

--- a/astroquery/skyview/tests/test_skyview_remote.py
+++ b/astroquery/skyview/tests/test_skyview_remote.py
@@ -1,5 +1,6 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 from astropy.tests.helper import remote_data
+from astropy.io.fits import HDUList
 
 from ...skyview import SkyView
 from .test_skyview import data_path
@@ -15,11 +16,9 @@ def test_get_image_list():
 
 @remote_data
 def test_get_images():
-    images = SkyView().get_image_list(position='Eta Carinae',
-                                      survey=['2MASS-K'])
+    images = SkyView().get_images(position='Eta Carinae', survey=['2MASS-J'])
     assert len(images) == 1
-    for im in images:
-        assert im.startswith('http://skyview.gsfc.nasa.gov/')
+    assert isinstance(images[0], HDUList)
 
 @remote_data
 def test_survey_list():


### PR DESCRIPTION
This fixes #593 

It tentatively fixes the (remote) unit test accordingly, to actually download the image and catch this bug.
There is no change for the local unit test.
