### PR TITLE
Adding verify kwarg to requests to avoid SSLErrors

### DIFF
--- a/astroquery/astroquery.cfg
+++ b/astroquery/astroquery.cfg
@@ -60,8 +60,8 @@
 [magpis]
 
 # Name of the MAGPIS server.
-# Options: http://third.ucllnl.org/cgi-bin/gpscutout
-#magpis_server = http://third.ucllnl.org/cgi-bin/gpscutout
+# Options: https://third.ucllnl.org/cgi-bin/gpscutout
+#magpis_server = https://third.ucllnl.org/cgi-bin/gpscutout
 
 # time limit for connecting to MAGPIS server
 #timeout = 60

--- a/astroquery/magpis/__init__.py
+++ b/astroquery/magpis/__init__.py
@@ -19,7 +19,7 @@ class Conf(_config.ConfigNamespace):
     Configuration parameters for `astroquery.magpis`.
     """
     server = _config.ConfigItem(
-        ['http://third.ucllnl.org/cgi-bin/gpscutout'],
+        ['https://third.ucllnl.org/cgi-bin/gpscutout'],
         'Name of the MAGPIS server.')
     timeout = _config.ConfigItem(
         60,

--- a/astroquery/magpis/core.py
+++ b/astroquery/magpis/core.py
@@ -115,7 +115,7 @@ class MagpisClass(BaseQuery):
         if get_query_payload:
             return request_payload
         response = self._request("POST", url=self.URL, data=request_payload,
-                                 timeout=self.TIMEOUT)
+                                 timeout=self.TIMEOUT, verify=False)
         return response
 
     def list_surveys(self):

--- a/astroquery/magpis/tests/test_magpis.py
+++ b/astroquery/magpis/tests/test_magpis.py
@@ -2,7 +2,6 @@
 from __future__ import print_function
 
 import os
-import requests
 
 import numpy.testing as npt
 import pytest

--- a/astroquery/query.py
+++ b/astroquery/query.py
@@ -53,11 +53,12 @@ class AstroQuery(object):
         else:
             self._timeout = value
 
-    def request(self, session, cache_location=None, stream=False, auth=None):
+    def request(self, session, cache_location=None, stream=False,
+                auth=None, verify=True):
         return session.request(self.method, self.url, params=self.params,
                                data=self.data, headers=self.headers,
                                files=self.files, timeout=self.timeout,
-                               stream=stream, auth=auth)
+                               stream=stream, auth=auth, verify=verify)
 
     def hash(self):
         if self._hash is None:
@@ -131,7 +132,7 @@ class BaseQuery(object):
 
     def _request(self, method, url, params=None, data=None, headers=None,
                  files=None, save=False, savedir='', timeout=None, cache=True,
-                 stream=False, auth=None, continuation=True):
+                 stream=False, auth=None, continuation=True, verify=True):
         """
         A generic HTTP request method, similar to `requests.Session.request`
         but with added caching-related tools
@@ -142,7 +143,8 @@ class BaseQuery(object):
 
         Parameters
         ----------
-        method : 'GET' or 'POST'
+        method : str
+            'GET' or 'POST'
         url : str
         params : None or dict
         data : None or dict
@@ -157,6 +159,11 @@ class BaseQuery(object):
         savedir : str
             The location to save the local file if you want to save it
             somewhere other than `BaseQuery.cache_location`
+        timeout : int
+        cache : bool
+        verify : bool
+        continuation : bool
+        stream : bool
 
         Returns
         -------
@@ -187,14 +194,15 @@ class BaseQuery(object):
                     (not cache)):
                 with suspend_cache(self):
                     response = query.request(self._session, stream=stream,
-                                             auth=auth)
+                                             auth=auth, verify=verify)
             else:
                 response = query.from_cache(self.cache_location)
                 if not response:
                     response = query.request(self._session,
                                              self.cache_location,
                                              stream=stream,
-                                             auth=auth)
+                                             auth=auth,
+                                             verify=verify)
                     to_cache(response, query.request_file(self.cache_location))
             self._last_query = query
             return response

--- a/astroquery/utils/testing_tools.py
+++ b/astroquery/utils/testing_tools.py
@@ -35,7 +35,8 @@ class MockResponse(object):
     """
 
     def __init__(self, content=None, url=None, headers={},
-                 content_type=None, stream=False, auth=None, status_code=200):
+                 content_type=None, stream=False, auth=None, status_code=200,
+                 verify=True):
         assert content is None or hasattr(content, 'decode')
         self.content = content
         self.raw = content


### PR DESCRIPTION
The url of magpis has been changed to use https, while there is no certificate available with it, so we receive an ``urllib3.exceptions.SSLError: [SSL: CERTIFICATE_VERIFY_FAILED] certificate verify failed``. 

The clearest workaround is to use the ``verify=False`` kwarg in the request, so this PR adds it as a kwarg.