### PR TITLE
Add 'resume download' capability

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -27,7 +27,7 @@ env:
         - MAIN_CMD='python setup.py'
         - NUMPY_VERSION=stable
         - ASTROPY_VERSION=stable
-        - CONDA_DEPENDENCIES='requests beautifulsoup4 html5lib keyring aplpy pyregion jinja2'
+        - CONDA_DEPENDENCIES='requests beautifulsoup4 html5lib keyring aplpy pyregion jinja2 flask httpbin'
         - PIP_DEPENDENCIES=''
         - SETUP_CMD='test'
         - CONDA_CHANNELS='astropy-ci-extras astropy'
@@ -125,9 +125,9 @@ matrix:
                SETUP_CMD='' EVENT_TYPE='push pull_request'
 
 install:
-    - pip install https://github.com/keflavich/httpbin/archive/master.zip
     - git clone git://github.com/astropy/ci-helpers.git
     - source ci-helpers/travis/setup_conda_$TRAVIS_OS_NAME.sh
+    - pip install https://github.com/keflavich/httpbin/archive/master.zip
 
 script:
    - python -c 'import httpbin; httpbin.app.run()'

--- a/.travis.yml
+++ b/.travis.yml
@@ -125,10 +125,12 @@ matrix:
                SETUP_CMD='' EVENT_TYPE='push pull_request'
 
 install:
+    - pip install https://github.com/keflavich/httpbin/archive/master.zip
     - git clone git://github.com/astropy/ci-helpers.git
     - source ci-helpers/travis/setup_conda_$TRAVIS_OS_NAME.sh
 
 script:
+   - python -c 'import httpbin; httpbin.app.run()'
    - $MAIN_CMD $SETUP_CMD
 
 after_success:

--- a/.travis.yml
+++ b/.travis.yml
@@ -130,7 +130,7 @@ install:
     - pip install https://github.com/keflavich/httpbin/archive/master.zip
 
 script:
-   - python -c 'import httpbin; httpbin.app.run()'
+   - python -c 'import httpbin; httpbin.app.run()' &
    - $MAIN_CMD $SETUP_CMD
 
 after_success:

--- a/.travis.yml
+++ b/.travis.yml
@@ -27,7 +27,7 @@ env:
         - MAIN_CMD='python setup.py'
         - NUMPY_VERSION=stable
         - ASTROPY_VERSION=stable
-        - CONDA_DEPENDENCIES='requests beautifulsoup4 html5lib keyring aplpy pyregion'
+        - CONDA_DEPENDENCIES='requests beautifulsoup4 html5lib keyring aplpy pyregion jinja2'
         - PIP_DEPENDENCIES=''
         - SETUP_CMD='test'
         - CONDA_CHANNELS='astropy-ci-extras astropy'

--- a/.travis.yml
+++ b/.travis.yml
@@ -27,8 +27,8 @@ env:
         - MAIN_CMD='python setup.py'
         - NUMPY_VERSION=stable
         - ASTROPY_VERSION=stable
-        - CONDA_DEPENDENCIES='requests beautifulsoup4 html5lib keyring aplpy pyregion jinja2 flask httpbin'
-        - PIP_DEPENDENCIES=''
+        - CONDA_DEPENDENCIES='requests beautifulsoup4 html5lib keyring aplpy pyregion jinja2 flask'
+        - PIP_DEPENDENCIES='https://github.com/keflavich/httpbin/archive/master.zip'
         - SETUP_CMD='test'
         - CONDA_CHANNELS='astropy-ci-extras astropy'
         - CONDA_DEPENDENCIES_OLD='requests beautiful-soup matplotlib html5lib'
@@ -127,7 +127,6 @@ matrix:
 install:
     - git clone git://github.com/astropy/ci-helpers.git
     - source ci-helpers/travis/setup_conda_$TRAVIS_OS_NAME.sh
-    - pip install https://github.com/keflavich/httpbin/archive/master.zip
 
 script:
    - python -c 'import httpbin; httpbin.app.run()' &

