### PR TITLE
Simbad.list_votable_fields() filter list is not correct

### DIFF
--- a/astroquery/simbad/data/votable_fields_notes.json
+++ b/astroquery/simbad/data/votable_fields_notes.json
@@ -1,5 +1,5 @@
 [
-  "The parameter filtername must correspond to an existing filter. Filters include: B,V,R,I,J,K,L.  They are checked by SIMBAD but not astroquery.simbad", 
+  "The parameter filtername must correspond to an existing filter. Filters include: B,V,R,I,J,K.  They are checked by SIMBAD but not astroquery.simbad", 
   "Fields beginning with rvz display the data as it is in the database. Fields beginning with rv force the display as a radial velocity. Fields beginning with z force the display as a redshift", 
   "For each measurement catalog, the VOTable contains all fields of the first measurement. When applicable, the first measurement is the mean one. "
 ]


### PR DESCRIPTION
In Simbad.list_votable_fields() documentation, the following is stated:

    1. The parameter filtername must correspond to an existing filter. Filters include: B,V,R,I,J,K,L.
    They are checked by SIMBAD but not astroquery.simbad

I found out that the filter L is causing trouble, and fails to perform the query. The reason is that L is not in Simbad's filters list, as seen in Simbad's [Options and outputs](http://simbad.u-strasbg.fr/simbad/sim-fout), Fluxes/Magnitudes section. On the other hand, other filters such as H, u, g, r , i, and z, can be included.

The documentation should be changed to show the available filters and to avoid crashes due to this issue.