### PR TITLE
Fixing some links and permanent redirects

### DIFF
--- a/astroquery/cosmosim/__init__.py
+++ b/astroquery/cosmosim/__init__.py
@@ -6,7 +6,7 @@ CosmoSim Database Query Tool
     Access to all cosmological simulations stored in the CosmoSim database,
     via the uws service.
 
-    http://www.cosmosim.org/uws/query
+    https://www.cosmosim.org/uws/query
 
     :Author: Austen M. Groener <Austen.M.Groener@drexel.edu>
 """
@@ -20,10 +20,10 @@ class Conf(_config.ConfigNamespace):
     """
 
     query_url = _config.ConfigItem(
-        ['http://www.cosmosim.org/uws/query'],
+        ['https://www.cosmosim.org/uws/query'],
         'CosmoSim UWS query URL.')
     schema_url = _config.ConfigItem(
-        ['http://www.cosmosim.org/query/account/databases/json'],
+        ['https://www.cosmosim.org/query/account/databases/json'],
         'CosmoSim json query URL for generating database schema.')
     timeout = _config.ConfigItem(
         60.0,

--- a/astroquery/fermi/__init__.py
+++ b/astroquery/fermi/__init__.py
@@ -2,8 +2,8 @@
 """
 Access to Fermi Gamma-ray Space Telescope data.
 
-http://fermi.gsfc.nasa.gov
-http://fermi.gsfc.nasa.gov/ssc/data/
+https://fermi.gsfc.nasa.gov
+https://fermi.gsfc.nasa.gov/ssc/data/
 """
 from astropy import config as _config
 
@@ -14,7 +14,7 @@ class Conf(_config.ConfigNamespace):
     """
 
     url = _config.ConfigItem(
-        'http://fermi.gsfc.nasa.gov/cgi-bin/ssc/LAT/LATDataQuery.cgi',
+        'https://fermi.gsfc.nasa.gov/cgi-bin/ssc/LAT/LATDataQuery.cgi',
         'Fermi query URL.')
     timeout = _config.ConfigItem(
         60,

--- a/astroquery/ned/__init__.py
+++ b/astroquery/ned/__init__.py
@@ -17,7 +17,7 @@ Extragalactic Database (NED):
     :Acknowledgements:
 
         Based off Adam Ginsburg's Splatalogue search routine:
-            http://code.google.com/p/agpy/source/browse/trunk/agpy/query_splatalogue.py
+            https://github.com/keflavich/agpy/blob/master/agpy/query_splatalogue.py
 
         Service URLs to acquire the VO Tables are taken from Mazzarella et
         al. (2007) The National Virtual Observatory: Tools and Techniques

--- a/docs/alma/alma.rst
+++ b/docs/alma/alma.rst
@@ -10,10 +10,10 @@ Example Notebooks
 =================
 A series of example notebooks can be found here:
 
- * `What has ALMA observed toward all Messier objects? (an example of querying many sources) <http://nbviewer.ipython.org/gist/keflavich/e798e10e3bf9a93d1453>`_
- * `ALMA finder chart of the Cartwheel galaxy and public Cycle 1 data quicklooks <http://nbviewer.ipython.org/gist/keflavich/d5af22578094853e2d24>`_
- * `Finder charts toward many sources with different backgrounds <http://nbviewer.ipython.org/gist/keflavich/2ef877ec90d774645fee>`_
- * `Finder chart and downloaded data from Cycle 0 observations of Sombrero Galaxy <http://nbviewer.ipython.org/gist/keflavich/9934c9412d8f58299962>`_
+ * `What has ALMA observed toward all Messier objects? (an example of querying many sources) <http://nbviewer.jupyter.org/gist/keflavich/e798e10e3bf9a93d1453>`_
+ * `ALMA finder chart of the Cartwheel galaxy and public Cycle 1 data quicklooks <http://nbviewer.jupyter.org/gist/keflavich/d5af22578094853e2d24>`_
+ * `Finder charts toward many sources with different backgrounds <http://nbviewer.jupyter.org/gist/keflavich/2ef877ec90d774645fee>`_
+ * `Finder chart and downloaded data from Cycle 0 observations of Sombrero Galaxy <http://nbviewer.jupyter.org/gist/keflavich/9934c9412d8f58299962>`_
 
 Getting started
 ===============

--- a/docs/eso/eso.rst
+++ b/docs/eso/eso.rst
@@ -104,7 +104,7 @@ Identifying available instrument-specific queries
 
 The direct retrieval of datasets is better explained with a running example, continuing from the
 authentication example above. The first thing to do is to identify the instrument to query. The
-list of available instrument-specific queries can be obtiained with the
+list of available instrument-specific queries can be obtained with the
 :meth:`~astroquery.eso.EsoClass.list_instruments` method.
 
 .. code-block:: python

--- a/docs/fermi/fermi.rst
+++ b/docs/fermi/fermi.rst
@@ -16,10 +16,10 @@ centered on M 31 for the energy range 1 to 100 GeV for the first day in 2013.
     >>> result = fermi.FermiLAT.query_object('M31', energyrange_MeV='1000, 100000',
     ...                                      obsdates='2013-01-01 00:00:00, 2013-01-02 00:00:00')
     >>> print(result)
-    ['http://fermi.gsfc.nasa.gov/FTP/fermi/data/lat/queries/L1309041729388EB8D2B447_SC00.fits',
-     'http://fermi.gsfc.nasa.gov/FTP/fermi/data/lat/queries/L1309041729388EB8D2B447_PH00.fits']
+    ['https://fermi.gsfc.nasa.gov/FTP/fermi/data/lat/queries/L1309041729388EB8D2B447_SC00.fits',
+     'https://fermi.gsfc.nasa.gov/FTP/fermi/data/lat/queries/L1309041729388EB8D2B447_PH00.fits']
     >>> from astropy.io import fits
-    >>> sc = fits.open('http://fermi.gsfc.nasa.gov/FTP/fermi/data/lat/queries/L1309041729388EB8D2B447_SC00.fits')
+    >>> sc = fits.open('https://fermi.gsfc.nasa.gov/FTP/fermi/data/lat/queries/L1309041729388EB8D2B447_SC00.fits')
 
 
 Reference/API

--- a/docs/gaia/gaia.rst
+++ b/docs/gaia/gaia.rst
@@ -16,9 +16,10 @@ This amounts to about 1 per cent of the Galactic stellar population.
 If you use public Gaia DR1 data in your paper, please take note of our guide_ on
 how to acknowledge and cite Gaia DR1.
 
-.. _guide: http://gaia.esac.esa.int/documentation/GDR1/Miscellaneous/sec_credit_and_citation_instructions.html
+.. _guide: https://gaia.esac.esa.int/documentation/GDR1/Miscellaneous/sec_credit_and_citation_instructions.html
 
-This package allows the access to the European Space Agency Gaia Archive (http://archives.esac.esa.int/gaia)
+This package allows the access to the European Space Agency Gaia Archive
+(http://gea.esac.esa.int/archive/)
 
 Gaia Archive access is based on a TAP+ REST service. TAP+ is an extension of
 Table Access Protocol (TAP: http://www.ivoa.net/documents/TAP/) specified by the

--- a/docs/gallery.rst
+++ b/docs/gallery.rst
@@ -166,9 +166,9 @@ Example 7
 +++++++++
 Find ALMA pointings that have been observed toward M83, then overplot the
 various fields-of view on a 2MASS image retrieved from SkyView.  See
-http://nbviewer.ipython.org/gist/keflavich/19175791176e8d1fb204 for the
+http://nbviewer.jupyter.org/gist/keflavich/19175791176e8d1fb204 for the
 notebook.  There is an even more sophisticated version at
-http://nbviewer.ipython.org/gist/keflavich/bb12b772d6668cf9181a, which shows
+http://nbviewer.jupyter.org/gist/keflavich/bb12b772d6668cf9181a, which shows
 Orion KL in all observed bands.
 
 .. code-block:: python

--- a/docs/heasarc/heasarc.rst
+++ b/docs/heasarc/heasarc.rst
@@ -10,7 +10,7 @@ Getting started
 ===============
 
 This is a python interface for querying the
-`HEASARC <http://heasarc.gsfc.nasa.gov/>`__
+`HEASARC <https://heasarc.gsfc.nasa.gov/>`__
 archive web service.
 
 The capabilities are currently very limited ... feature requests and contributions welcome!

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -42,7 +42,7 @@ Using conda
 ^^^^^^^^^^^
 
 It is also possible to install the latest astroquery with `anaconda
-<http://continuum.io/>`_ from the astropy channel:
+<https://anaconda.com/>`_ from the astropy channel:
 
 .. code-block:: bash
 
@@ -75,7 +75,7 @@ The following packages are required for astroquery installation & use:
 * `astropy <http://www.astropy.org>`__ (>=1.0)
 * `requests <http://docs.python-requests.org/en/latest/>`_
 * `keyring <https://pypi.python.org/pypi/keyring>`_
-* `Beautiful Soup <http://www.crummy.com/software/BeautifulSoup/>`_
+* `Beautiful Soup <https://www.crummy.com/software/BeautifulSoup/>`_
 * `html5lib <https://pypi.python.org/pypi/html5lib>`_
 
 and for running the tests:

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -14,8 +14,10 @@ Introduction
 Astroquery is a set of tools for querying astronomical web forms and databases.
 
 There are two other packages with complimentary functionality as Astroquery:
-`astropy.vo <http://docs.astropy.org/en/latest/vo/index.html>`_ is in the Astropy core and
-`pyvo <https://pyvo.readthedocs.io/en/latest/>`_ is an Astropy affiliated package.
+`pyvo <https://pyvo.readthedocs.io/en/latest/>`_ is an Astropy affiliated package, and
+`Simple-Cone-Search-Creator <https://github.com/tboch/Simple-Cone-Search-Creator/>`_ to
+generate a cone search service complying with the
+`IVOA standard <http://www.ivoa.net/documents/latest/ConeSearch.html>`_.
 They are more oriented to general `virtual observatory <http://www.virtualobservatory.org>`_
 discovery and queries, whereas Astroquery has web service specific interfaces.
 

--- a/docs/mast/mast.rst
+++ b/docs/mast/mast.rst
@@ -253,7 +253,7 @@ Filtering
 ^^^^^^^^^
 
 Filter keyword arguments can be applied to download only data products that meet the given criteria.
-Available filters are "mrp_only" (Minium Recommended Products), "extension" (file extension),
+Available filters are "mrp_only" (Minimum Recommended Products), "extension" (file extension),
 and all products fields listed `here <https://mast.stsci.edu/api/v0/_productsfields.html>`_.
 
 **Important: mrp_only defaults to True.**
@@ -274,7 +274,7 @@ The below example illustrates downloading all product files with the extension "
                 Downloading URL https://mast.stsci.edu/api/v0/download/file/HST/product/ib3p11q9q_raw.fits to ./mastDownload/HST/IB3P11Q9Q/ib3p11q9q_raw.fits ... [Done]
 
 
-Product filtering can also be appllied directly to a table of products without proceeding to the download step. 
+Product filtering can also be applied directly to a table of products without proceeding to the download step.
 
 .. code-block:: python
 

--- a/docs/ned/ned.rst
+++ b/docs/ned/ned.rst
@@ -262,4 +262,4 @@ Reference/API
 .. automodapi:: astroquery.ned
     :no-inheritance-diagram:
 
-.. _IAU format: http://cdsweb.u-strasbg.fr/Dic/iau-spec.html.
+.. _IAU format: http://cdsweb.u-strasbg.fr/Dic/iau-spec.htx

--- a/docs/skyview/skyview.rst
+++ b/docs/skyview/skyview.rst
@@ -9,7 +9,7 @@ Skyview Queries (`astroquery.skyview`)
 Getting started
 ===============
 
-The `SkyView <skyview.gsfc.nasa.gov>`_ service offers a cutout service for a
+The `SkyView <https://skyview.gsfc.nasa.gov/>`_ service offers a cutout service for a
 number of imaging surveys.
 
 To see the list of surveys, use the `~astroquery.skyview.SkyViewClass.list_surveys` method:

--- a/docs/splatalogue/splatalogue.rst
+++ b/docs/splatalogue/splatalogue.rst
@@ -23,7 +23,7 @@ Searching for Lines
 -------------------
 
 In the Splatalogue web interface, you select "species" of interest using the left side menu
-seen in the `query interface`_  You can access the line list:
+seen in the `query interface`_.  You can access the line list:
 
 .. code-block:: python
 
@@ -89,8 +89,9 @@ online interface.  In principle, we can make a higher level wrapper, but it is
 not obvious what other parameters one might want to query on (whereas with
 catalogs, you almost always need a sky-position based query tool).
 
-Any feature you can change on the Splatalogue `query interface`_ can be
-modified in the :meth:`~astroquery.splatalogue.SplatalogueClass.query_lines` tool.
+Any feature you can change on the `Splatalogue web form <query interface_>`_
+can be modified in the
+:meth:`~astroquery.splatalogue.SplatalogueClass.query_lines` tool.
 
 For any Splatalogue query, you *must* specify a minimum/maximum frequency.
 However, you can do it with astropy units, so wavelengths are OK too.

--- a/docs/splatalogue/splatalogue.rst
+++ b/docs/splatalogue/splatalogue.rst
@@ -89,7 +89,7 @@ online interface.  In principle, we can make a higher level wrapper, but it is
 not obvious what other parameters one might want to query on (whereas with
 catalogs, you almost always need a sky-position based query tool).
 
-Any feature you can change on the `Splatalogue web form <splat_b>`_ can be
+Any feature you can change on the Splatalogue `query interface`_ can be
 modified in the :meth:`~astroquery.splatalogue.SplatalogueClass.query_lines` tool.
 
 For any Splatalogue query, you *must* specify a minimum/maximum frequency.
@@ -238,5 +238,5 @@ Reference/API
 .. _Splatalogue: http://www.splatalogue.net
 .. _Splatalogue web service: http://www.splatalogue.net
 .. _query interface: http://www.cv.nrao.edu/php/splat/b.php
-.. _An example ipynb from an interactive tutorial session at NRAO in April 2014: http://nbviewer.ipython.org/gist/keflavich/10477775
+.. _An example ipynb from an interactive tutorial session at NRAO in April 2014: http://nbviewer.jupyter.org/gist/keflavich/10477775
 

--- a/docs/vamdc/vamdc.rst
+++ b/docs/vamdc/vamdc.rst
@@ -10,7 +10,7 @@ Getting Started
 ===============
 
 The astroquery vamdc interface requires vamdclib_.  The documentation is sparse
-to nonexistant, but installation is straightforward::
+to nonexistent, but installation is straightforward::
 
     pip install https://github.com/keflavich/vamdclib/archive/master.zip
 


### PR DESCRIPTION
The link to the latest `astropy.vo` in index.html is broken because the service has been removed in astropy 3.0. I have removed this link and added an additional reference to the `Simple-Cone-Search-Creator` tool. There are some changes in source files in f9dbecb16e4df432549b3570864b68b9a8f7db0 but these are only to fix URL redirection so the PR could be considered as docs-only.