### PR TITLE
Adapt to the removal of requests.Session.redirect_cache.

### DIFF
--- a/astroquery/eso/core.py
+++ b/astroquery/eso/core.py
@@ -661,6 +661,12 @@ class EsoClass(QueryWithLogin):
                 filename = self._request("GET", fileLink, save=True,
                                          continuation=True)
                 files.append(system_tools.gunzip(filename))
+        # Empty the redirect cache of this request session
+        # Only available and needed for requests versions < 2.17
+        try:
+            self._session.redirect_cache.clear()
+        except:
+            pass
         log.info("Done!")
         if (not return_list) and (len(files) == 1):
             files = files[0]

--- a/astroquery/eso/core.py
+++ b/astroquery/eso/core.py
@@ -661,8 +661,6 @@ class EsoClass(QueryWithLogin):
                 filename = self._request("GET", fileLink, save=True,
                                          continuation=True)
                 files.append(system_tools.gunzip(filename))
-        # Empty the redirect cache of this request session
-        self._session.redirect_cache.clear()
         log.info("Done!")
         if (not return_list) and (len(files) == 1):
             files = files[0]

--- a/astroquery/eso/core.py
+++ b/astroquery/eso/core.py
@@ -665,7 +665,7 @@ class EsoClass(QueryWithLogin):
         # Only available and needed for requests versions < 2.17
         try:
             self._session.redirect_cache.clear()
-        except:
+        except AttributeError:
             pass
         log.info("Done!")
         if (not return_list) and (len(files) == 1):


### PR DESCRIPTION
The redirect_cache was removed in requests version 2.17.
See:  http://docs.python-requests.org/en/master/community/updates/#id11