### PR TITLE
STScIDSI-31: Enable downloading MAST HST data from S3

### DIFF
--- a/astroquery/mast/core.py
+++ b/astroquery/mast/core.py
@@ -1331,6 +1331,22 @@ class ObservationsClass(MastClass):
         obs_id = dataProduct['obs_id']
 
         obs_id = obs_id.lower()
+        
+        # This next part is a bit funky.  Let me explain why:
+        # We have 2 different possible URI schemes for HST:
+        #   mast:HST/product/obs_id_filename.type (old style)
+        #   mast:HST/product/obs_id/obs_id_filename.type (new style)
+        # The first scheme was developed thinking that the obs_id in the filename
+        # would *always* match the actual obs_id folder the file was placed in.
+        # Unfortunately this assumption was false.
+        # We have been trying to switch to the new uri scheme as it specifies the 
+        # obs_id used in the folder path correctly.
+        # The cherry on top is that the obs_id in the new style URI is not always correct either!
+        # When we are looking up files we have some code which iterates through all of
+        # the possible permutations of the obs_id's last char which can be *ANYTHING*
+        #
+        # So in conclusion we can't trust the last char obs_id from the file or from the database
+        # So with that in mind, hold your nose when reading the following:
 
         # magic associations logic per Brian - 0-9/a-e we convert to 0
         magicValues = "123456789abcde"

--- a/astroquery/mast/core.py
+++ b/astroquery/mast/core.py
@@ -1299,7 +1299,8 @@ class ObservationsClass(MastClass):
 
     def enable_s3_hst_dataset(self):
         """
-        Attempts to enable downloading HST public files from S3 instead of MAST.  Requires the boto3 library to function.
+        Attempts to enable downloading HST public files from S3 instead of MAST.
+        Requires the boto3 library to function.
         """
         import boto3
         self._boto3 = boto3
@@ -1418,7 +1419,6 @@ class ObservationsClass(MastClass):
                 if self._boto3 is not None and dataProduct["dataURI"].startswith("mast:HST/product"):
                     try:
                         self._download_from_s3(dataProduct, localPath, cache)
-                        s3_fetch_ok = True
                     except Exception as ex:
                         log.exception("Error pulling from S3 bucket: %s" % ex)
                         log.warn("Falling back to mast download...")

--- a/astroquery/mast/core.py
+++ b/astroquery/mast/core.py
@@ -1335,8 +1335,10 @@ class ObservationsClass(MastClass):
         # magic associations logic per Brian - 0-9/a-e we convert to 0
         magicValues = "123456789abcde"
         if obs_id[-1] in magicValues:
+            # We only replace the first occurrence in the folder
+            # The filename remains with the original obs_id as part of the name
             new_obs_id = obs_id[:-1] + "0"
-            dataUri = dataUri.replace(obs_id, new_obs_id)
+            dataUri = dataUri.replace(obs_id, new_obs_id, 1)
             obs_id = new_obs_id
             log.warning("This data product's path may not have been properly identified %s" % dataUri)
 

--- a/astroquery/mast/core.py
+++ b/astroquery/mast/core.py
@@ -1294,6 +1294,9 @@ class ObservationsClass(MastClass):
         return manifest
 
     def enable_s3_hst_dataset(self):
+        """
+        Attempts to enable downloading HST public files from S3 instead of MAST
+        """
         try:
             global boto3
             import boto3
@@ -1307,6 +1310,9 @@ class ObservationsClass(MastClass):
         print("If you have not configured boto3, follow the instructions here: https://boto3.readthedocs.io/en/latest/guide/configuration.html")
 
     def disable_s3_hst_dataset(self):
+        """
+        Disables downloading HST public files from S3 instead of MAST
+        """
         global boto3
         boto3 = None
 


### PR DESCRIPTION
Users who are running jobs on AWS can now retrieve public HST data directly from a S3 bucket through AWS's public dataset program.  https://aws.amazon.com/public-datasets/

This functionality is **disabled** by default and is opt in due to the nature of a required small service charge for pulling the data from S3.


Example:
```
from astroquery.mast import Observations
obsTable = Observations.query_object("M101",radius=0.02)
hstObs = obsTable[obsTable["obs_collection"]=="HST"]
products = Observations.get_product_list(hstObs[:4])
Observations.enable_s3_hst_dataset()
manifest = Observations.download_products(products)
```