### PR TITLE
Heasarc query allcols

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,6 +1,7 @@
 0.3.8 (unreleased)
 ------------------
 
+- heasarc: Add additional functionality and expand query capabilities [#1047]
 - ATOMIC: Fixed remote tests that were broken. [#1038]
 - vo_conesearch: URL for validated services have changed. Old URL should still
   redirect but it is deprecated. [#1033]

--- a/astroquery/heasarc/__init__.py
+++ b/astroquery/heasarc/__init__.py
@@ -21,6 +21,12 @@ class Conf(_config.ConfigNamespace):
         ['http://heasarc.gsfc.nasa.gov/cgi-bin/W3Browse/w3query_noredir.pl'],
         'Name of the HEASARC server to use.')
 
+    # The above server does not work for querying available missions.
+    # The following server does.
+    mission_server = _config.ConfigItem(
+        ['https://heasarc.gsfc.nasa.gov/db-perl/W3Browse/w3query.pl'],
+        'Name of the HEASARC server used to query available missions.')
+
     timeout = _config.ConfigItem(
         30,
         'Time limit for connecting to HEASARC server.')

--- a/astroquery/heasarc/core.py
+++ b/astroquery/heasarc/core.py
@@ -98,6 +98,10 @@ class HeasarcClass(BaseQuery):
             **kwargs
         )
 
+        # Return payload if requested
+        if get_query_payload:
+            return request_payload
+
         # Submit the request
         return self.query_async(request_payload, cache)
 

--- a/astroquery/heasarc/core.py
+++ b/astroquery/heasarc/core.py
@@ -63,8 +63,7 @@ class HeasarcClass(BaseQuery):
                            **kwargs):
         """
         Returns a list containing the names of columns that can be returned for
-        a given mission table. By default all column names are returned. A list
-        of the default columns can be obtained by setting `fields='Standard'`
+        a given mission table. By default all column names are returned.
 
         Parameters
         ----------
@@ -110,8 +109,8 @@ class HeasarcClass(BaseQuery):
         mission : str
             Mission table to search from
         **kwargs :
-            see :func:`_args_to_payload` for list of additional parameters that
-            can be used to refine search query
+            see `~astroquery.heasarc.HeasarcClass._args_to_payload` for list
+            of additional parameters that can be used to refine search query
         """
         request_payload = self._args_to_payload(
             mission=mission,
@@ -148,8 +147,8 @@ class HeasarcClass(BaseQuery):
             Astropy Quantity object, or a string that can be parsed into one.
             e.g., '1 degree' or 1*u.degree.
         **kwargs :
-            see :func:`_args_to_payload` for list of additional parameters that
-            can be used to refine search query
+            see `~astroquery.heasarc.HeasarcClass._args_to_payload` for list
+            of additional parameters that can be used to refine search query
         """
         # Convert the coordinates to FK5
         c = commons.parse_coordinates(position).transform_to(coordinates.FK5)

--- a/astroquery/heasarc/core.py
+++ b/astroquery/heasarc/core.py
@@ -16,7 +16,8 @@ __all__ = ['Heasarc', 'HeasarcClass']
 @async_to_sync
 class HeasarcClass(BaseQuery):
 
-    """HEASARC query class.
+    """
+    HEASARC query class.
 
     For a list of available HEASARC mission tables, visit:
         https://heasarc.gsfc.nasa.gov/cgi-bin/W3Browse/w3catindex.pl
@@ -24,6 +25,7 @@ class HeasarcClass(BaseQuery):
 
     URL = conf.server
     TIMEOUT = conf.timeout
+    coord_systems = ['fk5', 'fk4', 'equatorial', 'galactic']
 
     def query_async(self, request_payload, cache=True, url=conf.server):
         """
@@ -50,7 +52,7 @@ class HeasarcClass(BaseQuery):
         # Parse the results specially (it's ascii format, not fits)
         response = self.query_async(
             request_payload,
-            url='https://heasarc.gsfc.nasa.gov/db-perl/W3Browse/w3query.pl',
+            url=conf.mission_server,
             cache=cache
         )
         data = BytesIO(response.content)
@@ -287,6 +289,10 @@ class HeasarcClass(BaseQuery):
 
         elif coordsys.lower() == 'galactic':
             request_payload['Coordinates'] = 'Galactic: LII BII'
+
+        else:
+            raise ValueError("'coordsys' parameter must be one of {!s}"
+                             .format(self.coord_systems))
 
         # Specify which table columns are to be returned
         fields = kwargs.get('fields', None)

--- a/astroquery/heasarc/core.py
+++ b/astroquery/heasarc/core.py
@@ -99,7 +99,8 @@ class HeasarcClass(BaseQuery):
     def query_object_async(self, object_name, mission,
                            cache=True, get_query_payload=False,
                            **kwargs):
-        """ Query around a specific object within a given mission catalog
+        """
+        Query around a specific object within a given mission catalog
 
         Parameters
         ----------

--- a/astroquery/heasarc/core.py
+++ b/astroquery/heasarc/core.py
@@ -34,35 +34,36 @@ class HeasarcClass(BaseQuery):
                                  timeout=self.TIMEOUT, cache=cache)
         return response
 
-    def query_mission_list(self, 
-                           cache=True, get_query_payload=False):
+    def query_mission_list(self, cache=True, get_query_payload=False):
         """
         Returns a list of all available mission tables with descriptions
         """
         request_payload = self._args_to_payload(
-            Entry   = 'none',
-            mission = 'xxx',
-            displaymode = 'BatchDisplay'
+            Entry='none',
+            mission='xxx',
+            displaymode='BatchDisplay'
         )
 
         if get_query_payload:
             return request_payload
 
         # Parse the results specially (it's ascii format, not fits)
-        response = self.query_async(request_payload,
-                   url='https://heasarc.gsfc.nasa.gov/db-perl/W3Browse/w3query.pl',
-                   cache=cache)
+        response = self.query_async(
+            request_payload,
+            url='https://heasarc.gsfc.nasa.gov/db-perl/W3Browse/w3query.pl',
+            cache=cache
+        )
         data = BytesIO(response.content)
-        table = Table.read(data, format='ascii.fixed_width_two_line',delimiter='+',
-                           header_start=1, position_line=2, data_start=3, data_end=-1)
+        table = Table.read(data, format='ascii.fixed_width_two_line',
+                           delimiter='+', header_start=1, position_line=2,
+                           data_start=3, data_end=-1)
         return table
 
