### PR TITLE
Make the download progress bar optional

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,7 +1,7 @@
 0.3.3.dev
 ---------
 
-- none yet
+- Option to toggle the display of the download bar (#734)
 
 0.3.2 (2016-06-10)
 ------------------

--- a/astroquery/alfalfa/core.py
+++ b/astroquery/alfalfa/core.py
@@ -160,7 +160,7 @@ class AlfalfaClass(BaseQuery):
         else:
             return None
 
-    def get_spectrum_async(self, agc):
+    def get_spectrum_async(self, agc, show_progress=True):
         """
         Download spectrum from ALFALFA catalogue.
 
@@ -186,11 +186,11 @@ class AlfalfaClass(BaseQuery):
         agc = str(agc).zfill(6)
 
         link = "%s/A%s.fits" % (self.FITS_PREFIX, agc)
-        result = commons.FileContainer(link)
+        result = commons.FileContainer(link, show_progress=show_progress)
         return result
 
     @prepend_docstr_noreturns(get_spectrum_async.__doc__)
-    def get_spectrum(self, agc):
+    def get_spectrum(self, agc, show_progress=True):
         """
         Returns
         -------
@@ -199,7 +199,7 @@ class AlfalfaClass(BaseQuery):
 
         """
 
-        result = self.get_spectrum_async(agc)
+        result = self.get_spectrum_async(agc, show_progress=show_progress)
         hdulist = result.get_fits()
         return hdulist
 

--- a/astroquery/irsa_dust/core.py
+++ b/astroquery/irsa_dust/core.py
@@ -47,7 +47,8 @@ class IrsaDustClass(BaseQuery):
     }
 
     def get_images(self, coordinate, radius=None,
-                   image_type=None, timeout=TIMEOUT, get_query_payload=False):
+                   image_type=None, timeout=TIMEOUT, get_query_payload=False,
+                   show_progress=True):
         """
         A query function that performs a coordinate-based query to acquire
         Irsa-Dust images.
@@ -85,11 +86,12 @@ class IrsaDustClass(BaseQuery):
             return self._args_to_payload(coordinate, radius=radius)
         readable_objs = self.get_images_async(
             coordinate, radius=radius, image_type=image_type, timeout=timeout,
-            get_query_payload=get_query_payload)
+            get_query_payload=get_query_payload, show_progress=show_progress)
         return [obj.get_fits() for obj in readable_objs]
 
     def get_images_async(self, coordinate, radius=None, image_type=None,
-                         timeout=TIMEOUT, get_query_payload=False):
+                         timeout=TIMEOUT, get_query_payload=False,
+                         show_progress=True):
         """
         A query function similar to
         `astroquery.irsa_dust.IrsaDustClass.get_images` but returns
@@ -133,7 +135,8 @@ class IrsaDustClass(BaseQuery):
 
         # Images are assumed to be FITS files
         # they MUST be read as binary for python3 to parse them
-        return [commons.FileContainer(U, encoding='binary')
+        return [commons.FileContainer(U, encoding='binary',
+                                      show_progress=show_progress)
                 for U in image_urls]
 
     def get_image_list(self, coordinate, radius=None, image_type=None,
@@ -176,7 +179,8 @@ class IrsaDustClass(BaseQuery):
         response = commons.send_request(url, request_payload, timeout)
         return self.extract_image_urls(response.text, image_type=image_type)
 
-    def get_extinction_table(self, coordinate, radius=None, timeout=TIMEOUT):
+    def get_extinction_table(self, coordinate, radius=None, timeout=TIMEOUT,
+                             show_progress=True):
         """
         Query function that fetches the extinction table from the query
         result.
@@ -201,16 +205,16 @@ class IrsaDustClass(BaseQuery):
         --------
         table : `~astropy.table.Table`
         """
-        readable_obj = self.get_extinction_table_async(coordinate,
-                                                       radius=radius,
-                                                       timeout=timeout)
+        readable_obj = self.get_extinction_table_async(
+            coordinate, radius=radius, timeout=timeout,
+            show_progress=show_progress)
         # guess=False to suppress error messages related to bad guesses
         table = Table.read(readable_obj.get_string(), format='ipac',
                            guess=False)
         return table
 
     def get_extinction_table_async(self, coordinate, radius=None,
-                                   timeout=TIMEOUT):
+                                   timeout=TIMEOUT, show_progress=True):
         """
         A query function similar to
         `astroquery.irsa_dust.IrsaDustClass.get_extinction_table` but
