### PR TITLE
Make MockRemote a context manager

### DIFF
--- a/astroquery/utils/tests/test_utils.py
+++ b/astroquery/utils/tests/test_utils.py
@@ -381,6 +381,12 @@ def patch_getreadablefileobj(request):
         def __init__(self, fn, *args, **kwargs):
             self.file = open(fn, 'rb')
 
+        def __enter__(self):
+            return self
+
+        def __exit__(self, exc_type, exc_val, exc_tb):
+            self.close()
+
         def info(self):
             return {'Content-Length': filesize}
 


### PR DESCRIPTION
This should fix the problems with against astropy master (that I introduced in https://github.com/astropy/astropy/pull/6743