### PR TITLE
ALMA: Do not create filenames containing 'null'

### DIFF
--- a/astroquery/alma/core.py
+++ b/astroquery/alma/core.py
@@ -895,9 +895,11 @@ class AlmaClass(QueryWithLogin):
         """
         columns = {'uid': [], 'URL': [], 'size': []}
         for entry in data['node_data']:
-            is_file = (entry['de_type'] == 'MOUS' and
-                       (entry['file_name'] != 'null' and
-                        entry['file_key'] != 'null'))
+            # de_type can be useful (e.g., MOUS), but it is not necessarily
+            # specified
+            # file_name and file_key *must* be specified.
+            is_file = (entry['file_name'] != 'null' and
+                       entry['file_key'] != 'null')
             if is_file:
                 # "de_name": "ALMA+uid://A001/X122/X35e",
                 columns['uid'].append(entry['de_name'][5:])

--- a/astroquery/alma/core.py
+++ b/astroquery/alma/core.py
@@ -895,7 +895,7 @@ class AlmaClass(QueryWithLogin):
         """
         columns = {'uid': [], 'URL': [], 'size': []}
         for entry in data['node_data']:
-            is_file = (entry['de_type'] == 'MOUS' or
+            is_file = (entry['de_type'] == 'MOUS' and
                        (entry['file_name'] != 'null' and
                         entry['file_key'] != 'null'))
             if is_file:
@@ -922,6 +922,9 @@ class AlmaClass(QueryWithLogin):
                                    entry['file_key'],
                                    entry['file_name'],
                                    )
+                if 'null' in url:
+                    raise ValueError("The URL {0} was created containing "
+                                     "'null', which is invalid.".format(url))
                 columns['URL'].append(url)
 
         columns['size'] = u.Quantity(columns['size'], u.Gbyte)


### PR DESCRIPTION
In a recent query, I had the following URLs generated:
```
https://almascience.eso.org/dataPortal/requests/keflavich/970527572/ALMA/2013.1.00546.S_uid___A001_X122_X364_001_of_001.tar/2013.1.00546.S_uid___A001_X122_X364_001_of_001.tar
                          https://almascience.eso.org/dataPortal/requests/keflavich/970527572/ALMA/uid___A002_X9707f1_Xfee/2013.1.00546.S_uid___A002_X9707f1_Xfee.asdm.sdm.tar
https://almascience.eso.org/dataPortal/requests/keflavich/970527572/ALMA/2013.1.00546.S_uid___A001_X122_X366_001_of_001.tar/2013.1.00546.S_uid___A001_X122_X366_001_of_001.tar
                          https://almascience.eso.org/dataPortal/requests/keflavich/970527572/ALMA/uid___A002_X86dcae_X416/2013.1.00546.S_uid___A002_X86dcae_X416.asdm.sdm.tar
                                                                                            https://almascience.eso.org/dataPortal/requests/keflavich/970527572/ALMA/null/null
https://almascience.eso.org/dataPortal/requests/keflavich/970527572/ALMA/2013.1.00546.S_uid___A001_X147_X327_001_of_001.tar/2013.1.00546.S_uid___A001_X147_X327_001_of_001.tar
                          https://almascience.eso.org/dataPortal/requests/keflavich/970527572/ALMA/uid___A002_Xa10d09_X47a/2013.1.00546.S_uid___A002_Xa10d09_X47a.asdm.sdm.tar
                            https://almascience.eso.org/dataPortal/requests/keflavich/970527572/ALMA/uid___A002_Xa10d09_Xdb/2013.1.00546.S_uid___A002_Xa10d09_Xdb.asdm.sdm.tar
                        https://almascience.eso.org/dataPortal/requests/keflavich/970527572/ALMA/uid___A002_Xa14be9_X4b58/2013.1.00546.S_uid___A002_Xa14be9_X4b58.asdm.sdm.tar
                        https://almascience.eso.org/dataPortal/requests/keflavich/970527572/ALMA/uid___A002_Xa14be9_X4e9b/2013.1.00546.S_uid___A002_Xa14be9_X4e9b.asdm.sdm.tar
                        https://almascience.eso.org/dataPortal/requests/keflavich/970527572/ALMA/uid___A002_Xa14be9_X5121/2013.1.00546.S_uid___A002_Xa14be9_X5121.asdm.sdm.tar
                        https://almascience.eso.org/dataPortal/requests/keflavich/970527572/ALMA/uid___A002_Xa14be9_X542d/2013.1.00546.S_uid___A002_Xa14be9_X542d.asdm.sdm.tar
                        https://almascience.eso.org/dataPortal/requests/keflavich/970527572/ALMA/uid___A002_Xa6a120_X3cc6/2013.1.00546.S_uid___A002_Xa6a120_X3cc6.asdm.sdm.tar
                        https://almascience.eso.org/dataPortal/requests/keflavich/970527572/ALMA/uid___A002_Xa6a120_X474b/2013.1.00546.S_uid___A002_Xa6a120_X474b.asdm.sdm.tar
                        https://almascience.eso.org/dataPortal/requests/keflavich/970527572/ALMA/uid___A002_Xa6a120_X48b4/2013.1.00546.S_uid___A002_Xa6a120_X48b4.asdm.sdm.tar
                        https://almascience.eso.org/dataPortal/requests/keflavich/970527572/ALMA/uid___A002_Xa6c1df_X25dc/2013.1.00546.S_uid___A002_Xa6c1df_X25dc.asdm.sdm.tar
                        https://almascience.eso.org/dataPortal/requests/keflavich/970527572/ALMA/uid___A002_Xa6c1df_X334e/2013.1.00546.S_uid___A002_Xa6c1df_X334e.asdm.sdm.tar
```

The one containing 'null' is not valid