### PR TITLE
Simbad flux qual fix

### DIFF
--- a/astroquery/simbad/data/votable_fields_dict.json
+++ b/astroquery/simbad/data/votable_fields_dict.json
@@ -27,7 +27,7 @@
   "flux_bibcode(filtername)": "bibcode", 
   "flux_error(filtername)": "error value of the flux measurement", 
   "flux_name(filtername)": "name of the filter", 
-  "flux_quality(filtername)": "quality (A:best, E:worst) of the flux", 
+  "flux_qual(filtername)": "quality (A:best, E:worst) of the flux", 
   "flux_unit(filtername)": "flux unit (mag, jy, ...)", 
   "fluxdata(filtername)": "all fields related with a particular filter.", 
   "gcrv": "General Catalogue of Radial Velocities", 

--- a/astroquery/simbad/data/votable_fields_table.txt
+++ b/astroquery/simbad/data/votable_fields_table.txt
@@ -27,6 +27,6 @@ flux(filtername) otype(opt) rvz_wavelength
 flux_bibcode(filtername) parallax sao
 flux_error(filtername) plx sp
 flux_name(filtername) plx_bibcode sp_bibcode
-flux_quality(filtername) plx_error sp_nature
+flux_qual(filtername) plx_error sp_nature
 flux_unit(filtername) plx_prec sp_qual
 sptype -- --

--- a/astroquery/simbad/tests/test_simbad_remote.py
+++ b/astroquery/simbad/tests/test_simbad_remote.py
@@ -147,3 +147,10 @@ class TestSimbad(object):
             equinox=2000.0, epoch='J2000')
         # This should find a single star, BD+36 4308
         assert len(result) == 1
+
+    def test_simbad_flux_qual():
+	    '''Regression test for issue 680'''
+	    request = Simbad()
+	    request.add_votable_fields("flux_qual(V)")
+	    response = request.query_object('algol')
+	    assert("FLUX_QUAL_V" in response.keys())


### PR DESCRIPTION
Astroquery is not returning flux quality from SIMBAD because it is using a misnamed votable field. This change fixes the problem by renaming the field.