### PR TITLE
fix parsing of radius option in Simbad queries.

### DIFF
--- a/astroquery/simbad/core.py
+++ b/astroquery/simbad/core.py
@@ -811,13 +811,11 @@ def _parse_radius(radius):
             index = 2  # use arcseconds when radius smaller than 1 arcsecond
         unit = ('d', 'm', 's')[index]
         if unit == 'd':
-            return str(int(angle.degree)) + unit
+            return str(angle.degree) + unit
         if unit == 'm':
-            sec_to_min = abs(angle.dms[2]) * u.arcsec.to(u.arcmin)
-            total_min = abs(angle.dms[1]) + sec_to_min
-            return str(total_min) + unit
+            return str(angle.arcmin) + unit
         if unit == 's':
-            return str(abs(angle.dms[2])) + unit
+            return str(angle.arcsec) + unit
     except (coord.errors.UnitsError, AttributeError):
         raise ValueError("Radius specified incorrectly")
 

--- a/astroquery/simbad/tests/test_simbad.py
+++ b/astroquery/simbad/tests/test_simbad.py
@@ -74,6 +74,7 @@ def post_mockreturn(url, data, timeout, **kwargs):
                           ('5.0d', '5d'),
                           (5 * u.deg, '5d'),
                           (5.0 * u.deg, '5d'),
+                          (1.2 * u.deg, '1.2d'),
                           (0.432 * u.deg, '25.92m'),
                           ('0d1m12s', '1.2m'),
                           (0.003 * u.deg, '10.8s'),

--- a/astroquery/simbad/tests/test_simbad.py
+++ b/astroquery/simbad/tests/test_simbad.py
@@ -69,13 +69,13 @@ def post_mockreturn(url, data, timeout, **kwargs):
 
 
 @pytest.mark.parametrize(('radius', 'expected_radius'),
-                         [('5d0m0s', '5d'),
+                         [('5d0m0s', '5.0d'),
                           ('5d', '5d'),
-                          ('5.0d', '5d'),
-                          (5 * u.deg, '5d'),
-                          (5.0 * u.deg, '5d'),
+                          ('5.0d', '5.0d'),
+                          (5 * u.deg, '5.0d'),
+                          (5.0 * u.deg, '5.0d'),
                           (1.2 * u.deg, '1.2d'),
-                          (0.432 * u.deg, '25.92m'),
+                          (0.5 * u.deg, '30.0m'),
                           ('0d1m12s', '1.2m'),
                           (0.003 * u.deg, '10.8s'),
                           ('0d0m15s', '15.0s')
@@ -136,7 +136,7 @@ votable_fields = ",".join(simbad.core.Simbad.get_votable_fields())
                            ("\nvotable {" + votable_fields + "}\n"
                             "votable open\n"
                             "query coo  5:35:17.3 -80:52:00 "
-                            "radius=5d frame=ICRS equi=2000.0 epoch=J2000 \n"
+                            "radius=5.0d frame=ICRS equi=2000.0 epoch=J2000 \n"
                             "votable close")),
                           (["m [0-9]"], dict(wildcard=True,
                                              caller='query_object_async'),

--- a/astroquery/simbad/tests/test_simbad.py
+++ b/astroquery/simbad/tests/test_simbad.py
@@ -70,7 +70,7 @@ def post_mockreturn(url, data, timeout, **kwargs):
 
 @pytest.mark.parametrize(('radius', 'expected_radius'),
                          [('5d0m0s', '5.0d'),
-                          ('5d', '5d'),
+                          ('5d', '5.0d'),
                           ('5.0d', '5.0d'),
                           (5 * u.deg, '5.0d'),
                           (5.0 * u.deg, '5.0d'),


### PR DESCRIPTION
Hi, 

Currently radius is incorrectly parsed when doing Simbad queries: 
Here is the illustration of the problem 

```
In [1]: import astropy.units as u
In [2]: import astroquery.simbad.core
In [3]: astroquery.simbad.core._parse_radius(1.92*u.degree)
Out[3]: '1d'
```
My patch fixes that. I also added a regression test for this issue.

```
In [1]: import astropy.units as u
In [2]: import astroquery.simbad.core
In [3]: astroquery.simbad.core._parse_radius(1.92*u.degree)
Out[3]: '1.92d'
```

Cheers,
      Sergey