@@ -242,7 +246,8 @@ class IrsaDustClass(BaseQuery):
         response = commons.send_request(url, request_payload, timeout)
         xml_tree = utils.xml(response.text)
         result = SingleDustResult(xml_tree, coordinate)
-        return commons.FileContainer(result.ext_detail_table())
+        return commons.FileContainer(result.ext_detail_table(),
+                                     show_progress=show_progress)
 
     def get_query_table(self, coordinate, radius=None,
                         section=None, timeout=TIMEOUT, url=DUST_SERVICE_URL):

--- a/astroquery/irsa_dust/tests/test_irsa_dust.py
+++ b/astroquery/irsa_dust/tests/test_irsa_dust.py
@@ -331,8 +331,10 @@ class TestDust(DustTestCase):
         return MockResponse
 
     def get_ext_table_async_mockreturn(self, coordinate, radius=None,
-                                       timeout=IrsaDust.TIMEOUT):
-        return(commons.FileContainer(self.data(EXT_TBL)))
+                                       timeout=IrsaDust.TIMEOUT,
+                                       show_progress=True):
+        return(commons.FileContainer(self.data(EXT_TBL),
+                                     show_progress=show_progress))
 
     def get_image_list_mockreturn(
         self, coordinate, radius=None, image_type=None,
@@ -341,9 +343,11 @@ class TestDust(DustTestCase):
 
     def get_images_async_mockreturn(self, coordinate, radius=None,
                                     image_type=None, timeout=IrsaDust.TIMEOUT,
-                                    get_query_payload=False):
+                                    get_query_payload=False,
+                                    show_progress=True):
         readable_obj = commons.FileContainer(self.data(IMG_FITS),
-                                             encoding='binary')
+                                             encoding='binary',
+                                             show_progress=show_progress)
         return [readable_obj]
 
     def set_ext_table_text(self, text, xml_tree):

--- a/astroquery/ned/core.py
+++ b/astroquery/ned/core.py
@@ -343,7 +343,8 @@ class NedClass(BaseQuery):
                                         Ned.TIMEOUT, request_type='GET')
         return response
 
-    def get_images(self, object_name, get_query_payload=False):
+    def get_images(self, object_name, get_query_payload=False,
+                   show_progress=True):
         """
         Query function to fetch FITS images for a given identifier.
 
@@ -361,13 +362,15 @@ class NedClass(BaseQuery):
 
         """
         readable_objs = self.get_images_async(
-            object_name, get_query_payload=get_query_payload)
+            object_name, get_query_payload=get_query_payload,
+            show_progress=show_progress)
 
         if get_query_payload:
             return readable_objs
         return [obj.get_fits() for obj in readable_objs]
 
-    def get_images_async(self, object_name, get_query_payload=False):
+    def get_images_async(self, object_name, get_query_payload=False,
+                         show_progress=True):
         """
         Serves the same purpose as `~NedClass.get_images` but returns
         file-handlers to the remote files rather than downloading them.
@@ -389,10 +392,12 @@ class NedClass(BaseQuery):
                                          get_query_payload=get_query_payload)
         if get_query_payload:
             return image_urls
-        return [commons.FileContainer(U, encoding='binary')
+        return [commons.FileContainer(U, encoding='binary',
+                                      show_progress=show_progress)
                 for U in image_urls]
 
-    def get_spectra(self, object_name, get_query_payload=False):
+    def get_spectra(self, object_name, get_query_payload=False,
+                    show_progress=True):
         """
         Query function to fetch FITS files of spectra for a given identifier.
 
