### PR TITLE
Removing astropy dev testing using python2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -88,11 +88,9 @@ matrix:
         - os: linux
           env: NUMPY_VERSION=1.12 ASTROPY_VERSION=1.3
 
-        # Now try Astropy dev and LTS vesions with the latest 3.x and 2.7.
+        # Now try Astropy dev and LTS vesions with the latest Python.
         # The dev version only need to be tested on PRs as there are pull
         # and cron builds above already.
-        - os: linux
-          env: PYTHON_VERSION=2.7 ASTROPY_VERSION=development EVENT_TYPE='pull_request'
         - os: linux
           env: ASTROPY_VERSION=development EVENT_TYPE='pull_request'
 


### PR DESCRIPTION
We shouldn't test this combination as it will always fails as astropy dev is alreay python3+ only.