### PR TITLE
Fixes variable mismatch in docstring for #865 [skip ci]

### DIFF
--- a/astroquery/magpis/core.py
+++ b/astroquery/magpis/core.py
@@ -47,7 +47,7 @@ class MagpisClass(BaseQuery):
             the appropriate `astropy.coordinates` object. ICRS coordinates
             may also be entered as strings as specified in the
             `astropy.coordinates` module.
-        radius : str or `~astropy.units.Quantity` object, optional
+        image_size : str or `~astropy.units.Quantity` object, optional
            The string must be parsable by `astropy.coordinates.Angle`. The
            appropriate `~astropy.units.Quantity` object from `astropy.units`
            may also be used. Specifies the symmetric size of the


### PR DESCRIPTION
@bsipocz  The mismatch between the name of the variable ``radius`` >> ``image_size`` in function ``_args_to_payload()`` is fixed by this PR. NO need to build hence ``[skip ci]`` as only docstring change in one line.