### PR TITLE
Allow multiple entries in NRAO queries

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,6 +1,7 @@
 0.3.7 (unreleased)
 ------------------
 
+- NRAO: Allow multiple configurations, telescopes in queries [#1020]
 - New tool: Exoplanet Orbit Catalog, NASA Exoplanet Archive [#771]
 - MAST: Added convenience function to list available missions. [#947]
 - SIMBAD: adding 'get_query_payload' kwarg to all public methods to return

--- a/astroquery/nrao/tests/test_nrao.py
+++ b/astroquery/nrao/tests/test_nrao.py
@@ -101,6 +101,6 @@ def test_query_region_multiconfig(patch_post, patch_parse_coordinates):
     # remote tests for that)
     result = nrao.core.Nrao.query_region(
         commons.ICRSCoordGenerator("05h35.8m 35d43m"), querytype='ARCHIVE',
-        telescope_config=['A','AB','B','BC','C','CD','D'],
+        telescope_config=['A', 'AB', 'B', 'BC', 'C', 'CD', 'D'],
     )
     assert isinstance(result, Table)

--- a/astroquery/nrao/tests/test_nrao.py
+++ b/astroquery/nrao/tests/test_nrao.py
@@ -93,3 +93,14 @@ def test_query_region_archive(patch_post, patch_parse_coordinates):
     assert isinstance(result, Table)
     assert len(result) == 230
     assert result['Obs. Data Starts'][0] == '78-Jun-18 14:17:49'
+
+def test_query_region_multiconfig(patch_post, patch_parse_coordinates):
+    # regression test for issue 1020
+    # All we're testing for is that the list-form telescope_config is parsed
+    # properly and doesn't crash; this does NOT test for correctness (see
+    # remote tests for that)
+    result = nrao.core.Nrao.query_region(
+        commons.ICRSCoordGenerator("05h35.8m 35d43m"), querytype='ARCHIVE',
+        telescope_config=['A','AB','B','BC','C','CD','D'],
+    )
+    assert isinstance(result, Table)

--- a/astroquery/nrao/tests/test_nrao.py
+++ b/astroquery/nrao/tests/test_nrao.py
@@ -94,6 +94,7 @@ def test_query_region_archive(patch_post, patch_parse_coordinates):
     assert len(result) == 230
     assert result['Obs. Data Starts'][0] == '78-Jun-18 14:17:49'
 
+
 def test_query_region_multiconfig(patch_post, patch_parse_coordinates):
     # regression test for issue 1020
     # All we're testing for is that the list-form telescope_config is parsed

--- a/astroquery/nrao/tests/test_nrao_remote.py
+++ b/astroquery/nrao/tests/test_nrao_remote.py
@@ -4,6 +4,7 @@ from __future__ import print_function
 from astropy.tests.helper import remote_data
 from astropy.table import Table
 import astropy.coordinates as coord
+from astropy import units as u
 import requests
 import imp
 
@@ -36,3 +37,21 @@ class TestNrao:
             retry=5, radius='1d')
         assert len(result) >= 230
         assert 'VLA_XH78003_file15.dat' in result['Archive File']
+
+    def test_query_multiconfig(self):
+        # regression test for issue 1020
+        orion = coord.SkyCoord.from_name("Orion Core")
+        result = nrao.core.Nrao.query_region(coordinates=orion,
+                                             radius=1*u.arcmin,
+                                             telescope='jansky_vla',
+                                             telescope_config=['A','AB','B'],
+                                             obs_band=['K','Ka', 'Q'])
+        assert b'ORION-KL' in [x.strip() for x in result['Source']]
+
+        # NOTE: This could change if future observations in AB config are ever
+        # taken, or A- or B- config observations with fewer antennae.  Neither
+        # are *expected*, but it could happen.
+        assert set(result['Telescope:config']) == {'EVLA:A:1:26',
+                                                   'EVLA:A:1:27',
+                                                   'EVLA:B:1:26',
+                                                   'EVLA:B:1:27'}

--- a/astroquery/nrao/tests/test_nrao_remote.py
+++ b/astroquery/nrao/tests/test_nrao_remote.py
@@ -44,8 +44,8 @@ class TestNrao:
         result = nrao.core.Nrao.query_region(coordinates=orion,
                                              radius=1*u.arcmin,
                                              telescope='jansky_vla',
-                                             telescope_config=['A','AB','B'],
-                                             obs_band=['K','Ka', 'Q'])
+                                             telescope_config=['A', 'AB', 'B'],
+                                             obs_band=['K', 'Ka', 'Q'])
         assert b'ORION-KL' in [x.strip() for x in result['Source']]
 
         # NOTE: This could change if future observations in AB config are ever


### PR DESCRIPTION
This is a bugfix for the NRAO query tool.  Previously, only single telescope configurations and single telescopes (e.g., just 'vla' or just 'gbt' or just 'all') were permitted, but the NRAO archive accepts arrays of entries.