### PR TITLE
Fix a bug in Gaia.load_tables

### DIFF
--- a/astroquery/utils/tap/core.py
+++ b/astroquery/utils/tap/core.py
@@ -130,7 +130,7 @@ class Tap(object):
         A list of table objects
         """
         # share_info=true&share_accessible=true&only_tables=true
-        flags = None
+        flags = ""
         addedItem = False
         if only_names:
             flags = "only_tables=true"


### PR DESCRIPTION
Issue: `Gaia.load_tables` fails with `include_shared_tables=True`.
```python
# load Gaia and login
Gaia.load_tables(include_shared_tables=True)

---------------------------------------------------------------------------
TypeError                                 Traceback (most recent call last)
<ipython-input-3-6f21118199fa> in <module>()
----> 1 Gaia.load_tables(include_shared_tables=True, verbose=True)

~/projects/opensource/astroquery/astroquery/gaia/core.py in load_tables(self, only_names, include_shared_tables, verbose)
     60         return self.__gaiatap.load_tables(only_names,
     61                                           include_shared_tables,
---> 62                                           verbose)
     63 
     64     def load_table(self, table, verbose=False):

~/projects/opensource/astroquery/astroquery/utils/tap/core.py in load_tables(self, only_names, include_shared_tables, verbose)
    631         return self._Tap__load_tables(only_names=only_names,
    632                                   include_shared_tables=include_shared_tables,
--> 633                                   verbose=verbose)
    634 
    635     def load_table(self, table, verbose=False):

~/projects/opensource/astroquery/astroquery/utils/tap/core.py in __load_tables(self, only_names, include_shared_tables, verbose)
    139             if addedItem:
    140                 flags += "&"
--> 141             flags += "share_accessible=true"
    142             addedItem = True
    143         print("Retrieving tables...")

TypeError: unsupported operand type(s) for +=: 'NoneType' and 'str'
```

The simplest fix seems to be make flags an empty string unless there's a reason not to.
Tests only test default and all options True (https://github.com/astropy/astroquery/blob/83644f33412473561eb5fdc2f1ff6718d9c97f91/astroquery/gaia/tests/test_gaiatap.py#L40).