### PR TITLE
Remove 2 VO cone search services that don't work

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -17,7 +17,7 @@
 - MAST: Added login capabilities [#982]
 - vo_conesearch: Fixed bad query for service that cannot accept '&&'
   in URL. [#993]
-- vo_conesearch: Removed broken services from default list. [#997]
+- vo_conesearch: Removed broken services from default list. [#997, #1002]
 - utils: upgrade ``prepend_docstr_noreturns`` to work with multiple
   sections, and thus rename it to ``prepend_docstr_nosections``. [#988]
 

--- a/astroquery/vo_conesearch/validator/data/conesearch_urls.txt
+++ b/astroquery/vo_conesearch/validator/data/conesearch_urls.txt
@@ -1,6 +1,4 @@
-http://archive.noao.edu/nvo/usno.php?cat=a&amp;
 http://gsss.stsci.edu/webservices/vo/ConeSearch.aspx?CAT=GSC23&amp;
-http://irsa.ipac.caltech.edu/cgi-bin/Oasis/CatSearch/nph-catsearch?CAT=fp_psc&amp;
 http://vizier.u-strasbg.fr/viz-bin/votable/-A?-out.all&amp;-source=I/220/out&amp;
 http://vizier.u-strasbg.fr/viz-bin/votable/-A?-out.all&amp;-source=I/243/out&amp;
 http://vizier.u-strasbg.fr/viz-bin/votable/-A?-out.all&amp;-source=I/252/out&amp;


### PR DESCRIPTION
Follow up of #997 in a campaign to clean out "dead" services from nightly validation. These two are not registered with STScI VAO registry anymore and don't work.

Part of #871