### PR TITLE
Fix units in IRSA dust extinction table

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,6 +1,7 @@
 0.3.7 (unreleased)
 ------------------
 
+- IRSA Dust: fix units in extinction by band table. [#1016]
 - New tool: Exoplanet Orbit Catalog, NASA Exoplanet Archive [#771]
 - MAST: Added convenience function to list available missions. [#947]
 - SIMBAD: adding 'get_query_payload' kwarg to all public methods to return

--- a/astroquery/irsa_dust/core.py
+++ b/astroquery/irsa_dust/core.py
@@ -212,6 +212,10 @@ class IrsaDustClass(BaseQuery):
         # guess=False to suppress error messages related to bad guesses
         table = Table.read(readable_obj.get_string(), format='ipac',
                            guess=False)
+        # Fix up units: 'micron' and 'mag', not 'microns' and 'mags'
+        for column in table.columns.values():
+            if str(column.unit) in {'microns', 'mags'}:
+                column.unit = str(column.unit)[:-1]
         return table
 
     def get_extinction_table_async(self, coordinate, radius=None,

--- a/astroquery/irsa_dust/tests/test_irsa_dust_remote.py
+++ b/astroquery/irsa_dust/tests/test_irsa_dust_remote.py
@@ -1,6 +1,7 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 import imp
 import os
+import astropy.units as u
 import pytest
 import requests
 
@@ -131,11 +132,15 @@ class TestDust(DustTestCase):
         table = irsa_dust.core.IrsaDust.get_extinction_table("m51")
         expected_table = Table.read(self.data(M51_EXT_TBL), format='ipac')
         assert table.meta == expected_table.meta
+        assert table['LamEff'].unit == u.micron
+        assert table['A_SandF'].unit == table['A_SFD'].unit == u.mag
 
     def test_get_extinction_table_instance(self):
         table = irsa_dust.core.IrsaDust().get_extinction_table("m51")
         expected_table = Table.read(self.data(M51_EXT_TBL), format='ipac')
         assert table.meta == expected_table.meta
+        assert table['LamEff'].unit == u.micron
+        assert table['A_SandF'].unit == table['A_SFD'].unit == u.mag
 
     @pytest.mark.parametrize(('image_type', 'expected_tails'),
                              [(None, M31_URL_ALL),


### PR DESCRIPTION
The IRSA dust 'extinction by band' service, queried by `IrsaDust.get_extinction_table()`, returns wavelength units of `microns` and extinction units of `mags`, which are not recognized by `astropy.units.Unit` because of the plural suffix. Strip off the plural suffix so that the units are correctly recognized.