### PR TITLE
Import parse_lamda_datafile into package level

### DIFF
--- a/astroquery/lamda/__init__.py
+++ b/astroquery/lamda/__init__.py
@@ -15,4 +15,4 @@ Note:
   references to the original papers providing the spectroscopic and collisional
   data are encouraged.
 """
-from .core import Lamda
+from .core import Lamda, parse_lamda_datafile

--- a/astroquery/lamda/core.py
+++ b/astroquery/lamda/core.py
@@ -181,6 +181,21 @@ def _absurl_from_url(url, base_url):
 
 
 def parse_lamda_datafile(filename):
+    """
+    Read a datafile that follows the format adopted for the atomic and
+    molecular data in the LAMDA database.
+
+    Parameters
+    ----------
+    filename : str
+        Fully qualified path of the file to read.
+
+    Returns
+    -------
+    Tuple of tables: ({rateid: Table, },
+                        Table,
+                        Table)
+    """
     with open(filename) as f:
         lines = f.readlines()
     return parse_lamda_lines(lines)


### PR DESCRIPTION
This function is useful to read locally modified versions of molecular datafiles in LAMDA format.