### PR TITLE
Add retype_password parameter for keyring using login()s

### DIFF
--- a/astroquery/alma/__init__.py
+++ b/astroquery/alma/__init__.py
@@ -10,7 +10,7 @@ class Conf(_config.ConfigNamespace):
     Configuration parameters for `astroquery.alma`.
     """
 
-    timeout = _config.ConfigItem(60, "Timeout in seconds")
+    timeout = _config.ConfigItem(60, "Timeout in seconds.")
 
     archive_url = _config.ConfigItem(
         ['http://almascience.org',
@@ -18,7 +18,11 @@ class Conf(_config.ConfigNamespace):
          'http://almascience.nrao.edu',
          'http://almascience.nao.ac.jp',
          'http://beta.cadc-ccda.hia-iha.nrc-cnrc.gc.ca'],
-        'The ALMA Archive mirror to use')
+        'The ALMA Archive mirror to use.')
+
+    username = _config.ConfigItem(
+        "",
+        'Optional default username for ALMA archive.')
 
 conf = Conf()
 

--- a/astroquery/alma/core.py
+++ b/astroquery/alma/core.py
@@ -24,7 +24,7 @@ from astropy import units as u
 import astropy.io.votable as votable
 
 from ..exceptions import (RemoteServiceError, TableParseError,
-                          InvalidQueryError)
+                          InvalidQueryError, LoginError)
 from ..utils import commons, system_tools
 from ..utils.process_asyncs import async_to_sync
 from ..query import QueryWithLogin
@@ -38,6 +38,7 @@ class AlmaClass(QueryWithLogin):
 
     TIMEOUT = conf.timeout
     archive_url = conf.archive_url
+    USERNAME = conf.username
 
     def __init__(self):
         super(AlmaClass, self).__init__()
@@ -394,7 +395,31 @@ class AlmaClass(QueryWithLogin):
         table = first_table.to_table(use_names_over_ids=True)
         return table
 
-    def _login(self, username, store_password=False):
+    def _login(self, username=None, store_password=False,
+               retype_password=False):
+        """
+        Login to the ALMA Science Portal.
+
+        Parameters
+        ----------
+        username : str, optional
+            Username to the ALMA Science Portal. If not given, it should be
+            specified in the config file.
+        store_password : bool, optional
+            Stores the password securely in your keyring. Default is False.
+        retype_password : bool, optional
+            Asks for the password even if it is already stored in the
+            keyring. This is the way to overwrite an already stored passwork
+            on the keyring. Default is False.
+        """
+
+        if username is None:
+            if self.USERNAME == "":
+                raise LoginError("If you do not pass a username to login(), "
+                                 "you should configure a default one!")
+            else:
+                username = self.USERNAME
+
         # Check if already logged in
         loginpage = self._request("GET", "https://asa.alma.cl/cas/login",
                                   cache=False)
@@ -404,8 +429,12 @@ class AlmaClass(QueryWithLogin):
             return True
 
         # Get password from keyring or prompt
-        password_from_keyring = keyring.get_password("astroquery:asa.alma.cl",
-                                                     username)
+        if retype_password is False:
+            password_from_keyring = keyring.get_password(
+                "astroquery:asa.alma.cl", username)
+        else:
+            password_from_keyring = None
+
         if password_from_keyring is None:
             if system_tools.in_ipynb():
                 log.warn("You may be using an ipython notebook:"

--- a/astroquery/alma/core.py
+++ b/astroquery/alma/core.py
@@ -396,7 +396,7 @@ class AlmaClass(QueryWithLogin):
         return table
 
     def _login(self, username=None, store_password=False,
-               retype_password=False):
+               reenter_password=False):
         """
         Login to the ALMA Science Portal.
 
@@ -407,7 +407,7 @@ class AlmaClass(QueryWithLogin):
             specified in the config file.
         store_password : bool, optional
             Stores the password securely in your keyring. Default is False.
