### PR TITLE
Remove pinned QT versions in CI files again

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -27,11 +27,11 @@ env:
         - MAIN_CMD='python setup.py'
         - NUMPY_VERSION=stable
         - ASTROPY_VERSION=stable
-        - CONDA_DEPENDENCIES='requests beautifulsoup4 matplotlib html5lib keyring aplpy pyregion qt=4'
+        - CONDA_DEPENDENCIES='requests beautifulsoup4 matplotlib html5lib keyring aplpy pyregion'
         - PIP_DEPENDENCIES=''
         - SETUP_CMD='test'
         - CONDA_CHANNELS='astropy-ci-extras astropy'
-        - CONDA_DEPENDENCIES_OLD='requests beautiful-soup matplotlib html5lib qt=4'
+        - CONDA_DEPENDENCIES_OLD='requests beautiful-soup matplotlib html5lib'
         - PIP_DEPENDENCIES_OLD='pyregion aplpy keyring'
 
     matrix:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -10,7 +10,7 @@ environment:
       PYTHON_ARCH: "64" # needs to be set for CMD_IN_ENV to succeed. If a mix
                         # of 32 bit and 64 bit builds are needed, move this
                         # to the matrix section.
-      CONDA_DEPENDENCIES: "requests beautifulsoup4 matplotlib html5lib keyring aplpy pyregion qt=4"
+      CONDA_DEPENDENCIES: "requests beautifulsoup4 matplotlib html5lib keyring aplpy pyregion"
       CONDA_CHANNELS: "astropy"
 
   matrix:


### PR DESCRIPTION
This reverses #749 again because the temporary build errors should be resolved by now.

Closes #748 