### PR TITLE
bugfix: making mast deal gracefully with no results returned

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -23,6 +23,8 @@
 - MAST: Updated dowload functionality [#1004]
 - ATOMIC: Added ability to select which rows are returned from the atomic
   line database. [#1006]
+- MAST: Fixed no results bug [#1003]
+
 
 0.3.6 (2017-07-03)
 ------------------

--- a/astroquery/mast/core.py
+++ b/astroquery/mast/core.py
@@ -443,7 +443,12 @@ class MastClass(QueryWithLogin):
             resTable = _mashup_json_to_table(result, colConfig)
             resultList.append(resTable)
 
-        return vstack(resultList)
+        allResults = vstack(resultList)
+
+        # Check for no results
+        if not allResults:
+            warnings.warn("Query returned no results.", NoResultsWarning)
+        return allResults
 
     def _login(self, username=None, password=None, session_token=None,
                store_password=False, reenter_password=False):  # pragma: no cover


### PR DESCRIPTION
Because the result of dict.get(key) is false both in the case where a key is not present and where the value of the key's dictionary entry is an empty list, an erroneous exception was being through when a query returned no results.  This PR fixes that behavior.