@@ -410,13 +415,15 @@ class NedClass(BaseQuery):
 
         """
         readable_objs = self.get_spectra_async(
-            object_name, get_query_payload=get_query_payload)
+            object_name, get_query_payload=get_query_payload,
+            show_progress=show_progress)
 
         if get_query_payload:
             return readable_objs
         return [obj.get_fits() for obj in readable_objs]
 
-    def get_spectra_async(self, object_name, get_query_payload=False):
+    def get_spectra_async(self, object_name, get_query_payload=False,
+                          show_progress=True):
         """
         Serves the same purpose as `~NedClass.get_spectra` but returns
         file-handlers to the remote files rather than downloading them.
@@ -438,7 +445,8 @@ class NedClass(BaseQuery):
                                          get_query_payload=get_query_payload)
         if get_query_payload:
             return image_urls
-        return [commons.FileContainer(U, encoding='binary')
+        return [commons.FileContainer(U, encoding='binary',
+                                      show_progress=show_progress)
                 for U in image_urls]
 
     def get_image_list(self, object_name, item='image',

--- a/astroquery/ned/tests/test_ned.py
+++ b/astroquery/ned/tests/test_ned.py
@@ -48,7 +48,8 @@ def patch_get(request):
 
 @pytest.fixture
 def patch_get_readable_fileobj(request):
-    def get_readable_fileobj_mockreturn(filename, cache=True, encoding=None):
+    def get_readable_fileobj_mockreturn(filename, cache=True, encoding=None,
+                                        show_progress=True):
         # Need to read FITS files with binary encoding: should raise error
         # otherwise
         assert encoding == 'binary'

--- a/astroquery/nvas/core.py
+++ b/astroquery/nvas/core.py
@@ -36,7 +36,7 @@ class NvasClass(BaseQuery):
 
     def get_images(self, coordinates, radius=0.25 * u.arcmin, max_rms=10000,
                    band="all", get_uvfits=False, verbose=True,
-                   get_query_payload=False):
+                   get_query_payload=False, show_progress=True):
         """
         Get an image around a target/ coordinates from the NVAS image archive.
 
@@ -74,7 +74,7 @@ class NvasClass(BaseQuery):
         readable_objs = self.get_images_async(
             coordinates, radius=radius, max_rms=max_rms,
             band=band, get_uvfits=get_uvfits, verbose=verbose,
-            get_query_payload=get_query_payload)
+            get_query_payload=get_query_payload, show_progress=show_progress)
         if get_query_payload:
             return readable_objs
 
@@ -84,7 +84,8 @@ class NvasClass(BaseQuery):
 
     def get_images_async(self, coordinates, radius=0.25 * u.arcmin,
                          max_rms=10000, band="all", get_uvfits=False,
-                         verbose=True, get_query_payload=False):
+                         verbose=True, get_query_payload=False,
+                         show_progress=True):
         """
         Serves the same purpose as `get_images` but
         returns a list of file handlers to remote files.
@@ -131,7 +132,8 @@ class NvasClass(BaseQuery):
         if verbose:
             print("{num} images found.".format(num=len(image_urls)))
 
-        return [commons.FileContainer(U, encoding='binary')
+        return [commons.FileContainer(U, encoding='binary',
+                                      show_progress=show_progress)
                 for U in image_urls]
 
     def get_image_list(self, coordinates, radius=0.25 * u.arcmin,

--- a/astroquery/sdss/core.py
+++ b/astroquery/sdss/core.py
@@ -478,7 +478,7 @@ class SDSSClass(BaseQuery):
     def get_spectra_async(self, coordinates=None, radius=2. * u.arcsec,
                           matches=None, plate=None, fiberID=None, mjd=None,
                           timeout=TIMEOUT, get_query_payload=False,
-                          data_release=12, cache=True):
+                          data_release=12, cache=True, show_progress=True):
         """
         Download spectrum from SDSS.
 
@@ -590,14 +590,16 @@ class SDSSClass(BaseQuery):
 
             results.append(commons.FileContainer(link,
                                                  encoding='binary',
-                                                 remote_timeout=timeout))
+                                                 remote_timeout=timeout,
+                                                 show_progress=show_progress))
 
         return results
 
     @prepend_docstr_noreturns(get_spectra_async.__doc__)
     def get_spectra(self, coordinates=None, radius=2. * u.arcsec,
                     matches=None, plate=None, fiberID=None, mjd=None,
-                    timeout=TIMEOUT, cache=True, data_release=12):
+                    timeout=TIMEOUT, cache=True, data_release=12,
+                    show_progress=True):
         """
         Returns
         -------
@@ -609,7 +611,8 @@ class SDSSClass(BaseQuery):
                                                radius=radius, matches=matches,
                                                plate=plate, fiberID=fiberID,
                                                mjd=mjd, timeout=timeout,
-                                               data_release=data_release)
+                                               data_release=data_release,
+                                               show_progress=show_progress)
 
         if readable_objs is not None:
             if isinstance(readable_objs, dict):
