### PR TITLE
Workaround for deprecationswarnings coming from pyopenssl

### DIFF
--- a/astroquery/conftest.py
+++ b/astroquery/conftest.py
@@ -27,7 +27,19 @@ except (NameError, KeyError):
 
 # Uncomment the following line to treat all DeprecationWarnings as
 # exceptions
-enable_deprecations_as_exceptions()
+#
+# These warnings can be removed once pyopenssl 1.7.20+ is out. The workaround requires astropy 2.0+
+_warnings = {
+    (2, 7): set([
+        r"DeprecationWarning: OpenSSL.rand is deprecated - you should use os.urandom instead", ]),
+    (3, 4): set([
+        r"DeprecationWarning: OpenSSL.rand is deprecated - you should use os.urandom instead", ]),
+    (3, 5): set([
+        r"DeprecationWarning: OpenSSL.rand is deprecated - you should use os.urandom instead", ]),
+    (3, 6): set([
+        r"DeprecationWarning: OpenSSL.rand is deprecated - you should use os.urandom instead", ])}
+
+enable_deprecations_as_exceptions(warnings_to_ignore_by_pyver=_warnings)
 
 
 # This is to figure out the affiliated package version, rather than

--- a/astroquery/conftest.py
+++ b/astroquery/conftest.py
@@ -28,7 +28,7 @@ except (NameError, KeyError):
 # Uncomment the following line to treat all DeprecationWarnings as
 # exceptions
 #
-# These warnings can be removed once pyopenssl 1.7.20+ is out. The workaround requires astropy 2.0+
+# These warnings can be removed once pyopenssl 1.7.20+ is out.
 _warnings = {
     (2, 7): set([
         r"DeprecationWarning: OpenSSL.rand is deprecated - you should use os.urandom instead", ]),
@@ -39,8 +39,10 @@ _warnings = {
     (3, 6): set([
         r"DeprecationWarning: OpenSSL.rand is deprecated - you should use os.urandom instead", ])}
 
-enable_deprecations_as_exceptions(warnings_to_ignore_by_pyver=_warnings)
-
+import astropy
+if int(astropy.__version__[0]) > 1:
+    # The warnings_to_ignore_by_pyver parameter was added in astropy 2.0
+    enable_deprecations_as_exceptions(warnings_to_ignore_by_pyver=_warnings)
 
 # This is to figure out the affiliated package version, rather than
 # using Astropy's

--- a/astroquery/conftest.py
+++ b/astroquery/conftest.py
@@ -28,21 +28,11 @@ except (NameError, KeyError):
 # Uncomment the following line to treat all DeprecationWarnings as
 # exceptions
 #
-# These warnings can be removed once pyopenssl 1.7.20+ is out.
-_warnings = {
-    (2, 7): set([
-        r"DeprecationWarning: OpenSSL.rand is deprecated - you should use os.urandom instead", ]),
-    (3, 4): set([
-        r"DeprecationWarning: OpenSSL.rand is deprecated - you should use os.urandom instead", ]),
-    (3, 5): set([
-        r"DeprecationWarning: OpenSSL.rand is deprecated - you should use os.urandom instead", ]),
-    (3, 6): set([
-        r"DeprecationWarning: OpenSSL.rand is deprecated - you should use os.urandom instead", ])}
-
+# The workaround can be removed once pyopenssl 1.7.20+ is out.
 import astropy
 if int(astropy.__version__[0]) > 1:
     # The warnings_to_ignore_by_pyver parameter was added in astropy 2.0
-    enable_deprecations_as_exceptions(warnings_to_ignore_by_pyver=_warnings)
+    enable_deprecations_as_exceptions(modules_to_ignore_on_import=['requests'])
 
 # This is to figure out the affiliated package version, rather than
 # using Astropy's


### PR DESCRIPTION
Hopefully this will work around the errors we saw recently in #970 for the appveyor builds.