### PR TITLE
ALMA: Allow kwargs as input

### DIFF
--- a/astroquery/alma/core.py
+++ b/astroquery/alma/core.py
@@ -105,7 +105,7 @@ class AlmaClass(QueryWithLogin):
                                 science=science, **kwargs)
 
     def query_async(self, payload, cache=True, public=True, science=True,
-                    view_format='raw', get_query_payload=False):
+                    view_format='raw', get_query_payload=False, **kwargs):
         """
         Perform a generic query with user-specified payload
 
@@ -125,6 +125,7 @@ class AlmaClass(QueryWithLogin):
 
         url = urljoin(self._get_dataarchive_url(), 'aq/')
 
+        payload.update(kwargs)
         payload.update({'result_view': view_format, 'format': 'VOTABLE',
                         'download': 'true'})
         if public:

--- a/docs/alma/alma.rst
+++ b/docs/alma/alma.rst
@@ -127,6 +127,16 @@ Region queries are just like any other in astroquery:
     >>> print(len(gc_data))
     383
 
+Querying by other parameters
+============================
+
+As of version 0.3.4, you can also query other fields by keyword. For example,
+if you want to find all projects with a particular PI, you could do:
+
+.. code-block:: python
+
+   >>> rslt = Alma.query_object('W51', pi_name='Ginsburg', public=False)
+
 Downloading Data
 ================
 


### PR DESCRIPTION
Previously, to include kwargs like `pi_name`, you had to use
`payload={'pi_name':'your_name'}`, which is annoying and unnecessary.  This
change allows them to be passed directly as kwargs.