### PR TITLE
Astroquery.splatalogue query not respecting "exclude" keyword(?)

### DIFF
--- a/astroquery/splatalogue/__init__.py
+++ b/astroquery/splatalogue/__init__.py
@@ -7,7 +7,7 @@ Splatalogue Catalog Query Tool
 
 :Originally contributed by:
 
-     Magnus Vilehlm Persson (magnusp@vilhelm.nu)
+     Magnus Vilhelm Persson (magnusp@vilhelm.nu)
 """
 from astropy import config as _config
 

--- a/astroquery/splatalogue/core.py
+++ b/astroquery/splatalogue/core.py
@@ -185,7 +185,9 @@ class SplatalogueClass(BaseQuery):
         exclude : list
             Types of lines to exclude.  Default is:
             (``'potential'``, ``'atmospheric'``, ``'probable'``)
-            Can also exclude ``'known'``
+            Can also exclude ``'known'``.
+            To exclude nothing, use 'none', not the python object None, since
+            the latter is meant to indicate 'leave as default'
         only_NRAO_recommended : bool
             Show only NRAO recommended species?
         line_lists : list

--- a/astroquery/splatalogue/core.py
+++ b/astroquery/splatalogue/core.py
@@ -123,7 +123,7 @@ class SplatalogueClass(BaseQuery):
                       chem_re_flags=0, energy_min=None, energy_max=None,
                       energy_type=None, intensity_lower_limit=None,
                       intensity_type=None, transition=None, version=None,
-                      exclude='none', only_NRAO_recommended=None,
+                      exclude=None, only_NRAO_recommended=None,
                       line_lists=None, line_strengths=None, energy_levels=None,
                       export=None, export_limit=None, noHFS=None,
                       displayHFS=None, show_unres_qn=None,

--- a/astroquery/splatalogue/core.py
+++ b/astroquery/splatalogue/core.py
@@ -293,13 +293,13 @@ class SplatalogueClass(BaseQuery):
             raise ValueError("Invalid version specified.  Allowed versions "
                              "are {vers}".format(vers=str(self.versions)))
 
-        if exclude is not None:
+        if exclude == 'none':
+            for e in ('potential', 'atmospheric', 'probable', 'known'):
+                if 'no_'+e in payload:
+                    del payload['no_' + e]
+        elif exclude is not None:
             for e in exclude:
                 payload['no_' + e] = 'no_' + e
-        elif exclude == 'none':
-            for e in exclude:
-                if 'no_e'+e in payload:
-                    del payload['no_' + e]
 
         if only_NRAO_recommended:
             payload['include_only_nrao'] = 'include_only_nrao'

--- a/astroquery/splatalogue/core.py
+++ b/astroquery/splatalogue/core.py
@@ -294,6 +294,10 @@ class SplatalogueClass(BaseQuery):
         if exclude is not None:
             for e in exclude:
                 payload['no_' + e] = 'no_' + e
+        elif exclude == 'none':
+            for e in exclude:
+                if 'no_e'+e in payload:
+                    del payload['no_' + e]
 
         if only_NRAO_recommended:
             payload['include_only_nrao'] = 'include_only_nrao'

--- a/astroquery/splatalogue/core.py
+++ b/astroquery/splatalogue/core.py
@@ -8,6 +8,7 @@ ftp://ftp.cv.nrao.edu/NRAO-staff/bkent/slap/idl/
 import warnings
 from astropy.io import ascii
 from astropy import units as u
+from astropy import log
 from ..query import BaseQuery
 from ..utils import async_to_sync
 from ..utils.docstr_chompers import prepend_docstr_noreturns
@@ -294,9 +295,11 @@ class SplatalogueClass(BaseQuery):
                              "are {vers}".format(vers=str(self.versions)))
 
         if exclude == 'none':
+            log.debug("Exclude is 'none'")
             for e in ('potential', 'atmospheric', 'probable', 'known'):
-                if 'no_'+e in payload:
-                    del payload['no_' + e]
+                # Setting a keyword value to 'None' removes it (see query_lines_async)
+                log.debug("Setting no_{0} to None".format(e))
+                payload['no_' + e] = None
         elif exclude is not None:
             for e in exclude:
                 payload['no_' + e] = 'no_' + e
@@ -388,6 +391,9 @@ class SplatalogueClass(BaseQuery):
             data_payload.update(self._parse_kwargs(min_frequency=min_frequency,
                                                    max_frequency=max_frequency,
                                                    **kwargs))
+
+        # Add an extra step: sometimes, need to REMOVE keywords
+        data_payload = {k:v for k,v in data_payload.items() if v is not None}
 
         if get_query_payload:
             return data_payload

--- a/astroquery/splatalogue/tests/test_splatalogue.py
+++ b/astroquery/splatalogue/tests/test_splatalogue.py
@@ -107,23 +107,25 @@ def test_band_crashorno():
     assert exc.value.args[0] == "Invalid frequency band."
 
 
-# regression test : version selection should work
-# Unfortunately, it looks like version1 = version2 on the web page now, so this
-# may no longer be a valid test
-@remote_data
-def test_version_selection():
-    results = splatalogue.Splatalogue.query_lines(
-			    min_frequency= 703*u.GHz,
-			    max_frequency=706*u.GHz,
-			    chemical_name='Acetaldehyde',
-			    version='v1.0'
-			    )
-    assert len(results)==1
+#Upstream changed: there is no distinction between versions for this molecule
+# # regression test : version selection should work
+# # Unfortunately, it looks like version1 = version2 on the web page now, so this
+# # may no longer be a valid test
+# @remote_data
+# def test_version_selection():
+#     results = splatalogue.Splatalogue.query_lines(
+# 			    min_frequency= 703*u.GHz,
+# 			    max_frequency=706*u.GHz,
+# 			    chemical_name='Acetaldehyde',
+# 			    version='v1.0'
+# 			    )
+#     assert len(results)==1
 
 def test_exclude(patch_post):
     # regression test for issue 616
     d = splatalogue.Splatalogue.query_lines_async(114 * u.GHz, 116 * u.GHz,
                                                   chemical_name=' CO ',
+                                                  exclude=None,
                                                   get_query_payload=True)
 
     exclusions = {'no_atmospheric': 'no_atmospheric',
@@ -155,7 +157,7 @@ def test_exclude_remote():
         energy_type='eu_k',
         line_lists=['CDMS'],
         export_limit=1000.,
-        exclude=None,
+        exclude='none',
         version='v2.0',
         show_upper_degeneracy=True,
         )

--- a/astroquery/splatalogue/tests/test_splatalogue.py
+++ b/astroquery/splatalogue/tests/test_splatalogue.py
@@ -149,6 +149,7 @@ def test_exclude(patch_post):
 @remote_data
 def test_exclude_remote():
     # regression test for issue 616
+    # only entry should be  D213CO  Formaldehyde 351.96064  3.9e-06            --            -- 6(2,4)-5(2,3)            -2.0065 ...            0.0                          -2.94058                  --      44.097 63.44616    55.83714 80.33772     CDMS
     results = splatalogue.Splatalogue.query_lines(
         min_frequency=351.9*u.GHz,
         max_frequency=352.*u.GHz,

--- a/astroquery/splatalogue/tests/test_splatalogue.py
+++ b/astroquery/splatalogue/tests/test_splatalogue.py
@@ -153,12 +153,6 @@ def test_exclude_remote():
         min_frequency=351.9*u.GHz,
         max_frequency=352.*u.GHz,
         chemical_name='Formaldehyde',
-        energy_max=4000,
-        energy_type='eu_k',
-        line_lists=['CDMS'],
-        export_limit=1000.,
         exclude='none',
-        version='v2.0',
-        show_upper_degeneracy=True,
         )
     assert len(results) >= 1

--- a/astroquery/splatalogue/tests/test_splatalogue.py
+++ b/astroquery/splatalogue/tests/test_splatalogue.py
@@ -143,3 +143,20 @@ def test_exclude(patch_post):
 
     for k in d:
         assert k[:3] != 'no_'
+
+@remote_data
+def test_exclude_remote():
+    # regression test for issue 616
+    results = splatalogue.Splatalogue.query_lines(
+        min_frequency=351.9*u.GHz,
+        max_frequency=352.*u.GHz,
+        chemical_name='Formaldehyde',
+        energy_max=4000,
+        energy_type='eu_k',
+        line_lists=['CDMS'],
+        export_limit=1000.,
+        exclude=None,
+        version='v2.0',
+        show_upper_degeneracy=True,
+        )
+    assert len(results) >= 1


### PR DESCRIPTION
There might be an issue with the "exlcude" parameter in Splatalogue modeul of Astroquery. The example below will only work if "potential" and "probable" are not selected (i.e only 'atmospheric' selected), I run it with None (which should work as well).
Running (in Astroquery 0.3.0)

```
from astroquery import splatalogue
import astropy.units as u
results = splatalogue.Splatalogue.query_lines(
    min_frequency=351.9*u.GHz,
    max_frequency=352.*u.GHz,
    chemical_name='Formaldehyde',
    energy_max=4000,
    energy_type='eu_k',
    line_lists=['CDMS'],
    export_limit=1000.,
    exclude=None,
    version='v2.0',
    show_upper_degeneracy=True,
    )
results.pprint()
```

should give one hit on 'D213CO', but gives an empty table, i.e.:

```
Species Chemical Name Freq-GHz ... E_U (K) Upper State Degeneracy Linelist
------- ------------- -------- ... ------- ---------------------- --------
```

The direct URL for the query is
http://www.cv.nrao.edu/php/splat/c.php?submit=submit&sid[]=&chemical_name=Formaldehyde&el4=el4&ls1=ls1&ls5=ls5&displayCDMS=displayCDMS&data_version=v2.0&from=351.9&to=352&frequency_units=GHz&energy_range_to=1000&energy_range_type=eu_k&submit=1
and indeed gives one hit.

Can someone double check if this is an issue?
