### PR TITLE
minor fixes to jplhorizons

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -107,7 +107,7 @@ List of Modules
   * `GAMA database <http://astroquery.readthedocs.io/en/latest/gama/gama.html>`_
   * `NVAS archive <http://astroquery.readthedocs.io/en/latest/nvas/nvas.html>`_
   * `Open Expolanet Catalog (OEC) <http://astroquery.readthedocs.io/en/latest/open_exoplanet_catalogue/open_exoplanet_catalogue.html>`_
-  * `Solar System Resources <http://astroquery.readthedocs.io/en/latest/solarsystem/solarsystem.html>`_: JPL Solar System Dynamics Horizons Service
+  * `JPL Horizons <http://astroquery.readthedocs.io/en/latest/jplhorizons/jplhorizons.html>`_: JPL Solar System Dynamics Horizons Service
     
 Additional Links
 ----------------

--- a/astroquery/jplhorizons/core.py
+++ b/astroquery/jplhorizons/core.py
@@ -134,36 +134,9 @@ class HorizonsClass(BaseQuery):
                           get_raw_response=False, cache=True):
 
         """
-        Query JPL Horizons for ephemerides. The ``location`` parameter in
-        ``HorizonsClass`` refers in this case to the location of the observer.
-
-        Parameters
-        ----------
-        airmass_lessthan : float, optional
-            Defines a maximum airmass for the query, default: 99
-        solar_elongation : tuple, optional
-            Permissible solar elongation range: (minimum, maximum); default:
-            (0,180)
-        hour_angle : float, optional
-            Defines a maximum hour angle for the query, default: 0
-        skip_daylight : boolean, optional
-            Crop daylight epochs in query, default: False
-        closest_apparition : boolean, optional
-            Only applies to comets. This option will choose the
-            closest apparition available in time to the selected
-            epoch; default: False. Do not use this option for
-            non-cometary objects.
-        no_fragments : boolean, optional
-            Only applies to comets. Reject all comet fragments from
-            selection; default: False. Do not use this option for
-            non-cometary objects.
-        get_query_payload : boolean, optional
-            When set to `True` the method returns the HTTP request parameters
-            as a dict, default: False
-        get_raw_response : boolean, optional
-            Return raw data as obtained by JPL Horizons without parsing the
-            data into a table, default: False
-
+        Query JPL Horizons for ephemerides. The ``location`` parameter
+        in ``HorizonsClass`` refers in this case to the location of
+        the observer.
 
         The following table lists the values queried, their
         definitions, data types, units, and original Horizons
@@ -260,11 +233,38 @@ class HorizonsClass(BaseQuery):
         +------------------+-----------------------------------------------+
 
 
+        Parameters
+        ----------
+        airmass_lessthan : float, optional
+            Defines a maximum airmass for the query, default: 99
+        solar_elongation : tuple, optional
+            Permissible solar elongation range: (minimum, maximum); default:
+            (0,180)
+        hour_angle : float, optional
+            Defines a maximum hour angle for the query, default: 0
+        skip_daylight : boolean, optional
+            Crop daylight epochs in query, default: False
+        closest_apparition : boolean, optional
+            Only applies to comets. This option will choose the
+            closest apparition available in time to the selected
+            epoch; default: False. Do not use this option for
+            non-cometary objects.
+        no_fragments : boolean, optional
+            Only applies to comets. Reject all comet fragments from
+            selection; default: False. Do not use this option for
+            non-cometary objects.
+        get_query_payload : boolean, optional
+            When set to `True` the method returns the HTTP request parameters
+            as a dict, default: False
+        get_raw_response : boolean, optional
+            Return raw data as obtained by JPL Horizons without parsing the
+            data into a table, default: False
+
+
         Returns
         -------
         response : `requests.Response`
             The response of the HTTP request.
-
 
 
         Examples
@@ -294,6 +294,7 @@ class HorizonsClass(BaseQuery):
             0.0
                1 Ceres 2010-Feb-20 00:00   2455247.5 ...  7.976737       0.0
             0.0
+
         """
 
         URL = conf.horizons_server
@@ -393,26 +394,6 @@ class HorizonsClass(BaseQuery):
         parameter in ``HorizonsClass`` refers in this case to the  center
         body relative to which the elements are provided.
 
