### PR TITLE
Stop using old astropy.coordinates API

### DIFF
--- a/astroquery/irsa/tests/test_irsa_remote.py
+++ b/astroquery/irsa/tests/test_irsa_remote.py
@@ -3,7 +3,7 @@ from __future__ import print_function
 
 from astropy.tests.helper import remote_data
 from astropy.table import Table
-import astropy.coordinates as coord
+from astropy.coordinates import SkyCoord
 import astropy.units as u
 
 import requests
@@ -14,7 +14,8 @@ from ... import irsa
 imp.reload(requests)
 
 OBJ_LIST = ["m31", "00h42m44.330s +41d16m07.50s",
-            coord.Galactic(l=121.1743, b=-21.5733, unit=(u.deg, u.deg))]
+            SkyCoord(l=121.1743, b=-21.5733, unit=(u.deg, u.deg),
+                     frame='galactic')]
 
 
 @remote_data
@@ -43,9 +44,9 @@ class TestIrsa:
         assert isinstance(result, Table)
 
     def test_query_region_async_polygon(self):
-        polygon = [coord.SkyCoord(ra=10.1, dec=10.1, unit=(u.deg, u.deg)),
-                   coord.SkyCoord(ra=10.0, dec=10.1, unit=(u.deg, u.deg)),
-                   coord.SkyCoord(ra=10.0, dec=10.0, unit=(u.deg, u.deg))]
+        polygon = [SkyCoord(ra=10.1, dec=10.1, unit=(u.deg, u.deg)),
+                   SkyCoord(ra=10.0, dec=10.1, unit=(u.deg, u.deg)),
+                   SkyCoord(ra=10.0, dec=10.0, unit=(u.deg, u.deg))]
         response = irsa.core.Irsa.query_region_async(
             "m31", catalog="fp_psc", spatial="Polygon", polygon=polygon)
 

--- a/astroquery/lcogt/tests/test_lcogt.py
+++ b/astroquery/lcogt/tests/test_lcogt.py
@@ -6,7 +6,7 @@ import numpy as np
 
 from astropy.tests.helper import pytest
 from astropy.table import Table
-import astropy.coordinates as coord
+from astropy.coordinates import SkyCoord
 import astropy.units as u
 
 from ...utils.testing_tools import MockResponse
@@ -117,9 +117,9 @@ def test_query_region_box(coordinates, patch_get):
 
     assert isinstance(result, Table)
 
-poly1 = [coord.ICRS(ra=10.1, dec=10.1, unit=(u.deg, u.deg)),
-         coord.ICRS(ra=10.0, dec=10.1, unit=(u.deg, u.deg)),
-         coord.ICRS(ra=10.0, dec=10.0, unit=(u.deg, u.deg))]
+poly1 = [SkyCoord(ra=10.1, dec=10.1, unit=(u.deg, u.deg), frame='icrs'),
+         SkyCoord(ra=10.0, dec=10.1, unit=(u.deg, u.deg), frame='icrs'),
+         SkyCoord(ra=10.0, dec=10.0, unit=(u.deg, u.deg), frame='icrs')]
 poly2 = [(10.1 * u.deg, 10.1 * u.deg), (10.0 * u.deg, 10.1 * u.deg),
          (10.0 * u.deg, 10.0 * u.deg)]
 

--- a/astroquery/lcogt/tests/test_lcogt_remote.py
+++ b/astroquery/lcogt/tests/test_lcogt_remote.py
@@ -3,7 +3,7 @@ from __future__ import print_function
 
 from astropy.tests.helper import remote_data
 from astropy.table import Table
-import astropy.coordinates as coord
+from astropy.coordinates import SkyCoord
 import astropy.units as u
 
 import requests
@@ -14,7 +14,8 @@ from ... import lcogt
 imp.reload(requests)
 
 OBJ_LIST = ["m31", "00h42m44.330s +41d16m07.50s",
-            coord.Galactic(l=121.1743, b=-21.5733, unit=(u.deg, u.deg))]
+            SkyCoord(l=121.1743, b=-21.5733, unit=(u.deg, u.deg),
+                     frame='galactic')]
 
 
 @remote_data
