### PR TITLE
Removing warnings for eso upgrade

### DIFF
--- a/astroquery/eso/__init__.py
+++ b/astroquery/eso/__init__.py
@@ -2,8 +2,6 @@
 """
 ESO service.
 """
-import warnings
-
 from astropy import config as _config
 
 
@@ -26,8 +24,3 @@ from .core import Eso, EsoClass
 __all__ = ['Eso', 'EsoClass',
            'Conf', 'conf',
            ]
-
-warnings.warn("ESO is deploying new query forms in the first half of April "
-              "2016. While we aim to accommodate the changes as soon as "
-              "possible into astroquery, please be advised that things "
-              "might break temporarily.")

--- a/docs/eso/eso.rst
+++ b/docs/eso/eso.rst
@@ -6,11 +6,6 @@
 ESO Queries (`astroquery.eso`)
 ******************************
 
-.. warning::
-    ESO is deploying new query forms in the first half of April 2016. While
-    we aim to accommodate the changes as soon as possible into astroquery,
-    please be advised that things might break temporarily.
-
 Getting started
 ===============
 


### PR DESCRIPTION
#696 did the job of upgrading to use the new API, thus we don't need these any more.