-
-        Parameters
-        ----------
-        closest_apparition : boolean, optional
-            Only applies to comets. This option will choose the
-            closest apparition available in time to the selected
-            epoch; default: False. Do not use this option for
-            non-cometary objects.
-        no_fragments : boolean, optional
-            Only applies to comets. Reject all comet fragments from
-            selection; default: False. Do not use this option for
-            non-cometary objects.
-        get_query_payload : boolean, optional
-            When set to `True` the method returns the HTTP request parameters
-            as a dict, default: False
-        get_raw_response: boolean, optional
-            Return raw data as obtained by JPL Horizons without parsing the
-            data into a table, default: False
-
-
         The following table lists the values queried, their
         definitions, data types, units, and original Horizons
         designations (in quotation marks; where available).
@@ -464,6 +445,25 @@ class HorizonsClass(BaseQuery):
         +------------------+-----------------------------------------------+
         | Q                | apoapsis distance (float, au, "AD")           |
         +------------------+-----------------------------------------------+
+
+
+        Parameters
+        ----------
+        closest_apparition : boolean, optional
+            Only applies to comets. This option will choose the
+            closest apparition available in time to the selected
+            epoch; default: False. Do not use this option for
+            non-cometary objects.
+        no_fragments : boolean, optional
+            Only applies to comets. Reject all comet fragments from
+            selection; default: False. Do not use this option for
+            non-cometary objects.
+        get_query_payload : boolean, optional
+            When set to `True` the method returns the HTTP request parameters
+            as a dict, default: False
+        get_raw_response: boolean, optional
+            Return raw data as obtained by JPL Horizons without parsing the
+            data into a table, default: False
 
 
         Returns
@@ -576,26 +576,6 @@ class HorizonsClass(BaseQuery):
         parameter in ``HorizonsClass`` refers in this case to the center
         body relative to which the vectors are provided.
 
-
-        Parameters
-        ----------
-        closest_apparition : boolean, optional
-            Only applies to comets. This option will choose the
-            closest apparition available in time to the selected
-            epoch; default: False. Do not use this option for
-            non-cometary objects.
-        no_fragments : boolean, optional
-            Only applies to comets. Reject all comet fragments from
-            selection; default: False. Do not use this option for
-            non-cometary objects.
-        get_query_payload : boolean, optional
-            When set to `True` the method returns the HTTP request parameters
-            as a dict, default: False
-        get_raw_response: boolean, optional
-            Return raw data as obtained by JPL Horizons without parsing the
-            data into a table, default: False
-
-
         The following table lists the values queried, their
         definitions, data types, units, and original Horizons
         designations (in quotation marks; where available).
@@ -641,6 +621,25 @@ class HorizonsClass(BaseQuery):
         +------------------+-----------------------------------------------+
         | range_rate       | range rate (float, au/d, "RR")                |
         +------------------+-----------------------------------------------+
+
+
+        Parameters
+        ----------
+        closest_apparition : boolean, optional
+            Only applies to comets. This option will choose the
+            closest apparition available in time to the selected
+            epoch; default: False. Do not use this option for
+            non-cometary objects.
+        no_fragments : boolean, optional
+            Only applies to comets. Reject all comet fragments from
+            selection; default: False. Do not use this option for
+            non-cometary objects.
+        get_query_payload : boolean, optional
+            When set to `True` the method returns the HTTP request parameters
+            as a dict, default: False
+        get_raw_response: boolean, optional
+            Return raw data as obtained by JPL Horizons without parsing the
+            data into a table, default: False
 
 
         Returns

--- a/astroquery/jplhorizons/tests/test_jplhorizons_remote.py
+++ b/astroquery/jplhorizons/tests/test_jplhorizons_remote.py
@@ -12,7 +12,7 @@ from ... import jplhorizons
 @remote_data
 class TestHorizonsClass:
 
-    def test_ephemerides_query(patch_request):
+    def test_ephemerides_query(self):
         # check values of Ceres for a given epoch
         # orbital uncertainty of Ceres is basically zero
         res = jplhorizons.Horizons(id='Ceres', location='500',
@@ -49,7 +49,7 @@ class TestHorizonsClass:
              res['GlxLat'],
              res['RA_3sigma'], res['DEC_3sigma']])
 
