### PR TITLE
BUGFIX:  ALMA private queries, plus checking that queries succeed

### DIFF
--- a/astroquery/alma/core.py
+++ b/astroquery/alma/core.py
@@ -295,6 +295,11 @@ class AlmaClass(QueryWithLogin):
 
         username = self._username if hasattr(self, '_username') else 'anonymous'
 
+        # templates:
+        # https://almascience.eso.org/dataPortal/requests/keflavich/946895898/ALMA/
+        # 2013.1.00308.S_uid___A001_X196_X93_001_of_001.tar/2013.1.00308.S_uid___A001_X196_X93_001_of_001.tar
+        # uid___A002_X9ee74a_X26f0/2013.1.00308.S_uid___A002_X9ee74a_X26f0.asdm.sdm.tar
+
         url_decomposed = urlparse(data_page_url)
         base_url = ('{uri.scheme}://{uri.netloc}/'
                     'dataPortal/requests/{username}/'
@@ -894,13 +899,26 @@ class AlmaClass(QueryWithLogin):
                 # example template for constructing url:
                 # https://almascience.eso.org/dataPortal/requests/keflavich/940238268/ALMA/
                 # uid___A002_X9d6f4c_X154/2013.1.00546.S_uid___A002_X9d6f4c_X154.asdm.sdm.tar
-                # above is WRONG
+                # above is WRONG... except for ASDMs, when it's right
                 # should be:
                 # 2013.1.00546.S_uid___A002_X9d6f4c_X154.asdm.sdm.tar/2013.1.00546.S_uid___A002_X9d6f4c_X154.asdm.sdm.tar
-                url = os.path.join(base_url,
-                                   entry['file_name'],
-                                   entry['file_name'],
-                                  )
+                #
+                # apparently ASDMs are different from others:
+                # templates:
+                # https://almascience.eso.org/dataPortal/requests/keflavich/946895898/ALMA/
+                # 2013.1.00308.S_uid___A001_X196_X93_001_of_001.tar/2013.1.00308.S_uid___A001_X196_X93_001_of_001.tar
+                # uid___A002_X9ee74a_X26f0/2013.1.00308.S_uid___A002_X9ee74a_X26f0.asdm.sdm.tar
+                if 'asdm' in entry['file_name']:
+                    uid = entry['de_name'][5:].replace("/","_").replace(":","_")
+                    url = os.path.join(base_url,
+                                       uid,
+                                       entry['file_name'],
+                                      )
+                else:
+                    url = os.path.join(base_url,
+                                       entry['file_name'],
+                                       entry['file_name'],
+                                      )
                 columns['URL'].append(url)
 
         columns['size'] = u.Quantity(columns['size'], u.Gbyte)

--- a/astroquery/alma/core.py
+++ b/astroquery/alma/core.py
@@ -892,7 +892,10 @@ class AlmaClass(QueryWithLogin):
         """
         columns = {'uid':[], 'URL':[], 'size':[]}
         for entry in data['node_data']:
-            if entry['file_name'] != 'null':
+            if entry['de_type'] == 'MOUS':
+                # sanity checks: if this fails, the parser will
+                assert entry['file_name'] != 'null'
+                assert entry['file_key'] != 'null'
                 # "de_name": "ALMA+uid://A001/X122/X35e",
                 columns['uid'].append(entry['de_name'][5:])
                 columns['size'].append((int(entry['file_size'])*u.B).to(u.Gbyte))

--- a/astroquery/alma/core.py
+++ b/astroquery/alma/core.py
@@ -892,10 +892,10 @@ class AlmaClass(QueryWithLogin):
         """
         columns = {'uid':[], 'URL':[], 'size':[]}
         for entry in data['node_data']:
-            if entry['de_type'] == 'MOUS':
-                # sanity checks: if this fails, the parser will
-                assert entry['file_name'] != 'null'
-                assert entry['file_key'] != 'null'
+            is_file = (entry['de_type'] == 'MOUS'
+                       or (entry['file_name'] != 'null'
+                           and entry['file_key'] != 'null'))
+            if is_file:
                 # "de_name": "ALMA+uid://A001/X122/X35e",
                 columns['uid'].append(entry['de_name'][5:])
                 columns['size'].append((int(entry['file_size'])*u.B).to(u.Gbyte))

--- a/astroquery/alma/core.py
+++ b/astroquery/alma/core.py
@@ -908,17 +908,10 @@ class AlmaClass(QueryWithLogin):
                 # https://almascience.eso.org/dataPortal/requests/keflavich/946895898/ALMA/
                 # 2013.1.00308.S_uid___A001_X196_X93_001_of_001.tar/2013.1.00308.S_uid___A001_X196_X93_001_of_001.tar
                 # uid___A002_X9ee74a_X26f0/2013.1.00308.S_uid___A002_X9ee74a_X26f0.asdm.sdm.tar
-                if 'asdm' in entry['file_name']:
-                    uid = entry['de_name'][5:].replace("/","_").replace(":","_")
-                    url = os.path.join(base_url,
-                                       uid,
-                                       entry['file_name'],
-                                      )
-                else:
-                    url = os.path.join(base_url,
-                                       entry['file_name'],
-                                       entry['file_name'],
-                                      )
+                url = os.path.join(base_url,
+                                   entry['file_key'],
+                                   entry['file_name'],
+                                  )
                 columns['URL'].append(url)
 
         columns['size'] = u.Quantity(columns['size'], u.Gbyte)

--- a/astroquery/alma/core.py
+++ b/astroquery/alma/core.py
@@ -293,11 +293,15 @@ class AlmaClass(QueryWithLogin):
         summary.raise_for_status()
         self._staging_log['json_data'] = json_data = summary.json()
 
+        username = self._username if hasattr(self, '_username') else 'anonymous'
+
         url_decomposed = urlparse(data_page_url)
         base_url = ('{uri.scheme}://{uri.netloc}/'
-                    'dataPortal/requests/anonymous/'
+                    'dataPortal/requests/{username}/'
                     '{staging_page_id}/ALMA'.format(uri=url_decomposed,
-                                                    staging_page_id=dpid))
+                                                    staging_page_id=dpid,
+                                                    username=username,
+                                                   ))
         tbl = self._json_summary_to_table(json_data, base_url=base_url)
 
         # staging_root = BeautifulSoup(data_page.content)