-    def query_mission_cols(self, mission, 
-                           cache=True, get_query_payload=False,
+    def query_mission_cols(self, mission, cache=True, get_query_payload=False,
                            **kwargs):
         """
-        Returns a list containing the names of columns that will be returned for
-        a given mission table. By default, all column names are returned. A list
+        Returns a list containing the names of columns that can be returned for
+        a given mission table. By default all column names are returned. A list
         of the default columns can be obtained by setting `fields='Standard'`
 
         Parameters
@@ -86,7 +87,7 @@ class HeasarcClass(BaseQuery):
             kwargs['fields'] = 'All'
 
         response = self.query_region_async(position='0.0 0.0', mission=mission,
-                                           radius='361 degree', cache=cache, 
+                                           radius='361 degree', cache=cache,
                                            get_query_payload=get_query_payload,
                                            **kwargs)
 
@@ -104,17 +105,17 @@ class HeasarcClass(BaseQuery):
         Parameters
         ----------
         object_name : str
-            Object to query around. To set search radius use the hidden 'radius'
+            Object to query around. To set search radius use the 'radius'
             parameter.
         mission : str
             Mission table to search from
-        **kwargs : 
+        **kwargs :
             see :func:`_args_to_payload` for list of additional parameters that
             can be used to refine search query
         """
         request_payload = self._args_to_payload(
-            mission = mission,
-            entry   = object_name,
+            mission=mission,
+            entry=object_name,
             **kwargs
         )
 
@@ -128,10 +129,10 @@ class HeasarcClass(BaseQuery):
                            cache=True, get_query_payload=False,
                            **kwargs):
         """
-        Query around a specific set of coordinates within a given mission catalog.
-        This method first converts the supplied coordinates into the FK5 
+        Query around specific set of coordinates within a given mission
+        catalog. Method first converts the supplied coordinates into the FK5
         reference frame and searches for sources from there. Because of this,
-        the returned offset coordinates may look different than the ones supplied.
+        returned offset coordinates may look different than the ones supplied.
 
         Parameters
         ----------
@@ -143,10 +144,10 @@ class HeasarcClass(BaseQuery):
             (adapted from nrao module)
         mission : str
             Mission table to search from
-        radius : 
-            An astropy Quantity object, or a string that can be parsed into one.
+        radius :
+            Astropy Quantity object, or a string that can be parsed into one.
             e.g., '1 degree' or 1*u.degree.
-        **kwargs : 
+        **kwargs :
             see :func:`_args_to_payload` for list of additional parameters that
             can be used to refine search query
         """
@@ -157,9 +158,9 @@ class HeasarcClass(BaseQuery):
 
         # Generate the request
         request_payload = self._args_to_payload(
-            mission = mission,
-            entry   = "{},{}".format(c.ra.degree, c.dec.degree),
-            radius  = u.Quantity(radius),
+            mission=mission,
+            entry="{},{}".format(c.ra.degree, c.dec.degree),
+            radius=u.Quantity(radius),
             **kwargs
         )
 
@@ -222,27 +223,29 @@ class HeasarcClass(BaseQuery):
             Object or position for center of query. A blank value will return
             all entries in the mission table. Acceptable formats:
             * Object name : Name of object, e.g. 'Crab'
-            * Coordinates : X,Y coordinates, either as 'degrees,degrees' or 
+            * Coordinates : X,Y coordinates, either as 'degrees,degrees' or
               'hh mm ss,dd mm ss'
         fields : str, optional
             Return format for columns from the server available options:
             * Standard (default) : Return default table columns
             * All                : Return all table columns
-            * <custom>           : User defined csv list of columns to be returned
+            * <custom>           : User defined csv list of columns to be
+              returned
         radius : float (arcmin), optional
-            An astropy Quantity object, or a string that can be parsed into one.
+            Astropy Quantity object, or a string that can be parsed into one.
             e.g., '1 degree' or 1*u.degree.
         coordsys: str, optional
-            If 'entry' is a set of coordinates, this specifies the coordinate 
+            If 'entry' is a set of coordinates, this specifies the coordinate
             system used to interpret them. By default, equatorial coordinates
             are assumed. Possible values:
             * 'fk5' <default> (FK5 J2000 equatorial coordinates)
             * 'fk4'           (FK4 B1950 equatorial coordinates)
-            * 'equatorial'    (equatorial coordinates, `equinox` param determines epoch)
+            * 'equatorial'    (equatorial coordinates, `equinox` param
+              determines epoch)
             * 'galactic'      (Galactic coordinates)
         equinox : int, optional
-            Epoch by which to interpret supplied equatorial coordinates (defaults
-            to 2000, ignored if `coordsys` is not 'equatorial')
+            Epoch by which to interpret supplied equatorial coordinates
+            (defaults to 2000, ignored if `coordsys` is not 'equatorial')
         resultmax : int, optional
             Set maximum query results to be returned
         sortvar : str, optional
@@ -250,18 +253,18 @@ class HeasarcClass(BaseQuery):
             the results are sorted by distance from queried object/position
 
         displaymode : str, optional
