### PR TITLE
Changing urls and payload for SDSS queries

### DIFF
--- a/astroquery/sdss/core.py
+++ b/astroquery/sdss/core.py
@@ -30,7 +30,8 @@ sdss_arcsec_per_pixel = 0.396 * u.arcsec / u.pixel
 @async_to_sync
 class SDSSClass(BaseQuery):
     TIMEOUT = conf.timeout
-    QUERY_URL_SUFFIX_DR_OLD = '/dr{dr}/en/tools/search/sql.asp'
+    QUERY_URL_SUFFIX_DR_OLD = '/dr{dr}/en/tools/search/x_sql.asp'
+    QUERY_URL_SUFFIX_DR_10 = '/dr{dr}/en/tools/search/x_sql.aspx'
     QUERY_URL_SUFFIX_DR_NEW = '/dr{dr}/en/tools/search/x_results.aspx'
     XID_URL_SUFFIX = '/dr{dr}/en/tools/crossid/x_crossid.aspx'
     IMAGING_URL_SUFFIX = ('{base}/dr{dr}/boss/photoObj/frames/'
@@ -1010,13 +1011,17 @@ class SDSSClass(BaseQuery):
                                  '`run`, `camcol` or `field`')
 
         sql = "{0} {1} {2} {3}".format(q_select, q_from, q_join, q_where)
-
-        request_payload = dict(cmd=sql, format='csv', searchtool='SQL')
+        if data_release < 11:
+            request_payload = dict(cmd=sql, format='csv')
+        else:
+            request_payload = dict(cmd=sql, format='csv', searchtool='SQL')
         return request_payload
 
     def _get_query_url(self, data_release):
-        if data_release < 11:
+        if data_release < 10:
             suffix = self.QUERY_URL_SUFFIX_DR_OLD
+        elif data_release == 10:
+            suffix = self.QUERY_URL_SUFFIX_DR_10
         else:
             suffix = self.QUERY_URL_SUFFIX_DR_NEW
 

--- a/astroquery/sdss/core.py
+++ b/astroquery/sdss/core.py
@@ -31,7 +31,7 @@ sdss_arcsec_per_pixel = 0.396 * u.arcsec / u.pixel
 class SDSSClass(BaseQuery):
     TIMEOUT = conf.timeout
     QUERY_URL_SUFFIX_DR_OLD = '/dr{dr}/en/tools/search/sql.asp'
-    QUERY_URL_SUFFIX_DR_NEW = '/dr{dr}/en/tools/search/x_sql.aspx'
+    QUERY_URL_SUFFIX_DR_NEW = '/dr{dr}/en/tools/search/x_results.aspx'
     XID_URL_SUFFIX = '/dr{dr}/en/tools/crossid/x_crossid.aspx'
     IMAGING_URL_SUFFIX = ('{base}/dr{dr}/boss/photoObj/frames/'
                           '{rerun}/{run}/{camcol}/'
@@ -1010,8 +1010,8 @@ class SDSSClass(BaseQuery):
                                  '`run`, `camcol` or `field`')
 
         sql = "{0} {1} {2} {3}".format(q_select, q_from, q_join, q_where)
-        request_payload = dict(cmd=sql, format='csv')
 
+        request_payload = dict(cmd=sql, format='csv', searchtool='SQL')
         return request_payload
 
     def _get_query_url(self, data_release):

--- a/astroquery/sdss/core.py
+++ b/astroquery/sdss/core.py
@@ -33,7 +33,8 @@ class SDSSClass(BaseQuery):
     QUERY_URL_SUFFIX_DR_OLD = '/dr{dr}/en/tools/search/x_sql.asp'
     QUERY_URL_SUFFIX_DR_10 = '/dr{dr}/en/tools/search/x_sql.aspx'
     QUERY_URL_SUFFIX_DR_NEW = '/dr{dr}/en/tools/search/x_results.aspx'
-    XID_URL_SUFFIX = '/dr{dr}/en/tools/crossid/x_crossid.aspx'
+    XID_URL_SUFFIX_OLD = '/dr{dr}/en/tools/crossid/x_crossid.aspx'
+    XID_URL_SUFFIX_NEW = '/dr{dr}/en/tools/crossid/X_Results.aspx'
     IMAGING_URL_SUFFIX = ('{base}/dr{dr}/boss/photoObj/frames/'
                           '{rerun}/{run}/{camcol}/'
                           'frame-{band}-{run:06d}-{camcol}-'
@@ -157,6 +158,9 @@ class SDSSClass(BaseQuery):
                                format='csv', photoScope='nearPrim',
                                radius=radius,
                                photoUpType='ra-dec', searchType='photo')
