### PR TITLE
NRAO votable: datatype specified incorrectly

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -2,6 +2,7 @@
 ---------
 
 - Fix NASA ADS, which had an internal syntax error (#602)
+- Bugifx in NRAO queries: telescope config was parsed incorrectly (#629)
 - IBE - added new module for locating data from PTF, WISE, and 2MASS from IRSA.
   See <http://irsa.ipac.caltech.edu/ibe/> for more information about IBE and
   <http://www.ptf.caltech.edu/page/ibe> for more information about PTF survey

--- a/astroquery/nrao/core.py
+++ b/astroquery/nrao/core.py
@@ -197,6 +197,7 @@ class NraoClass(BaseQuery):
     @prepend_docstr_noreturns(_args_to_payload.__doc__)
     def query_async(self,
                     get_query_payload=False,
+                    cache=True,
                     **kwargs):
         """
         Returns
@@ -209,10 +210,8 @@ class NraoClass(BaseQuery):
 
         if get_query_payload:
             return request_payload
-        response = commons.send_request(Nrao.DATA_URL,
-                                        request_payload,
-                                        Nrao.TIMEOUT,
-                                        request_type='POST')
+        response = self._request('POST', self.DATA_URL, params=request_payload,
+                                 timeout=self.TIMEOUT, cache=cache)
         return response
 
     @prepend_docstr_noreturns(_args_to_payload.__doc__)
@@ -255,9 +254,9 @@ class NraoClass(BaseQuery):
         new_content = degrees_re.sub(r'unit="degrees"  datatype="char" '
                                      'arraysize="*"', new_content)
         telconfig_re = re.compile(r'datatype="char"  name="Telescope:config"')
-        new_content = telconfig_re.sub(r'datatype="char"'
-                                       'name="Telescope:config"'
-                                       ' arraysize="*"', new_content)
+        new_content = telconfig_re.sub(r'datatype="unicodeChar" '
+                                       'name="Telescope:config" '
+                                       ' arraysize="*" ', new_content)
 
         datatype_mapping = {'integer':'long'}
 

--- a/astroquery/nrao/tests/test_nrao.py
+++ b/astroquery/nrao/tests/test_nrao.py
@@ -28,29 +28,20 @@ def patch_parse_coordinates(request):
     return mp
 
 
-@pytest.fixture
-def patch_get(request):
-    mp = request.getfuncargvalue("monkeypatch")
-    mp.setattr(requests, 'get', get_mockreturn)
-    return mp
-
 
 @pytest.fixture
 def patch_post(request):
     mp = request.getfuncargvalue("monkeypatch")
-    mp.setattr(requests, 'post', post_mockreturn)
+    mp.setattr(requests.Session, 'request', post_mockreturn)
     return mp
 
 
-def get_mockreturn(url, params=None, timeout=10, **kwargs):
+def post_mockreturn(self, method, url, data=None, timeout=10, files=None,
+                    params=None, headers=None, **kwargs):
+    if method != 'POST':
+        raise ValueError("A 'post request' was made with method != POST")
     filename = data_path(DATA_FILES['votable'])
-    content = open(filename, 'rb').read()
-    return MockResponse(content, **kwargs)
-
-
-def post_mockreturn(url, data=None, timeout=10, **kwargs):
-    filename = data_path(DATA_FILES['votable'])
-    content = open(filename, 'rb').read()
+    content = open(filename, "rb").read()
     return MockResponse(content, **kwargs)
 
 


### PR DESCRIPTION
In the NRAO-returned VOTables that are parsed by astroquery, the field `<FIELD datatype="char"  name="Telescope:config"  ucd="VOX:Telescope"  />` incorrectly specifies `dataype="char"` without specifying `arraysize="*"`, even though the entries typically look like this: `<TD>VLA:A:1:26</TD>`.

This is an upstream error but I'd like to solve it here too, since there's no guarantee of an upstream fix.