### PR TITLE
astroquery.tap should be importable even without pytest

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -4,7 +4,10 @@
 - LAMDA: Add function to write LAMDA-formatted Tables to a datafile
 - ALMA: Fix to queries and tests that were broken by changes in the archive.
   Note that as of April 2017, the archive is significantly broken and missing
-  many data sets (#881,#888).
+  many data sets. [#881,#888]
+- ``turn_off_internet`` and ``turn_on_internet`` is not available any more
+  from the main ``utils`` namespace, use them directly from
+  ``utils.testing_tools``. [940]
 
 0.3.5 (2017-03-29)
 ------------------

--- a/astroquery/utils/__init__.py
+++ b/astroquery/utils/__init__.py
@@ -3,6 +3,7 @@
 Common non-package specific utility
 functions that will ultimately be merged into `astropy.utils`.
 """
+import warnings
 
 from .progressbar import *
 from .download_file_list import *
@@ -10,4 +11,3 @@ from .class_or_instance import *
 from .commons import *
 from .process_asyncs import async_to_sync
 from .docstr_chompers import prepend_docstr_noreturns
-from .testing_tools import turn_off_internet, turn_on_internet


### PR DESCRIPTION
Currently ``astroquery.gaia`` is not importable when there is no pytest installed. I think it should be fine not to import ``turn_off_internet`` and ``turn_on_internet`` to the main ``utils`` namespace