### PR TITLE
Remove limit in number of epochs in jplhorizons

### DIFF
--- a/astroquery/jplhorizons/core.py
+++ b/astroquery/jplhorizons/core.py
@@ -6,7 +6,6 @@ from numpy import nan as nan
 from numpy import isnan
 from numpy import ndarray
 from collections import OrderedDict
-import warnings
 
 # 2. third party imports
 from astropy.table import Column
@@ -17,8 +16,6 @@ from astropy.time import Time
 # commonly required local imports shown below as example
 # all Query classes should inherit from BaseQuery.
 from ..query import BaseQuery
-# prepend_docstr is a way to copy docstrings between methods
-from ..utils import prepend_docstr_nosections
 # async_to_sync generates the relevant query tools from _async methods
 from ..utils import async_to_sync
 # import configurable items declared in __init__.py

--- a/astroquery/jplhorizons/core.py
+++ b/astroquery/jplhorizons/core.py
@@ -343,10 +343,6 @@ class HorizonsClass(BaseQuery):
 
         # parse self.epochs
         if type(self.epochs) is list:
-            if len(self.epochs) > 15:
-                self.epochs = self.epochs[:15]
-                warnings.warn("Only the first 15 elements of 'epochs' will " +
-                              "be queried")
             request_payload['TLIST'] = "".join(['"' + str(epoch) + '"'
                                                 for epoch
                                                 in self.epochs])
@@ -532,10 +528,6 @@ class HorizonsClass(BaseQuery):
 
         # parse self.epochs
         if type(self.epochs) is list:
-            if len(self.epochs) > 15:
-                self.epochs = self.epochs[:15]
-                warnings.warn("Only the first 15 elements of 'epochs' will " +
-                              "be queried")
             request_payload['TLIST'] = "".join(['"' + str(epoch) + '"'
                                                 for epoch
                                                 in self.epochs])
@@ -725,10 +717,6 @@ class HorizonsClass(BaseQuery):
 
         # parse self.epochs
         if type(self.epochs) is list:
-            if len(self.epochs) > 15:
-                self.epochs = self.epochs[:15]
-                warnings.warn("Only the first 15 elements of 'epochs' will " +
-                              "be queried")
             request_payload['TLIST'] = "".join(['"' + str(epoch) + '"'
                                                 for epoch
                                                 in self.epochs])

--- a/astroquery/jplhorizons/core.py
+++ b/astroquery/jplhorizons/core.py
@@ -37,19 +37,19 @@ class HorizonsClass(BaseQuery):
         ----------
         id : str, required
             Name, number, or designation of the object to be queried
-        location: str, optional
+        location : str, optional
             Observer's location for ephemerides queries or center body
             name for orbital element or vector queries. Uses the same
             codes as JPL Horizons. If no location is provided, Earth's
             center is used for ephemerides queries and the Sun's
             center for elements and vectors queries.
-        epochs: scalar, list, or dictionary, optional
-            Either a list of epochs in JD format or a dictionary
+        epochs : scalar, list-like, or dictionary, optional
+            Either a list of epochs in JD or MJD format or a dictionary
             defining a range of times and dates; the range dictionary has to
             be of the form {``'start'``:'YYYY-MM-DD [HH:MM:SS]',
             ``'stop'``:'YYYY-MM-DD [HH:MM:SS]', ``'step'``:'n[y|d|m|s]'}. If no
             epochs are provided, the current time is used.
-        id_type: str, optional
+        id_type : str, optional
             Identifier type, options:
             ``'smallbody'``, ``'majorbody'`` (planets but also
             anything that is not a small body), ``'designation'``,

--- a/astroquery/jplhorizons/core.py
+++ b/astroquery/jplhorizons/core.py
@@ -342,7 +342,7 @@ class HorizonsClass(BaseQuery):
         )
 
         # parse self.epochs
-        if type(self.epochs) is list:
+        if isinstance(self.epochs, (list, tuple, ndarray)):
             request_payload['TLIST'] = "".join(['"' + str(epoch) + '"'
                                                 for epoch
                                                 in self.epochs])
@@ -527,7 +527,7 @@ class HorizonsClass(BaseQuery):
         )
 
         # parse self.epochs
-        if type(self.epochs) is list:
+        if isinstance(self.epochs, (list, tuple, ndarray)):
             request_payload['TLIST'] = "".join(['"' + str(epoch) + '"'
                                                 for epoch
                                                 in self.epochs])
