### PR TITLE
Configurable URL for ESO's instrument-specific and main queries

### DIFF
--- a/astroquery/eso/__init__.py
+++ b/astroquery/eso/__init__.py
@@ -16,6 +16,9 @@ class Conf(_config.ConfigNamespace):
     username = _config.ConfigItem(
         "",
         'Optional default username for ESO archive.')
+    query_instrument_url = _config.ConfigItem(
+        "http://archive.eso.org/wdb/wdb/eso",
+        'Root query URL for main and instrument queries.')
 
 
 conf = Conf()

--- a/astroquery/eso/core.py
+++ b/astroquery/eso/core.py
@@ -41,6 +41,7 @@ class EsoClass(QueryWithLogin):
 
     ROW_LIMIT = conf.row_limit
     USERNAME = conf.username
+    QUERY_INSTRUMENT_URL = conf.query_instrument_url
 
     def __init__(self):
         super(EsoClass, self).__init__()
@@ -404,7 +405,7 @@ class EsoClass(QueryWithLogin):
             ROW_LIMIT configuration item.
 
         """
-        url = "http://archive.eso.org/wdb/wdb/eso/eso_archive_main/form"
+        url = self.QUERY_INSTRUMENT_URL+"/eso_archive_main/form"
         return self._query(url, column_filters=column_filters, columns=columns,
                            open_form=open_form, help=help, cache=cache, **kwargs)
 
@@ -442,7 +443,7 @@ class EsoClass(QueryWithLogin):
 
         """
 
-        url = 'http://archive.eso.org/wdb/wdb/eso/{0}/form'.format(instrument.lower())
+        url = self.QUERY_INSTRUMENT_URL+'/{0}/form'.format(instrument.lower())
         return self._query(url, column_filters=column_filters, columns=columns,
                            open_form=open_form, help=help, cache=cache, **kwargs)
 


### PR DESCRIPTION
This does not change the current behavior of `astroquery.eso` but let users with special access adjust the URL to a different interface, for e.g. access to engineering datasets.