### PR TITLE
Dropping old numpy and python versions in testing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -39,7 +39,6 @@ env:
 
     matrix:
         - PYTHON_VERSION=2.7 SETUP_CMD='egg_info'
-        - PYTHON_VERSION=3.3 SETUP_CMD='egg_info'
         - PYTHON_VERSION=3.4 SETUP_CMD='egg_info'
         - PYTHON_VERSION=3.5 SETUP_CMD='egg_info'
         - PYTHON_VERSION=3.6 SETUP_CMD='egg_info'
@@ -82,22 +81,9 @@ matrix:
         # versions of Python, we can vary Python and Numpy versions at the same
         # time. We don't expect any of these to fail in master for cron jobs.
         - os: linux
-          env: PYTHON_VERSION=2.7 NUMPY_VERSION=1.7
-               CONDA_DEPENDENCIES=$CONDA_DEPENDENCIES_OLD
-               PIP_DEPENDENCIES=$PIP_DEPENDENCIES_OLD
-               RUN_HTTPBIN=""
+          env: PYTHON_VERSION=2.7 NUMPY_VERSION=1.9
         - os: linux
-          env: PYTHON_VERSION=3.3 NUMPY_VERSION=1.8
-               CONDA_DEPENDENCIES=$CONDA_DEPENDENCIES_OLD
-               PIP_DEPENDENCIES=$PIP_DEPENDENCIES_OLD
-               RUN_HTTPBIN=""
-        - os: linux
-          env: PYTHON_VERSION=3.4 NUMPY_VERSION=1.9
-               CONDA_DEPENDENCIES=$CONDA_DEPENDENCIES_OLD
-               PIP_DEPENDENCIES=$PIP_DEPENDENCIES_OLD
-               RUN_HTTPBIN=""
-        - os: linux
-          env: PYTHON_VERSION=3.5 NUMPY_VERSION=1.10
+          env: PYTHON_VERSION=3.4 NUMPY_VERSION=1.10
         - os: linux
           env: PYTHON_VERSION=3.5 NUMPY_VERSION=1.11
 

--- a/astroquery/lamda/tests/test_lamda.py
+++ b/astroquery/lamda/tests/test_lamda.py
@@ -2,6 +2,10 @@
 import os
 import tempfile
 import numpy as np
+import pytest
+import sys
+import platform
+
 from ...lamda import core
 
 DATA_FILES = {'co': 'co.txt'}
@@ -21,6 +25,9 @@ def test_parser():
     assert len(radtransitions) == 40
 
 
+@pytest.mark.xfail(platform.system() == 'Windows' and sys.version_info[0] >= 3,
+                   reason=("https://github.com/astropy/astroquery/pull/894 and "
+                           "https://github.com/astropy/astropy/issues/5126"))
 def test_writer():
     tables = core.parse_lamda_datafile(data_path('co.txt'))
     coll, radtrans, enlevels = tables

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -67,12 +67,12 @@ The development version can be obtained and installed from github:
 Requirements
 ------------
 
-Astroquery works with Python 2.7 and 3.3 or later.
+Astroquery works with Python 2.7 and 3.4 or later.
 
 The following packages are required for astroquery installation & use:
 
-* `numpy <http://www.numpy.org>`_ >= 1.6
-* `astropy <http://www.astropy.org>`__ (>=0.4)
+* `numpy <http://www.numpy.org>`_ >= 1.9
+* `astropy <http://www.astropy.org>`__ (>=1.0)
 * `requests <http://docs.python-requests.org/en/latest/>`_
 * `keyring <https://pypi.python.org/pypi/keyring>`_
 * `Beautiful Soup <http://www.crummy.com/software/BeautifulSoup/>`_

--- a/setup.py
+++ b/setup.py
@@ -110,7 +110,7 @@ for root, dirs, files in os.walk(PACKAGENAME):
                     os.path.relpath(root, PACKAGENAME), filename))
 package_info['package_data'][PACKAGENAME].extend(c_files)
 
-required_packages = ['astropy>=0.4.1', 'requests>=2.4.3', 'keyring>=4.0',
+required_packages = ['astropy>=1.0', 'requests>=2.4.3', 'keyring>=4.0',
                      'beautifulsoup4>=4.3.2', 'html5lib>=0.999']
 
 setup(name=PACKAGENAME,


### PR DESCRIPTION
Numpy <1.9 and python 3.3 become unsupported in astropy 2.0, so I suggest to drop testing for those. Also we may want to revise our requirements for smallest astropy version required. 
