### PR TITLE
Skip Access Denied entries in ALMA lists

### DIFF
--- a/astroquery/alma/core.py
+++ b/astroquery/alma/core.py
@@ -613,6 +613,13 @@ class AlmaClass(QueryWithLogin):
                           "A partially completed download list is "
                           "in Alma.partial_file_list")
                 raise ex
+            except requests.HTTPError as ex:
+                if ex.response.status_code == 401:
+                    log.info("Access denied to {url}.  Skipping to"
+                             " next file".format(url=url))
+                    continue
+                else:
+                    raise ex
 
             fitsfilelist = self.get_files_from_tarballs([tarball_name],
                                                         regex=regex, path=path,

--- a/astroquery/alma/tests/test_alma_remote.py
+++ b/astroquery/alma/tests/test_alma_remote.py
@@ -25,7 +25,8 @@ class TestAlma:
 
     def setup_class(cls):
         # new test server
-        Alma.archive_url = "https://2016-03.asa-test.alma.cl/aq/"
+        # this server seems not to serve a help page?
+        # Alma.archive_url = "https://2016-03.asa-test.alma.cl/aq/"
         # starting somewhere between Nov 2015 and Jan 2016, the beta server
         # stopped serving the actual data, making all staging attempts break
         #Alma.archive_url = 'http://beta.cadc-ccda.hia-iha.nrc-cnrc.gc.ca'

--- a/astroquery/alma/tests/test_alma_remote.py
+++ b/astroquery/alma/tests/test_alma_remote.py
@@ -24,6 +24,7 @@ all_colnames = ['Project code', 'Source name', 'RA', 'Dec', 'Band',
 class TestAlma:
 
     def setup_class(cls):
+        pass
         # new test server
         # this server seems not to serve a help page?
         # Alma.archive_url = "https://2016-03.asa-test.alma.cl/aq/"

--- a/astroquery/alma/tests/test_alma_remote.py
+++ b/astroquery/alma/tests/test_alma_remote.py
@@ -24,7 +24,8 @@ all_colnames = ['Project code', 'Source name', 'RA', 'Dec', 'Band',
 class TestAlma:
 
     def setup_class(cls):
-        pass
+        # new test server
+        Alma.archive_url = "https://2016-03.asa-test.alma.cl/aq/"
         # starting somewhere between Nov 2015 and Jan 2016, the beta server
         # stopped serving the actual data, making all staging attempts break
         #Alma.archive_url = 'http://beta.cadc-ccda.hia-iha.nrc-cnrc.gc.ca'


### PR DESCRIPTION
ALMA archive queries will sometimes return data sets for which the user does
not have access permission.  This change skips over those when downloading.
However, a better solution is to discover which entries are not accessible and
exclude them from the original download list.