-            Return format from server. Since the user does not interact with 
+            Return format from server. Since the user does not interact with
             this directly, it's best to leave this alone
         action : str, optional
             Type of action to be taken (defaults to 'Query')
         """
         # Define the basic query for this object
         request_payload = dict(
-            tablehead   = ('name=BATCHRETRIEVALCATALOG_2.0 {}'
-                          .format(kwargs.get('mission'))),
-            Entry       = kwargs.get('entry', 'none'),
-            Action      = kwargs.get('action', 'Query'),
-            displaymode = kwargs.get('displaymode','FitsDisplay')
+            tablehead=('name=BATCHRETRIEVALCATALOG_2.0 {}'
+                       .format(kwargs.get('mission'))),
+            Entry=kwargs.get('entry', 'none'),
+            Action=kwargs.get('action', 'Query'),
+            displaymode=kwargs.get('displaymode', 'FitsDisplay')
         )
 
         # Fill in optional information for refined queries
@@ -273,14 +276,14 @@ class HeasarcClass(BaseQuery):
 
         elif coordsys.lower() == 'fk4':
             request_payload['Coordinates'] = 'Equatorial: R.A. Dec'
-            request_payload['equinox']     = 1950
+            request_payload['equinox'] = 1950
 
         elif coordsys.lower() == 'equatorial':
             request_payload['Coordinates'] = 'Equatorial: R.A. Dec'
 
             equinox = kwargs.get('equinox', None)
             if equinox is not None:
-                request_payload['Equinox'] = str(equinox) 
+                request_payload['Equinox'] = str(equinox)
 
         elif coordsys.lower() == 'galactic':
             request_payload['Coordinates'] = 'Galactic: LII BII'
@@ -309,7 +312,7 @@ class HeasarcClass(BaseQuery):
         sortvar = kwargs.get('sortvar', None)
         if sortvar is not None:
             request_payload['sortvar'] = sortvar.lower()
-              
+
         return request_payload
 
 

--- a/astroquery/heasarc/core.py
+++ b/astroquery/heasarc/core.py
@@ -182,6 +182,9 @@ class HeasarcClass(BaseQuery):
             to 2000, ignored if `coordsys` is not 'equatorial')
         resultmax: int, optional
             Set maximum query results to be returned
+        sortvar : str, optional
+            Set the name of the column by which to sort the results. By default
+            the results are sorted by distance from queried object/position
 
         displaymode : str, optional
             Return format from server. Since the user does not interact with 
@@ -229,15 +232,20 @@ class HeasarcClass(BaseQuery):
             else:
                 request_payload['varon'] = fields.lower().split(',')
 
+        # Set search radius (arcmin)
+        radius = kwargs.get('radius', None)
+        if radius is not None:
+            request_payload['Radius'] = radius
+
         # Maximum number of results to be returned
         resultmax = kwargs.get('resultmax', None)
         if resultmax is not None:
             request_payload['ResultMax'] = int(resultmax)
 
-        # Set search radius (arcmin)
-        radius = kwargs.get('radius', None)
-        if radius is not None:
-            request_payload['Radius'] = radius
+        # Set variable for sorting results
+        sortvar = kwargs.get('sortvar', None)
+        if sortvar is not None:
+            request_payload['sortvar'] = sortvar.lower()
               
         return request_payload
 

--- a/astroquery/heasarc/core.py
+++ b/astroquery/heasarc/core.py
@@ -131,6 +131,8 @@ class HeasarcClass(BaseQuery):
         equinox : int, optional
             Epoch by which to interpret supplied equatorial coordinates (ignored
             if coordsys is galactic)
+        resultmax: int, optional
+            Set maximum query results to be returned
 
         displaymode : str, optional
             Return format from server. Since the user does not interact with 
@@ -149,19 +151,7 @@ class HeasarcClass(BaseQuery):
 
         # Fill in optional information
 
-        fields = kwargs.get('fields', None)
-        if fields is not None:
-            if fields.lower() == 'standard':
-                request_payload['Fields'] = 'Standard'
-            elif fields.lower() == 'all':
-                request_payload['Fields'] = 'All'
-            else:
-                request_payload['varon'] = fields.lower().split(',')
-
-        radius = kwargs.get('radius', None)
-        if radius is not None:
-            request_payload['Radius'] = radius
-            
+        # Handle queries involving coordinates
         coordinates = kwargs.get('coordsys', 'equatorial')
         if coordinates.lower() == 'equatorial':
             request_payload['Coordinates'] = 'Equatorial: R.A. Dec'
@@ -172,6 +162,26 @@ class HeasarcClass(BaseQuery):
 
         elif coordinates.lower() == 'galactic':
             request_payload['Coordinates'] = 'Galactic: LII BII'
+
+        # Specify which columns are to be returned
+        fields = kwargs.get('fields', None)
+        if fields is not None:
+            if fields.lower() == 'standard':
+                request_payload['Fields'] = 'Standard'
+            elif fields.lower() == 'all':
+                request_payload['Fields'] = 'All'
+            else:
+                request_payload['varon'] = fields.lower().split(',')
+
+        # Maximum number of results to be returned
+        resultmax = kwargs.get('resultmax', None)
+        if resultmax is not None:
+            request_payload['ResultMax'] = int(resultmax)
+
+        # Set search radius (arcmin)
+        radius = kwargs.get('radius', None)
+        if radius is not None:
+            request_payload['Radius'] = radius
               
         return request_payload
 

--- a/astroquery/heasarc/core.py
+++ b/astroquery/heasarc/core.py
@@ -15,31 +15,52 @@ __all__ = ['Heasarc', 'HeasarcClass']
 class HeasarcClass(BaseQuery):
 
     """HEASARC query class.
+
+    For a list of available HEASARC mission tables, visit:
+        https://heasarc.gsfc.nasa.gov/cgi-bin/W3Browse/w3catindex.pl
     """
 
     URL = conf.server
     TIMEOUT = conf.timeout
 
-    def query_object_async(self, object_name, mission, cache=True,
-                           get_query_payload=False,
-                           display_mode='FitsDisplay'):
-        """TODO: document this!
-
-        (maybe start by copying over from some other service.)
+    def query_async(self, request_payload, cache=True):
         """
-        request_payload = dict()
-        request_payload['Entry'] = object_name
-        request_payload['tablehead'] = ('BATCHRETRIEVALCATALOG_2.0 {}'
-                                        .format(mission))
-        request_payload['Action'] = 'Query'
-        request_payload['displaymode'] = display_mode
-
-        if get_query_payload:
-            return request_payload
-
+        Submit a query based on a given request_payload. This allows detailed
+        control of the query to be submitted.
+        """
         response = self._request('GET', self.URL, params=request_payload,
                                  timeout=self.TIMEOUT, cache=cache)
         return response
