### PR TITLE
Force string type for HTTP response object in NIST _parse_result() method

### DIFF
--- a/astroquery/nist/core.py
+++ b/astroquery/nist/core.py
@@ -159,7 +159,7 @@ class NistClass(BaseQuery):
 
         pre_re = re.compile("<pre>(.*)</pre>", flags=re.DOTALL)
         links_re = re.compile(r"<a.*?>\s*(\w+)\s*</a>")
-        content = response.text
+        content = str(response.text)
 
         try:
             pre = pre_re.findall(content)[0]


### PR DESCRIPTION
This is an attempt to fix #714.

``requests.Response.text`` returns the content of the response in ``unicode`` type for python 2, while it is ``str`` type for python 3. Forcing the ``str`` type seems to suffice and solves the problem pointed out in #714, however I'm still not sure what was really messing up the parsing procedure.

I tried to play with response.encoding, but couldn't find anything.

Thoughts? @bsipocz @CameronSamuell