-    def test_ephemerides_query_two(patch_request):
+    def test_ephemerides_query_two(self):
         # check comet ephemerides using solarsystem.ephemerides options
         obj = jplhorizons.Horizons(id='Halley', id_type='comet_name',
                                    location='290',
@@ -73,7 +73,7 @@ class TestHorizonsClass:
         assert 'H' not in res
         assert 'G' not in res
 
-    def test_ephemerides_query_three(patch_request):
+    def test_ephemerides_query_three(self):
         # checks no_fragments option for comets
         obj = jplhorizons.Horizons(id='73P', id_type='designation',
                                    location='290',
@@ -97,14 +97,14 @@ class TestHorizonsClass:
         assert 'H' not in res
         assert 'G' not in res
 
-    def test_ephemerides_query_raw(patch_request):
+    def test_ephemerides_query_raw(self):
         res = (jplhorizons.Horizons(id='Ceres', location='500',
                                     epochs=2451544.5).
                ephemerides(get_raw_response=True))
 
         assert len(res) == 15335
 
-    def test_ephemerides_query_payload(patch_request):
+    def test_ephemerides_query_payload(self):
         obj = jplhorizons.Horizons(id='Halley', id_type='comet_name',
                                    location='290',
                                    epochs={'start': '2080-01-01',
@@ -133,7 +133,7 @@ class TestHorizonsClass:
             ('AIRMASS', '1.2'),
             ('SKIP_DAYLT', 'YES')])
 
-    def test_elements_query(patch_request):
+    def test_elements_query(self):
         res = jplhorizons.Horizons(id='Ceres', location='500@10',
                                    epochs=2451544.5).elements()[0]
 
@@ -160,14 +160,14 @@ class TestHorizonsClass:
              res['a'], res['Q'],
              res['P']])
 
-    def test_elements_query_raw(patch_request):
+    def test_elements_query_raw(self):
         res = jplhorizons.Horizons(id='Ceres', location='500@10',
                                    epochs=2451544.5).elements(
                                        get_raw_response=True)
 
         assert len(res) == 7576
 
-    def test_elements_query_payload(patch_request):
+    def test_elements_query_payload(self):
         res = (jplhorizons.Horizons(id='Ceres', location='500@10',
                                     epochs=2451544.5).elements(
                                         get_query_payload=True))
@@ -186,7 +186,7 @@ class TestHorizonsClass:
             ('OBJ_DATA', 'YES'),
             ('TLIST', '"2451544.5"')])
 
-    def test_vectors_query(patch_request):
+    def test_vectors_query(self):
         # check values of Ceres for a given epoch
         # orbital uncertainty of Ceres is basically zero
         res = jplhorizons.Horizons(id='Ceres', location='500@10',
@@ -211,14 +211,14 @@ class TestHorizonsClass:
              res['lighttime'], res['range'],
              res['range_rate']])
 
-    def test_vectors_query_raw(patch_request):
+    def test_vectors_query_raw(self):
         res = jplhorizons.Horizons(id='Ceres', location='500@10',
                                    epochs=2451544.5).vectors(
                                        get_raw_response=True)
 
         assert len(res) == 7032
 
-    def test_vectors_query_payload(patch_request):
+    def test_vectors_query_payload(self):
         res = jplhorizons.Horizons(id='Ceres', location='500@10',
                                    epochs=2451544.5).vectors(
                                        get_query_payload=True)
@@ -237,14 +237,14 @@ class TestHorizonsClass:
             ('OBJ_DATA', 'YES'),
             ('TLIST', '"2451544.5"')])
 
-    def test_unknownobject(patch_request):
+    def test_unknownobject(self):
         try:
             jplhorizons.Horizons(id='spamspamspameggsspam', location='500',
                                  epochs=2451544.5).ephemerides()
         except ValueError:
             pass
 
-    def test_multipleobjects(patch_request):
+    def test_multipleobjects(self):
         try:
             jplhorizons.Horizons(id='73P', location='500',
                                  epochs=2451544.5).ephemerides()

--- a/docs/jplhorizons/jplhorizons.rst
+++ b/docs/jplhorizons/jplhorizons.rst
@@ -75,8 +75,8 @@ respective id number or record number as ``id`` and use ``id_type=id``:
      2P/Encke 2018-Jan-17 05:06:07.709 2458135.712589224 ...        --         --
 
 
-JPL Horizons
-------------
+Querying JPL Horizons
+---------------------
 
 The `JPL Horizons`_ system provides ephemerides, orbital elements, and
 state vectors for almost all known Solar System bodies. These queries


### PR DESCRIPTION
some minor fixes to `astroquery.jplhorizons`:

* changed the first argument of the remote tests to `self` from `patch-request` as suggested by @keflavich in  #1023 
* fixed the link to the `jplhorizons` docs in `README.rst`
* moved tables in `core.py` docstrings out of 'parameters' space to fix display
* minor changes in `jplhorizons` docs

