### PR TITLE
Upgrading utils.prepend_docstr_nosections

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -15,6 +15,9 @@
 - ESO: Disabled caching for all Eso.retrieve_data() operations. [#976]
 - vo_conesearch: Fix bad query for service that cannot accept '&&'
   in URL. [#993]
+- utils: upgrade ``prepend_docstr_noreturns`` to work with multiple
+  sections, and thus rename it to ``prepend_docstr_nosections``. [#988]
+
 
 0.3.6 (2017-07-03)
 ------------------

--- a/astroquery/alfalfa/core.py
+++ b/astroquery/alfalfa/core.py
@@ -11,9 +11,8 @@ import numpy as np
 import numpy.ma as ma
 from astropy import units as u
 from astropy import coordinates as coord
-from ..utils import commons
+from ..utils import commons, prepend_docstr_nosections
 from ..query import BaseQuery
-from ..utils.docstr_chompers import prepend_docstr_noreturns
 
 __all__ = ['Alfalfa', 'AlfalfaClass']
 
@@ -189,7 +188,7 @@ class AlfalfaClass(BaseQuery):
         result = commons.FileContainer(link, show_progress=show_progress)
         return result
 
-    @prepend_docstr_noreturns(get_spectrum_async.__doc__)
+    @prepend_docstr_nosections(get_spectrum_async.__doc__)
     def get_spectrum(self, agc, show_progress=True):
         """
         Returns

--- a/astroquery/atomic/core.py
+++ b/astroquery/atomic/core.py
@@ -13,9 +13,9 @@ from astropy import units as u
 from bs4 import BeautifulSoup
 
 from ..query import BaseQuery
-from ..utils import prepend_docstr_nosections, async_to_sync, is_valid_transitions_param
+from ..utils import prepend_docstr_nosections, async_to_sync
 from . import conf
-
+from .utils import is_valid_transitions_param
 
 __all__ = ['AtomicLineList', 'AtomicLineListClass']
 

--- a/astroquery/atomic/core.py
+++ b/astroquery/atomic/core.py
@@ -13,10 +13,8 @@ from astropy import units as u
 from bs4 import BeautifulSoup
 
 from ..query import BaseQuery
-from ..utils import prepend_docstr_noreturns
-from ..utils import async_to_sync
+from ..utils import prepend_docstr_nosections, async_to_sync, is_valid_transitions_param
 from . import conf
-from .utils import is_valid_transitions_param
 
 
 __all__ = ['AtomicLineList', 'AtomicLineListClass']
@@ -155,7 +153,7 @@ class AtomicLineListClass(BaseQuery):
         table = self._parse_result(response)
         return table
 
-    @prepend_docstr_noreturns(query_object.__doc__)
+    @prepend_docstr_nosections(query_object.__doc__)
     def query_object_async(self, wavelength_range=None, wavelength_type='',
                            wavelength_accuracy=None, element_spectrum=None,
                            minimal_abundance=None, depl_factor=None,

--- a/astroquery/besancon/core.py
+++ b/astroquery/besancon/core.py
@@ -11,9 +11,7 @@ from astropy.io import ascii
 from astropy.extern.six.moves.urllib_error import URLError
 from collections import OrderedDict
 from ..query import BaseQuery
-from ..utils import commons
-from ..utils import prepend_docstr_noreturns
-from ..utils import async_to_sync
+from ..utils import commons, prepend_docstr_nosections, async_to_sync
 from . import conf
 
 __all__ = ['Besancon', 'BesanconClass', 'parse_besancon_model_string']
@@ -288,7 +286,7 @@ class BesanconClass(BaseQuery):
 
         return request_data
 
-    @prepend_docstr_noreturns("\n" + _parse_args.__doc__ +
+    @prepend_docstr_nosections("\n" + _parse_args.__doc__ +
                               _parse_result.__doc__)
     def query_async(self, *args, **kwargs):
         """

--- a/astroquery/magpis/core.py
+++ b/astroquery/magpis/core.py
@@ -5,8 +5,7 @@ import astropy.units as u
 import astropy.coordinates as coord
 from astropy.io import fits
 from ..query import BaseQuery
-from ..utils.docstr_chompers import prepend_docstr_noreturns
-from ..utils import commons
+from ..utils import commons, prepend_docstr_nosections
 from . import conf
 from ..exceptions import InvalidQueryError
 
@@ -71,7 +70,7 @@ class MagpisClass(BaseQuery):
         request_payload["MaxImSize"] = self.maximsize if maximsize is None else maximsize
         return request_payload
 
-    @prepend_docstr_noreturns("\n" + _args_to_payload.__doc__)
+    @prepend_docstr_nosections("\n" + _args_to_payload.__doc__)
     def get_images(self, coordinates, image_size=1 * u.arcmin,
                    survey='bolocam', get_query_payload=False):
         """
@@ -94,7 +93,7 @@ class MagpisClass(BaseQuery):
         except IOError:
             raise InvalidQueryError(response.content)
 
-    @prepend_docstr_noreturns("\n" + _args_to_payload.__doc__)
+    @prepend_docstr_nosections("\n" + _args_to_payload.__doc__)
     def get_images_async(self, coordinates, image_size=1 * u.arcmin,
                          survey='bolocam', get_query_payload=False):
         """

--- a/astroquery/nist/core.py
+++ b/astroquery/nist/core.py
@@ -7,8 +7,7 @@ import astropy.units as u
 import astropy.io.ascii as asciitable
 
 from ..query import BaseQuery
-from ..utils import async_to_sync
-from ..utils.docstr_chompers import prepend_docstr_noreturns
+from ..utils import async_to_sync, prepend_docstr_nosections
 from . import conf
 from ..exceptions import TableParseError
 
@@ -122,7 +121,7 @@ class NistClass(BaseQuery):
         request_payload["page_size"] = 15
         return request_payload
 
-    @prepend_docstr_noreturns("\n" + _args_to_payload.__doc__)
+    @prepend_docstr_nosections("\n" + _args_to_payload.__doc__)
     def query_async(self, minwav, maxwav, linename="H I",
                     energy_level_unit='eV', output_order='wavelength',
                     wavelength_type='vacuum', get_query_payload=False):

--- a/astroquery/nrao/core.py
+++ b/astroquery/nrao/core.py
@@ -18,8 +18,7 @@ from astropy import log
 from bs4 import BeautifulSoup
 
 from ..query import QueryWithLogin
-from ..utils import commons, async_to_sync, system_tools
-from ..utils.docstr_chompers import prepend_docstr_noreturns
+from ..utils import commons, async_to_sync, system_tools, prepend_docstr_nosections
 from ..exceptions import TableParseError, LoginError
 
 from . import conf
@@ -320,7 +319,7 @@ class NraoClass(QueryWithLogin):
 
         return authenticated
 
-    @prepend_docstr_noreturns(_args_to_payload.__doc__)
+    @prepend_docstr_nosections(_args_to_payload.__doc__)
     def query_async(self,
                     get_query_payload=False,
                     cache=True,
@@ -359,7 +358,7 @@ class NraoClass(QueryWithLogin):
 
         return response
 
-    @prepend_docstr_noreturns(_args_to_payload.__doc__)
+    @prepend_docstr_nosections(_args_to_payload.__doc__)
     def query_region_async(self, coordinates, radius=1 * u.arcmin,
                            equinox='J2000', telescope='all', start_date="",
                            end_date="", freq_low=None, freq_up=None,

--- a/astroquery/ogle/core.py
+++ b/astroquery/ogle/core.py
@@ -7,8 +7,7 @@ import numpy as np
 from astropy.table import Table
 
 from ..query import BaseQuery
-from ..utils import commons, async_to_sync
-from ..utils.docstr_chompers import prepend_docstr_noreturns
+from ..utils import commons, async_to_sync, prepend_docstr_nosections
 
 from . import conf
 
@@ -126,7 +125,7 @@ class OgleClass(BaseQuery):
         files = {'file1': file_data}
         return files
 
-    @prepend_docstr_noreturns(_args_to_payload.__doc__)
+    @prepend_docstr_nosections(_args_to_payload.__doc__)
     def query_region_async(self, *args, **kwargs):
         """
         Returns

--- a/astroquery/sdss/core.py
+++ b/astroquery/sdss/core.py
@@ -14,8 +14,7 @@ from astropy.table import Table, Column
 
 from ..query import BaseQuery
 from . import conf
-from ..utils import commons, async_to_sync
-from ..utils.docstr_chompers import prepend_docstr_noreturns
+from ..utils import commons, async_to_sync, prepend_docstr_nosections
 from ..exceptions import RemoteServiceError, NoResultsWarning
 from .field_names import (photoobj_defs, specobj_defs,
                           crossid_defs, get_field_info)
@@ -595,7 +594,7 @@ class SDSSClass(BaseQuery):
 
         return results
 
-    @prepend_docstr_noreturns(get_spectra_async.__doc__)
+    @prepend_docstr_nosections(get_spectra_async.__doc__)
     def get_spectra(self, coordinates=None, radius=2. * u.arcsec,
                     matches=None, plate=None, fiberID=None, mjd=None,
                     timeout=TIMEOUT, cache=True, data_release=12,
@@ -740,7 +739,7 @@ class SDSSClass(BaseQuery):
 
         return results
 
-    @prepend_docstr_noreturns(get_images_async.__doc__)
+    @prepend_docstr_nosections(get_images_async.__doc__)
     def get_images(self, coordinates=None, radius=2. * u.arcsec,
                    matches=None, run=None, rerun=301, camcol=None, field=None,
                    band='g', timeout=TIMEOUT, cache=True,
@@ -817,7 +816,7 @@ class SDSSClass(BaseQuery):
 
         return results
 
-    @prepend_docstr_noreturns(get_spectral_template_async.__doc__)
+    @prepend_docstr_nosections(get_spectral_template_async.__doc__)
     def get_spectral_template(self, kind='qso', timeout=TIMEOUT,
                               show_progress=True):
         """

--- a/astroquery/skyview/core.py
+++ b/astroquery/skyview/core.py
@@ -7,7 +7,7 @@ from astropy import units as u
 
 from . import conf
 from ..query import BaseQuery
-from ..utils import prepend_docstr_noreturns, commons, async_to_sync
+from ..utils import prepend_docstr_nosections, commons, async_to_sync
 
 
 __doctest_skip__ = [
@@ -206,7 +206,7 @@ class SkyViewClass(BaseQuery):
                                                  show_progress=show_progress)
         return [obj.get_fits() for obj in readable_objects]
 
-    @prepend_docstr_noreturns(get_images.__doc__)
+    @prepend_docstr_nosections(get_images.__doc__)
     def get_images_async(self, position, survey, coordinates=None,
                          projection=None, pixels=None, scaling=None,
                          sampler=None, resolver=None, deedger=None, lut=None,
@@ -227,7 +227,7 @@ class SkyViewClass(BaseQuery):
                                       show_progress=show_progress)
                 for url in image_urls]
 
-    @prepend_docstr_noreturns(get_images.__doc__)
+    @prepend_docstr_nosections(get_images.__doc__, sections=['Returns', 'Examples'])
     def get_image_list(self, position, survey, coordinates=None,
                        projection=None, pixels=None, scaling=None,
                        sampler=None, resolver=None, deedger=None, lut=None,
@@ -238,6 +238,13 @@ class SkyViewClass(BaseQuery):
         -------
         list of image urls
 
+        Examples
+        --------
+        >>> SkyView().get_image_list(position='Eta Carinae',
+        ...                          survey=['Fermi 5', 'HRI', 'DSS'])
+        [u'http://skyview.gsfc.nasa.gov/tempspace/fits/skv6183161285798_1.fits',
+         u'http://skyview.gsfc.nasa.gov/tempspace/fits/skv6183161285798_2.fits',
+         u'http://skyview.gsfc.nasa.gov/tempspace/fits/skv6183161285798_3.fits']
         """
 
         self._validate_surveys(survey)

--- a/astroquery/splatalogue/core.py
+++ b/astroquery/splatalogue/core.py
@@ -12,8 +12,7 @@ from astropy.io import ascii
 from astropy import units as u
 from astropy import log
 from ..query import BaseQuery
-from ..utils import async_to_sync
-from ..utils.docstr_chompers import prepend_docstr_noreturns
+from ..utils import async_to_sync, prepend_docstr_nosections
 from . import conf
 from . import load_species_table
 
@@ -414,7 +413,7 @@ class SplatalogueClass(BaseQuery):
                 raise ValueError("Must specify either min/max frequency or "
                                  "a valid Band.")
 
-    @prepend_docstr_noreturns("\n" + _parse_kwargs.__doc__)
+    @prepend_docstr_nosections("\n" + _parse_kwargs.__doc__)
     def query_lines_async(self, min_frequency=None, max_frequency=None,
                           cache=True, **kwargs):
         """

--- a/astroquery/template_module/core.py
+++ b/astroquery/template_module/core.py
@@ -18,7 +18,7 @@ from ..query import BaseQuery
 # has common functions required by most modules
 from ..utils import commons
 # prepend_docstr is a way to copy docstrings between methods
-from ..utils import prepend_docstr_noreturns
+from ..utils import prepend_docstr_nosections
 # async_to_sync generates the relevant query tools from _async methods
 from ..utils import async_to_sync
 # import configurable items declared in __init__.py
@@ -252,7 +252,7 @@ class TemplateClass(BaseQuery):
         # otherwise return the images as a list of astropy.fits.HDUList
         return [obj.get_fits() for obj in readable_objs]
 
-    @prepend_docstr_noreturns(get_images.__doc__)
+    @prepend_docstr_nosections(get_images.__doc__)
     def get_images_async(self, coordinates, radius, get_query_payload=False):
         """
         Returns
@@ -274,7 +274,7 @@ class TemplateClass(BaseQuery):
     # the get_image_list method, simply returns the download
     # links for the images as a list
 
-    @prepend_docstr_noreturns(get_images.__doc__)
+    @prepend_docstr_nosections(get_images.__doc__)
     def get_image_list(self, coordinates, radius, get_query_payload=False,
                        cache=True):
         """

--- a/astroquery/utils/__init__.py
+++ b/astroquery/utils/__init__.py
@@ -10,4 +10,4 @@ from .download_file_list import *
 from .class_or_instance import *
 from .commons import *
 from .process_asyncs import async_to_sync
-from .docstr_chompers import prepend_docstr_noreturns
+from .docstr_chompers import prepend_docstr_nosections

--- a/astroquery/utils/docstr_chompers.py
+++ b/astroquery/utils/docstr_chompers.py
@@ -10,22 +10,22 @@ def append_docstr(doc):
     return dec
 
 
-def prepend_docstr_noreturns(doc):
+def prepend_docstr_nosections(doc, sections=['Returns', ]):
     """
     Decorator to prepend to the function's docstr after stripping out the
-    "Returns".
+    list of sections provided (by default "Returns" only).
     """
     def dec(fn):
-        fn.__doc__ = ("\n".join(remove_returns(doc)) +
+        fn.__doc__ = ("\n".join(remove_sections(doc, sections)) +
                       textwrap.dedent(fn.__doc__))
         return fn
     return dec
 
 
-def remove_returns(doc):
+def remove_sections(doc, sections):
     """
-    Given a numpy-formatted docstring, remove the "Returns" block
-    and dedent the whole thing.
+    Given a numpy-formatted docstring, remove the section blocks provided in
+    ``sections`` and dedent the whole thing.
 
     Returns
     -------
@@ -37,7 +37,7 @@ def remove_returns(doc):
     rblock = False
     for line in lines:
         lstrip = line.rstrip()
-        if lstrip == "Returns":
+        if lstrip in sections:
             rblock = True
             continue
         elif rblock:

--- a/astroquery/utils/process_asyncs.py
+++ b/astroquery/utils/process_asyncs.py
@@ -5,7 +5,7 @@ Process all "async" methods into direct methods.
 import textwrap
 import functools
 from .class_or_instance import class_or_instance
-from .docstr_chompers import remove_returns
+from .docstr_chompers import remove_sections
 
 
 def async_to_sync(cls):
@@ -79,7 +79,7 @@ def async_to_sync_docstr(doc, returntype='table'):
 
     # all docstrings have a blank first line
     # strip it out, so that we can prepend
-    outlines = remove_returns(doc.lstrip('\n'))
+    outlines = remove_sections(doc.lstrip('\n'), sections=['Returns', ])
 
     # then the '' here is to add back the blank line
     newdoc = "\n".join(

--- a/astroquery/utils/tests/test_utils.py
+++ b/astroquery/utils/tests/test_utils.py
@@ -309,7 +309,6 @@ def test_return_chomper(doc=docstr3, out=docstr3_out):
                 [x.lstrip() for x in out.split('\n')])
 
 
-
 def dummyfunc1():
     """
     Returns

--- a/astroquery/utils/tests/test_utils.py
+++ b/astroquery/utils/tests/test_utils.py
@@ -19,7 +19,7 @@ import astropy.utils.data as aud
 
 from ...utils import chunk_read, chunk_report, class_or_instance, commons
 from ...utils.process_asyncs import async_to_sync_docstr, async_to_sync
-from ...utils.docstr_chompers import remove_returns, prepend_docstr_noreturns
+from ...utils.docstr_chompers import remove_sections, prepend_docstr_nosections
 
 
 class SimpleQueryClass(object):
@@ -284,6 +284,10 @@ def test_async_to_sync(cls=Dummy):
 
 
 docstr3 = """
+    Parameters
+    ----------
+    first_param
+
     Returns
     -------
     Nothing!
@@ -301,10 +305,12 @@ docstr3_out = """
 
 
 def test_return_chomper(doc=docstr3, out=docstr3_out):
-    assert remove_returns(doc) == [x.lstrip() for x in out.split('\n')]
+    assert (remove_sections(doc, sections=['Returns', 'Parameters']) ==
+                [x.lstrip() for x in out.split('\n')])
 
 
-def dummyfunc():
+
+def dummyfunc1():
     """
     Returns
     -------
@@ -317,15 +323,28 @@ def dummyfunc():
     pass
 
 
+def dummyfunc2():
+    """
+    Returns
+    -------
+    Nothing!
+    """
+    pass
+
+
 docstr4 = """
     Blah Blah Blah
 
     Returns
     -------
     nothing
+
+    Examples
+    --------
+    no_examples_at_all
 """
 
-docstr4_out = """
+docstr4_out1 = """
     Blah Blah Blah
 
     Returns
@@ -337,10 +356,20 @@ docstr4_out = """
     Nada
 """
 
+docstr4_out2 = """
+    Blah Blah Blah
 
-def test_prepend_docstr(doc=docstr4, func=dummyfunc, out=docstr4_out):
-    fn = prepend_docstr_noreturns(doc)(func)
-    assert fn.__doc__ == textwrap.dedent(docstr4_out)
+    Returns
+    -------
+    Nothing!
+"""
+
+
+@pytest.mark.parametrize("func, out", [(dummyfunc1, docstr4_out1),
+                                       (dummyfunc2, docstr4_out2)])
+def test_prepend_docstr(func, out, doc=docstr4):
+    fn = prepend_docstr_nosections(doc, sections=['Returns', 'Examples'])(func)
+    assert fn.__doc__ == textwrap.dedent(out)
 
 
 @async_to_sync

--- a/astroquery/xmatch/core.py
+++ b/astroquery/xmatch/core.py
@@ -7,9 +7,7 @@ from astropy.table import Table
 
 from . import conf
 from ..query import BaseQuery
-from ..utils import (url_helpers,
-                     prepend_docstr_noreturns, async_to_sync,
-                     )
+from ..utils import url_helpers, prepend_docstr_nosections, async_to_sync
 
 
 @async_to_sync
@@ -64,7 +62,7 @@ class XMatchClass(BaseQuery):
             return response
         return ascii.read(response.text, format='csv')
 
-    @prepend_docstr_noreturns("\n" + query.__doc__)
+    @prepend_docstr_nosections("\n" + query.__doc__)
     def query_async(self, cat1, cat2, max_distance, colRA1=None, colDec1=None,
                     colRA2=None, colDec2=None, cache=True,
                     get_query_payload=False):


### PR DESCRIPTION
In #986 I had to remove the ``Example`` section to satisfy the bit more rigorous requirement of the new numpydoc (as the docstring of ``get_image_list`` was created by prepending of the one of ``get_images``, end thus ending up with two Example sections).

This PR thus upgrades ``prepend_docstr_noreturn`` to ``prepend_docstr_nosections``. 

I'm not sure whether we need to deprecate the previous one (I don't mind to do it if that's what we decide). It was in the public API, but was noted with 
```
The following Astroquery modules are mostly meant for internal use of services in Astroquery, you can use them for your scripts, but we don’t guarantee API stability.
```

Nevertheless I added a changelog entry for it. 

``remove_returns``, that also got upgraded to be ``remove_sections`` however wasn't part of the public API, thus probably won't need a deprecation at all.


These utilities however seem very useful and generic, so I wonder whether they should be moved upstream to astropy.utils? cc @pllim and @eteq