### PR TITLE
Import OrderedDict from collections instead of astropy.utils

### DIFF
--- a/astroquery/utils/commons.py
+++ b/astroquery/utils/commons.py
@@ -15,7 +15,7 @@ from astropy.extern.six.moves.urllib_error import URLError
 from astropy.extern import six
 import astropy.units as u
 from astropy import coordinates as coord
-from astropy.utils import OrderedDict
+from collections import OrderedDict
 import astropy.utils.data as aud
 from astropy.io import fits, votable
 

--- a/astroquery/utils/tests/test_utils.py
+++ b/astroquery/utils/tests/test_utils.py
@@ -13,7 +13,7 @@ from astropy.table import Table
 from astropy.tests.helper import pytest, remote_data
 import astropy.io.votable as votable
 import textwrap
-from astropy.utils import OrderedDict
+from collections import OrderedDict
 import os
 from astropy.io import fits
 import astropy.utils.data as aud

--- a/astroquery/vizier/core.py
+++ b/astroquery/vizier/core.py
@@ -13,7 +13,7 @@ import astropy.units as u
 import astropy.coordinates as coord
 import astropy.table as tbl
 import astropy.utils.data as aud
-from astropy.utils import OrderedDict
+from collections import OrderedDict
 import astropy.io.votable as votable
 from astropy.io import ascii, fits
 


### PR DESCRIPTION
astropy.utils.OrderedDict is deprecated per upcoming astropy 1.2.
Since astroquery does not support Python 2.6 or before,
collections.OrderedDict can be used instead.