### PR TITLE
Rename async keyword to async_job

### DIFF
--- a/astroquery/gaia/core.py
+++ b/astroquery/gaia/core.py
@@ -210,7 +210,7 @@ class GaiaClass(object):
         return self.__gaiatap.list_async_jobs(verbose)
 
     def __query_object(self, coordinate, radius=None, width=None, height=None,
-                     async=False, verbose=False):
+                       async_job=False, verbose=False):
         """Launches a job
         TAP & TAP+
 
@@ -224,7 +224,7 @@ class GaiaClass(object):
             box width
         height : astropy.units, required if no 'radius' is provided
             box height
-        async : bool, optional, default 'False'
+        async_job : bool, optional, default 'False'
             executes the query (job) in asynchronous/synchronous mode (default
             synchronous)
         verbose : bool, optional, default 'False'
@@ -237,7 +237,8 @@ class GaiaClass(object):
         coord = self.__getCoordInput(coordinate, "coordinate")
         job = None
         if radius is not None:
-            job = self.__cone_search(coord, radius, async=async, verbose=verbose)
+            job = self.__cone_search(coord, radius,
+                                     async_job=async_job, verbose=verbose)
         else:
             raHours, dec = commons.coord_to_radec(coord)
             ra = raHours * 15.0  # Converts to degrees
@@ -254,7 +255,7 @@ class GaiaClass(object):
                 BOX('ICRS',"+str(ra)+","+str(dec)+", "+str(widthDeg.value)+", "\
                 + str(heightDeg.value)+"))=1 \
                 ORDER BY dist ASC"
-            if async:
+            if async_job:
                 job = self.__gaiatap.launch_job_async(query, verbose=verbose)
             else:
                 job = self.__gaiatap.launch_job(query, verbose=verbose)
@@ -286,7 +287,7 @@ class GaiaClass(object):
                                  radius,
                                  width,
                                  height,
-                                 async=False,
+                                 async_job=False,
                                  verbose=verbose)
 
     def query_object_async(self, coordinate, radius=None, width=None,
@@ -304,7 +305,7 @@ class GaiaClass(object):
             box width
         height : astropy.units, required if no 'radius' is provided
             box height
-        async : bool, optional, default 'False'
+        async_job : bool, optional, default 'False'
             executes the query (job) in asynchronous/synchronous mode (default synchronous)
         verbose : bool, optional, default 'False'
             flag to display information about the process
@@ -317,12 +318,13 @@ class GaiaClass(object):
                                  radius,
                                  width,
                                  height,
-                                 async=True,
+                                 async_job=True,
                                  verbose=verbose)
 
-    def __cone_search(self, coordinate, radius, async=False, background=False,
-                    output_file=None, output_format="votable", verbose=False,
-                    dump_to_file=False):
+    def __cone_search(self, coordinate, radius, async_job=False,
+                      background=False,
+                      output_file=None, output_format="votable", verbose=False,
+                      dump_to_file=False):
         """Cone search sorted by distance
         TAP & TAP+
 
@@ -332,7 +334,7 @@ class GaiaClass(object):
             coordinates center point
         radius : astropy.units, mandatory
             radius
-        async : bool, optional, default 'False'
+        async_job : bool, optional, default 'False'
             executes the job in asynchronous/synchronous mode (default
             synchronous)
         background : bool, optional, default 'False'
@@ -365,7 +367,7 @@ class GaiaClass(object):
             POINT('ICRS',"+str(MAIN_GAIA_TABLE_RA)+","+str(MAIN_GAIA_TABLE_DEC)+"),\
             CIRCLE('ICRS',"+str(ra)+","+str(dec)+", "+str(radiusDeg)+"))=1 \
             ORDER BY dist ASC"
