### PR TITLE
Retrieve the full list of bibcodes for one object (SIMBAD)

### DIFF
--- a/astroquery/simbad/tests/test_simbad.py
+++ b/astroquery/simbad/tests/test_simbad.py
@@ -205,6 +205,37 @@ def test_query_objectids(patch_post):
     assert isinstance(result2, Table)
 
 
+def test_query_bibcodelist_async(patch_post):
+    response1 = simbad.core.Simbad.query_bibcodelist_async('Polaris')
+    response2 = simbad.core.Simbad().query_bibcodelist_async('Polaris')
+    
+    response3 = simbad.core.Simbad.query_bibcodelist_async('QSO J0210+0118')
+    response4 = simbad.core.Simbad().query_bibcodelist_async('QSO J0210+0118')
+    
+    assert response1 is not None and response2 is not None
+    assert response1.content == response2.content
+    
+    assert response3 is not None and response4 is not None
+    assert response3.content == response4.content
+
+
+def test_query_bibcodelist(patch_post):
+    response1 = simbad.core.Simbad.query_bibcodelist('Polaris')
+    response2 = simbad.core.Simbad().query_bibcodelist('Polaris')
+    
+    response3 = simbad.core.Simbad.query_bibcodelist('QSO J0210+0118')
+    response4 = simbad.core.Simbad().query_bibcodelist('QSO J0210+0118')
+    
+    assert isinstance(result1, Table)
+    assert isinstance(result2, Table)
+    
+    assert isinstance(result3, Table)
+    assert isinstance(result4, Table)
+    assert "2009A&A...505..385A" in reponse3["BIBCODE"][0]
+    assert "QSO J0210+0118"==reponse3["MAIN_ID"][0]
+    
+    
+    
 def test_query_bibobj_async(patch_post):
     response1 = simbad.core.Simbad.query_bibobj_async('2005A&A.430.165F')
     response2 = simbad.core.Simbad().query_bibobj_async('2005A&A.430.165F')

--- a/docs/simbad/simbad.rst
+++ b/docs/simbad/simbad.rst
@@ -366,6 +366,27 @@ associated with an object.
 	     PLX  299.00
     WDS J02318+8916Aa,Ab
 
+Query object bibcodes
+------------------------
+
+
+These queries can be used to retrieve all bibcodes associated with an object.
+
+.. code-block:: python
+
+    >>> from astroquery.simbad import Simbad
+    >>> result_table = Simbad.query_bibcode("QSO J0210+0118")
+    >>>  print(result_table["MAIN_ID"])
+   	    MAIN_ID    
+	--------------
+	QSO J0210+0118
+    >>> print(result_table["BIBCODE"])
+	      BIBCODE                                                                  
+-------------------------------------------------------------------------------------------------------------------------------------------
+2014A&A...563A..54P;2012MNRAS.426..851K;2010A&A...518A..10V;2009A&A...505..385A;2006A&A...455..773V;2001ApJS..135..227B;1998ApJ...494..503B
+
+
+
 Query a bibobj
 --------------
 


### PR DESCRIPTION
Method: query_bibcodelist

Return the list of all bibcodes for one object, queried from Simbad. The bibcodes are contained in one row (and are separated by ";". The first column gives the "Main ID" of the object)
(Until now, only the "Coordinate reference" was accessible)

(Simple tests and basic documentation added)