+
+
+    def query_object_async(self, object_name, mission,
+                           cache=True, get_query_payload=False,
+                           display_mode='FitsDisplay', **kwargs):
+        """ Query around a specific object within a given mission catalog
+
+        Parameters
+        ----------
+        object_name : str
+            Object to query around. To set search radius use the hidden 'radius'
+            parameter.
+        mission : str
+            Mission table to search from
+        **kwargs : 
+            see :func:`_args_to_payload` for list of additional parameters that
+            can be used to refine search query
+        """
+        request_payload = self._args_to_payload(
+            mission = mission,
+            entry   = object_name,
+            **kwargs
+        )
+
+        # Return payload if requested
+        if get_query_payload:
+            return request_payload
+
+        return self.query_async(request_payload, cache)
+
 
     def _fallback(self, content):
         """
@@ -80,6 +101,79 @@ class HeasarcClass(BaseQuery):
             return table
         except ValueError:
             return self._fallback(response.content)
+
+
+    def _args_to_payload(self, **kwargs):
+        """
+        Generates the payload based on user supplied arguments
+
+        Parameters
+        ----------
+        mission : str
+            Mission table to query
+        entry : str, optional
+            Object or position for center of query. A blank value will return
+            all entries in the mission table. Acceptable formats:
+            * Object name : Name of object, e.g. 'Crab'
+            * Coordinates : CSV list of coordinates, either as 'degrees,degrees' or 'hh mm ss,hh mm ss'
+        fields : str, optional
+            Return format for columns from the server available options:
+            * Standard (default) : Return default table columns
+            * All                : Return all table columns
+            * <custom>           : User defined csv list of columns to be returned
+        radius : float (arcmin), optional
+            Return all mission entries within a given distance of search query.
+            If not supplied, the server default will be used (~ 60 arcmin)
+        coordsys: str ('equatorial' or 'galactic'), optional
+            If 'entry' is a set of coordinates, this specifies the coordinate 
+            system used to interpret them. By default, equatorial coordinates
+            are assumed.
+        equinox : int, optional
+            Epoch by which to interpret supplied equatorial coordinates (ignored
+            if coordsys is galactic)
+
+        displaymode : str, optional
+            Return format from server. Since the user does not interact with 
+            this directly, it's best to leave this alone
+        action : str, optional
+            Type of action to be taken (defaults to 'Query')
+        """
+        # Define the basic query for this object
+        request_payload = dict(
+            tablehead   = ('name=BATCHRETRIEVALCATALOG_2.0 {}'
+                          .format(kwargs.get('mission'))),
+            Entry       = kwargs.get('entry', 'none'),
+            Action      = kwargs.get('action', 'Query'),
+            displaymode = kwargs.get('displaymode','FitsDisplay')
+        )
+
+        # Fill in optional information
+
+        fields = kwargs.get('fields', None)
+        if fields is not None:
+            if fields.lower() == 'standard':
+                request_payload['Fields'] = 'Standard'
+            elif fields.lower() == 'all':
+                request_payload['Fields'] = 'All'
+            else:
+                request_payload['varon'] = fields.lower().split(',')
+
+        radius = kwargs.get('radius', None)
+        if radius is not None:
+            request_payload['Radius'] = radius
+            
+        coordinates = kwargs.get('coordsys', 'equatorial')
+        if coordinates.lower() == 'equatorial':
+            request_payload['Coordinates'] = 'Equatorial: R.A. Dec'
+
+            equinox = kwargs.get('equinox', None)
+            if equinox is not None:
+                request_payload['Equinox'] = str(equinox) 
+
+        elif coordinates.lower() == 'galactic':
+            request_payload['Coordinates'] = 'Galactic: LII BII'
+              
+        return request_payload
 
 
 Heasarc = HeasarcClass()

--- a/astroquery/heasarc/tests/test_heasarc_remote.py
+++ b/astroquery/heasarc/tests/test_heasarc_remote.py
@@ -3,7 +3,7 @@ from __future__ import print_function
 
 from astropy.tests.helper import remote_data
 from ...heasarc import Heasarc
-
+from ...utils import commons
 
 @remote_data
 class TestHeasarc:
@@ -14,5 +14,23 @@ class TestHeasarc:
 
         heasarc = Heasarc()
         table = heasarc.query_object(object_name, mission=mission)
+
+        assert len(table) == 63
+
+    def test_mission_list(self):
+        heasarc = Heasarc()
+        missions = heasarc.query_mission_list()
+
+        # Assert that there are indeed a large number of tables
+        # Number of tables could change, but should be > 900 (currently 956)
+        assert len(missions) > 900
+
+    def test_query_position(self):
+        heasarc = Heasarc()
+        mission = 'rospublic'
+
+        # Define coordinates for '3c273' object
+        c = commons.coord.SkyCoord('12h29m06.70s +02d03m08.7s', frame='icrs')
+        table = heasarc.query_position(position=c, mission=mission)
 
         assert len(table) == 63

--- a/astroquery/heasarc/tests/test_heasarc_remote.py
+++ b/astroquery/heasarc/tests/test_heasarc_remote.py
@@ -25,12 +25,25 @@ class TestHeasarc:
         # Number of tables could change, but should be > 900 (currently 956)
         assert len(missions) > 900
 
-    def test_query_position(self):
+    def test_mission_cols(self):
+        heasarc = Heasarc()
+        mission = 'rospublic'
+        cols = heasarc.query_mission_cols(mission=mission)
+
+        assert len(cols) == 28
+
+        # Test that the cols list contains known names
+        assert 'EXPOSURE' in cols
+        assert 'RA' in cols
+        assert 'DEC' in cols
+        assert 'SEARCH_OFFSET_' in cols
+
+    def test_query_region(self):
         heasarc = Heasarc()
         mission = 'rospublic'
 
         # Define coordinates for '3c273' object
         c = commons.coord.SkyCoord('12h29m06.70s +02d03m08.7s', frame='icrs')
-        table = heasarc.query_position(position=c, mission=mission)
+        table = heasarc.query_region(c, mission=mission, radius='1 degree')
 
         assert len(table) == 63

--- a/astroquery/heasarc/tests/test_heasarc_remote.py
+++ b/astroquery/heasarc/tests/test_heasarc_remote.py
@@ -4,6 +4,7 @@ from __future__ import print_function
 from astropy.tests.helper import remote_data
 from ...heasarc import Heasarc
 from ...utils import commons
+import requests
 
 
 @remote_data
@@ -38,6 +39,24 @@ class TestHeasarc:
         assert 'RA' in cols
         assert 'DEC' in cols
         assert 'SEARCH_OFFSET_' in cols
+
+    def test_query_object_async(self):
+        mission = 'rospublic'
+        object_name = '3c273'
+
+        heasarc = Heasarc()
+        response = heasarc.query_object_async(object_name, mission=mission)
+        assert response is not None
+        assert type(response) is requests.models.Response
+
+    def test_query_region_async(self):
+        heasarc = Heasarc()
+        mission = 'rospublic'
+        c = commons.coord.SkyCoord('12h29m06.70s +02d03m08.7s', frame='icrs')
+        response = heasarc.query_region_async(c, mission=mission,
+                                              radius='1 degree')
+        assert response is not None
+        assert type(response) is requests.models.Response
 
     def test_query_region(self):
         heasarc = Heasarc()

--- a/astroquery/heasarc/tests/test_heasarc_remote.py
+++ b/astroquery/heasarc/tests/test_heasarc_remote.py
@@ -5,6 +5,7 @@ from astropy.tests.helper import remote_data
 from ...heasarc import Heasarc
 from ...utils import commons
 
+
 @remote_data
 class TestHeasarc:
 

--- a/docs/heasarc/heasarc.rst
+++ b/docs/heasarc/heasarc.rst
@@ -87,7 +87,7 @@ following modifies the search radius to 120 arcmin:
 
     >>> from astroquery.heasarc import Heasarc
     >>> heasarc = Heasarc()
-    >>> table = heasarc.query_object(object_name='3c273', mission='rospublic', radius='120 arcmin')
+    >>> table = heasarc.query_object(object_name, mission='rospublic', radius='120 arcmin')
 
 ``radius`` takes an angular distance specified as an astropy Quantity object, 
 or a string that can be parsed into one (e.g., '1 degree' or 1*u.degree). The
@@ -95,28 +95,28 @@ following are equivalent:
 
 .. code-block:: python
 
-    >>> table = heasarc.query_object(object_name='3c273', mission='rospublic', radius='120 arcmin')
-    >>> table = heasarc.query_object(object_name='3c273', mission='rospublic', radius='2 degree')
+    >>> table = heasarc.query_object(object_name, mission='rospublic', radius='120 arcmin')
+    >>> table = heasarc.query_object(object_name, mission='rospublic', radius='2 degree')
     >>> from astropy import units as u
-    >>> table = heasarc.query_object(object_name='3c273', mission='rospublic', radius=120*u.arcmin)
-    >>> table = heasarc.query_object(object_name='3c273', mission='rospublic', radius=2*u.degree)
+    >>> table = heasarc.query_object(object_name, mission='rospublic', radius=120*u.arcmin)
+    >>> table = heasarc.query_object(object_name, mission='rospublic', radius=2*u.degree)
 
 As per the astroquery specifications, the ``query_region()`` method requires the 
-user to supply a radius parameter.
+user to supply the radius parameter.
 
 The results can also be sorted by the value in a given column using the ``sortvar``
 parameter. The following sorts the results by the value in the 'EXPOSURE' column.
 
 .. code-block:: python
 
-    >>> table = heasarc.query_object(object_name='3c273', mission='rospublic', sortvar='EXPOSURE')
+    >>> table = heasarc.query_object(object_name, mission='rospublic', sortvar='EXPOSURE')
 
 Setting the ``resultmax`` parameter controls the maximum number of results to be
 returned. The following will store only the first 10 results:
 
 .. code-block:: python
 
-    >>> table = heasarc.query_object(object_name='3c273', mission='rospublic', resultmax=10)
+    >>> table = heasarc.query_object(object_name, mission='rospublic', resultmax=10)
 
 All of the above parameters can be mixed and matched to refine the query results.
 
@@ -130,8 +130,8 @@ that can be queried.
     
     >>> from astroquery.heasarc import Heasarc
     >>> heasarc = Heasarc()
-    >>> missions = heasarc.query_mission_list()
-    >>> missions.pprint()
+    >>> table = heasarc.query_mission_list()
+    >>> table.pprint()
 
 The returned table includes both the names and a short description of each 
 mission table.

--- a/docs/heasarc/heasarc.rst
+++ b/docs/heasarc/heasarc.rst
@@ -18,6 +18,9 @@ The capabilities are currently very limited ... feature requests and contributio
 Getting lists of available datasets
 -----------------------------------
 
+There are two ways to obtain a list of objects. The first is by querying around
+an object by name:
+
 .. code-block:: python
 
     >>> from astroquery.heasarc import Heasarc
@@ -27,6 +30,32 @@ Getting lists of available datasets
     >>> table = heasarc.query_object(object_name, mission=mission)
     >>> table[:3].pprint()
 
+Alternatively, a query can also be conducted around a specific set of sky
+coordinates:
+
+.. code-block:: python
+
+    >>> from astroquery.heasarc import Heasarc
+    >>> from astropy.coordinates import SkyCoord
+    >>> heasarc = Heasarc()
+    >>> mission = 'rospublic'
+    >>> coords = SkyCoord('12h29m06.70s +02d03m08.7s', frame='icrs')
+    >>> table = heasarc.query_position(coords, mission=mission)
+    >>> table[:3].pprint()
+
+Getting list of available missions
+----------------------------------
+
+.. code-block:: python
+    
+    >>> from astroquery.heasarc import Heasarc
+    >>> heasarc = Heasarc()
+    >>> missions = heasarc.query_mission_list()
+    >>> missions.pprint()
+
+This will store a list of available missions that can be queried in the
+`missions` object. This includes a list of both the names and descriptions of
+each mission.
 
 Downloading identified datasets
 -------------------------------

--- a/docs/heasarc/heasarc.rst
+++ b/docs/heasarc/heasarc.rst
@@ -65,13 +65,47 @@ specify which columns will be returned:
 
     >>> table = heasarc.query_object(object_name='3c273', mission='rospublic', fields='SEQ_ID,RA,BII')
 
-To obtain a list of all available columns for a given mission table, do the 
+To obtain a list of available columns for a given mission table, do the 
 following:
 
 .. code-block:: python
 
     >>> cols = heasarc.query_mission_cols(mission='rospublic')
     >>> print(cols)
+    
+Additional query parameters
+---------------------------
+
+By default, the search for objects from a queried table returns all objects within
+approximately 60 arcmin of the object/position. This can be modified by supplying
+the `radius` parameter. This parameter takes a distance (in arcmin) to look For
+objects. The following extends the search radius to 120 arcmin:
+
+.. code-block:: python
+
+    >>> from astroquery.heasarc import Heasarc
+    >>> heasarc = Heasarc()
+    >>> table = heasarc.query_object(object_name='3c273', mission='rospublic', radius=120)
+
+The results can also be sorted by the value in a given column using the `sortvar`
+parameter. The following sorts the results by the value in the 'EXPOSURE' column.
+
+.. code-block:: python
+
+    >>> from astroquery.heasarc import Heasarc
+    >>> heasarc = Heasarc()
+    >>> table = heasarc.query_object(object_name='3c273', mission='rospublic', sortvar='EXPOSURE')
+
+Setting the `resultmax` parameter controls the maximum number of results to be
+returned. The following will store only the first 10 results:
+
+.. code-block:: python
+
+    >>> from astroquery.heasarc import Heasarc
+    >>> heasarc = Heasarc()
+    >>> table = heasarc.query_object(object_name='3c273', mission='rospublic', resultmax=10)
+
+All of the above parameters can be mixed and matched to refine the query results.
 
 Getting list of available missions
 ----------------------------------

--- a/docs/heasarc/heasarc.rst
+++ b/docs/heasarc/heasarc.rst
@@ -29,6 +29,12 @@ an object by name:
     >>> object_name = '3c273'
     >>> table = heasarc.query_object(object_name, mission=mission)
     >>> table[:3].pprint()
+       SEQ_ID   INSTRUMENT EXPOSURE   RA    DEC           NAME         PUBLIC_DATE  SEARCH_OFFSET_
+                              S     DEGREE DEGREE                          MJD
+    ----------- ---------- -------- ------ ------ -------------------- ----------- ---------------
+    RH701576N00 HRI           68154 187.28   2.05 3C 273                     50186  0.192 (3C273)
+    RP600242A01 PSPCB         24822 186.93    1.6 GIOVANELLI-HAYNES CL       50437 34.236 (3C273)
+    RH700234N00 HRI           17230 187.28   2.05 3C 273                     50312  0.192 (3C273)
 
 Alternatively, a query can also be conducted around a specific set of sky
 coordinates:
@@ -40,11 +46,17 @@ coordinates:
     >>> heasarc = Heasarc()
     >>> mission = 'rospublic'
     >>> coords = SkyCoord('12h29m06.70s +02d03m08.7s', frame='icrs')
-    >>> table = heasarc.query_position(coords, mission=mission, radius='1 degree')
+    >>> table = heasarc.query_region(coords, mission=mission, radius='1 degree')
     >>> table[:3].pprint()
+       SEQ_ID   INSTRUMENT EXPOSURE   RA   ...         NAME         PUBLIC_DATE                  SEARCH_OFFSET_
+                              S     DEGREE ...                          MJD
+    ----------- ---------- -------- ------ ... -------------------- ----------- -----------------------------------------------
+    RH701576N00 HRI           68154 187.28 ... 3C 273                     50186  0.191 (187.27792281980047,2.0524148595265435)
+    RP600242A01 PSPCB         24822 186.93 ... GIOVANELLI-HAYNES CL       50437 34.237 (187.27792281980047,2.0524148595265435)
+    RH700234N00 HRI           17230 187.28 ... 3C 273                     50312  0.191 (187.27792281980047,2.0524148595265435)
 
-Note that the `query_position` converts the passed coordinates to the FK5
-reference frame before submitting the query.
+Note that the :meth:`~astroquery.heasarc.HeasarcClass.query_region` converts 
+the passed coordinates to the FK5 reference frame before submitting the query.
 
 Modifying returned table columns
 --------------------------------
@@ -64,6 +76,13 @@ specify which columns will be returned:
 .. code-block:: python
 
     >>> table = heasarc.query_object(object_name='3c273', mission='rospublic', fields='EXPOSURE,RA,DEC')
+    >>> table[:3].pprint()
+    EXPOSURE   RA    DEC    SEARCH_OFFSET_
+       S     DEGREE DEGREE
+    -------- ------ ------ ---------------
+       68154 187.28   2.05  0.192 (3C273)
+       24822 186.93    1.6 34.236 (3C273)
+       17230 187.28   2.05  0.192 (3C273)
 
 Note that the ``SEARCH_OFFSET_`` column will always be included in the results.
 If a column name is passed to the ``fields`` parameter which does not exist in
@@ -74,14 +93,20 @@ columns for a given mission table, do the following:
 
     >>> cols = heasarc.query_mission_cols(mission='rospublic')
     >>> print(cols)
+    ['SEQ_ID', 'INSTRUMENT', 'EXPOSURE', 'RA', 'DEC', 'NAME', 'PUBLIC_DATE', 
+    'BII', 'CLASS', 'DEC_1950', 'DIST_DATE', 'END_DATE','FILTER', 'FITS_TYPE', 
+    'INDEX_ID', 'LII', 'PI_FNAME', 'PI_LNAME', 'PROC_REV', 'QA_NUMBER', 'RA_1950', 
+    'REQUESTED_EXPOSURE', 'ROR', 'SITE', 'START_DATE', 'SUBJ_CAT', 'TITLE', 
+    'SEARCH_OFFSET_']
     
 Additional query parameters
 ---------------------------
 
-By default, the ``query_object()`` method returns all entries within approximately 
-one degree of the specified object. This can be modified by supplying the 
-``radius`` parameter. This parameter takes a distance to look for objects. The 
-following modifies the search radius to 120 arcmin:
+By default, the :meth:`~astroquery.heasarc.HeasarcClass.query_object` method
+returns all entries within approximately one degree of the specified object.
+This can be modified by supplying the ``radius`` parameter. This parameter
+takes a distance to look for objects. The following modifies the search radius
+to 120 arcmin:
 
 .. code-block:: python
 
@@ -101,8 +126,8 @@ following are equivalent:
     >>> table = heasarc.query_object(object_name, mission='rospublic', radius=120*u.arcmin)
     >>> table = heasarc.query_object(object_name, mission='rospublic', radius=2*u.degree)
 
-As per the astroquery specifications, the ``query_region()`` method requires the 
-user to supply the radius parameter.
+As per the astroquery specifications, the :meth:`~astroquery.heasarc.HeasarcClass.query_region`
+method requires the user to supply the radius parameter.
 
 The results can also be sorted by the value in a given column using the ``sortvar``
 parameter. The following sorts the results by the value in the 'EXPOSURE' column.
@@ -110,6 +135,13 @@ parameter. The following sorts the results by the value in the 'EXPOSURE' column
 .. code-block:: python
 
     >>> table = heasarc.query_object(object_name, mission='rospublic', sortvar='EXPOSURE')
+    >>> table[:3].pprint()
+       SEQ_ID   INSTRUMENT EXPOSURE   RA    DEC           NAME         PUBLIC_DATE  SEARCH_OFFSET_
+                              S     DEGREE DEGREE                          MJD
+    ----------- ---------- -------- ------ ------ -------------------- ----------- ---------------
+    RH120001N00 HRI               0 187.27   2.05 XRT/HRI NORTH DUMMY        55844  0.495 (3C273)
+    RH701979N00 HRI             354 187.28   2.05 3C273                      50137  0.192 (3C273)
+    RP141520N00 PSPCB           485 187.27   2.05 3C273                      49987  0.495 (3C273)
 
 Setting the ``resultmax`` parameter controls the maximum number of results to be
 returned. The following will store only the first 10 results:
@@ -132,6 +164,27 @@ that can be queried.
     >>> heasarc = Heasarc()
     >>> table = heasarc.query_mission_list()
     >>> table.pprint()
+    Archive    name               Table_Description
+    ------- ---------- ----------------------------------------
+    HEASARC         a1           HEAO 1 A1 X-Ray Source Catalog
+    HEASARC    a1point                    HEAO 1 A1 Lightcurves
+    HEASARC  a2lcpoint            HEAO 1 A2 Pointed Lightcurves
+    HEASARC   a2lcscan            HEAO 1 A2 Scanned Lightcurves
+    HEASARC      a2led                    HEAO 1 A2 LED Catalog
+    HEASARC      a2pic             HEAO 1 A2 Piccinotti Catalog
+    HEASARC    a2point               HEAO 1 A2 Pointing Catalog
+    HEASARC    a2rtraw                      HEAO 1 A2 Raw Rates
+        ...        ...                                      ...
+    HEASARC  xteasscat          XTE All-Sky Slew Survey Catalog
+    HEASARC   xteindex                 XTE Target Index Catalog
+    HEASARC  xtemaster                       XTE Master Catalog
+    HEASARC   xtemlcat          XTE Mission-Long Source Catalog
+    HEASARC    xteslew            XTE Archived Public Slew Data
+    HEASARC       xwas             XMM-Newton Wide Angle Survey
+    HEASARC       zcat CfA Redshift Catalog (June 1995 Version)
+    HEASARC zwclusters                          Zwicky Clusters
+    HEASARC      zzbib             METADATA: Bibliography Codes
+    Length = 956 rows
 
 The returned table includes both the names and a short description of each 
 mission table.

--- a/docs/heasarc/heasarc.rst
+++ b/docs/heasarc/heasarc.rst
@@ -49,15 +49,15 @@ before making submitting the query.
 Modifying returned table columns
 --------------------------------
 
-Each table has a set of default columns that are returned when submitting to the
+Each table has a set of default columns that are returned when querying the
 database. You can return all available columns for a given query by specifying
-the `fields` parameter in either of the above queries. For exampe:
+the ``fields`` parameter in either of the above queries. For exampe:
 
 .. code-block:: python
 
     >>> table = heasarc.query_object(object_name='3c273', mission='rospublic', fields='All')
 
-will return all available columns from the 'rospublic' mission table.
+will return all available columns from the ``rospublic`` mission table.
 Alternatively, a comma-separated list of column names can also be provided to
 specify which columns will be returned:
 
@@ -78,7 +78,7 @@ Additional query parameters
 
 By default, the search for objects from a queried table returns all objects within
 approximately 60 arcmin of the object/position. This can be modified by supplying
-the `radius` parameter. This parameter takes a distance (in arcmin) to look For
+the ``radius`` parameter. This parameter takes a distance (in arcmin) to look For
 objects. The following extends the search radius to 120 arcmin:
 
 .. code-block:: python
@@ -87,22 +87,18 @@ objects. The following extends the search radius to 120 arcmin:
     >>> heasarc = Heasarc()
     >>> table = heasarc.query_object(object_name='3c273', mission='rospublic', radius=120)
 
-The results can also be sorted by the value in a given column using the `sortvar`
+The results can also be sorted by the value in a given column using the ``sortvar``
 parameter. The following sorts the results by the value in the 'EXPOSURE' column.
 
 .. code-block:: python
 
-    >>> from astroquery.heasarc import Heasarc
-    >>> heasarc = Heasarc()
     >>> table = heasarc.query_object(object_name='3c273', mission='rospublic', sortvar='EXPOSURE')
 
-Setting the `resultmax` parameter controls the maximum number of results to be
+Setting the ``resultmax`` parameter controls the maximum number of results to be
 returned. The following will store only the first 10 results:
 
 .. code-block:: python
 
-    >>> from astroquery.heasarc import Heasarc
-    >>> heasarc = Heasarc()
     >>> table = heasarc.query_object(object_name='3c273', mission='rospublic', resultmax=10)
 
 All of the above parameters can be mixed and matched to refine the query results.
@@ -110,16 +106,16 @@ All of the above parameters can be mixed and matched to refine the query results
 Getting list of available missions
 ----------------------------------
 
+The ``query_mission_list()`` method will return a list of available missions 
+that can be queried in the. This includes a list of both the names and a short
+descriptions of each mission table.
+
 .. code-block:: python
     
     >>> from astroquery.heasarc import Heasarc
     >>> heasarc = Heasarc()
     >>> missions = heasarc.query_mission_list()
     >>> missions.pprint()
-
-This will store a list of available missions that can be queried in the
-`missions` object. This includes a list of both the names and descriptions of
-each mission.
 
 Downloading identified datasets
 -------------------------------

--- a/docs/heasarc/heasarc.rst
+++ b/docs/heasarc/heasarc.rst
@@ -43,6 +43,36 @@ coordinates:
     >>> table = heasarc.query_position(coords, mission=mission)
     >>> table[:3].pprint()
 
+Note that the `query_position` converts the passed coordinates to FK5 internally
+before making submitting the query.
+
+Modifying returned table columns
+--------------------------------
+
+Each table has a set of default columns that are returned when submitting to the
+database. You can return all available columns for a given query by specifying
+the `fields` parameter in either of the above queries. For exampe:
+
+.. code-block:: python
+
+    >>> table = heasarc.query_object(object_name='3c273', mission='rospublic', fields='All')
+
+will return all available columns from the 'rospublic' mission table.
+Alternatively, a comma-separated list of column names can also be provided to
+specify which columns will be returned:
+
+.. code-block:: python
+
+    >>> table = heasarc.query_object(object_name='3c273', mission='rospublic', fields='SEQ_ID,RA,BII')
+
+To obtain a list of all available columns for a given mission table, do the 
+following:
+
+.. code-block:: python
+
+    >>> cols = heasarc.query_mission_cols(mission='rospublic')
+    >>> print(cols)
+
 Getting list of available missions
 ----------------------------------
 

--- a/docs/heasarc/heasarc.rst
+++ b/docs/heasarc/heasarc.rst
@@ -43,14 +43,14 @@ coordinates:
     >>> table = heasarc.query_position(coords, mission=mission)
     >>> table[:3].pprint()
 
-Note that the `query_position` converts the passed coordinates to FK5 internally
-before making submitting the query.
+Note that the `query_position` converts the passed coordinates to the FK5
+reference frame before submitting the query.
 
 Modifying returned table columns
 --------------------------------
 
 Each table has a set of default columns that are returned when querying the
-database. You can return all available columns for a given query by specifying
+database. You can return all available columns for a given mission by specifying
 the ``fields`` parameter in either of the above queries. For exampe:
 
 .. code-block:: python
@@ -78,7 +78,7 @@ Additional query parameters
 
 By default, the search for objects from a queried table returns all objects within
 approximately 60 arcmin of the object/position. This can be modified by supplying
-the ``radius`` parameter. This parameter takes a distance (in arcmin) to look For
+the ``radius`` parameter. This parameter takes a distance (in arcmin) to look for
 objects. The following extends the search radius to 120 arcmin:
 
 .. code-block:: python
@@ -107,8 +107,7 @@ Getting list of available missions
 ----------------------------------
 
 The ``query_mission_list()`` method will return a list of available missions 
-that can be queried in the. This includes a list of both the names and a short
-descriptions of each mission table.
+that can be queried.
 
 .. code-block:: python
     
@@ -116,6 +115,9 @@ descriptions of each mission table.
     >>> heasarc = Heasarc()
     >>> missions = heasarc.query_mission_list()
     >>> missions.pprint()
+
+The returned table includes both the names and a short description of each 
+mission table.
 
 Downloading identified datasets
 -------------------------------

--- a/docs/heasarc/heasarc.rst
+++ b/docs/heasarc/heasarc.rst
@@ -40,7 +40,7 @@ coordinates:
     >>> heasarc = Heasarc()
     >>> mission = 'rospublic'
     >>> coords = SkyCoord('12h29m06.70s +02d03m08.7s', frame='icrs')
-    >>> table = heasarc.query_position(coords, mission=mission)
+    >>> table = heasarc.query_position(coords, mission=mission, radius='1 degree')
     >>> table[:3].pprint()
 
 Note that the `query_position` converts the passed coordinates to the FK5
@@ -63,10 +63,12 @@ specify which columns will be returned:
 
 .. code-block:: python
 
-    >>> table = heasarc.query_object(object_name='3c273', mission='rospublic', fields='SEQ_ID,RA,BII')
+    >>> table = heasarc.query_object(object_name='3c273', mission='rospublic', fields='EXPOSURE,RA,DEC')
 
-To obtain a list of available columns for a given mission table, do the 
-following:
+Note that the ``SEARCH_OFFSET_`` column will always be included in the results.
+If a column name is passed to the ``fields`` parameter which does not exist in
+the requested mission table, the query will fail. To obtain a list of available 
+columns for a given mission table, do the following:
 
 .. code-block:: python
 
@@ -76,16 +78,31 @@ following:
 Additional query parameters
 ---------------------------
 
-By default, the search for objects from a queried table returns all objects within
-approximately 60 arcmin of the object/position. This can be modified by supplying
-the ``radius`` parameter. This parameter takes a distance (in arcmin) to look for
-objects. The following extends the search radius to 120 arcmin:
+By default, the ``query_object()`` method returns all entries within approximately 
+one degree of the specified object. This can be modified by supplying the 
+``radius`` parameter. This parameter takes a distance to look for objects. The 
+following modifies the search radius to 120 arcmin:
 
 .. code-block:: python
 
     >>> from astroquery.heasarc import Heasarc
     >>> heasarc = Heasarc()
-    >>> table = heasarc.query_object(object_name='3c273', mission='rospublic', radius=120)
+    >>> table = heasarc.query_object(object_name='3c273', mission='rospublic', radius='120 arcmin')
+
+``radius`` takes an angular distance specified as an astropy Quantity object, 
+or a string that can be parsed into one (e.g., '1 degree' or 1*u.degree). The
+following are equivalent:
+
+.. code-block:: python
+
+    >>> table = heasarc.query_object(object_name='3c273', mission='rospublic', radius='120 arcmin')
+    >>> table = heasarc.query_object(object_name='3c273', mission='rospublic', radius='2 degree')
+    >>> from astropy import units as u
+    >>> table = heasarc.query_object(object_name='3c273', mission='rospublic', radius=120*u.arcmin)
+    >>> table = heasarc.query_object(object_name='3c273', mission='rospublic', radius=2*u.degree)
+
+As per the astroquery specifications, the ``query_region()`` method requires the 
+user to supply a radius parameter.
 
 The results can also be sorted by the value in a given column using the ``sortvar``
 parameter. The following sorts the results by the value in the 'EXPOSURE' column.


### PR DESCRIPTION
This expands the functionality of the heasarc module in astroquery. Changes include:

- Add several methods:
   - ```query_range_async()```: Query around a given sky position within a given radius
   - ```query_mission_list()```: Return table of available missions with short descriptions
   - ```query_mission_cols()```: Return list of available column names for a given mission
- Add additional parameters to allow refining query results:
   - ```radius```: Radius for table search
   - ```sortvar```: Column name for sorting returned query results
   - ```fields```: Specify which table columns are returned (e.g. 'All' returns all columns)
   - ```resultmax```: Maximum number of results to be returned from query

Other changes:
- Added dedicated method ```_args_to_payload()``` for assembling request_payload from user supplied arguments
- Expanded the documentation to include the above changes
- Added additional tests to make sure the above behaves as expected

The changes should not break any scripts currently using the heasarc module. I'm happy to hear any feedback you have on these changes!