### PR TITLE
Login capability for astroquery.mast

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -13,6 +13,7 @@
 - ESO: Implemented Eso.query_main() to query all instruments with the main form
   (even the ones without a specific form). [#976]
 - ESO: Disabled caching for all Eso.retrieve_data() operations. [#976]
+- MAST: Added login capabilities [#982]
 
 
 0.3.6 (2017-07-03)

--- a/astroquery/exceptions.py
+++ b/astroquery/exceptions.py
@@ -6,7 +6,9 @@ Custom exceptions used in the astroquery query classes
 from astropy.utils.exceptions import AstropyWarning
 
 __all__ = ['TimeoutError', 'InvalidQueryError', 'RemoteServiceError',
-           'TableParseError', 'LoginError', 'NoResultsWarning']
+           'TableParseError', 'LoginError', 'ResolverError',
+           'NoResultsWarning', 'LargeQueryWarning', 'InputWarning',
+           'AuthenticationWarning', 'MaxResultsWarning']
 
 
 class TimeoutError(Exception):
@@ -19,6 +21,9 @@ class TimeoutError(Exception):
 
 
 class InvalidQueryError(Exception):
+    """
+    Errors related to invalid queries.
+    """
     pass
 
 
@@ -46,37 +51,47 @@ class LoginError(Exception):
     """
     pass
 
+
 class ResolverError(Exception):
     """
-    Errors due to failing to resolve an object name/id to a specific 
+    Errors due to failing to resolve an object name/id to a specific
     sky coordinate.
     """
+    pass
+
     
 class NoResultsWarning(AstropyWarning):
     """
     Astroquery warning class to be issued when a query returns no result.
     """
+    pass
 
+    
 class LargeQueryWarning(AstropyWarning):
     """
     Astroquery warning class to be issued when a query is larger than
     recommended for a given service.
     """
+    pass
 
+    
 class InputWarning(AstropyWarning):
     """
     Astroquery warning class to be issued when use input is incorrect
     in some way but doesn't prevent the function from running.
     """
+    pass
 
+    
 class AuthenticationWarning(AstropyWarning):
     """
-    Astroquery warning class to be issued when there are problems with 
+    Astroquery warning class to be issued when there are problems with
     user authentication.
     """
 
 class MaxResultsWarning(AstropyWarning):
     """
-    Astroquery warning class to be issued when the maximum allowed 
+    Astroquery warning class to be issued when the maximum allowed
     results are returned.
     """
+    pass

--- a/astroquery/exceptions.py
+++ b/astroquery/exceptions.py
@@ -59,14 +59,14 @@ class ResolverError(Exception):
     """
     pass
 
-    
+
 class NoResultsWarning(AstropyWarning):
     """
     Astroquery warning class to be issued when a query returns no result.
     """
     pass
 
-    
+
 class LargeQueryWarning(AstropyWarning):
     """
     Astroquery warning class to be issued when a query is larger than
@@ -74,7 +74,7 @@ class LargeQueryWarning(AstropyWarning):
     """
     pass
 
-    
+
 class InputWarning(AstropyWarning):
     """
     Astroquery warning class to be issued when use input is incorrect
@@ -82,12 +82,13 @@ class InputWarning(AstropyWarning):
     """
     pass
 
-    
+
 class AuthenticationWarning(AstropyWarning):
     """
     Astroquery warning class to be issued when there are problems with
     user authentication.
     """
+
 
 class MaxResultsWarning(AstropyWarning):
     """

--- a/astroquery/exceptions.py
+++ b/astroquery/exceptions.py
@@ -46,15 +46,37 @@ class LoginError(Exception):
     """
     pass
 
-
+class ResolverError(Exception):
+    """
+    Errors due to failing to resolve an object name/id to a specific 
+    sky coordinate.
+    """
+    
 class NoResultsWarning(AstropyWarning):
     """
     Astroquery warning class to be issued when a query returns no result.
     """
 
-
 class LargeQueryWarning(AstropyWarning):
     """
     Astroquery warning class to be issued when a query is larger than
     recommended for a given service.
+    """
+
+class InputWarning(AstropyWarning):
+    """
+    Astroquery warning class to be issued when use input is incorrect
+    in some way but doesn't prevent the function from running.
+    """
+
+class AuthenticationWarning(AstropyWarning):
+    """
+    Astroquery warning class to be issued when there are problems with 
+    user authentication.
+    """
+
+class MaxResultsWarning(AstropyWarning):
+    """
+    Astroquery warning class to be issued when the maximum allowed 
+    results are returned.
     """

--- a/astroquery/exoplanet_orbit_database/exoplanet_orbit_database.py
+++ b/astroquery/exoplanet_orbit_database/exoplanet_orbit_database.py
@@ -53,6 +53,7 @@ class ExoplanetOrbitDatabaseClass(object):
         table_path : str (optional)
             Path to a local table file. Default `None` will trigger a
             download of the table from the internet.
+
         Returns
         -------
         table : `~astropy.table.QTable`
@@ -97,8 +98,8 @@ class ExoplanetOrbitDatabaseClass(object):
             Path to a local table file. Default `None` will trigger a
             download of the table from the internet.
 
-        Return
-        ------
+        Returns
+        -------
         table : `~astropy.table.QTable`
             Table of one exoplanet's properties.
         """

--- a/astroquery/mast/__init__.py
+++ b/astroquery/mast/__init__.py
@@ -16,9 +16,13 @@ class Conf(_config.ConfigNamespace):
 
     server = _config.ConfigItem(
         'https://mast.stsci.edu',
+        #'https://dwmastiisv3.stsci.edu',
+        #'https://masttest.stsci.edu',
         'Name of the MAST server.')
     ssoserver = _config.ConfigItem(
         'https://ssoportal.stsci.edu',
+        #'https://ssodevidp.stsci.edu',
+        #'https://sso-testadx.stsci.edu',
         'MAST SSO Portal server.')
     timeout = _config.ConfigItem(
         600,

--- a/astroquery/mast/__init__.py
+++ b/astroquery/mast/__init__.py
@@ -17,6 +17,9 @@ class Conf(_config.ConfigNamespace):
     server = _config.ConfigItem(
         'https://mast.stsci.edu',
         'Name of the MAST server.')
+    ssoserver = _config.ConfigItem(
+        'https://ssoportal.stsci.edu',
+        'MAST SSO Portal server.')
     timeout = _config.ConfigItem(
         600,
         'Time limit for requests from the STScI server.')

--- a/astroquery/mast/__init__.py
+++ b/astroquery/mast/__init__.py
@@ -16,13 +16,9 @@ class Conf(_config.ConfigNamespace):
 
     server = _config.ConfigItem(
         'https://mast.stsci.edu',
-        #'https://dwmastiisv3.stsci.edu',
-        #'https://masttest.stsci.edu',
         'Name of the MAST server.')
     ssoserver = _config.ConfigItem(
         'https://ssoportal.stsci.edu',
-        #'https://ssodevidp.stsci.edu',
-        #'https://sso-testadx.stsci.edu',
         'MAST SSO Portal server.')
     timeout = _config.ConfigItem(
         600,

--- a/astroquery/mast/core.py
+++ b/astroquery/mast/core.py
@@ -667,8 +667,7 @@ class MastClass(QueryWithLogin):
         else:
             retrieveAll = False
 
-        # TODO: remove "Clara development" before pull request
-        headers = {"User-Agent": self._session.headers["User-Agent"] + " Clara development",
+        headers = {"User-Agent": self._session.headers["User-Agent"],
                    "Content-type": "application/x-www-form-urlencoded",
                    "Accept": "text/plain"}
 

--- a/astroquery/mast/core.py
+++ b/astroquery/mast/core.py
@@ -1419,6 +1419,5 @@ class ObservationsClass(MastClass):
         return manifest
 
 
-
 Observations = ObservationsClass()
 Mast = MastClass()

--- a/astroquery/mast/core.py
+++ b/astroquery/mast/core.py
@@ -1213,7 +1213,7 @@ class ObservationsClass(MastClass):
             mask = np.full(len(products), False, dtype=bool)
             for elt in vals:
                 if colname == 'extension':  # extension is not actually a column
-                    mask |= [False if isinstance(x, np.ma.core.MaskedConstant) else x.endswith(elt) \
+                    mask |= [False if isinstance(x, np.ma.core.MaskedConstant) else x.endswith(elt) 
                              for x in products["productFilename"]]
                 else:
                     mask |= (products[colname] == elt)

--- a/astroquery/mast/core.py
+++ b/astroquery/mast/core.py
@@ -1384,8 +1384,8 @@ class ObservationsClass(MastClass):
             The manifest of files downloaded, or status of files on disk if curl option chosen.
         """
 
-        # If the products list is not already a table of products we need to  get the products and
-        # filter them appropriately
+        # If the products list is not already a table of products we need to
+        # get the products and filter them appropriately
         if type(products) != Table:
 
             if type(products) == str:

--- a/astroquery/mast/core.py
+++ b/astroquery/mast/core.py
@@ -32,7 +32,8 @@ from astropy.utils.exceptions import AstropyWarning
 from ..query import QueryWithLogin
 from ..utils import commons, async_to_sync
 from ..utils.class_or_instance import class_or_instance
-from ..exceptions import TimeoutError, InvalidQueryError, NoResultsWarning, RemoteServiceError
+from ..exceptions import TimeoutError, InvalidQueryError, RemoteServiceError, LoginError
+from ..exceptions import NoResultsWarning
 from . import conf
 
 
@@ -42,11 +43,6 @@ __all__ = ['Observations', 'ObservationsClass',
 
 class ResolverError(Exception):
     pass
-
-
-class SessionTokenError(Exception):
-    pass
-
 
 class InputWarning(AstropyWarning):
     pass
@@ -187,7 +183,7 @@ class MastClass(QueryWithLogin):
         if isinstance(session_token, Cookie):
             # check it's a shibsession cookie
             if not "shibsession" in session_token.name:
-                raise SessionTokenError("Invalid session token")
+                raise LoginError("Invalid session token")
 
             # add cookie to session
             self._session.cookies.set_cookie(session_token)
@@ -204,14 +200,14 @@ class MastClass(QueryWithLogin):
                     break
 
             if not value:
-                raise SessionTokenError("Invalid session token")
+                raise LoginError("Invalid session token")
 
             # add cookie to session
             self._session.cookies.set(name, value)
 
         else:
             # raise datatype error
-            raise SessionTokenError("Session token must be given as a dictionary or http.cookiejar.Cookie object")
+            raise LoginError("Session token must be given as a dictionary or http.cookiejar.Cookie object")
 
         # Print session info
         # get user information
@@ -613,7 +609,7 @@ class MastClass(QueryWithLogin):
             infoDict = dict(zip(userCats, (None, "anonymous", "", "")))
         else:
             infoDict = dict(zip(userCats, userInfo[0]))
-            infoDict['Session Expiration'] = int(re.findall("(\d+) minute\(s\)",
+            infoDict['Session Expiration'] = int(re.findall(r"(\d+) minute\(s\)",
                                                             infoDict['Session Expiration'])[0])*u.min
 
         if not silent:

--- a/astroquery/mast/core.py
+++ b/astroquery/mast/core.py
@@ -390,7 +390,7 @@ class MastClass(QueryWithLogin):
 
     def _get_col_config(self, service):
         """
-        Gets the columnsConfig entry for given service and stores it in self._column_configs.
+        Gets the columnsConfig entry for given service and stores it in `self._column_configs`.
 
         Parameters
         ----------

--- a/astroquery/mast/core.py
+++ b/astroquery/mast/core.py
@@ -169,7 +169,7 @@ class MastClass(QueryWithLogin):
         if username or session_token:
             self.login(username, password, session_token)
 
-    def _attach_cookie(self, session_token):
+    def _attach_cookie(self, session_token): # pragma: no cover
         """
         Attaches a valid shibboleth session cookie to the current session.
 
@@ -233,7 +233,7 @@ class MastClass(QueryWithLogin):
         print("Session Expiration: {}".format(exp))
         return True
 
-    def _shib_login(self, username, password):
+    def _shib_login(self, username, password): # pragma: no cover
         """
         Given username and password, logs into the MAST shibboleth client.
 
@@ -462,7 +462,7 @@ class MastClass(QueryWithLogin):
         return vstack(resultList)
 
     def _login(self, username=None, password=None, session_token=None,
-               store_password=False, reenter_password=False):
+               store_password=False, reenter_password=False): # pragma: no cover
         """
         Log into the MAST portal.
 
@@ -523,7 +523,7 @@ class MastClass(QueryWithLogin):
             return self._shib_login(username, password)
 
     def login(self, username=None, password=None, session_token=None,
-              store_password=False, reenter_password=False):
+              store_password=False, reenter_password=False): # pragma: no cover
         """
         Log into the MAST portal.
 
@@ -556,14 +556,14 @@ class MastClass(QueryWithLogin):
         return super(MastClass, self).login(username=username, password=password, session_token=session_token,
                                             store_password=store_password, reenter_password=reenter_password)
 
-    def logout(self):
+    def logout(self): # pragma: no cover 
         """
         Log out of current MAST session.
         """
         self._session.cookies.clear_session_cookies()
         self._authenticated = False
 
-    def get_token(self):
+    def get_token(self): # pragma: no cover
         """
         Returns MAST session cookie.
 
@@ -1213,7 +1213,7 @@ class ObservationsClass(MastClass):
             mask = np.full(len(products), False, dtype=bool)
             for elt in vals:
                 if colname == 'extension':  # extension is not actually a column
-                    mask |= [x.endswith(elt) for x in products["productFilename"]]
+                    mask |= [False if isinstance(x,np.ma.core.MaskedConstant) else x.endswith(elt) for x in products["productFilename"]]
                 else:
                     mask |= (products[colname] == elt)
 

--- a/astroquery/mast/core.py
+++ b/astroquery/mast/core.py
@@ -74,7 +74,7 @@ def _mashup_json_to_table(json_obj):
 
     Returns
     -------
-    response: `astropy.table.Table`
+    response : `~astropy.table.Table`
     """
 
     dataTable = Table()
@@ -238,7 +238,7 @@ class MastClass(BaseQuery):
 
         Returns
         -------
-        response: list of ``requests.Response``
+        response : list of ``requests.Response``
         """
 
         # setting up pagination
@@ -366,7 +366,7 @@ class ObservationsClass(MastClass):
 
         Returns
         -------
-        response: list(dict)
+        response : list(dict)
             The mashup json filter object.
         """
 
@@ -466,7 +466,7 @@ class ObservationsClass(MastClass):
 
         Returns
         -------
-        response: list of ``requests.Response``
+        response : list of ``requests.Response``
         """
 
         # Put coordinates and radius into consistant format
@@ -510,7 +510,7 @@ class ObservationsClass(MastClass):
 
         Returns
         -------
-        response: list of ``requests.Response``
+        response : list of ``requests.Response``
         """
 
         coordinates = self._resolve_object(objectname)
@@ -545,7 +545,7 @@ class ObservationsClass(MastClass):
 
         Returns
         -------
-        response: list(`requests.Response`)
+        response : list(`requests.Response`)
         """
 
         # Seperating any position info from the rest of the filters
@@ -615,7 +615,7 @@ class ObservationsClass(MastClass):
 
         Returns
         -------
-            response: int
+        response : int
         """
 
         # build the coordinates string needed by Mast.Caom.Filtered.Position
@@ -657,7 +657,7 @@ class ObservationsClass(MastClass):
 
         Returns
         -------
-        response: int
+        response : int
         """
 
         coordinates = self._resolve_object(objectname)
@@ -690,7 +690,7 @@ class ObservationsClass(MastClass):
 
         Returns
         -------
-        response: int
+        response : int
         """
 
         # Seperating any position info from the rest of the filters
@@ -750,7 +750,7 @@ class ObservationsClass(MastClass):
 
         Returns
         -------
-            response: list(`requests.Response`)
+            response : list(`requests.Response`)
         """
 
         # getting the obsid list
@@ -772,11 +772,11 @@ class ObservationsClass(MastClass):
 
         Parameters
         ----------
-        products: `astropy.table.Table`
+        products : `astropy.table.Table`
             Table containing data products to be filtered.
-        mrp_only: bool, optional
+        mrp_only : bool, optional
             Default True. When set to true only "Minimum Recommended Products" will be returned.
-        **filters:
+        **filters :
             Filters to be applied.  Valid filters are all products fields listed
             `here <https://masttest.stsci.edu/api/v0/_productsfields.html>`__ and 'extension'
             which is the desired file extension.
@@ -787,7 +787,7 @@ class ObservationsClass(MastClass):
 
         Returns
         -------
-            response : `astropy.table.Table`
+        response : `~astropy.table.Table`
         """
 
         # Dealing with mrp first, b/c it's special
@@ -825,7 +825,7 @@ class ObservationsClass(MastClass):
 
         Returns
         -------
-            response : `astropy.table.Table`
+        response : `astropy.table.Table`
         """
 
         urlList = products['dataURI']
@@ -886,7 +886,7 @@ class ObservationsClass(MastClass):
 
         Returns
         -------
-            response : `astropy.table.Table`
+        response : `~astropy.table.Table`
         """
         manifestArray = []
         for dataProduct in products:
@@ -961,9 +961,9 @@ class ObservationsClass(MastClass):
             Filter behavior is AND between the filters and OR within a filter set.
             For example: productType="SCIENCE",extension=["fits","jpg"]
 
-        Return
-        ------
-        response: `astropy.table.Table`
+        Returns
+        -------
+        response : `~astropy.table.Table`
             The manifest of files downloaded, or status of files on disk if curl option chosen.
         """
 

--- a/astroquery/mast/core.py
+++ b/astroquery/mast/core.py
@@ -562,7 +562,7 @@ class MastClass(QueryWithLogin):
         Log out of current MAST session.
         """
         self._session.cookies.clear_session_cookies()
-        selt._authenticated = False
+        self._authenticated = False
 
     def get_token(self):
         """

--- a/astroquery/mast/core.py
+++ b/astroquery/mast/core.py
@@ -14,6 +14,7 @@ import json
 import time
 import os
 import re
+import keyring
 
 import numpy as np
 
@@ -149,7 +150,7 @@ class MastClass(QueryWithLogin):
     def __init__(self, username=None, password=None, session_token=None):
 
         super(MastClass, self).__init__()
-        
+
         self._MAST_REQUEST_URL = conf.server + "/api/v0/invoke"
         self._MAST_DOWNLOAD_URL = conf.server + "/api/v0/download/file/"
         self._COLUMNS_CONFIG_URL = conf.server + "/portal/Mashup/Mashup.asmx/columnsconfig"

--- a/astroquery/mast/core.py
+++ b/astroquery/mast/core.py
@@ -1213,7 +1213,7 @@ class ObservationsClass(MastClass):
             mask = np.full(len(products), False, dtype=bool)
             for elt in vals:
                 if colname == 'extension':  # extension is not actually a column
-                    mask |= [False if isinstance(x, np.ma.core.MaskedConstant) else x.endswith(elt) 
+                    mask |= [False if isinstance(x, np.ma.core.MaskedConstant) else x.endswith(elt)
                              for x in products["productFilename"]]
                 else:
                     mask |= (products[colname] == elt)

--- a/astroquery/mast/core.py
+++ b/astroquery/mast/core.py
@@ -169,7 +169,7 @@ class MastClass(QueryWithLogin):
         if username or session_token:
             self.login(username, password, session_token)
 
-    def _attach_cookie(self, session_token): # pragma: no cover
+    def _attach_cookie(self, session_token):  # pragma: no cover
         """
         Attaches a valid shibboleth session cookie to the current session.
 
@@ -233,7 +233,7 @@ class MastClass(QueryWithLogin):
         print("Session Expiration: {}".format(exp))
         return True
 
-    def _shib_login(self, username, password): # pragma: no cover
+    def _shib_login(self, username, password):  # pragma: no cover
         """
         Given username and password, logs into the MAST shibboleth client.
 
@@ -462,7 +462,7 @@ class MastClass(QueryWithLogin):
         return vstack(resultList)
 
     def _login(self, username=None, password=None, session_token=None,
-               store_password=False, reenter_password=False): # pragma: no cover
+               store_password=False, reenter_password=False):  # pragma: no cover
         """
         Log into the MAST portal.
 
@@ -523,7 +523,7 @@ class MastClass(QueryWithLogin):
             return self._shib_login(username, password)
 
     def login(self, username=None, password=None, session_token=None,
-              store_password=False, reenter_password=False): # pragma: no cover
+              store_password=False, reenter_password=False):  # pragma: no cover
         """
         Log into the MAST portal.
 
@@ -556,14 +556,14 @@ class MastClass(QueryWithLogin):
         return super(MastClass, self).login(username=username, password=password, session_token=session_token,
                                             store_password=store_password, reenter_password=reenter_password)
 
-    def logout(self): # pragma: no cover 
+    def logout(self):  # pragma: no cover
         """
         Log out of current MAST session.
         """
         self._session.cookies.clear_session_cookies()
         self._authenticated = False
 
-    def get_token(self): # pragma: no cover
+    def get_token(self):  # pragma: no cover
         """
         Returns MAST session cookie.
 
@@ -1213,7 +1213,8 @@ class ObservationsClass(MastClass):
             mask = np.full(len(products), False, dtype=bool)
             for elt in vals:
                 if colname == 'extension':  # extension is not actually a column
-                    mask |= [False if isinstance(x,np.ma.core.MaskedConstant) else x.endswith(elt) for x in products["productFilename"]]
+                    mask |= [False if isinstance(x, np.ma.core.MaskedConstant) else x.endswith(elt) \
+                             for x in products["productFilename"]]
                 else:
                     mask |= (products[colname] == elt)
 

--- a/astroquery/mast/core.py
+++ b/astroquery/mast/core.py
@@ -148,9 +148,9 @@ class MastClass(BaseQuery):
         self._COLUMNS_CONFIG_URL = conf.server + "/portal/Mashup/Mashup.asmx/columnsconfig"
 
         # shibbolith urls
-        self._SP_TARGET = "https://masttest.stsci.edu/portal/Mashup/Login/login.html" # TODO: change to ops
-        self._IDP_ENDPOINT = "https://sso-testadx.stsci.edu/idp/profile/SAML2/SOAP/ECP" # TODO: change to ops
-        self._SESSION_INFO_URL = "https://masttest.stsci.edu/Shibboleth.sso/Session" # TODO: change to ops
+        self._SP_TARGET = "https://mast.stsci.edu/portal/Mashup/Login/login.html" 
+        self._IDP_ENDPOINT = "https://ssoportal.stsci.edu/idp/profile/SAML2/SOAP/ECP"
+        self._SESSION_INFO_URL = "https://mast.stsci.edu/Shibboleth.sso/Session" 
 
         self.TIMEOUT = conf.timeout
         self.PAGESIZE = conf.pagesize

--- a/astroquery/mast/core.py
+++ b/astroquery/mast/core.py
@@ -44,9 +44,6 @@ __all__ = ['Observations', 'ObservationsClass',
            'Mast', 'MastClass']
 
 
-
-
-
 def _prepare_service_request_string(json_obj):
     """
     Takes a mashup JSON request object and turns it into a url-safe string.

--- a/astroquery/mast/tests/test_mast.py
+++ b/astroquery/mast/tests/test_mast.py
@@ -39,6 +39,9 @@ def patch_post(request):
     mp.setattr(mast.Mast, '_request', post_mockreturn)
     mp.setattr(mast.Observations, '_request', post_mockreturn)
     mp.setattr(mast.Mast, '_download_file', download_mockreturn)
+    mp.setattr(mast.Observations, '_download_file', download_mockreturn)
+    mp.setattr(mast.Mast, 'session_info', session_info_mockreturn)
+    mp.setattr(mast.Observations, 'session_info', session_info_mockreturn)
     return mp
 
 
@@ -48,6 +51,8 @@ def post_mockreturn(method="POST", url=None, data=None, timeout=10, **kwargs):
         service = "columnsconfig"
     else:
         service = re.search(r"service%22%3A%20%22([\w\.]*)%22", data).group(1)
+
+    print(service)
 
     # need to distiguish counts queries
     if ("Filtered" in service) and (re.search(r"COUNT_BIG%28%2A%29", data)):
@@ -62,6 +67,14 @@ def post_mockreturn(method="POST", url=None, data=None, timeout=10, **kwargs):
 
 def download_mockreturn(method="GET", url=None, data=None, timeout=10, **kwargs):
     return
+
+def session_info_mockreturn(silent=False):
+    anonSession = {'First Name': '',
+                   'Last Name': '',
+                   'Session Expiration': None,
+                   'Username': 'anonymous'}
+    
+    return anonSession
 
 
 # Mast MastClass tests ##

--- a/astroquery/mast/tests/test_mast.py
+++ b/astroquery/mast/tests/test_mast.py
@@ -68,12 +68,13 @@ def post_mockreturn(method="POST", url=None, data=None, timeout=10, **kwargs):
 def download_mockreturn(method="GET", url=None, data=None, timeout=10, **kwargs):
     return
 
+
 def session_info_mockreturn(silent=False):
     anonSession = {'First Name': '',
                    'Last Name': '',
                    'Session Expiration': None,
                    'Username': 'anonymous'}
-    
+
     return anonSession
 
 

--- a/astroquery/mast/tests/test_mast.py
+++ b/astroquery/mast/tests/test_mast.py
@@ -52,8 +52,6 @@ def post_mockreturn(method="POST", url=None, data=None, timeout=10, **kwargs):
     else:
         service = re.search(r"service%22%3A%20%22([\w\.]*)%22", data).group(1)
 
-    print(service)
-
     # need to distiguish counts queries
     if ("Filtered" in service) and (re.search(r"COUNT_BIG%28%2A%29", data)):
         service = "Counts"

--- a/astroquery/mast/tests/test_mast_remote.py
+++ b/astroquery/mast/tests/test_mast_remote.py
@@ -13,7 +13,10 @@ from ... import mast
 @remote_data
 class TestMast(object):
 
-    # MastClass tests
+    #####################
+    ## MastClass tests ##
+    #####################
+
     def test_mast_service_request_async(self):
         service = 'Mast.Caom.Cone'
         params = {'ra': 184.3,
@@ -40,7 +43,14 @@ class TestMast(object):
         # Are the two GALEX observations with obs_id 6374399093149532160 in the results table
         assert len(result[np.where(result["obs_id"] == "6374399093149532160")]) == 2
 
-    # ObservationsClass tests ##
+    def test_sesion_info(self):
+        sessionInfo = mast.Mast.session_info(True)
+        assert sessionInfo['Username'] == 'anonymous'
+        assert sessionInfo['Session Expiration'] is None
+
+    #############################
+    ## ObservationsClass tests ##
+    #############################
 
     def test_list_missions(self):
         missions = mast.Observations.list_missions()
@@ -58,6 +68,11 @@ class TestMast(object):
         assert isinstance(result, Table)
         assert len(result) >= 1826
         assert result[np.where(result['obs_id'] == '00031992001')]
+
+        result = mast.Observations.query_region("322.49324 12.16683", radius="0.1 deg",
+                                                pagesize=1, page=1)
+        assert isinstance(result, Table)
+        assert len(result) == 1
 
     def test_observations_query_object_async(self):
         responses = mast.Observations.query_object_async("M8", radius=".02 deg")

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -238,6 +238,7 @@ generally return a table listing the available data first.
   ibe/ibe.rst
   irsa/irsa.rst
   magpis/magpis.rst
+  mast/mast.rst
   ned/ned.rst
   nrao/nrao.rst
   nvas/nvas.rst

--- a/docs/mast/mast.rst
+++ b/docs/mast/mast.rst
@@ -293,6 +293,73 @@ Product filtering can also be appllied directly to a table of products without p
 
                
 
+Accessing Proprietary Data
+==========================
+
+To access data that is not publicly available users may log into their
+`MyST Account <https://archive.stsci.edu/registration/index.html>`_.
+This can be done by using the `~astroquery.mast.MastClass.login` function,
+or by initializing a class instance with a username/password.
+If a password is not supplied, the user will be prompted to enter one.
+
+.. code-block:: python
+
+                >>> from astroquery.mast import Observations
+                >>> Observations.login(username="testUser@stsci.edu",password="testPwd")
+
+                Authentication successful!
+                Session Expiration: 600 minute(s)
+
+                >>> sessionInfo = Observations.session_info()
+
+                Session Expiration: 559.0 min
+                Username: testUser@stsci.edu
+                First Name: Test
+                Last Name: User
+
+              
+.. code-block:: python
+
+                >>> from astroquery.mast import Observations
+                >>> mySession = Observations(username="testUser@stsci.edu",password="testPwd")
+
+                Authentication successful!
+                Session Expiration: 600 minute(s)
+
+                >>> sessionInfo = mySession.session_info()
+
+                Session Expiration: 559.0 min
+                Username: testUser@stsci.edu
+                First Name: Test
+                Last Name: User
+
+\* For security passwords should not be typed into a terminal or Jupyter notebook
+but instead input using a more secure method such as `~getpass.getpass`.
+
+
+MAST login can also be achieved with a "session token," from an existing valid MAST session.
+
+.. code-block:: python
+
+                >>> from astroquery.mast import Observations
+                >>> from astroquery.mast import Mast
+                >>> myObsSession = Observations(username="testUser@stsci.edu",password="testPwd")
+
+                Authentication successful!
+                Session Expiration: 600 minute(s)
+
+                >>> myToken = myObsSession.get_token()
+                >>> Mast.login(session_token=myToken)
+
+                Authentication successful!
+                Session Expiration: 599 minute(s)
+
+
+MAST sessions expire after 600 minutes, at which point the user must login again.
+The store_password argument can be used to store the username and password securely in the users keyring.
+If the username/password are thus stored, only the username need be entered to login.
+This password can be overwritten using the reenter_password argument.
+
 
    
 Direct Mast Queries

--- a/docs/mast/mast.rst
+++ b/docs/mast/mast.rst
@@ -356,9 +356,10 @@ MAST login can also be achieved with a "session token," from an existing valid M
 
 
 MAST sessions expire after 600 minutes, at which point the user must login again.
-The store_password argument can be used to store the username and password securely in the users keyring.
+The ``store_password`` argument can be used to store the username and password securely in the user's keyring.
 If the username/password are thus stored, only the username need be entered to login.
-This password can be overwritten using the reenter_password argument.
+This password can be overwritten using the ``reenter_password`` argument.
+To logout before a session expires, the `~astroquery.mast.MastClass.logout` method may be used.
 
 
    


### PR DESCRIPTION
This PR is related to the [mast query tool issue](https://github.com/astropy/astroquery/issues/896).

New functionality implemented in this PR is:

- Log in capabilities
   Allows users to log in with their MyST credentials to access proprietary data.
   Can supply username/password or be prompted.
   Can attach existing session token to a mast class instance.
   Can save username/password in keyring if so desired.

- Updated return Tables to be masked
   The returned astropy tables are now masked tables, with missing data values masked and "default values" matching what is found in the [MAST Discovery Portal](mast.stsci.edu).

- Provision for "obstype" selection (science vs calibration data) has been added in preparation for the next Portal release which adds this functionality
   This does not interfere with current functionality, but has no effect on queries until that release.
    Documentation of this option has not yet been included since the functionality is not yet live. 