### PR TITLE
Atomic, expand and specify allowed output columns

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -21,7 +21,8 @@
 - utils: upgrade ``prepend_docstr_noreturns`` to work with multiple
   sections, and thus rename it to ``prepend_docstr_nosections``. [#988]
 - MAST: Updated dowload functionality [#1004]
-
+- ATOMIC: Added ability to select which rows are returned from the atomic
+  line database. [#1006]
 
 0.3.6 (2017-07-03)
 ------------------

--- a/astroquery/atomic/core.py
+++ b/astroquery/atomic/core.py
@@ -37,7 +37,7 @@ class AtomicLineListClass(BaseQuery):
                      multiplet=None, transitions=None,
                      show_fine_structure=None,
                      show_auto_ionizing_transitions=None,
-                     output_format=('spec', 'type', 'conf',
+                     output_columns=('spec', 'type', 'conf',
                                     'term', 'angm', 'prob',
                                     'ener')):
         """
@@ -136,7 +136,7 @@ class AtomicLineListClass(BaseQuery):
             the ground state of the next ion are considered auto-ionizing
             levels.
 
-        output_format : tuple
+        output_columns : tuple
             A Tuple of strings indicating which output columns are retrieved.
             A subset of ('spec', 'type', 'conf', 'term', 'angm', 'prob',
             'ener') should be used. Where each string corresponds to the
@@ -161,7 +161,7 @@ class AtomicLineListClass(BaseQuery):
             multiplet=multiplet, transitions=transitions,
             show_fine_structure=show_fine_structure,
             show_auto_ionizing_transitions=show_auto_ionizing_transitions,
-            output_format=output_format)
+            output_columns=output_columns)
         table = self._parse_result(response)
         return table
 
@@ -174,7 +174,7 @@ class AtomicLineListClass(BaseQuery):
                            multiplet=None, transitions=None,
                            show_fine_structure=None,
                            show_auto_ionizing_transitions=None,
-                           output_format=('spec', 'type', 'conf',
+                           output_columns=('spec', 'type', 'conf',
                                           'term', 'angm', 'prob',
                                           'ener')):
         """
@@ -244,7 +244,7 @@ class AtomicLineListClass(BaseQuery):
             'type2': type2,
             'hydr': show_fine_structure,
             'auto': show_auto_ionizing_transitions,
-            'form': output_format,
+            'form': output_columns,
             'tptype': 'as_a'}
         response = self._submit_form(input)
         return response

--- a/astroquery/atomic/core.py
+++ b/astroquery/atomic/core.py
@@ -171,7 +171,7 @@ class AtomicLineListClass(BaseQuery):
         if self._default_form_values is None:
             response = self._request("GET", url=self.FORM_URL, data={},
                                      timeout=self.TIMEOUT)
-            bs = BeautifulSoup(response.text)
+            bs = BeautifulSoup(response.text, 'lxml')
             form = bs.find('form')
             self._default_form_values = self._get_default_form_values(form)
         default_values = self._default_form_values
@@ -233,7 +233,7 @@ class AtomicLineListClass(BaseQuery):
         return response
 
     def _parse_result(self, response):
-        data = StringIO(BeautifulSoup(response.text).find('pre').text.strip())
+        data = StringIO(BeautifulSoup(response.text, 'lxml').find('pre').text.strip())
         # `header` is e.g.:
         # "u'-LAMBDA-VAC-ANG-|-SPECTRUM--|TT|--------TERM---------|---J-J---|----LEVEL-ENERGY--CM-1----'"
         # `colnames` is then
@@ -273,7 +273,7 @@ class AtomicLineListClass(BaseQuery):
             input = {}
         response = self._request("GET", url=self.FORM_URL, data={},
                                  timeout=self.TIMEOUT)
-        bs = BeautifulSoup(response.text)
+        bs = BeautifulSoup(response.text, 'lxml')
         form = bs.find('form')
         # cache the default values to save HTTP traffic
         if self._default_form_values is None:

--- a/astroquery/atomic/core.py
+++ b/astroquery/atomic/core.py
@@ -186,7 +186,7 @@ class AtomicLineListClass(BaseQuery):
         if self._default_form_values is None:
             response = self._request("GET", url=self.FORM_URL, data={},
                                      timeout=self.TIMEOUT)
-            bs = BeautifulSoup(response.text, 'lxml')
+            bs = BeautifulSoup(response.text)
             form = bs.find('form')
             self._default_form_values = self._get_default_form_values(form)
         default_values = self._default_form_values
@@ -250,7 +250,7 @@ class AtomicLineListClass(BaseQuery):
         return response
 
     def _parse_result(self, response):
-        data = StringIO(BeautifulSoup(response.text, 'lxml').find('pre').text.strip())
+        data = StringIO(BeautifulSoup(response.text).find('pre').text.strip())
         # `header` is e.g.:
         # "u'-LAMBDA-VAC-ANG-|-SPECTRUM--|TT|--------TERM---------|---J-J---|----LEVEL-ENERGY--CM-1----'"
         # `colnames` is then
@@ -293,7 +293,7 @@ class AtomicLineListClass(BaseQuery):
             input = {}
         response = self._request("GET", url=self.FORM_URL, data={},
                                  timeout=self.TIMEOUT)
-        bs = BeautifulSoup(response.text, 'lxml')
+        bs = BeautifulSoup(response.text)
         form = bs.find('form')
         # cache the default values to save HTTP traffic
         if self._default_form_values is None:

--- a/astroquery/atomic/core.py
+++ b/astroquery/atomic/core.py
@@ -38,8 +38,8 @@ class AtomicLineListClass(BaseQuery):
                      show_fine_structure=None,
                      show_auto_ionizing_transitions=None,
                      output_columns=('spec', 'type', 'conf',
-                                    'term', 'angm', 'prob',
-                                    'ener')):
+                                     'term', 'angm', 'prob',
+                                     'ener')):
         """
         Queries Atomic Line List for the given parameters adnd returns the
         result as a `~astropy.table.Table`. All parameters are optional.
@@ -175,8 +175,8 @@ class AtomicLineListClass(BaseQuery):
                            show_fine_structure=None,
                            show_auto_ionizing_transitions=None,
                            output_columns=('spec', 'type', 'conf',
-                                          'term', 'angm', 'prob',
-                                          'ener')):
+                                           'term', 'angm', 'prob',
+                                           'ener')):
         """
         Returns
         -------

