### PR TITLE
Assertion Error related to data_page_url

### DIFF
--- a/astroquery/alma/core.py
+++ b/astroquery/alma/core.py
@@ -251,7 +251,6 @@ class AlmaClass(QueryWithLogin):
                                      "not logged in.")
 
         request_id = response.url.split("/")[-2]
-        assert len(request_id) == 36
         self._staging_log['request_id'] = request_id
         log.debug("Request ID: {0}".format(request_id))
 
@@ -267,7 +266,6 @@ class AlmaClass(QueryWithLogin):
         data_page_url = staging_submission.url
         self._staging_log['data_page_url'] = data_page_url
         dpid = data_page_url.split("/")[-1]
-        assert len(dpid) == 9
         self._staging_log['staging_page_id'] = dpid
 
         # CANNOT cache this step: please_wait will happen infinitely

--- a/astroquery/alma/core.py
+++ b/astroquery/alma/core.py
@@ -653,7 +653,7 @@ class AlmaClass(QueryWithLogin):
             querypage = self._request(
                 'GET', self._get_dataarchive_url() + "/aq/",
                 cache=cache, timeout=self.TIMEOUT)
-            root = BeautifulSoup(querypage.content)
+            root = BeautifulSoup(querypage.content, "html5lib")
             sections = root.findAll('td', class_='category')
 
             whitespace = re.compile("\s+")

--- a/astroquery/alma/tests/test_alma_remote.py
+++ b/astroquery/alma/tests/test_alma_remote.py
@@ -73,6 +73,10 @@ class TestAlma:
         uids = np.unique(m83_data['Member ous id'])
         link_list = alma.stage_data(uids)
 
+        # On Feb 8, 2016 there were 83 hits.  This number should never go down.
+        assert len(link_list) >= 83
+
+
     def test_stage_data(self, temp_dir):
         alma = Alma()
         alma.cache_location = temp_dir
@@ -83,8 +87,8 @@ class TestAlma:
 
         result = alma.stage_data([uid])
 
-        assert (os.path.split(result['URL'][0])[1] ==
-                'uid___A002_X47ed8e_X6c.asdm.sdm.tar')
+        assert ('uid___A002_X47ed8e' in
+                os.path.split(result['URL'][0])[1])
 
     def test_doc_example(self, temp_dir):
         alma = Alma()
@@ -92,10 +96,12 @@ class TestAlma:
         alma2 = Alma()
         alma2.cache_location = temp_dir
         m83_data = alma.query_object('M83')
-        assert m83_data.colnames == all_colnames
+        # the order can apparently sometimes change
+        assert set(m83_data.colnames) == set(all_colnames)
         galactic_center = coordinates.SkyCoord(0 * u.deg, 0 * u.deg,
                                                frame='galactic')
         gc_data = alma.query_region(galactic_center, 1 * u.deg)
+        assert len(gc_data) >= 425 # Feb 8, 2016
 
         uids = np.unique(m83_data['Asdm uid'])
         assert b'uid://A002/X3b3400/X90f' in uids

--- a/astroquery/alma/tests/test_alma_utils.py
+++ b/astroquery/alma/tests/test_alma_utils.py
@@ -69,4 +69,4 @@ def test_make_finder_chart():
     assert len(images) >= 1
     assert 3 in hit_mask_public
     # Feb 8 2016: apparently the 60s integration hasn't actually been released yet...
-    assert hit_mask_public[3][256,256] >= 30.24
+    assert hit_mask_public[3][256,256] >= 30.23

--- a/astroquery/alma/tests/test_alma_utils.py
+++ b/astroquery/alma/tests/test_alma_utils.py
@@ -68,4 +68,5 @@ def test_make_finder_chart():
     assert len(catalog) >= 7
     assert len(images) >= 1
     assert 3 in hit_mask_public
-    assert hit_mask_public[3][256,256] >= 60
+    # Feb 8 2016: apparently the 60s integration hasn't actually been released yet...
+    assert hit_mask_public[3][256,256] >= 30.24


### PR DESCRIPTION
I'm getting a new assertion error from alma queries that previously worked. It's even appearing in a simple M83 query:
```
m83_data = Alma.query_object('M83')
uids = np.unique(m83_data['Member ous id'])
link_list = Alma().stage_data(uids)
```

Gives:
```
---------------------------------------------------------------------------
AssertionError                            Traceback (most recent call last)
<ipython-input-4-6962eb9a6af3> in <module>()
----> 1 link_list = Alma().stage_data(uids)

/Users/nlee/anaconda/lib/python2.7/site-packages/astroquery-0.3.1.dev3090-py2.7.egg/astroquery/alma/core.pyc in stage_data(self, uids)
    271         self._staging_log['data_page_url'] = data_page_url
    272         dpid = data_page_url.split("/")[-1]
--> 273         assert len(dpid) == 9
    274         self._staging_log['staging_page_id'] = dpid
    275 
```

From diving into the python debugger:
```
(Pdb) dpid
u'1013086814'
(Pdb) len(dpid)
10
(Pdb) data_page_url
u'https://almascience.eso.org/rh/requests/anonymous/1013086814'
```
I'm assuming that ALMA has changed their IDs/URLs. Is there a reason for the length assertion on data page IDs?