@@ -716,7 +716,7 @@ class HorizonsClass(BaseQuery):
         )
 
         # parse self.epochs
-        if type(self.epochs) is list:
+        if isinstance(self.epochs, (list, tuple, ndarray)):
             request_payload['TLIST'] = "".join(['"' + str(epoch) + '"'
                                                 for epoch
                                                 in self.epochs])

--- a/astroquery/jplhorizons/core.py
+++ b/astroquery/jplhorizons/core.py
@@ -343,9 +343,8 @@ class HorizonsClass(BaseQuery):
 
         # parse self.epochs
         if isinstance(self.epochs, (list, tuple, ndarray)):
-            request_payload['TLIST'] = "".join(['"' + str(epoch) + '"'
-                                                for epoch
-                                                in self.epochs])
+            request_payload['TLIST'] = "\n".join([str(epoch) for epoch in
+                                                 self.epochs])
         elif type(self.epochs) is dict:
             if ('start' not in self.epochs or 'stop' not in self.epochs or
                 'step' not in self.epochs):
@@ -528,9 +527,8 @@ class HorizonsClass(BaseQuery):
 
         # parse self.epochs
         if isinstance(self.epochs, (list, tuple, ndarray)):
-            request_payload['TLIST'] = "".join(['"' + str(epoch) + '"'
-                                                for epoch
-                                                in self.epochs])
+            request_payload['TLIST'] = "\n".join([str(epoch) for epoch in
+                                                 self.epochs])
         elif type(self.epochs) is dict:
             if ('start' not in self.epochs or 'stop' not in self.epochs or
                 'step' not in self.epochs):
@@ -717,9 +715,8 @@ class HorizonsClass(BaseQuery):
 
         # parse self.epochs
         if isinstance(self.epochs, (list, tuple, ndarray)):
-            request_payload['TLIST'] = "".join(['"' + str(epoch) + '"'
-                                                for epoch
-                                                in self.epochs])
+            request_payload['TLIST'] = "\n".join([str(epoch) for epoch in
+                                                 self.epochs])
         elif type(self.epochs) is dict:
             if ('start' not in self.epochs or 'stop' not in self.epochs or
                 'step' not in self.epochs):

--- a/astroquery/jplhorizons/tests/test_jplhorizons_remote.py
+++ b/astroquery/jplhorizons/tests/test_jplhorizons_remote.py
@@ -102,7 +102,7 @@ class TestHorizonsClass:
                                     epochs=2451544.5).
                ephemerides(get_raw_response=True))
 
-        assert len(res) == 15335
+        assert len(res) == 15347
 
     def test_ephemerides_query_payload(self):
         obj = jplhorizons.Horizons(id='Halley', id_type='comet_name',
@@ -165,7 +165,7 @@ class TestHorizonsClass:
                                    epochs=2451544.5).elements(
                                        get_raw_response=True)
 
-        assert len(res) == 7576
+        assert len(res) == 7574
 
     def test_elements_query_payload(self):
         res = (jplhorizons.Horizons(id='Ceres', location='500@10',
@@ -184,7 +184,7 @@ class TestHorizonsClass:
             ('TP_TYPE', 'ABSOLUTE'),
             ('ELEM_LABELS', 'YES'),
             ('OBJ_DATA', 'YES'),
-            ('TLIST', '"2451544.5"')])
+            ('TLIST', '2451544.5')])
 
     def test_vectors_query(self):
         # check values of Ceres for a given epoch
@@ -216,7 +216,7 @@ class TestHorizonsClass:
                                    epochs=2451544.5).vectors(
                                        get_raw_response=True)
 
-        assert len(res) == 7032
+        assert len(res) == 7030
 
     def test_vectors_query_payload(self):
         res = jplhorizons.Horizons(id='Ceres', location='500@10',
@@ -235,7 +235,7 @@ class TestHorizonsClass:
             ('TP_TYPE', 'ABSOLUTE'),
             ('LABELS', 'YES'),
             ('OBJ_DATA', 'YES'),
-            ('TLIST', '"2451544.5"')])
+            ('TLIST', '2451544.5')])
 
     def test_unknownobject(self):
         try:


### PR DESCRIPTION
There is an issue with the Horizons cgi script that requires giving separate lines in the TLIST argument with at most 256 characters. This limitation may be fixed at some point by Horizons developers. To allow unlimited number of epochs in TLIST I have used a newline separator for the ephemerides, elements and vectors methods, that gets encoded when making the request. The epochs can also be provided as a numpy.ndarray object now.

@mommermi could you take a look at these changes?