### PR TITLE
Fix docstring in atomic to make rtd pdf build pass

### DIFF
--- a/astroquery/atomic/core.py
+++ b/astroquery/atomic/core.py
@@ -39,6 +39,9 @@ class AtomicLineListClass(BaseQuery):
                      show_fine_structure=None,
                      show_auto_ionizing_transitions=None):
         """
+        Queries Atomic Line List for the given parameters adnd returns the
+        result as a `~astropy.table.Table`. All parameters are optional.
+
         Parameters
         ----------
         wavelength_range : pair of `astropy.units.Unit` values


### PR DESCRIPTION
I could build the pdf locally without error with this fix.