### PR TITLE
ALMA example query not working

### DIFF
--- a/astroquery/alma/core.py
+++ b/astroquery/alma/core.py
@@ -898,7 +898,10 @@ class AlmaClass(QueryWithLogin):
             if is_file:
                 # "de_name": "ALMA+uid://A001/X122/X35e",
                 columns['uid'].append(entry['de_name'][5:])
-                columns['size'].append((int(entry['file_size'])*u.B).to(u.Gbyte))
+                if entry['file_size'] == 'null':
+                    columns['size'].append(np.nan)
+                else:
+                    columns['size'].append((int(entry['file_size'])*u.B).to(u.Gbyte))
                 # example template for constructing url:
                 # https://almascience.eso.org/dataPortal/requests/keflavich/940238268/ALMA/
                 # uid___A002_X9d6f4c_X154/2013.1.00546.S_uid___A002_X9d6f4c_X154.asdm.sdm.tar

--- a/astroquery/alma/core.py
+++ b/astroquery/alma/core.py
@@ -899,7 +899,7 @@ class AlmaClass(QueryWithLogin):
                 # "de_name": "ALMA+uid://A001/X122/X35e",
                 columns['uid'].append(entry['de_name'][5:])
                 if entry['file_size'] == 'null':
-                    columns['size'].append(np.nan)
+                    columns['size'].append(np.nan*u.Gbyte)
                 else:
                     columns['size'].append((int(entry['file_size'])*u.B).to(u.Gbyte))
                 # example template for constructing url:

--- a/astroquery/alma/tests/test_alma_remote.py
+++ b/astroquery/alma/tests/test_alma_remote.py
@@ -62,6 +62,15 @@ class TestAlma:
         result_c = alma.query_region(c, 1*u.deg)
         assert b'2011.0.00217.S' in result_c['Project code']
 
+    def test_m83(self, temp_dir):
+        alma = Alma()
+        alma.cache_location = temp_dir
+
+        result_s = alma.query_object('M83')
+        uids = np.unique(m83_data['Member ous id'])
+        link_list = Alma.stage_data(uids)
+        
+
     def test_stage_data(self, temp_dir):
         alma = Alma()
         alma.cache_location = temp_dir


### PR DESCRIPTION
For some reason, I can't get the ALMA query working. Specifically, I get a ValueError when I try to stage the data for M83.

Does anyone have any ideas what is wrong?  There's a warning message from beautiful-soup that I've also included, but I don't think it's causing the error. I've checked, and all of my modules should be updated to most recent versions. 

```
In [1]: import numpy as np
In [2]: from astroquery.alma import Alma
In [3]: m83_data = Alma.query_object('M83')
/Users/nlee/anaconda/lib/python2.7/site-packages/bs4/__init__.py:166: UserWarning: No parser was explicitly specified, so I'm using the best available HTML parser for this system ("lxml"). This usually isn't a problem, but if you run this code on another system, or in a different virtual environment, it may use a different parser and behave differently.

To get rid of this warning, change this:

 BeautifulSoup([your markup])

to this:

 BeautifulSoup([your markup], "lxml")

  markup_type=markup_type))

In [4]: uids = np.unique(m83_data['Member ous id'])
In [5]: link_list = Alma.stage_data(uids)
INFO: Staging files... [astroquery.alma.core]
................---------------------------------------------------------------------------
ValueError                                Traceback (most recent call last)
<ipython-input-5-dd3f14844fee> in <module>()
----> 1 link_list = Alma.stage_data(uids)

/Users/nlee/anaconda/lib/python2.7/site-packages/astroquery/alma/core.pyc in stage_data(self, uids)
    308                                                     username=username,
    309                                                    ))
--> 310         tbl = self._json_summary_to_table(json_data, base_url=base_url)
    311 
    312         # staging_root = BeautifulSoup(data_page.content)

/Users/nlee/anaconda/lib/python2.7/site-packages/astroquery/alma/core.pyc in _json_summary_to_table(self, data, base_url)
    899                 # "de_name": "ALMA+uid://A001/X122/X35e",
    900                 columns['uid'].append(entry['de_name'][5:])
--> 901                 columns['size'].append((int(entry['file_size'])*u.B).to(u.Gbyte))
    902                 # example template for constructing url:
    903                 # https://almascience.eso.org/dataPortal/requests/keflavich/940238268/ALMA/

ValueError: invalid literal for int() with base 10: 'null'
```

Thanks!