--- a/astroquery/atomic/core.py
+++ b/astroquery/atomic/core.py
@@ -36,7 +36,10 @@ class AtomicLineListClass(BaseQuery):
                      upper_level_energy_range=None, nmax=None,
                      multiplet=None, transitions=None,
                      show_fine_structure=None,
-                     show_auto_ionizing_transitions=None):
+                     show_auto_ionizing_transitions=None,
+                     output_format=('spec', 'type', 'conf',
+                                    'term', 'angm', 'prob',
+                                    'ener')):
         """
         Queries Atomic Line List for the given parameters adnd returns the
         result as a `~astropy.table.Table`. All parameters are optional.
@@ -133,6 +136,14 @@ class AtomicLineListClass(BaseQuery):
             the ground state of the next ion are considered auto-ionizing
             levels.
 
+        output_format : tuple
+            A Tuple of strings indicating which output columns are retrieved.
+            A subset of ('spec', 'type', 'conf', 'term', 'angm', 'prob',
+            'ener') should be used. Where each string corresponds to the
+            column titled Spectrum, Transition type, Configuration, Term,
+            Angular momentum, Transition probability and Level energies
+            respectively.
+
         Returns
         -------
         result : `~astropy.table.Table`
@@ -149,7 +160,8 @@ class AtomicLineListClass(BaseQuery):
             upper_level_energy_range=upper_level_energy_range, nmax=nmax,
             multiplet=multiplet, transitions=transitions,
             show_fine_structure=show_fine_structure,
-            show_auto_ionizing_transitions=show_auto_ionizing_transitions)
+            show_auto_ionizing_transitions=show_auto_ionizing_transitions,
+            output_format=output_format)
         table = self._parse_result(response)
         return table
 
@@ -161,7 +173,10 @@ class AtomicLineListClass(BaseQuery):
                            upper_level_energy_range=None, nmax=None,
                            multiplet=None, transitions=None,
                            show_fine_structure=None,
-                           show_auto_ionizing_transitions=None):
+                           show_auto_ionizing_transitions=None,
+                           output_format=('spec', 'type', 'conf',
+                                          'term', 'angm', 'prob',
+                                          'ener')):
         """
         Returns
         -------
@@ -229,7 +244,7 @@ class AtomicLineListClass(BaseQuery):
             'type2': type2,
             'hydr': show_fine_structure,
             'auto': show_auto_ionizing_transitions,
-            'form': ['spec', 'type', 'term', 'angm', 'prob', 'ener'],
+            'form': output_format,
             'tptype': 'as_a'}
         response = self._submit_form(input)
         return response
@@ -257,6 +272,7 @@ class AtomicLineListClass(BaseQuery):
                 if value:
                     row.append(value)
                 else:
+                    # maintain table dimensions when data missing
                     row.append('None')
             if row:
                 input.append('\t'.join(row))

--- a/astroquery/atomic/core.py
+++ b/astroquery/atomic/core.py
@@ -228,7 +228,9 @@ class AtomicLineListClass(BaseQuery):
             'type': _type,
             'type2': type2,
             'hydr': show_fine_structure,
-            'auto': show_auto_ionizing_transitions}
+            'auto': show_auto_ionizing_transitions,
+            'form': ['spec', 'type', 'term', 'angm', 'prob', 'ener'],
+            'tptype': 'as_a'}
         response = self._submit_form(input)
         return response
 
@@ -254,6 +256,8 @@ class AtomicLineListClass(BaseQuery):
                 value = line[start:end].strip()
                 if value:
                     row.append(value)
+                else:
+                    row.append('None')
             if row:
                 input.append('\t'.join(row))
         if input:
@@ -318,6 +322,7 @@ class AtomicLineListClass(BaseQuery):
                         value = option.get('value', option.text.strip())
             if value and value not in [None, u'None', u'null']:
                 res[key].append(value)
+
         # avoid values with size 1 lists
         d = dict(res)
         for k, v in six.iteritems(d):


### PR DESCRIPTION
This small update makes way for a new argument in both query_object and query_object_async. A tuple specifying which output columns you want to retrieve; allowing users access to the Einstein A coefficient or fewer columns if preferred.