@@ -620,7 +623,8 @@ class SDSSClass(BaseQuery):
     def get_images_async(self, coordinates=None, radius=2. * u.arcsec,
                          matches=None, run=None, rerun=301, camcol=None,
                          field=None, band='g', timeout=TIMEOUT,
-                         get_query_payload=False, cache=True, data_release=12):
+                         get_query_payload=False, cache=True, data_release=12,
+                         show_progress=True):
         """
         Download an image from SDSS.
 
@@ -730,10 +734,9 @@ class SDSSClass(BaseQuery):
                                       rerun=row['rerun'], camcol=row['camcol'],
                                       field=row['field'], band=b)
 
-                results.append(commons.FileContainer(link,
-                                                     encoding='binary',
-                                                     remote_timeout=timeout,
-                                                     cache=cache))
+                results.append(commons.FileContainer(
+                    link, encoding='binary', remote_timeout=timeout,
+                    cache=cache, show_progress=show_progress))
 
         return results
 
@@ -741,7 +744,8 @@ class SDSSClass(BaseQuery):
     def get_images(self, coordinates=None, radius=2. * u.arcsec,
                    matches=None, run=None, rerun=301, camcol=None, field=None,
                    band='g', timeout=TIMEOUT, cache=True,
-                   get_query_payload=False, data_release=12):
+                   get_query_payload=False, data_release=12,
+                   show_progress=True):
         """
         Returns
         -------
@@ -752,7 +756,8 @@ class SDSSClass(BaseQuery):
         readable_objs = self.get_images_async(
             coordinates=coordinates, radius=radius, matches=matches, run=run,
             rerun=rerun, data_release=data_release, camcol=camcol, field=field,
-            band=band, timeout=timeout, get_query_payload=get_query_payload)
+            band=band, timeout=timeout, get_query_payload=get_query_payload,
+            show_progress=show_progress)
 
         if readable_objs is not None:
             if isinstance(readable_objs, dict):
@@ -760,7 +765,8 @@ class SDSSClass(BaseQuery):
             else:
                 return [obj.get_fits() for obj in readable_objs]
 
-    def get_spectral_template_async(self, kind='qso', timeout=TIMEOUT):
+    def get_spectral_template_async(self, kind='qso', timeout=TIMEOUT,
+                                    show_progress=True):
         """
         Download spectral templates from SDSS DR-2.
 
@@ -806,12 +812,14 @@ class SDSSClass(BaseQuery):
             link = '%s-%s.fit' % (self.TEMPLATES_URL, name)
             results.append(commons.FileContainer(link,
                                                  remote_timeout=timeout,
-                                                 encoding='binary'))
+                                                 encoding='binary',
+                                                 show_progress=show_progress))
 
         return results
 
     @prepend_docstr_noreturns(get_spectral_template_async.__doc__)
-    def get_spectral_template(self, kind='qso', timeout=TIMEOUT):
+    def get_spectral_template(self, kind='qso', timeout=TIMEOUT,
+                              show_progress=True):
         """
         Returns
         -------
