### PR TITLE
Add option to update phase for background jobs

### DIFF
--- a/astroquery/utils/tap/model/job.py
+++ b/astroquery/utils/tap/model/job.py
@@ -157,6 +157,8 @@ class Job(object):
         if update:
             phase_request = "async/"+str(self.get_jobid())+"/phase"
             response = self.__connHandler.execute_get(phase_request)
+
+            self.__last_phase_response_status = response.status
             if response.status != 200:
                 raise Exception(response.reason)
 
@@ -576,20 +578,16 @@ class Job(object):
         verbose : bool, optional, default 'False'
             flag to display information about the process
         """
-        phaseRequest = "async/"+str(self.__jobid)+"/phase"
         currentResponse = None
         responseData = None
         while True:
-            response = self.__connHandler.execute_get(phaseRequest)
-            currentResponse = response.status
-            if response.status != 200:
-                raise Exception(response.reason)
-                break
-            responseData = str(response.read().decode('utf-8'))
-            data = responseData.lower().strip()
+            responseData = self.get_phase(update=True)
+            currentResponse = self.__last_phase_response_status
+
+            lphase = responseData.lower().strip()
             if verbose:
-                print("Job " + self.__jobid + " status: " + data)
-            if "pending" != data and "queued" != data and "executing" != data:
+                print("Job " + self.__jobid + " status: " + lphase)
+            if "pending" != lphase and "queued" != lphase and "executing" != lphase:
                 break
             # PENDING, QUEUED, EXECUTING, COMPLETED, ERROR, ABORTED, UNKNOWN,
             # HELD, SUSPENDED, ARCHIVED:

--- a/astroquery/utils/tap/model/job.py
+++ b/astroquery/utils/tap/model/job.py
@@ -141,13 +141,27 @@ class Job(object):
         """
         self.__phase = phase
 
-    def get_phase(self):
-        """Returns the job phase
+    def get_phase(self, update=False):
+        """Returns the job phase. May optionally update the job's phase.
+
+        Parameters
+        ----------
+        update : bool
+            if True, the phase will by updated by querying the server before
+            returning.
 
         Returns
         -------
         The job phase
         """
+        if update:
+            phase_request = "async/"+str(self.get_jobid())+"/phase"
+            response = self.__connHandler.execute_get(phase_request)
+            if response.status != 200:
+                raise Exception(response.reason)
+
+            self.set_phase(str(response.read().decode('utf-8')))
+
         return self.__phase
 
     def set_output_file(self, output_file):


### PR DESCRIPTION
The impetus for this PR was a straightforward use case:  I want to use ``job = Gaia.launch_job_async(..., background=True)`` and be able to periodically "check" on the job without it blocking my Python process until complete.  But of course we also want to maintain backwards compatibility. So this PR adds a keyword `update` to `utils.tab.job.Job.get_phase`.  If that keyword is true, I can simply ask the job at any time what it's phase is.  Then once it's completed I know it's safe to `get_results` and it won't block while waiting for the job to complete on the server.

It probably could use some tests (and a changelog entry), but I thought I would put it out there first in this form to make sure there aren't major concerns (especially from @jcsegovia).