### PR TITLE
Fixing sphinx 1.6+ warnings

### DIFF
--- a/astroquery/vamdc/core.py
+++ b/astroquery/vamdc/core.py
@@ -2,8 +2,7 @@
 from __future__ import print_function
 
 import os.path
-
-from astropy import log
+import warnings
 
 from ..utils.process_asyncs import async_to_sync
 from ..query import BaseQuery
@@ -110,5 +109,6 @@ class VamdcClass(BaseQuery):
 try:
     Vamdc = VamdcClass()
 except ImportError:
-    log.warning("vamdclib could not be imported; the vamdc astroquery module will not work")
+    warnings.warn("vamdclib could not be imported; the vamdc astroquery module "
+                  "will not work")
     Vamdc = VamdcClass(doimport=False)

--- a/astroquery/vo_conesearch/core.py
+++ b/astroquery/vo_conesearch/core.py
@@ -30,8 +30,8 @@ class ConeSearchClass(BaseQuery):
     The class for querying the Virtual Observatory (VO)
     Cone Search web service.
 
-    Example
-    -------
+    Examples
+    --------
     >>> from astropy import units as u
     >>> from astropy.coordinates import SkyCoord
     >>> from astroquery.vo_conesearch import ConeSearch


### PR DESCRIPTION
This came up when I was testing with the new helpers, and are making the docs build fail once we switch back to use the latest sphinx version.