@@ -52,9 +53,12 @@ class TestLcogt:
         assert isinstance(result, Table)
 
     def test_query_region_async_polygon(self):
-        polygon = [coord.ICRS(ra=10.1, dec=10.1, unit=(u.deg, u.deg)),
-                   coord.ICRS(ra=10.0, dec=10.1, unit=(u.deg, u.deg)),
-                   coord.ICRS(ra=10.0, dec=10.0, unit=(u.deg, u.deg))]
+        polygon = [SkyCoord(ra=10.1, dec=10.1, unit=(u.deg, u.deg),
+                            frame='icrs'),
+                   SkyCoord(ra=10.0, dec=10.1, unit=(u.deg, u.deg),
+                            frame='icrs'),
+                   SkyCoord(ra=10.0, dec=10.0, unit=(u.deg, u.deg),
+                            frame='icrs')]
         response = lcogt.core.Lcogt.query_region_async(
             "m31", catalog="lco_img", spatial="Polygon", polygon=polygon)
         assert response is not None

--- a/astroquery/magpis/tests/test_magpis_remote.py
+++ b/astroquery/magpis/tests/test_magpis_remote.py
@@ -1,7 +1,7 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 from __future__ import print_function
 
-import astropy.coordinates as coord
+from astropy.coordinates import SkyCoord
 import astropy.units as u
 from astropy.tests.helper import remote_data
 import requests
@@ -17,13 +17,13 @@ class TestMagpis:
 
     def test_get_images_async(self):
         response = magpis.core.Magpis.get_images_async(
-            coord.Galactic(10.5, 0.0, unit=(u.deg, u.deg)),
+            SkyCoord(10.5, 0.0, unit=(u.deg, u.deg), frame='galactic'),
             image_size='1 arcmin')
         assert response is not None
 
     def test_get_images(self):
         image = magpis.core.Magpis.get_images(
-            coord.Galactic(10.5, 0.0, unit=(u.deg, u.deg)),
+            SkyCoord(10.5, 0.0, unit=(u.deg, u.deg), frame='galactic'),
             image_size='1 arcmin')
         assert image is not None
         assert image[0].data.shape == (8, 8)

--- a/astroquery/nvas/tests/test_nvas_remote.py
+++ b/astroquery/nvas/tests/test_nvas_remote.py
@@ -1,7 +1,7 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 from __future__ import print_function
 
-import astropy.coordinates as coord
+from astropy.coordinates import SkyCoord
 import astropy.units as u
 from astropy.tests.helper import remote_data
 import requests
@@ -17,7 +17,8 @@ class TestNvas:
 
     def test_get_images_async(self):
         image_list = nvas.core.Nvas.get_images_async(
-            coord.Galactic(l=49.489, b=-0.37, unit=(u.deg, u.deg)), band="K")
+            SkyCoord(l=49.489, b=-0.37, unit=(u.deg, u.deg), frame='galactic'),
+            band="K")
 
         assert len(image_list) > 0
 

--- a/astroquery/ogle/core.py
+++ b/astroquery/ogle/core.py
@@ -105,9 +105,10 @@ class OgleClass(BaseQuery):
         --------
         Using astropy coordinates:
 
-        >>> from astropy import coordinates as coord
+        >>> from astropy.coordinates import SkyCoord
         >>> from astropy import units as u
-        >>> co = coord.Galactic(0.0, 3.0, unit=(u.degree, u.degree))
+        >>> co = SkyCoord(0.0, 3.0, unit=(u.degree, u.degree),
+        ...               frame='galactic')
         >>> from astroquery.ogle import Ogle
         >>> t = Ogle.query_region(coord=co)
         >>> t.pprint()

--- a/astroquery/ogle/tests/test_ogle.py
+++ b/astroquery/ogle/tests/test_ogle.py
@@ -4,7 +4,7 @@ from ... import ogle
 import os
 import requests
 from astropy.tests.helper import pytest