-        retype_password : bool, optional
+        reenter_password : bool, optional
             Asks for the password even if it is already stored in the
             keyring. This is the way to overwrite an already stored passwork
             on the keyring. Default is False.
@@ -429,7 +429,7 @@ class AlmaClass(QueryWithLogin):
             return True
 
         # Get password from keyring or prompt
-        if retype_password is False:
+        if reenter_password is False:
             password_from_keyring = keyring.get_password(
                 "astroquery:asa.alma.cl", username)
         else:

--- a/astroquery/cosmosim/__init__.py
+++ b/astroquery/cosmosim/__init__.py
@@ -21,13 +21,16 @@ class Conf(_config.ConfigNamespace):
 
     query_url = _config.ConfigItem(
         ['http://www.cosmosim.org/uws/query'],
-        'CosmoSim UWS query URL')
+        'CosmoSim UWS query URL.')
     schema_url = _config.ConfigItem(
         ['http://www.cosmosim.org/query/account/databases/json'],
-        'CosmoSim json query URL for generating database schema')
+        'CosmoSim json query URL for generating database schema.')
     timeout = _config.ConfigItem(
         60.0,
-        'Timeout for CosmoSim query')
+        'Timeout for CosmoSim query.')
+    username = _config.ConfigItem(
+        "",
+        'Optional default username for CosmoSim database.')
 
 conf = Conf()
 

--- a/astroquery/cosmosim/core.py
+++ b/astroquery/cosmosim/core.py
@@ -42,7 +42,7 @@ class CosmoSimClass(QueryWithLogin):
         super(CosmoSimClass, self).__init__()
 
     def _login(self, username=None, password=None, store_password=False,
-               retype_password=False):
+               reenter_password=False):
         """
         Login to the CosmoSim database.
 
@@ -53,7 +53,7 @@ class CosmoSimClass(QueryWithLogin):
             specified in the config file.
         store_password : bool, optional
             Stores the password securely in your keyring. Default is False.
-        retype_password : bool, optional
+        reenter_password : bool, optional
             Asks for the password even if it is already stored in the
             keyring. This is the way to overwrite an already stored passwork
             on the keyring. Default is False.
@@ -79,7 +79,7 @@ class CosmoSimClass(QueryWithLogin):
         self.username = username
 
         # Get password from keyring or prompt
-        if retype_password is False:
+        if reenter_password is False:
             password_from_keyring = keyring.get_password(
                 "astroquery:www.cosmosim.org", self.username)
         else:

--- a/astroquery/eso/core.py
+++ b/astroquery/eso/core.py
@@ -171,7 +171,7 @@ class EsoClass(QueryWithLogin):
         return response
 
     def _login(self, username=None, store_password=False,
-               retype_password=False):
+               reenter_password=False):
         """
         Login to the ESO User Portal.
 
@@ -182,7 +182,7 @@ class EsoClass(QueryWithLogin):
             specified in the config file.
         store_password : bool, optional
             Stores the password securely in your keyring. Default is False.
-        retype_password : bool, optional
+        reenter_password : bool, optional
             Asks for the password even if it is already stored in the
             keyring. This is the way to overwrite an already stored passwork
             on the keyring. Default is False.
@@ -195,7 +195,7 @@ class EsoClass(QueryWithLogin):
                 username = self.USERNAME
 
         # Get password from keyring or prompt
-        if retype_password is False:
+        if reenter_password is False:
             password_from_keyring = keyring.get_password(
                 "astroquery:www.eso.org", username)
         else:
@@ -318,7 +318,7 @@ class EsoClass(QueryWithLogin):
                 query_dict["max_rows_returned"] = self.ROW_LIMIT
             else:
                 query_dict["max_rows_returned"] = 10000
-    
+
             survey_response = self._activate_form(survey_form, form_index=0,
                                                   inputs=query_dict, cache=cache)
 


### PR DESCRIPTION
There was no other way to override a saved but since changed password.

If ``retype_password`` is True, the password is always asked for, if ``store_password`` is also True, it overwrites the one in keyring.

The name of the parameter may be not ideal, I'm open to better options.