### PR TITLE
Removing passing xfail mark

### DIFF
--- a/astroquery/simbad/tests/test_simbad.py
+++ b/astroquery/simbad/tests/test_simbad.py
@@ -167,7 +167,6 @@ def test_validation(epoch, equinox):
             simbad.core.validate_epoch(epoch)
 
 
-@pytest.mark.xfail()
 @pytest.mark.parametrize(('bibcode', 'wildcard'),
                          [('2006ApJ*', True),
                           ('2005A&A.430.165F', None)


### PR DESCRIPTION
This is passing now, and I have no recollection for the reason why it was marked at the first place.