### PR TITLE
Raise an error when attempting to download private data without first logging in

### DIFF
--- a/astroquery/alma/core.py
+++ b/astroquery/alma/core.py
@@ -287,6 +287,9 @@ class AlmaClass(QueryWithLogin):
                                  timeout=self.TIMEOUT, cache=False)
         self._staging_log['initial_response'] = response
         log.debug("First response URL: {0}".format(response.url))
+        if 'login' in response.url:
+            raise ValueError("You must login before downloading this data set.")
+
         if response.status_code == 405:
             if hasattr(self, '_last_successful_staging_log'):
                 log.warning("Error 405 received.  If you have previously staged "


### PR DESCRIPTION
All in the header; I ran into a case this morning with a really awkward error message that resulted in an ALMA internal server error because I used a non-logged-in instance of astroquery.alma