@@ -819,8 +827,8 @@ class SDSSClass(BaseQuery):
 
         """
 
-        readable_objs = self.get_spectral_template_async(kind=kind,
-                                                         timeout=timeout)
+        readable_objs = self.get_spectral_template_async(
+            kind=kind, timeout=timeout, show_progress=show_progress)
 
         if readable_objs is not None:
             return [obj.get_fits() for obj in readable_objs]

--- a/astroquery/skyview/core.py
+++ b/astroquery/skyview/core.py
@@ -87,7 +87,8 @@ class SkyViewClass(BaseQuery):
     def get_images(self, position, survey, coordinates=None, projection=None,
                    pixels=None, scaling=None, sampler=None, resolver=None,
                    deedger=None, lut=None, grid=None, gridlabels=None,
-                   radius=None, height=None, width=None, cache=True):
+                   radius=None, height=None, width=None, cache=True,
+                   show_progress=True):
         """
         Query the SkyView service, download the FITS file that will be
         found and return a generator over the local paths to the
@@ -201,7 +202,8 @@ class SkyViewClass(BaseQuery):
                                                  lut, grid, gridlabels,
                                                  radius=radius, height=height,
                                                  width=width,
-                                                 cache=cache)
+                                                 cache=cache,
+                                                 show_progress=show_progress)
         return [obj.get_fits() for obj in readable_objects]
 
     @prepend_docstr_noreturns(get_images.__doc__)
@@ -209,7 +211,7 @@ class SkyViewClass(BaseQuery):
                          projection=None, pixels=None, scaling=None,
                          sampler=None, resolver=None, deedger=None, lut=None,
                          grid=None, gridlabels=None, radius=None, height=None,
-                         width=None, cache=True):
+                         width=None, cache=True, show_progress=True):
         """
         Returns
         -------
@@ -221,7 +223,8 @@ class SkyViewClass(BaseQuery):
                                          gridlabels, radius=radius,
                                          height=height, width=width,
                                          cache=cache)
-        return [commons.FileContainer(url, encoding='binary')
+        return [commons.FileContainer(url, encoding='binary',
+                                      show_progress=show_progress)
                 for url in image_urls]
 
     @prepend_docstr_noreturns(get_images.__doc__)

--- a/astroquery/ukidss/core.py
+++ b/astroquery/ukidss/core.py
@@ -161,7 +161,8 @@ class UkidssClass(QueryWithLogin):
     def get_images(self, coordinates, waveband='all', frame_type='stack',
                    image_width=1 * u.arcmin, image_height=None, radius=None,
                    database='UKIDSSDR7PLUS', programme_id='all',
-                   verbose=True, get_query_payload=False):
+                   verbose=True, get_query_payload=False,
+                   show_progress=True):
         """
         Get an image around a target/ coordinates from UKIDSS catalog.
 
@@ -209,7 +210,8 @@ class UkidssClass(QueryWithLogin):
             coordinates, waveband=waveband, frame_type=frame_type,
             image_width=image_width, image_height=image_height,
             database=database, programme_id=programme_id, radius=radius,
-            verbose=verbose, get_query_payload=get_query_payload)
+            verbose=verbose, get_query_payload=get_query_payload,
+            show_progress=show_progress)
 
         if get_query_payload:
             return readable_objs
@@ -219,7 +221,8 @@ class UkidssClass(QueryWithLogin):
                          image_width=1 * u.arcmin, image_height=None,
                          radius=None, database='UKIDSSDR7PLUS',
                          programme_id='all', verbose=True,
-                         get_query_payload=False):
+                         get_query_payload=False,
+                         show_progress=True):
         """
         Serves the same purpose as `get_images` but
         returns a list of file handlers to remote files.
@@ -281,7 +284,8 @@ class UkidssClass(QueryWithLogin):
             print("Found {num} targets".format(num=len(image_urls)))
 
         return [commons.FileContainer(U, encoding='binary',
-                                      remote_timeout=self.TIMEOUT)
+                                      remote_timeout=self.TIMEOUT,
+                                      show_progress=show_progress)
                 for U in image_urls]
 
     @validate_frame


### PR DESCRIPTION
This is a suggestion to make the download progress bar optional.

I've implemented this only for the IRSA dust extinction table utility for now. If this suggestion is well received, I'll try to implement it for other queries as well.
