### PR TITLE
Allow SIMBAD to query multiple configurable fields

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -2,6 +2,7 @@
 ------------------
 
 - Fix VizieR to respect specification to return default columns only (#792)
+- SIMBAD queries allow multiple configurable parameters (#820)
 
 0.3.4 (2016-11-21)
 ------------------

--- a/astroquery/simbad/core.py
+++ b/astroquery/simbad/core.py
@@ -234,21 +234,13 @@ class SimbadClass(BaseQuery):
         with open(dict_file, "r") as f:
             fields_dict = json.load(f)
             fields_dict = dict(
-                ((strip_field(ff) if '(' in ff else ff, fields_dict[ff])
+                ((strip_field(ff), fields_dict[ff])
                  for ff in fields_dict))
 
         for field in args:
             sf = strip_field(field)
             if sf not in fields_dict:
                 raise KeyError("{field}: no such field".format(field=field))
-            elif sf in [strip_field(ff, keep_filters=True)
-                        for ff in self._VOTABLE_FIELDS]:
-                errmsg = "{field}: field already present. ".format(field=field)
-                errmsg += ("Fields ra,dec,id,otype, and bibcodelist can only "
-                           "be specified once.  To change their options, "
-                           "first remove the existing entry, then add a new "
-                           "one.")
-                raise KeyError(errmsg)
             else:
                 self._VOTABLE_FIELDS.append(field)
 

--- a/astroquery/simbad/tests/test_simbad.py
+++ b/astroquery/simbad/tests/test_simbad.py
@@ -385,13 +385,11 @@ def test_simbad_settings2():
 def test_regression_votablesettings():
     assert simbad.Simbad.get_votable_fields() == ['main_id', 'coordinates']
     simbad.core.Simbad.add_votable_fields('ra', 'dec(5)')
-    with pytest.raises(KeyError) as ex:
-        simbad.core.Simbad.add_votable_fields('ra(d)', 'dec(d)')
-    assert ex.value.args[0] == ('ra(d): field already present. Fields '
-                                'ra,dec,id,otype, and bibcodelist can only '
-                                'be specified once.  To change their options, '
-                                'first remove the existing entry, then add '
-                                'a new one.')
+    # this is now allowed:
+    simbad.core.Simbad.add_votable_fields('ra(d)', 'dec(d)')
+    assert simbad.Simbad.get_votable_fields() == ['main_id', 'coordinates',
+                                                  'ra', 'dec(5)', 'ra(d)',
+                                                  'dec(d)']
     # cleanup
     simbad.core.Simbad.remove_votable_fields('ra', 'dec', strip_params=True)
     assert simbad.Simbad.get_votable_fields() == ['main_id', 'coordinates']

--- a/astroquery/simbad/tests/test_simbad_remote.py
+++ b/astroquery/simbad/tests/test_simbad_remote.py
@@ -154,3 +154,34 @@ class TestSimbad(object):
         request.add_votable_fields("flux_qual(V)")
         response = request.query_object('algol')
         assert("FLUX_QUAL_V" in response.keys())
+
+    def test_multi_vo_fields(self):
+        '''Regression test for issue 820'''
+        request = simbad.core.Simbad()
+
+        request.add_votable_fields("flux_qual(V)")
+        request.add_votable_fields("flux_qual(R)")
+        request.add_votable_fields("coo(s)") # sexagesimal coordinates
+        request.add_votable_fields("coo(d)") # degree coordinates
+        request.add_votable_fields("ra(:;A;ICRS;J2000)")
+        request.add_votable_fields("ra(:;A;fk5;J2000)")
+        request.add_votable_fields("bibcodelist(2000-2006)")
+        request.add_votable_fields("bibcodelist(1990-2000)")
+        request.add_votable_fields("otype(S)")
+        request.add_votable_fields("otype(3)")
+        request.add_votable_fields("id(1)")
+        request.add_votable_fields("id(2MASS)")
+        request.add_votable_fields("id(s)")
+
+        response = request.query_object('algol')
+        assert("FLUX_QUAL_V" in response.keys())
+        assert("FLUX_QUAL_R" in response.keys())
+        assert("RA_d" in response.keys())
+        assert("RA_s" in response.keys())
+        assert("RA___A_ICRS_J2000" in response.keys())
+        assert("RA___A_fk5_J2000" in response.keys())
+        assert("OTYPE_S" in response.keys())
+        assert("OTYPE_3" in response.keys())
+        assert("id_1" in response.keys())
+        assert("id_2mass" in response.keys())
+        assert("id_s" in response.keys())

--- a/astroquery/simbad/tests/test_simbad_remote.py
+++ b/astroquery/simbad/tests/test_simbad_remote.py
@@ -170,7 +170,7 @@ class TestSimbad(object):
         request.add_votable_fields("otype(S)")
         request.add_votable_fields("otype(3)")
         request.add_votable_fields("id(1)")
-        request.add_votable_fields("id(2MASS)")
+        request.add_votable_fields("id(2mass)")
         request.add_votable_fields("id(s)")
 
         response = request.query_object('algol')
@@ -182,6 +182,6 @@ class TestSimbad(object):
         assert("RA___A_fk5_J2000" in response.keys())
         assert("OTYPE_S" in response.keys())
         assert("OTYPE_3" in response.keys())
-        assert("id_1" in response.keys())
-        assert("id_2mass" in response.keys())
-        assert("id_s" in response.keys())
+        assert("ID_1" in response.keys())
+        assert("ID_2mass" in response.keys())
+        assert("ID_s" in response.keys())


### PR DESCRIPTION
[This stackoverflow post](http://stackoverflow.com/questions/41369114/astroquery-simbad-obtaining-coordinates-for-all-frames) points out that it is not currently possible to query multiple SIMBAD votable fields with configurable options, even though this operation is supported by SIMBAD.  It's not clear why we ever forbid this.

I have a fix in progress.
