### PR TITLE
Heasarc: Fixed problem where lines where stripped to much

### DIFF
--- a/astroquery/heasarc/core.py
+++ b/astroquery/heasarc/core.py
@@ -53,9 +53,10 @@ class HeasarcClass(BaseQuery):
         collens = [int(float(y[1:]))
                    for x, y in header.items() if "TFORM" in x]
         new_table = []
-
-        old_table = content.split("END")[-1].strip()
-        for line in old_table.split("\n"):
+        # this stops lines which end in spaces being stripped to much
+        old_table = content.split("END")[-1].strip(" ")
+        # remove empty lines
+        for line in filter(None, old_table.split("\n")):
             newline = []
             for n, tup in enumerate(zip(colstart, collens), start=1):
                 cstart, clen = tup


### PR DESCRIPTION
I fixed a problem where the mini fits parser which adds -1 into blank number columns strips away if the last column is empty. This caused a problem with record not being the correct size (from what I can gather).