+
+        if data_release > 11:
+            request_payload['searchtool'] = 'CrossID'
 
         if get_query_payload:
             return request_payload
@@ -460,6 +464,9 @@ class SDSSClass(BaseQuery):
 
         request_payload = dict(cmd=self.__sanitize_query(sql_query),
                                format='csv')
+        if data_release > 11:
+            request_payload['searchtool'] = 'SQL'
+
         if kwargs.get('get_query_payload'):
             return request_payload
 
@@ -911,10 +918,11 @@ class SDSSClass(BaseQuery):
         request_payload : dict
 
         """
-        # TODO: replace this with something cleaner below
         url = self._get_query_url(data_release)
+        # TODO: replace this with something cleaner below
         photoobj_all = get_field_info(self, 'PhotoObjAll', url,
                                       self.TIMEOUT)['name']
+
         specobj_all = get_field_info(self, 'SpecObjAll', url,
                                      self.TIMEOUT)['name']
 
@@ -1011,10 +1019,12 @@ class SDSSClass(BaseQuery):
                                  '`run`, `camcol` or `field`')
 
         sql = "{0} {1} {2} {3}".format(q_select, q_from, q_join, q_where)
-        if data_release < 11:
-            request_payload = dict(cmd=sql, format='csv')
-        else:
-            request_payload = dict(cmd=sql, format='csv', searchtool='SQL')
+
+        request_payload = dict(cmd=sql, format='csv')
+
+        if data_release > 11:
+            request_payload['searchtool'] = 'SQL'
+
         return request_payload
 
     def _get_query_url(self, data_release):
@@ -1030,7 +1040,11 @@ class SDSSClass(BaseQuery):
         return url
 
     def _get_crossid_url(self, data_release):
-        suffix = self.XID_URL_SUFFIX
+        if data_release < 11:
+            suffix = self.XID_URL_SUFFIX_OLD
+        else:
+            suffix = self.XID_URL_SUFFIX_NEW
+
         url = conf.skyserver_baseurl + suffix.format(dr=data_release)
         self._last_url = url
         return url

--- a/astroquery/sdss/core.py
+++ b/astroquery/sdss/core.py
@@ -34,7 +34,7 @@ class SDSSClass(BaseQuery):
     QUERY_URL_SUFFIX_DR_10 = '/dr{dr}/en/tools/search/x_sql.aspx'
     QUERY_URL_SUFFIX_DR_NEW = '/dr{dr}/en/tools/search/x_results.aspx'
     XID_URL_SUFFIX_OLD = '/dr{dr}/en/tools/crossid/x_crossid.aspx'
-    XID_URL_SUFFIX_NEW = '/dr{dr}/en/tools/crossid/X_Results.aspx'
+    XID_URL_SUFFIX_NEW = '/dr{dr}/en/tools/search/X_Results.aspx'
     IMAGING_URL_SUFFIX = ('{base}/dr{dr}/boss/photoObj/frames/'
                           '{rerun}/{run}/{camcol}/'
                           'frame-{band}-{run:06d}-{camcol}-'

--- a/astroquery/sdss/field_names.py
+++ b/astroquery/sdss/field_names.py
@@ -30,7 +30,9 @@ def get_field_info(cls, tablename, sqlurl, timeout=conf.timeout):
     # Figure out the DR from the url
     data_release = int(sqlurl.split('/dr')[1].split('/')[0])
 
-    if key not in _cached_table_fields:
+    # Empty tables could be cached when running local mock tests, those should
+    # always be discarded
+    if key not in _cached_table_fields or not _cached_table_fields[key]:
         request_payload = {'cmd': ("select * from dbo.fDocColumns('{0}')"
                                    .format(tablename)),
                            'format': 'json'}

--- a/astroquery/sdss/field_names.py
+++ b/astroquery/sdss/field_names.py
@@ -27,11 +27,16 @@ _cached_table_fields = {}
 
 def get_field_info(cls, tablename, sqlurl, timeout=conf.timeout):
     key = (tablename, sqlurl)
+    # Figure out the DR from the url
+    data_release = int(sqlurl.split('/dr')[1].split('/')[0])
 
     if key not in _cached_table_fields:
         request_payload = {'cmd': ("select * from dbo.fDocColumns('{0}')"
                                    .format(tablename)),
                            'format': 'json'}
+        if data_release > 11:
+            request_payload['searchtool'] = 'SQL'
+
         qryres = cls._request("GET", sqlurl, params=request_payload,
                               timeout=timeout)
         # we're compelled to use JSON because CSV responses are broken in

--- a/astroquery/sdss/tests/test_sdss.py
+++ b/astroquery/sdss/tests/test_sdss.py
@@ -286,7 +286,7 @@ def test_query_crossid(patch_post, dr):
 # Payload tests
 
 @pytest.mark.parametrize("dr", [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 12])
-def test_list_coordinates_payload(dr):
+def test_list_coordinates_payload(patch_get, dr):
     expect = ("SELECT DISTINCT "
               "p.ra, p.dec, p.objid, p.run, p.rerun, p.camcol, p.field "
               "FROM PhotoObjAll AS p   WHERE "
@@ -302,7 +302,7 @@ def test_list_coordinates_payload(dr):
 
 
 @pytest.mark.parametrize("dr", [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 12])
-def test_column_coordinates_payload(dr):
+def test_column_coordinates_payload(patch_get, dr):
     expect = ("SELECT DISTINCT "
               "p.ra, p.dec, p.objid, p.run, p.rerun, p.camcol, p.field "
               "FROM PhotoObjAll AS p   WHERE "

--- a/astroquery/sdss/tests/test_sdss.py
+++ b/astroquery/sdss/tests/test_sdss.py
@@ -128,7 +128,7 @@ def url_tester_crossid(data_release):
     if data_release < 11:
         baseurl = 'http://skyserver.sdss.org/dr{}/en/tools/crossid/x_crossid.aspx'
     if data_release >= 12:
-        baseurl = 'http://skyserver.sdss.org/dr{}/en/tools/crossid/X_Results.aspx'
+        baseurl = 'http://skyserver.sdss.org/dr{}/en/tools/search/X_Results.aspx'
     assert sdss.SDSS._last_url == baseurl.format(data_release)
 
 

--- a/astroquery/sdss/tests/test_sdss.py
+++ b/astroquery/sdss/tests/test_sdss.py
@@ -115,15 +115,20 @@ coords_column = Column(coords_list, name='coordinates')
 # published results based on the DR11 data set. As such, not all data-access
 # interfaces are supported for DR11."
 def url_tester(data_release):
-    if data_release < 12:
-        baseurl = 'http://skyserver.sdss.org/dr{}/en/tools/search/sql.asp'
-    if data_release >= 12:
+    if data_release < 10:
+        baseurl = 'http://skyserver.sdss.org/dr{}/en/tools/search/x_sql.asp'
+    if data_release == 10:
         baseurl = 'http://skyserver.sdss.org/dr{}/en/tools/search/x_sql.aspx'
+    if data_release >= 12:
+        baseurl = 'http://skyserver.sdss.org/dr{}/en/tools/search/x_results.aspx'
     assert sdss.SDSS._last_url == baseurl.format(data_release)
 
 
 def url_tester_crossid(data_release):
-    baseurl = 'http://skyserver.sdss.org/dr{}/en/tools/crossid/x_crossid.aspx'
+    if data_release < 11:
+        baseurl = 'http://skyserver.sdss.org/dr{}/en/tools/crossid/x_crossid.aspx'
+    if data_release >= 12:
+        baseurl = 'http://skyserver.sdss.org/dr{}/en/tools/crossid/X_Results.aspx'
     assert sdss.SDSS._last_url == baseurl.format(data_release)
 
 


### PR DESCRIPTION
Something has changed in the remote API, and different urls and mandatory form fields got introduced recently for the DR12 of SDSS.

This PR addresses the issues and closes #685.

@keflavich - It seems that the remote server got faster as well, and thus we run into denied responses with the remote tests. Is there a machinery to slow down the consecutive runs, or should I just put in a few sleeps? (I'm not yet sure that this is the reason for the remote failures, but got different failures when running the tests for the whole module vs running only the remote test file).