-from astropy import coordinates as coord
+from astropy.coordinates import SkyCoord
 from astropy import units as u
 from ...utils.testing_tools import MockResponse
 
@@ -37,7 +37,7 @@ def test_ogle_single(patch_post):
     """
     Test a single pointing using an astropy coordinate instance
     """
-    co = coord.Galactic(0, 3, unit=(u.degree, u.degree))
+    co = SkyCoord(0, 3, unit=(u.degree, u.degree), frame='galactic')
     ogle.core.Ogle.query_region(coord=co)
 
 
@@ -45,7 +45,7 @@ def test_ogle_list(patch_post):
     """
     Test multiple pointings using a list of astropy coordinate instances
     """
-    co = coord.Galactic(0, 3, unit=(u.degree, u.degree))
+    co = SkyCoord(0, 3, unit=(u.degree, u.degree), frame='galactic')
     co_list = [co, co, co]
     ogle.core.Ogle.query_region(coord=co_list)
 

--- a/astroquery/ukidss/tests/test_ukidss_remote.py
+++ b/astroquery/ukidss/tests/test_ukidss_remote.py
@@ -3,7 +3,7 @@ from __future__ import print_function
 
 from astropy.tests.helper import remote_data
 from astropy.table import Table
-import astropy.coordinates as coord
+from astropy.coordinates import SkyCoord
 import astropy.units as u
 import requests
 import imp
@@ -23,7 +23,7 @@ class TestUkidss:
 
     def test_get_images_2(self):
         images = ukidss.core.Ukidss.get_images(
-            coord.Galactic(l=49.489, b=-0.27, unit=(u.deg, u.deg)),
+            SkyCoord(l=49.489, b=-0.27, unit=(u.deg, u.deg), frame='galactic'),
             image_width=5 * u.arcmin)
         assert images is not None
 
@@ -33,19 +33,20 @@ class TestUkidss:
 
     def test_get_image_list(self):
         urls = ukidss.core.Ukidss.get_image_list(
-            coord.ICRS(ra=83.633083, dec=22.0145, unit=(u.deg, u.deg)),
+            SkyCoord(ra=83.633083, dec=22.0145, unit=(u.deg, u.deg),
+                     frame='icrs'),
             frame_type='all', waveband='all')
         assert len(urls) > 0
 
     def test_query_region_async(self):
         response = ukidss.core.Ukidss.query_region_async(
-            coord.Galactic(l=10.625, b=-0.38, unit=(u.deg, u.deg)),
+            SkyCoord(l=10.625, b=-0.38, unit=(u.deg, u.deg), frame='galactic'),
             radius=6 * u.arcsec)
         assert response is not None
 
     def test_query_region(self):
         table = ukidss.core.Ukidss.query_region(
-            coord.Galactic(l=10.625, b=-0.38, unit=(u.deg, u.deg)),
+            SkyCoord(l=10.625, b=-0.38, unit=(u.deg, u.deg), frame='galactic'),
             radius=6 * u.arcsec)
         assert isinstance(table, Table)
         assert len(table) > 0

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -265,9 +265,10 @@ Standard usage should be along these lines:
     result = Ukidss.query_region("5.0 0.0 gal", catalog='GPS', radius='1 arcmin')
     # SUCCEEDS!  returns an astropy.Table
 
-    import astropy.coordinates as coords
+    from astropy.coordinates import SkyCoord
     import astropy.units as u
-    result = Ukidss.query_region(coords.Galactic(5,0,unit=('deg','deg')),
+    result = Ukidss.query_region(
+        SkyCoord(5,0,unit=('deg','deg'), frame='galactic'),
         catalog='GPS', region='circle', radius=5*u.arcmin)
     # returns an astropy.Table
 


### PR DESCRIPTION
It's been recently removed from astropy core, thus all travis builds using astropy dev is failing. This should remove all of the remaining usage of the old API.