### PR TITLE
Fix lamda writer windows failure

### DIFF
--- a/astroquery/lamda/core.py
+++ b/astroquery/lamda/core.py
@@ -214,6 +214,8 @@ def write_lamda_datafile(filename, tables):
     tables: tuple
         Tuple of Tables ({rateid: coll_table}, rad_table, mol_table)
     """
+    import platform
+    import sys
 
     collrates, radtransitions, enlevels = tables
 
@@ -247,7 +249,15 @@ def write_lamda_datafile(filename, tables):
                      """)
     coll_part_hdr = re.sub('^ +', '', coll_part_hdr, flags=re.MULTILINE)
 
-    with open(filename, 'w') as f:
+    if platform.system() == 'Windows':
+        if sys.version_info[0] >= 3:
+            stream = open(filename, 'w', newline='')
+        else:
+            stream = open(filename, 'wb')
+    else:
+        stream = open(filename, 'w')
+
+    with stream as f:
         f.write(levels_hdr.format(enlevels.meta['molecule'],
                                   enlevels.meta['molwt'],
                                   enlevels.meta['nenergylevels']))

--- a/astroquery/lamda/tests/test_lamda.py
+++ b/astroquery/lamda/tests/test_lamda.py
@@ -2,10 +2,6 @@
 import os
 import tempfile
 import numpy as np
-import pytest
-import sys
-import platform
-
 from ...lamda import core
 
 DATA_FILES = {'co': 'co.txt'}
@@ -25,9 +21,6 @@ def test_parser():
     assert len(radtransitions) == 40
 
 
-@pytest.mark.xfail(platform.system() == 'Windows' and sys.version_info[0] >= 3,
-                   reason=("https://github.com/astropy/astroquery/pull/894 and "
-                           "https://github.com/astropy/astropy/issues/5126"))
 def test_writer():
     tables = core.parse_lamda_datafile(data_path('co.txt'))
     coll, radtrans, enlevels = tables


### PR DESCRIPTION
This is to test that the lamda writer works on windows (#894) with the open file workaround using appveyor CI, as I can not test this myself.

EDIT: The appveyor tests passed.