--- a/CHANGES
+++ b/CHANGES
@@ -3,6 +3,8 @@
 
 - Fix VizieR to respect specification to return default columns only (#792)
 - SIMBAD queries allow multiple configurable parameters (#820)
+- Add a capability to resume partially-completed downloads for services that
+  support the http 'range' keyword.  Currently applied to ESO and ALMA (#812)
 
 0.3.4 (2016-11-21)
 ------------------

--- a/astroquery/alma/core.py
+++ b/astroquery/alma/core.py
@@ -349,7 +349,7 @@ class AlmaClass(QueryWithLogin):
 
         return data_sizes, totalsize.to(u.GB)
 
-    def download_files(self, files, cache=True):
+    def download_files(self, files, cache=True, continuation=True):
         """
         Given a list of file URLs, download them
 
@@ -359,7 +359,8 @@ class AlmaClass(QueryWithLogin):
         downloaded_files = []
         for fileLink in unique(files):
             filename = self._request("GET", fileLink, save=True,
-                                     timeout=self.TIMEOUT, cache=cache)
+                                     timeout=self.TIMEOUT, cache=cache,
+                                     continuation=continuation)
             downloaded_files.append(filename)
         return downloaded_files
 

--- a/astroquery/eso/core.py
+++ b/astroquery/eso/core.py
@@ -522,13 +522,13 @@ class EsoClass(QueryWithLogin):
 
     def data_retrieval(self, datasets):
         """
-        DEPRECATED: see ``retrieve_datasets``
+        DEPRECATED: see ``retrieve_data``
         """
 
         warnings.warn("data_retrieval has been replaced with retrieve_data",
                       DeprecationWarning)
 
-    def retrieve_data(self, datasets, cache=True):
+    def retrieve_data(self, datasets, cache=True, continuation=False):
         """
         Retrieve a list of datasets form the ESO archive.
 
@@ -575,13 +575,22 @@ class EsoClass(QueryWithLogin):
                                               local_filename)
             if os.path.exists(local_filename):
                 log.info("Found {0}.fits...".format(dataset))
-                files.append(local_filename)
+                if continuation:
+                    datasets_to_download.append(dataset)
+                else:
+                    files.append(local_filename)
             elif os.path.exists(local_filename + ".Z"):
                 log.info("Found {0}.fits.Z...".format(dataset))
-                files.append(local_filename + ".Z")
+                if continuation:
+                    datasets_to_download.append(dataset)
+                else:
+                    files.append(local_filename + ".Z")
             elif os.path.exists(local_filename + ".fz"):  # RICE-compressed
                 log.info("Found {0}.fits.fz...".format(dataset))
-                files.append(local_filename + ".fz")
+                if continuation:
+                    datasets_to_download.append(dataset)
+                else:
+                    files.append(local_filename + ".fz")
             else:
                 datasets_to_download.append(dataset)
 
@@ -641,7 +650,8 @@ class EsoClass(QueryWithLogin):
             for fileId in root.select('input[name=fileId]'):
                 fileLink = ("http://dataportal.eso.org/dataPortal" +
                             fileId.attrs['value'].split()[1])
-                filename = self._request("GET", fileLink, save=True)
+                filename = self._request("GET", fileLink, save=True,
+                                         continuation=True)
                 files.append(system_tools.gunzip(filename))
         # Empty the redirect cache of this request session
         self._session.redirect_cache.clear()

--- a/astroquery/query.py
+++ b/astroquery/query.py
@@ -219,9 +219,17 @@ class BaseQuery(object):
             open_mode = 'ab'
 
             existing_file_length = os.stat(local_filepath).st_size
-            if existing_file_length == length:
+            if existing_file_length >= length:
                 # all done!
+                log.info("Found cached file {0} with expected size {1}."
+                         .format(local_filepath, existing_file_length))
                 return
+            else:
+                log.info("Continuing download of file {0}, with {1} bytes to "
+                         "go ({2}%)".format(local_filepath,
+                                            length - existing_file_length,
+                                            (length-existing_file_length)/length*100))
+
 
             self._session.headers['Range'] = "bytes={0}-{1}".format(existing_file_length, length)
             response = self._session.get(url, timeout=timeout, stream=True,

--- a/astroquery/query.py
+++ b/astroquery/query.py
@@ -131,7 +131,7 @@ class BaseQuery(object):
 
     def _request(self, method, url, params=None, data=None, headers=None,
                  files=None, save=False, savedir='', timeout=None, cache=True,
-                 stream=False, auth=None):
+                 stream=False, auth=None, continuation=False):
         """
         A generic HTTP request method, similar to `requests.Session.request`
         but with added caching-related tools
@@ -177,7 +177,8 @@ class BaseQuery(object):
             # REDUNDANT: spinner has this log.info("Downloading
             # {0}...".format(local_filename))
             self._download_file(url, local_filepath, timeout=timeout,
-                                auth=auth, cache=cache)
+                                auth=auth, cache=cache,
+                                continuation=continuation)
             return local_filepath
         else:
             query = AstroQuery(method, url, params=params, data=data,
@@ -199,20 +200,34 @@ class BaseQuery(object):
             return response
 
     def _download_file(self, url, local_filepath, timeout=None, auth=None,
-                       cache=False):
+                       continuation=False, cache=False, **kwargs):
         """
         Download a file.  Resembles `astropy.utils.data.download_file` but uses
         the local ``_session``
         """
         response = self._session.get(url, timeout=timeout, stream=True,
-                                     auth=auth)
+                                     auth=auth, **kwargs)
         response.raise_for_status()
         if 'content-length' in response.headers:
             length = int(response.headers['content-length'])
         else:
             length = None
 
-        if cache and os.path.exists(local_filepath):
+        if ((os.path.exists(local_filepath) and ('Accept-Ranges' in
+                                                 response.headers) and
+             continuation)):
+            open_mode = 'ab'
+
+            existing_file_length = os.stat(local_filepath).st_size
+            if existing_file_length == length:
+                # all done!
+                return
+
+            self._session.headers['Range'] = "bytes={0}-{1}".format(existing_file_length, length)
+            response = self._session.get(url, timeout=timeout, stream=True,
+                                         auth=auth, **kwargs)
+
+        elif cache and os.path.exists(local_filepath):
             if length is not None:
                 statinfo = os.stat(local_filepath)
                 if statinfo.st_size != length:
@@ -230,6 +245,8 @@ class BaseQuery(object):
                 log.info("Found cached file {0}.".format(local_filepath))
                 response.close()
                 return
+        else:
+            open_mode = 'wb'
 
         blocksize = astropy.utils.data.conf.download_block_size
 
@@ -238,7 +255,7 @@ class BaseQuery(object):
         with ProgressBarOrSpinner(
             length, ('Downloading URL {0} to {1} ...'
                      .format(url, local_filepath))) as pb:
-            with open(local_filepath, 'wb') as f:
+            with open(local_filepath, open_mode) as f:
                 for block in response.iter_content(blocksize):
                     f.write(block)
                     bytes_read += blocksize

--- a/astroquery/query.py
+++ b/astroquery/query.py
@@ -131,7 +131,7 @@ class BaseQuery(object):
 
     def _request(self, method, url, params=None, data=None, headers=None,
                  files=None, save=False, savedir='', timeout=None, cache=True,
-                 stream=False, auth=None, continuation=False):
+                 stream=False, auth=None, continuation=True):
         """
         A generic HTTP request method, similar to `requests.Session.request`
         but with added caching-related tools
@@ -200,7 +200,7 @@ class BaseQuery(object):
             return response
 
     def _download_file(self, url, local_filepath, timeout=None, auth=None,
-                       continuation=False, cache=False, **kwargs):
+                       continuation=True, cache=False, **kwargs):
         """
         Download a file.  Resembles `astropy.utils.data.download_file` but uses
         the local ``_session``

--- a/astroquery/query.py
+++ b/astroquery/query.py
@@ -249,6 +249,7 @@ class BaseQuery(object):
                                 .format(local_filepath,
                                         statinfo.st_size,
                                         length))
+                    open_mode = 'wb'
                 else:
                     log.info("Found cached file {0} with expected size {1}."
                              .format(local_filepath, statinfo.st_size))

--- a/astroquery/tests/test_internet.py
+++ b/astroquery/tests/test_internet.py
@@ -2,7 +2,7 @@
 from astropy.tests.helper import remote_data
 import requests
 
-from . import version
+from .. import version
 
 
 @remote_data

--- a/astroquery/tests/test_internet.py
+++ b/astroquery/tests/test_internet.py
@@ -2,9 +2,13 @@
 from astropy.tests.helper import remote_data
 import requests
 
+from . import version
+
 
 @remote_data
 def test_net_connection():
     R = requests.post('http://httpbin.org/post',
-                      headers={'User-Agent': 'astropy:astroquery.0.1.dev'})
+                      headers={'User-Agent':
+                               'astropy:astroquery.{0}'
+                               .format(version.version)})
     R.raise_for_status()


### PR DESCRIPTION
Add the capability to resume partially-completed downloads using the
`continuation` keyword.  Unfortunately, `continue` is the correct keyword
(as used by wget and rsync), but it is a reserved keyword in python.  

Continuation will only be attempted if the `Accept-Ranges` parameter is present
in the request header.

TODO: enable this for all downloading utilities.

 * [x] ESO
 * [x] ALMA
 * [ ] UKIDSS