### PR TITLE
Write tuple of tables into a LAMDA datafile

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,7 +1,7 @@
-0.3.5 (unreleased)
+0.3.6 (unreleased)
 ------------------
 
- - none yet
+- LAMDA: Add function to write LAMDA-formatted Tables to a datafile
 
 0.3.5 (2017-03-29)
 ------------------

--- a/astroquery/lamda/__init__.py
+++ b/astroquery/lamda/__init__.py
@@ -15,4 +15,4 @@ Note:
   references to the original papers providing the spectroscopic and collisional
   data are encouraged.
 """
-from .core import Lamda, parse_lamda_datafile
+from .core import Lamda, parse_lamda_datafile, write_lamda_datafile

--- a/astroquery/lamda/core.py
+++ b/astroquery/lamda/core.py
@@ -217,32 +217,40 @@ def write_lamda_datafile(filename, tables):
 
     collrates, radtransitions, enlevels = tables
 
-    levels_hdr = ("! MOLECULE\n"
-              "{0}\n"
-              "! MOLECULAR WEIGHT\n"
-              "{1}\n"
-              "! NUMBER OF ENERGY LEVELS\n"
-              "{2}\n"
-              "! LEVEL + ENERGIES(cm^-1) + WEIGHT + J\n")
-    radtrans_hdr = ("! NUMBER OF RADIATIVE TRANSITIONS\n"
-                    "{0}\n"
-                    "! TRANS + UP + LOW + EINSTEINA(s^-1) + FREQ(GHz) + E_u(K)\n")
-    coll_hdr = ("! NUMBER OF COLL PARTNERS\n"
-                "{0}\n")
-    coll_part_hdr = ("! COLLISION PARTNER\n"
-                "{0} {1}\n"
-                "! NUMBER OF COLLISIONAL TRANSITIONS\n"
-                "{2}\n"
-                "! NUMBER OF COLLISION TEMPERATURES\n"
-                "{3}\n"
-                "! COLLISION TEMPERATURES\n"
-                "{4}\n"
-                "! TRANS + UP + LOW + RATE COEFFS(cm^3 s^-1)\n")
+    levels_hdr = ("""! MOLECULE
+                  {0}
+                  ! MOLECULAR WEIGHT
+                  {1}
+                  ! NUMBER OF ENERGY LEVELS
+                  {2}
+                  ! LEVEL + ENERGIES(cm^-1) + WEIGHT + J
+                  """)
+    levels_hdr = re.sub('^ +', '', levels_hdr, flags=re.MULTILINE)
+    radtrans_hdr = ("""! NUMBER OF RADIATIVE TRANSITIONS
+                    {0}
+                    ! TRANS + UP + LOW + EINSTEINA(s^-1) + FREQ(GHz) + E_u(K)
+                    """)
+    radtrans_hdr = re.sub('^ +', '', radtrans_hdr, flags=re.MULTILINE)
+    coll_hdr = ("""! NUMBER OF COLL PARTNERS
+                {0}
+                """)
+    coll_hdr = re.sub('^ +', '', coll_hdr, flags=re.MULTILINE)
+    coll_part_hdr = ("""! COLLISION PARTNER
+                     {0} {1}
+                     ! NUMBER OF COLLISIONAL TRANSITIONS
+                     {2}
+                     ! NUMBER OF COLLISION TEMPERATURES
+                     {3}
+                     ! COLLISION TEMPERATURES
+                     {4}
+                     ! TRANS + UP + LOW + RATE COEFFS(cm^3 s^-1)
+                     """)
+    coll_part_hdr = re.sub('^ +', '', coll_part_hdr, flags=re.MULTILINE)
 
     with open(filename, 'w') as f:
         f.write(levels_hdr.format(enlevels.meta['molecule'],
-                                 enlevels.meta['molwt'],
-                                 enlevels.meta['nenergylevels']))
+                                  enlevels.meta['molwt'],
+                                  enlevels.meta['nenergylevels']))
         enlevels.write(f, format='ascii.no_header')
         f.write(radtrans_hdr.format(radtransitions.meta['radtrans']))
         radtransitions.write(f, format='ascii.no_header')

--- a/astroquery/lamda/tests/test_lamda.py
+++ b/astroquery/lamda/tests/test_lamda.py
@@ -1,5 +1,7 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 import os
+import tempfile
+import numpy as np
 from ...lamda import core
 
 DATA_FILES = {'co': 'co.txt'}
@@ -17,3 +19,22 @@ def test_parser():
     assert set(collrates.keys()) == set(['PH2', 'OH2'])
     assert len(enlevels) == 41
     assert len(radtransitions) == 40
+
+
+def test_writer():
+    tables = core.parse_lamda_datafile(data_path('co.txt'))
+    coll, radtrans, enlevels = tables
+
+    tmpfd, tmpname = tempfile.mkstemp()
+    core.write_lamda_datafile(tmpname, tables)
+
+    coll2, radtrans2, enlevels2 = core.parse_lamda_datafile(tmpname)
+
+    np.testing.assert_almost_equal(enlevels['Energy'], enlevels2['Energy'])
+    np.testing.assert_almost_equal(radtrans['EinsteinA'],
+                                   radtrans2['EinsteinA'])
+    np.testing.assert_almost_equal(radtrans['Frequency'],
+                                   radtrans2['Frequency'])
+    for k in coll:
+        np.testing.assert_almost_equal(coll[k]['C_ij(T=5)'],
+                                       coll2[k]['C_ij(T=5)'])


### PR DESCRIPTION
The function `write_lamda_datafile` takes the molecular data tables and writes them to a file with LAMDA format specified by the user. This is useful to change some of the collisional parameters in the database or select a different number of levels.