-        if async:
+        if async_job:
             return self.__gaiatap.launch_job_async(query=query,
                                          output_file=output_file,
                                          output_format=output_format,
@@ -407,7 +409,7 @@ class GaiaClass(object):
         """
         return self.__cone_search(coordinate,
                                   radius=radius,
-                                  async=False,
+                                  async_job=False,
                                   background=False,
                                   output_file=output_file,
                                   output_format=output_format,
@@ -445,7 +447,7 @@ class GaiaClass(object):
         """
         return self.__cone_search(coordinate,
                                   radius=radius,
-                                  async=True,
+                                  async_job=True,
                                   background=background,
                                   output_file=output_file,
                                   output_format=output_format,

--- a/astroquery/utils/tap/core.py
+++ b/astroquery/utils/tap/core.py
@@ -206,7 +206,7 @@ class Tap(object):
                                         "sync",
                                         verbose,
                                         name)
-        job = Job(async=False, query=query, connhandler=self.__connHandler)
+        job = Job(async_job=False, query=query, connhandler=self.__connHandler)
         isError = self.__connHandler.check_launch_response_status(response,
                                                                   verbose,
                                                                   200)
@@ -286,7 +286,7 @@ class Tap(object):
         isError = self.__connHandler.check_launch_response_status(response,
                                                                   verbose,
                                                                   303)
-        job = Job(async=True, query=query, connhandler=self.__connHandler)
+        job = Job(async_job=True, query=query, connhandler=self.__connHandler)
         suitableOutputFile = self.__getSuitableOutputFile(True,
                                                           output_file,
                                                           response.getheaders(),
@@ -359,7 +359,7 @@ class Tap(object):
             raise Exception(response.reason)
             return None
         # parse job
-        jsp = JobSaxParser(async=True)
+        jsp = JobSaxParser(async_job=True)
         job = jsp.parseData(response)[0]
         job.set_connhandler(self.__connHandler)
         # load resulst
@@ -391,7 +391,7 @@ class Tap(object):
             raise Exception(response.reason)
             return None
         # parse jobs
-        jsp = JobListSaxParser(async=True)
+        jsp = JobListSaxParser(async_job=True)
         jobs = jsp.parseData(response)
         if jobs is not None:
             for j in jobs:
@@ -470,13 +470,13 @@ class Tap(object):
             print(response.getheaders())
         return response
 
-    def __getSuitableOutputFile(self, async, outputFile, headers, isError,
+    def __getSuitableOutputFile(self, async_job, outputFile, headers, isError,
                                 output_format):
         dateTime = datetime.now().strftime("%Y%m%d%H%M%S")
         ext = self.__connHandler.get_suitable_extension(headers)
         fileName = ""
         if outputFile is None:
-            if not async:
+            if not async_job:
                 fileName = "sync_" + str(dateTime) + ext
             else:
                 ext = self.__connHandler.get_suitable_extension_by_format(
@@ -697,7 +697,7 @@ class TapPlus(Tap):
             raise Exception(response.reason)
             return None
         # parse jobs
-        jsp = JobSaxParser(async=True)
+        jsp = JobSaxParser(async_job=True)
         jobs = jsp.parseData(response)
         if jobs is not None:
             for j in jobs:

--- a/astroquery/utils/tap/model/job.py
+++ b/astroquery/utils/tap/model/job.py
@@ -15,10 +15,10 @@ Created on 30 jun. 2016
 
 """
 
-from astroquery.utils.tap.xmlparser import utils
 import time
-import os
+
 from astroquery.utils.tap.model import modelutils
+from astroquery.utils.tap.xmlparser import utils
 
 __all__ = ['Job']
 
@@ -27,12 +27,12 @@ class Job(object):
     """Job class
     """
 
-    def __init__(self, async, query=None, connhandler=None):
+    def __init__(self, async_job, query=None, connhandler=None):
         """Constructor
 
         Parameters
         ----------
-        async : bool, mandatory
+        async_job : bool, mandatory
             'True' if the job is asynchronous
         query : str, optional, default None
             Query
@@ -41,7 +41,7 @@ class Job(object):
         """
         self.__internal_init()
         self.__connHandler = connhandler
-        self.__async = async
+        self.__async = async_job
         self.__parameters['query'] = query
 
     def __internal_init(self):

--- a/astroquery/utils/tap/model/tests/test_job.py
+++ b/astroquery/utils/tap/model/tests/test_job.py
@@ -30,14 +30,14 @@ def data_path(filename):
 class TestJob(unittest.TestCase):
 
     def test_job_basic(self):
-        job = Job(async=False)
+        job = Job(async_job=False)
         res = job.is_sync()
         assert res, \
             "Sync job, expected: %s, found: %s" % (str(True), str(res))
         res = job.is_async()
         assert res == False, \
             "Sync job, expected: %s, found: %s" % (str(False), str(res))
-        job = Job(async=True)
+        job = Job(async_job=True)
         res = job.is_sync()
         assert res == False, \
             "Async job, expected: %s, found: %s" % (str(False), str(res))
@@ -67,7 +67,7 @@ class TestJob(unittest.TestCase):
         locationid = "locationid"
         name = "name"
         quote = "quote"
-        job = Job(async=False, query=query)
+        job = Job(async_job=False, query=query)
         job.set_jobid(jobid)
         job.set_remote_location(remoteLocation)
         job.set_phase(phase)
@@ -139,7 +139,7 @@ class TestJob(unittest.TestCase):
                                                 job.get_quote())
 
     def test_job_get_results(self):
-        job = Job(async=True)
+        job = Job(async_job=True)
         jobid = "12345"
         outputFormat = "votable"
         job.set_jobid(jobid)

--- a/astroquery/utils/tap/xmlparser/jobListSaxParser.py
+++ b/astroquery/utils/tap/xmlparser/jobListSaxParser.py
@@ -33,12 +33,12 @@ class JobListSaxParser(xml.sax.ContentHandler):
     classdocs
     '''
 
-    def __init__(self, async=False):
+    def __init__(self, async_job=False):
         '''
         Constructor
         '''
         self.__internal_init()
-        self.__async = async
+        self.__async = async_job
 
     def __internal_init(self):
         self.__concatData = False

--- a/astroquery/utils/tap/xmlparser/jobSaxParser.py
+++ b/astroquery/utils/tap/xmlparser/jobSaxParser.py
@@ -45,12 +45,12 @@ class JobSaxParser(xml.sax.ContentHandler):
     classdocs
     '''
 
-    def __init__(self, async=False):
+    def __init__(self, async_job=False):
         '''
         Constructor
         '''
         self.__internal_init()
-        self.__async = async
+        self.__async = async_job
 
     def __internal_init(self):
         self.__concatData = False


### PR DESCRIPTION
 to avoid python3.7 deprecation (see PEP 492 for details)

Fixes #855 


~~There are sadly tons of unrelated PEP8 fixes that my editor did automatically. I'm opening a separate pep8 fixing PR and rebase this if needed.~~ now rebased