### PR TITLE
Updating download method

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -20,6 +20,7 @@
 - vo_conesearch: Removed broken services from default list. [#997, #1002]
 - utils: upgrade ``prepend_docstr_noreturns`` to work with multiple
   sections, and thus rename it to ``prepend_docstr_nosections``. [#988]
+- MAST: Updated dowload functionality [#1004]
 
 
 0.3.6 (2017-07-03)

--- a/astroquery/mast/core.py
+++ b/astroquery/mast/core.py
@@ -138,7 +138,7 @@ class MastClass(QueryWithLogin):
         super(MastClass, self).__init__()
 
         self._MAST_REQUEST_URL = conf.server + "/api/v0/invoke"
-        self._MAST_DOWNLOAD_URL = conf.server + "/api/v0/download/file/"
+        self._MAST_DOWNLOAD_URL = conf.server + "/api/v0/download/file"
         self._COLUMNS_CONFIG_URL = conf.server + "/portal/Mashup/Mashup.asmx/columnsconfig"
 
         # shibbolith urls
@@ -1287,16 +1287,7 @@ class ObservationsClass(MastClass):
         for dataProduct in products:
 
             localPath = base_dir + "/" + dataProduct['obs_collection'] + "/" + dataProduct['obs_id']
-
-            dataUrl = dataProduct['dataURI']
-            if "http" not in dataUrl:  # url is actually a uri
-                dataUrl = self._MAST_DOWNLOAD_URL + dataUrl.lstrip("mast:")
-
-                # HACK: user identity info not passed properly to downloader
-                # using /api/v0 url, so if user is logged in go through portal url
-                # (will be fixed server side in next, this is a temporary workaround)
-                if self.session_info(True)["Username"] != "anonymous":
-                    dataUrl = dataUrl.replace("api/v0", "portal")
+            dataUrl = self._MAST_DOWNLOAD_URL + "?uri=" + dataProduct['dataURI']
 
             if not os.path.exists(localPath):
                 os.makedirs(localPath)


### PR DESCRIPTION
MAST has made the switch to only uris for data access, so this update reflects that, and removes the check for url vs uri.  

I also removed the hack for downloading proprietary data as it is no longer needed.
