### PR TITLE
IRSA Dust: call over https

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -10,6 +10,7 @@
 - MAST: bugfix, removing filesize checking due to unreliable filesize reporting in the database [#1050]
 - MAST: Added Catalogs class. [#1049]
 - New tool: Open Astronomy Catalog API to obtain data products on supernovae, TDEs, and kilonovae. [#1053]
+- IRSA Dust: call over https. [#1069]
 
 0.3.7 (2018-01-25)
 ------------------

--- a/astroquery/irsa_dust/__init__.py
+++ b/astroquery/irsa_dust/__init__.py
@@ -18,7 +18,7 @@ class Conf(_config.ConfigNamespace):
     """
     # maintain a list of URLs in case the user wants to append a mirror
     server = _config.ConfigItem(
-        ['http://irsa.ipac.caltech.edu/cgi-bin/DUST/nph-dust'],
+        ['https://irsa.ipac.caltech.edu/cgi-bin/DUST/nph-dust'],
         'Name of the irsa_dust server to use.')
     timeout = _config.ConfigItem(
         30,

--- a/astroquery/irsa_dust/core.py
+++ b/astroquery/irsa_dust/core.py
@@ -59,7 +59,7 @@ class IrsaDustClass(BaseQuery):
             Can be either the name of an object or a coordinate string
             If a name, must be resolvable by NED, SIMBAD, 2MASS, or SWAS.
             Examples of acceptable coordinate strings, can be found `here.
-            <http://irsa.ipac.caltech.edu/applications/DUST/docs/coordinate.html>`_
+            <https://irsa.ipac.caltech.edu/applications/DUST/docs/coordinate.html>`_
         radius : str / `~astropy.units.Quantity`, optional
             The size of the region to include in the dust query, in radian,
             degree or hour as per format specified by
@@ -105,7 +105,7 @@ class IrsaDustClass(BaseQuery):
             Can be either the name of an object or a coordinate string
             If a name, must be resolvable by NED, SIMBAD, 2MASS, or SWAS.
             Examples of acceptable coordinate strings, can be found `here.
-            <http://irsa.ipac.caltech.edu/applications/DUST/docs/coordinate.html>`_
+            <https://irsa.ipac.caltech.edu/applications/DUST/docs/coordinate.html>`_
         radius : str / `~astropy.units.Quantity`, optional
             The size of the region to include in the dust query, in radian,
             degree or hour as per format specified by
@@ -151,7 +151,7 @@ class IrsaDustClass(BaseQuery):
             Can be either the name of an object or a coordinate string
             If a name, must be resolvable by NED, SIMBAD, 2MASS, or SWAS.
             Examples of acceptable coordinate strings, can be found `here.
-            <http://irsa.ipac.caltech.edu/applications/DUST/docs/coordinate.html>`_
+            <https://irsa.ipac.caltech.edu/applications/DUST/docs/coordinate.html>`_
         radius : str / `~astropy.units.Quantity`, optional
             The size of the region to include in the dust query, in radian,
             degree or hour as per format specified by
@@ -192,7 +192,7 @@ class IrsaDustClass(BaseQuery):
             Can be either the name of an object or a coordinate string
             If a name, must be resolvable by NED, SIMBAD, 2MASS, or SWAS.
             Examples of acceptable coordinate strings, can be found `here.
-            <http://irsa.ipac.caltech.edu/applications/DUST/docs/coordinate.html>`_
+            <https://irsa.ipac.caltech.edu/applications/DUST/docs/coordinate.html>`_
         radius : str / `~astropy.units.Quantity`, optional
             The size of the region to include in the dust query, in radian,
             degree or hour as per format specified by
@@ -233,7 +233,7 @@ class IrsaDustClass(BaseQuery):
             Can be either the name of an object or a coordinate string
             If a name, must be resolvable by NED, SIMBAD, 2MASS, or SWAS.
             Examples of acceptable coordinate strings, can be found `here.
-            <http://irsa.ipac.caltech.edu/applications/DUST/docs/coordinate.html>`_
+            <https://irsa.ipac.caltech.edu/applications/DUST/docs/coordinate.html>`_
         radius : str, optional
             The size of the region to include in the dust query, in radian,
             degree or hour as per format specified by
@@ -271,7 +271,7 @@ class IrsaDustClass(BaseQuery):
             Can be either the name of an object or a coordinate string
             If a name, must be resolvable by NED, SIMBAD, 2MASS, or SWAS.
             Examples of acceptable coordinate strings, can be found `here.
-            <http://irsa.ipac.caltech.edu/applications/DUST/docs/coordinate.html>`_
+            <https://irsa.ipac.caltech.edu/applications/DUST/docs/coordinate.html>`_
         radius : str / `~astropy.units.Quantity`, optional
             The size of the region to include in the dust query, in radian,
             degree or hour as per format specified by
@@ -319,7 +319,7 @@ class IrsaDustClass(BaseQuery):
             Can be either the name of an object or a coordinate string
             If a name, must be resolvable by NED, SIMBAD, 2MASS, or SWAS.
             Examples of acceptable coordinate strings, can be found `here
-            <http://irsa.ipac.caltech.edu/applications/DUST/docs/coordinate.html>`_
+            <https://irsa.ipac.caltech.edu/applications/DUST/docs/coordinate.html>`_
         radius : str / `~astropy.units.Quantity`, optional
             The size of the region to include in the dust query, in radian,
             degree or hour as per format specified by

--- a/astroquery/irsa_dust/tests/test_irsa_dust.py
+++ b/astroquery/irsa_dust/tests/test_irsa_dust.py
@@ -80,6 +80,10 @@ class DustTestCase(object):
         data_dir = os.path.join(os.path.dirname(__file__), 'data')
         return os.path.join(data_dir, filename)
 
+    def read_data(self, filename):
+        with open(self.data(filename), "r") as f:
+            return f.read()
+
 
 class TestDust(DustTestCase):
 
@@ -102,12 +106,12 @@ class TestDust(DustTestCase):
         assert expected_units == actual_units
 
     def test_xml_ok(self):
-        data = open(self.data(M31_XML), "r").read()
+        data = self.read_data(M31_XML)
         xml_tree = irsa_dust.utils.xml(data)
         assert xml_tree is not None
 
     def test_xml_err(self):
-        data = open(self.data(ERR_XML), "r").read()
+        data = self.read_data(ERR_XML)
         with pytest.raises(Exception):
             irsa_dust.utils.xml(data)
 
@@ -182,13 +186,13 @@ class TestDust(DustTestCase):
                               ('temperature', M31_URL_T),
                               ])
     def test_extract_image_urls_instance(self, image_type, expected_urls):
-        raw_xml = open(self.data(M31_XML), "r").read()
+        raw_xml = self.read_data(M31_XML)
         url_list = IrsaDust().extract_image_urls(
             raw_xml, image_type=image_type)
         assert url_list == expected_urls
 
     def test_extract_image_urls_instance__err(self):
-        raw_xml = open(self.data(M31_XML), "r").read()
+        raw_xml = self.read_data(M31_XML)
         with pytest.raises(ValueError):
             IrsaDust().extract_image_urls(
                 raw_xml, image_type="l")
@@ -200,13 +204,13 @@ class TestDust(DustTestCase):
                               ('temperature', M31_URL_T),
                               ])
     def test_extract_image_urls_class(self, image_type, expected_urls):
-        raw_xml = open(self.data(M31_XML), "r").read()
+        raw_xml = self.read_data(M31_XML)
         url_list = IrsaDust.extract_image_urls(
             raw_xml, image_type=image_type)
         assert url_list == expected_urls
 
     def test_extract_image_urls_class__err(self):
-        raw_xml = open(self.data(M31_XML), "r").read()
+        raw_xml = self.read_data(M31_XML)
         with pytest.raises(ValueError):
             IrsaDust.extract_image_urls(raw_xml, image_type="l")
 
@@ -330,7 +334,7 @@ class TestDust(DustTestCase):
 
     def send_request_mockreturn(self, method, url, data, timeout):
         class MockResponse:
-            text = open(self.data(M31_XML), "r").read()
+            text = self.read_data(M31_XML)
         return MockResponse
 
     def get_ext_table_async_mockreturn(self, coordinate, radius=None,


### PR DESCRIPTION
Note that besides a commit for the http to https change, this PR also includes a separate commit to ensure that files opened by the dust test cases are closed, thereby silencing quite a few pytest warnings.