@@ -444,6 +448,7 @@ class AlmaClass(QueryWithLogin):
 
         if authenticated:
             log.info("Authentication successful!")
+            self._username = username
         else:
             log.exception("Authentication failed!")
         # When authenticated, save password in keyring if needed

--- a/astroquery/alma/tests/test_alma_remote.py
+++ b/astroquery/alma/tests/test_alma_remote.py
@@ -70,7 +70,9 @@ class TestAlma:
         assert b'2011.0.00217.S' in result_s['Project code']
         uid = result_s['Asdm uid'][0]
 
-        alma.stage_data([uid])
+        result = alma.stage_data([uid])
+
+        assert os.path.split(result['URL'][0]) == 'uid___A002_X47ed8e_X6c.asdm.sdm.tar'
 
     def test_doc_example(self, temp_dir):
         alma = Alma()

--- a/astroquery/alma/tests/test_alma_remote.py
+++ b/astroquery/alma/tests/test_alma_remote.py
@@ -72,7 +72,7 @@ class TestAlma:
 
         result = alma.stage_data([uid])
 
-        assert os.path.split(result['URL'][0]) == 'uid___A002_X47ed8e_X6c.asdm.sdm.tar'
+        assert os.path.split(result['URL'][0])[1] == 'uid___A002_X47ed8e_X6c.asdm.sdm.tar'
 
     def test_doc_example(self, temp_dir):
         alma = Alma()

--- a/astroquery/query.py
+++ b/astroquery/query.py
@@ -180,7 +180,8 @@ class BaseQuery(object):
         the local ``_session``
         """
         response = self._session.get(url, timeout=timeout, stream=True,
-                                      auth=auth)
+                                     auth=auth)
+        response.raise_for_status()
         if 'content-length' in response.headers:
             length = int(response.headers['content-length'])
         else:

--- a/astroquery/query.py
+++ b/astroquery/query.py
@@ -197,6 +197,8 @@ class BaseQuery(object):
                                      statinfo.st_size,
                                      length))
                 else:
+                    log.info("Found cached file {0} with expected size {1}."
+                             .format(local_filepath, statinfo.st_size))
                     response.close()
                     return
             else:


### PR DESCRIPTION
(1) When running `save=True` in GET requests, there was no check that the
request was sucessful - this is fixed.

(2) ALMA queries require passing the username, not the previously-hard-coded
"anonymous", when performing queries & logged in. So far, there is no way to
test for this!