### PR TITLE
ESO: Fix upstream changes in form ordering

### DIFF
--- a/astroquery/eso/core.py
+++ b/astroquery/eso/core.py
@@ -402,8 +402,11 @@ class EsoClass(QueryWithLogin):
                 query_dict["max_rows_returned"] = self.ROW_LIMIT
             else:
                 query_dict["max_rows_returned"] = 10000
-            instrument_response = self._activate_form(
-                instrument_form, form_index=0, inputs=query_dict, cache=cache)
+            # used to be form 0, but now there's a new 'logout' form at the top
+            instrument_response = self._activate_form(instrument_form,
+                                                      form_index=-1,
+                                                      inputs=query_dict,
+                                                      cache=cache)
 
             content = instrument_response.content
             # First line is always garbage

--- a/astroquery/eso/core.py
+++ b/astroquery/eso/core.py
@@ -269,8 +269,14 @@ class EsoClass(QueryWithLogin):
             self._survey_list = []
             collections_table = root.find('table', id='collections_table')
             other_collections = root.find('select', id='collection_name_option')
-            for element in (collections_table.findAll('input', type='checkbox') +
-                            other_collections.findAll('option')):
+            # it is possible to have empty collections or other collections...
+            collection_elts = (collections_table.findAll('input', type='checkbox')
+                               if collections_table is not None
+                               else [])
+            other_elts = (other_collections.findAll('option')
+                          if other_collections is not None
+                          else [])
+            for element in (collection_elts + other_elts):
                 if 'value' in element.attrs:
                     survey = element.attrs['value']
                     if survey and survey not in self._survey_list and 'Any' not in survey:

--- a/astroquery/eso/tests/test_eso_remote.py
+++ b/astroquery/eso/tests/test_eso_remote.py
@@ -161,3 +161,23 @@ class TestEso:
                                             '2015-09-15', '2015-09-18'}
 
         assert np.all(tbl == tblb)
+
+    def test_each_instrument_SgrAstar(self, temp_dir):
+        eso = Eso()
+        eso.cache_location = temp_dir
+
+        instruments = eso.list_instruments(cache=False)
+        for instrument in instruments:
+            result_i = eso.query_instrument(instrument, coord1=266.41681662,
+                                            coord2=-29.00782497, cache=False)
+
+    def test_each_survey_SgrAstar(self, temp_dir):
+        eso = Eso()
+        eso.cache_location = temp_dir
+
+        surveys = eso.list_surveys(cache=False)
+        for survey in surveys:
+            result_s = eso.query_surveys(survey, coord1=266.41681662,
+                                         coord2=-29.00782497,
+                                         box='01 00 00',
+                                         cache=False)


### PR DESCRIPTION
ESO query pages added new forms

Remote tests now:

```
astroquery/eso/tests/test_eso.py ..
astroquery/eso/tests/test_eso_remote.py ......ss.......................
```