### PR TITLE
Fix XMatch for astropy.table.Table input

### DIFF
--- a/astroquery/xmatch/core.py
+++ b/astroquery/xmatch/core.py
@@ -102,13 +102,13 @@ class XMatchClass(BaseQuery):
         if isinstance(cat, six.string_types):
             payload[catstr] = cat
         elif isinstance(cat, Table):
-            # write the Table's content into a new, temporary CSV-file
+            # write the Table's content into a new, temporary VOT-file
             # so that it can be pointed to via the `files` option
             # file will be closed when garbage-collected
-            fp = six.StringIO()
-            cat.write(fp, format='ascii.csv')
+            fp = six.BytesIO()
+            cat.write(fp, format='votable')
             fp.seek(0)
-            kwargs['files'] = {catstr: ('cat1.csv', fp.read())}
+            kwargs['files'] = {catstr: ('cat1.vot', fp.read())}
         else:
             # assume it's a file-like object, support duck-typing
             kwargs['files'] = {catstr: ('cat1.csv', cat.read())}

--- a/astroquery/xmatch/core.py
+++ b/astroquery/xmatch/core.py
@@ -126,7 +126,9 @@ class XMatchClass(BaseQuery):
         available VizieR tables, otherwise False.
 
         """
-        if isinstance(table_id, six.string_types) and (table_id[:7] == 'vizier:'):
+        if not isinstance(table_id, six.string_types):
+            return False
+        if table_id.startswith('vizier:'):
             table_id = table_id[7:]
         return table_id in self.get_available_tables()
 


### PR DESCRIPTION
I had two smaller issues when trying to use XMatch with an astropy table and a Vizier table. This PR fixes the issues.