### PR TITLE
Add Gaia to the module list [skip ci]

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -109,6 +109,7 @@ List of Modules
   * `Open Expolanet Catalog (OEC) <http://astroquery.readthedocs.io/en/latest/open_exoplanet_catalogue/open_exoplanet_catalogue.html>`_
   * `JPL Horizons <http://astroquery.readthedocs.io/en/latest/jplhorizons/jplhorizons.html>`_: JPL Solar System Dynamics Horizons Service
   * `OAC API <http://astroquery.readthedocs.io/en/latest/oac/oac.html>`_: Open Astronomy Catalog REST API Service
+  * `Gaia <http://astroquery.readthedocs.io/en/latest/gaia/gaia.html>`_: European Space Agency Gaia Archive
 
 Additional Links
 ----------------


### PR DESCRIPTION
`astroquery.gaia` was missing