### PR TITLE
Avoid && in cone search URL

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -13,7 +13,8 @@
 - ESO: Implemented Eso.query_main() to query all instruments with the main form
   (even the ones without a specific form). [#976]
 - ESO: Disabled caching for all Eso.retrieve_data() operations. [#976]
-
+- vo_conesearch: Fix bad query for service that cannot accept '&&'
+  in URL. [#993]
 
 0.3.6 (2017-07-03)
 ------------------

--- a/astroquery/vo_conesearch/core.py
+++ b/astroquery/vo_conesearch/core.py
@@ -131,7 +131,13 @@ class ConeSearchClass(BaseQuery):
         if get_query_payload:
             return request_payload
 
-        response = self._request('GET', self.URL, params=request_payload,
+        # && in URL can break some queries, so remove trailing & if needed
+        if self.URL.endswith('&'):
+            url = self.URL[:-1]
+        else:
+            url = self.URL
+
+        response = self._request('GET', url, params=request_payload,
                                  timeout=self.TIMEOUT, cache=cache)
         result = self._parse_result(response, pars=request_payload,
                                     verbose=verbose)


### PR DESCRIPTION
Fix #992. Thanks for pointing that out, @MSeifert04 ! I did not add a test with the service that broke on purpose because I don't want to deal with the fallout when the service provider decides to take it offline.

Local tests passed using `python setup.py test -P vo_conesearch --remote-data`:
```
platform linux -- Python 3.5.4, pytest-3.2.1, py-1.4.34, pluggy-0.4.0

Running tests with astroquery version 0.3.7.dev4141.
Running tests in lib.linux-x86_64-3.5/astroquery/vo_conesearch docs/vo_conesearch.

Date: 2017-10-19T20:40:00

Platform: Linux-3.10.0-693.2.2.el7.x86_64-x86_64-with-redhat-7.4-Maipo

Full Python Version: 
3.5.4 |Anaconda, Inc.| (default, Sep 30 2017, 18:41:01) 
[GCC 7.2.0]

encodings: sys: utf-8, locale: UTF-8, filesystem: utf-8
byteorder: little
float info: dig: 15, mant_dig: 15

Numpy: 1.13.1
Matplotlib: 2.0.2
Pandas: 0.20.3
Astropy: 2.0.2
APLpy: not available
pyregion: not available
Using Astropy options: remote_data: any.

rootdir: /tmp/astroquery-test-rffqknj4, inifile: setup.cfg
plugins: xdist-1.17.1, mpl-0.8
collected 48 items                                                              

astroquery/vo_conesearch/tests/test_conesearch.py ......x..........x....
astroquery/vo_conesearch/tests/test_vos_catalog.py ...............
astroquery/vo_conesearch/validator/tests/test_inpect.py ....
astroquery/vo_conesearch/validator/tests/test_validate.py ....
../docs/vo_conesearch/client.rst .
../docs/vo_conesearch/validator.rst .
../docs/vo_conesearch/vo_conesearch.rst .

==================== 46 passed, 2 xfailed in 43.01 seconds =====================
```

Also passed in Python 2 (the dev number increased by one because I committed the changes, but not when I ran the other one above):
```
platform linux2 -- Python 2.7.14, pytest-3.2.1, py-1.4.34, pluggy-0.4.0

Running tests with astroquery version 0.3.7.dev4142.
Running tests in lib.linux-x86_64-2.7/astroquery/vo_conesearch docs/vo_conesearch.

Date: 2017-10-19T20:50:39

Platform: Linux-3.10.0-693.2.2.el7.x86_64-x86_64-with-redhat-7.4-Maipo

Full Python Version: 
2.7.14 |Anaconda, Inc.| (default, Oct 13 2017, 10:47:14) 
[GCC 7.2.0]

encodings: sys: ascii, locale: UTF-8, filesystem: UTF-8, unicode bits: 20
byteorder: little
float info: dig: 15, mant_dig: 15

Numpy: 1.13.3
Matplotlib: 2.1.0
Pandas: not available
Astropy: 2.0.2
APLpy: not available
pyregion: not available
Using Astropy options: remote_data: any.

rootdir: /tmp/astroquery-test-0qvH2w, inifile: setup.cfg
collected 48 items                                                              

astroquery/vo_conesearch/tests/test_conesearch.py .................x....
astroquery/vo_conesearch/tests/test_vos_catalog.py ...............
astroquery/vo_conesearch/validator/tests/test_inpect.py ....
astroquery/vo_conesearch/validator/tests/test_validate.py ....
../docs/vo_conesearch/client.rst .
../docs/vo_conesearch/validator.rst .
../docs/vo_conesearch/vo_conesearch.rst .

==================== 47 passed, 1 xfailed in 32.49 seconds =====================
```
Also tested this successfully in Python 3.6 using Astropy 3.0.dev20373.