### PR TITLE
Make gaia doc idioms a bit more consistent with astropy

### DIFF
--- a/docs/gaia/gaia.rst
+++ b/docs/gaia/gaia.rst
@@ -80,12 +80,11 @@ Examples
 
   >>> import astropy.units as u
   >>> from astropy.coordinates import SkyCoord
-  >>> from astropy.units import Quantity
   >>> from astroquery.gaia import Gaia
   >>>
   >>> coord = SkyCoord(ra=280, dec=-60, unit=(u.degree, u.degree), frame='icrs')
-  >>> width = Quantity(0.1, u.deg)
-  >>> height = Quantity(0.1, u.deg)
+  >>> width = u.Quantity(0.1, u.deg)
+  >>> height = u.Quantity(0.1, u.deg)
   >>> r = Gaia.query_object_async(coordinate=coord, width=width, height=height)
   >>> r.pprint()
 
@@ -123,11 +122,10 @@ Examples
 
   >>> import astropy.units as u
   >>> from astropy.coordinates import SkyCoord
-  >>> from astropy.units import Quantity
   >>> from astroquery.gaia import Gaia
   >>>
   >>> coord = SkyCoord(ra=280, dec=-60, unit=(u.degree, u.degree), frame='icrs')
-  >>> radius = Quantity(1.0, u.deg)
+  >>> radius = u.Quantity(1.0, u.deg)
   >>> j = Gaia.cone_search_async(coord, radius)
   >>> r = j.get_results()
   >>> r.pprint()

--- a/docs/gaia/gaia.rst
+++ b/docs/gaia/gaia.rst
@@ -79,7 +79,7 @@ Examples
 .. code-block:: python
 
   >>> import astropy.units as u
-  >>> from astropy.coordinates.sky_coordinate import SkyCoord
+  >>> from astropy.coordinates import SkyCoord
   >>> from astropy.units import Quantity
   >>> from astroquery.gaia import Gaia
   >>>
@@ -122,7 +122,7 @@ Examples
 .. code-block:: python
 
   >>> import astropy.units as u
-  >>> from astropy.coordinates.sky_coordinate import SkyCoord
+  >>> from astropy.coordinates import SkyCoord
   >>> from astropy.units import Quantity
   >>> from astroquery.gaia import Gaia
   >>>


### PR DESCRIPTION
I noticed a couple oddities in the Gaia section docs that I thought I would correct.

1. `SkyCoord` should not be imported from `astropy.coordinates.sky_coordinate` - `astropy.coordinates.sky_coordinate` is not part of the public API, so there's no guarantee of stability.  One should always import from `astropy.coordinates` instead.In this particular case I very much doubt it would change, but better to be safe than sorry (and not encourage this in user code).
2.  For consistency with `astropy` docs (and convention) I suggest importing `units as u` (already done her), but then doing `Quantity` as `u.Quantity`.  It's somewhat a matter of taste, but I think this is a bit cleaner for the users since `units` already has to be imported. (This is a but more opinion-y, so I can drop that one if someone strongly disagrees - its in a separate commit from the other item.)