### PR TITLE
Removed some deprecated methods from EsoClass

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -14,6 +14,8 @@
 - ESO: Implemented Eso.query_main() to query all instruments with the main form
   (even the ones without a specific form). [#976]
 - ESO: Disabled caching for all Eso.retrieve_data() operations. [#976]
+- ESO: Removed deprecated Eso.data_retrieval() and Eso.query_survey().
+  Please use Eso.retrieve_data() and Eso.query_surveys() instead. [#1019]
 - MAST: Added login capabilities [#982]
 - vo_conesearch: Fixed bad query for service that cannot accept '&&'
   in URL. [#993]

--- a/astroquery/eso/core.py
+++ b/astroquery/eso/core.py
@@ -834,11 +834,6 @@ class EsoClass(QueryWithLogin):
         print("\n".join(result_string))
         return result_string
 
-    def query_survey(self, **kwargs):
-        raise DeprecationWarning("query_survey is deprecated; use "
-                                 "query_surveys instead.  It should "
-                                 "accept the same arguments.")
-
     def _print_surveys_help(self, url, cache=True):
         """
         Download a form and print it in a quasi-human-readable way

--- a/astroquery/eso/core.py
+++ b/astroquery/eso/core.py
@@ -563,14 +563,6 @@ class EsoClass(QueryWithLogin):
         # Return as Table
         return Table(result)
 
-    def data_retrieval(self, datasets):
-        """
-        DEPRECATED: see ``retrieve_data``
-        """
-
-        warnings.warn("data_retrieval has been replaced with retrieve_data",
-                      DeprecationWarning)
-
     def retrieve_data(self, datasets, continuation=False, destination=None):
         """
         Retrieve a list of datasets form the ESO archive.

--- a/astroquery/eso/core.py
+++ b/astroquery/eso/core.py
@@ -600,6 +600,7 @@ class EsoClass(QueryWithLogin):
             raise TypeError("Datasets must be given as a list of strings.")
 
         # First: Detect datasets already downloaded
+        log.info("Detecting already downloaded datasets...")
         for dataset in datasets:
             if os.path.splitext(dataset)[1].lower() in ('.fits', '.tar'):
                 local_filename = dataset
@@ -633,6 +634,8 @@ class EsoClass(QueryWithLogin):
             else:
                 datasets_to_download.append(dataset)
 
+        # Second: Check that the datasets to download are in the archive
+        log.info("Checking availability of datasets to download...")
         valid_datasets = [self.verify_data_exists(ds)
                           for ds in datasets_to_download]
         if not all(valid_datasets):
@@ -641,12 +644,14 @@ class EsoClass(QueryWithLogin):
             raise ValueError("The following data sets were not found on the "
                              "ESO servers: {0}".format(invalid_datasets))
 
-        # Second: Download the other datasets
+        # Third: Download the other datasets
+        log.info("Downloading datasets...")
         if datasets_to_download:
             if not self.authenticated():
                 self.login()
             url = "http://archive.eso.org/cms/eso-data/eso-data-direct-retrieval.html"
             with suspend_cache(self):  # Never cache staging operations
+                log.info("Contacting retrieval server...")
                 retrieve_data_form = self._request("GET", url, cache=False)
                 retrieve_data_form.raise_for_status()
                 log.info("Staging request...")
@@ -690,15 +695,16 @@ class EsoClass(QueryWithLogin):
                     raise RemoteServiceError("There was a remote service "
                                              "error; perhaps the requested "
                                              "file could not be found?")
-            log.info("Downloading files...")
             for fileId in root.select('input[name=fileId]'):
+                log.info("Downloading file {0}...".format(fileId.attrs['value'].split()[0]))
                 fileLink = ("http://dataportal.eso.org/dataPortal" +
                             fileId.attrs['value'].split()[1])
                 filename = self._request("GET", fileLink, save=True,
                                          continuation=True)
+                log.info("Unzipping file {0}...".format(fileId.attrs['value'].split()[0]))
                 filename = system_tools.gunzip(filename)
                 if destination is not None:
-                    log.info("Copying file to {0}...".format(destination))
+                    log.info("Copying file {0} to {1}...".format(fileId.attrs['value'].split()[0], destination))
                     shutil.move(filename, os.path.join(destination, os.path.split(filename)[1]))
 
         # Empty the redirect cache of this request session

--- a/astroquery/eso/core.py
+++ b/astroquery/eso/core.py
@@ -647,12 +647,12 @@ class EsoClass(QueryWithLogin):
                 self.login()
             url = "http://archive.eso.org/cms/eso-data/eso-data-direct-retrieval.html"
             with suspend_cache(self):  # Never cache staging operations
-                data_retrieval_form = self._request("GET", url, cache=False)
-                data_retrieval_form.raise_for_status()
+                retrieve_data_form = self._request("GET", url, cache=False)
+                retrieve_data_form.raise_for_status()
                 log.info("Staging request...")
                 inputs = {"list_of_datasets": "\n".join(datasets_to_download)}
                 data_confirmation_form = self._activate_form(
-                    data_retrieval_form, form_index=-1, inputs=inputs,
+                    retrieve_data_form, form_index=-1, inputs=inputs,
                     cache=False)
 
                 data_confirmation_form.raise_for_status()

--- a/astroquery/eso/tests/test_eso_remote.py
+++ b/astroquery/eso/tests/test_eso_remote.py
@@ -88,7 +88,6 @@ class TestEso:
         eso = Eso()
         surveys = eso.list_surveys(cache=False)
         assert len(surveys) > 0
-        # result_s = eso.query_survey(surveys[0], target='M51')
         # Avoid SESAME
         result_s = eso.query_surveys(surveys[0], coord1=202.469575,
                                      coord2=47.195258, cache=False)

--- a/astroquery/eso/tests/test_eso_remote.py
+++ b/astroquery/eso/tests/test_eso_remote.py
@@ -114,15 +114,6 @@ class TestEso:
         # we only care about the sets matching
         assert set(inst) == set(instrument_list)
 
-    # REQUIRES LOGIN!
-    # Can we get a special login specifically for astroquery testing?
-    # def test_data_retrieval():
-    #
-    #    data_product_id = 'AMBER.2006-03-14T07:40:03.741'
-    #    data_files = eso.retrieve_data([data_product_id])
-    #    # How do we know if we're going to get .fits or .fits.Z?
-    #    assert 'AMBER.2006-03-14T07:40:03.741.fits' in data_files[0]
-
     @pytest.mark.skipif('not Eso.USERNAME')
     def test_retrieve_data(self):
         eso = Eso()


### PR DESCRIPTION
`data_retrieval()` has been deprecated for 4 years, and replaced by `retrieve_data()`.
`query_survey()` has been deprecated for 2 years, and replaced by `query_surveys()`.