### PR TITLE
Remove vo.astronet.ru from default VO Cone Search list

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -14,8 +14,9 @@
   (even the ones without a specific form). [#976]
 - ESO: Disabled caching for all Eso.retrieve_data() operations. [#976]
 - MAST: Added login capabilities [#982]
-- vo_conesearch: Fix bad query for service that cannot accept '&&'
+- vo_conesearch: Fixed bad query for service that cannot accept '&&'
   in URL. [#993]
+- vo_conesearch: Removed broken services from default list. [#997]
 - utils: upgrade ``prepend_docstr_noreturns`` to work with multiple
   sections, and thus rename it to ``prepend_docstr_nosections``. [#988]
 

--- a/astroquery/vo_conesearch/validator/data/conesearch_urls.txt
+++ b/astroquery/vo_conesearch/validator/data/conesearch_urls.txt
@@ -8,16 +8,6 @@ http://vizier.u-strasbg.fr/viz-bin/votable/-A?-out.all&amp;-source=I/254/out&amp
 http://vizier.u-strasbg.fr/viz-bin/votable/-A?-out.all&amp;-source=I/255/out&amp;
 http://vizier.u-strasbg.fr/viz-bin/votable/-A?-out.all&amp;-source=I/284/out&amp;
 http://vizier.u-strasbg.fr/viz-bin/votable/-A?-out.all&amp;-source=II/246/out&amp;
-http://vo.astronet.ru/sai_cas/conesearch?cat=sdssdr7&amp;tab=field&amp;
-http://vo.astronet.ru/sai_cas/conesearch?cat=sdssdr7&amp;tab=photoobjall&amp;
-http://vo.astronet.ru/sai_cas/conesearch?cat=sdssdr7&amp;tab=phototag&amp;
-http://vo.astronet.ru/sai_cas/conesearch?cat=sdssdr7&amp;tab=specobjall&amp;
-http://vo.astronet.ru/sai_cas/conesearch?cat=sdssdr7&amp;tab=specphotoall&amp;
-http://vo.astronet.ru/sai_cas/conesearch?cat=sdssdr7&amp;tab=sppparams&amp;
-http://vo.astronet.ru/sai_cas/conesearch?cat=twomass&amp;tab=psc&amp;
-http://vo.astronet.ru/sai_cas/conesearch?cat=twomass&amp;tab=xsc&amp;
-http://vo.astronet.ru/sai_cas/conesearch?cat=usnoa2&amp;tab=main&amp;
-http://vo.astronet.ru/sai_cas/conesearch?cat=usnob1&amp;tab=main&amp;
 http://wfaudata.roe.ac.uk/sdssdr7-dsa/DirectCone?DSACAT=SDSS_DR7&amp;DSATAB=Galaxy&amp;
 http://wfaudata.roe.ac.uk/sdssdr7-dsa/DirectCone?DSACAT=SDSS_DR7&amp;DSATAB=PhotoObj&amp;
 http://wfaudata.roe.ac.uk/sdssdr7-dsa/DirectCone?DSACAT=SDSS_DR7&amp;DSATAB=PhotoObjAll&amp;


### PR DESCRIPTION
`vo.astronet.ru` cone search service URLs have been broken for many months and I never heard back from their maintainer.

Part of #871 