### PR TITLE
Fix remote eso test

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -91,6 +91,8 @@ matrix:
                PIP_DEPENDENCIES=$PIP_DEPENDENCIES_OLD
         - os: linux
           env: PYTHON_VERSION=3.5 NUMPY_VERSION=1.10
+        - os: linux
+          env: PYTHON_VERSION=3.5 NUMPY_VERSION=1.11
 
         # Now try Astropy dev and LTS vesions with the latest 3.x and 2.7.
         - os: linux

--- a/astroquery/eso/tests/test_eso_remote.py
+++ b/astroquery/eso/tests/test_eso_remote.py
@@ -12,7 +12,7 @@ instrument_list = [u'fors1', u'fors2', u'sphere', u'vimos', u'omegacam',
                    u'hawki', u'isaac', u'naco', u'visir', u'vircam', u'apex',
                    u'giraffe', u'uves', u'xshooter', u'muse', u'crires',
                    u'kmos', u'sinfoni', u'amber', u'midi', u'pionier',
-                   u'harps', u'gravity']
+                   u'harps', u'gravity', u'feros']
 
 
 @remote_data


### PR DESCRIPTION
This PR adds FEROS to the local instruments list, and also adds numpy 1.11 to the travis matrix.