### PR TITLE
Keep module lists in sync [skip ci]

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -82,46 +82,51 @@ as possible.
 List of Modules
 ---------------
 
-  * `Simbad <http://astroquery.readthedocs.io/en/latest/simbad/simbad.html>`_:           Basic data, cross-identifications, bibliography and measurements for astronomical objects outside the solar system.
-  * `Vizier <http://astroquery.readthedocs.io/en/latest/vizier/vizier.html>`_:           Set of 11,000+ published, multiwavelength catalogues hosted by the CDS.
-  * `ESASky <http://astroquery.readthedocs.io/en/latest/esasky/esasky.html>`_:           ESASky is a science driven discovery portal providing easy visualizations and full access to the entire sky as observed with ESA Space astronomy missions.
-  * `IRSA Image Server program interface (IBE) Query Tool <http://astroquery.readthedocs.io/en/latest/ibe/ibe.html>`_: provides access to the 2MASS, WISE, and PTF image archives.
-  * `IRSA dust <http://astroquery.readthedocs.io/en/latest/irsa/irsa_dust.html>`_:     Galactic dust reddening and extinction maps from IRAS 100 um data.
-  * `NED <http://astroquery.readthedocs.io/en/latest/ned/ned.html>`_:                 NASA/IPAC Extragalactic Database. Multiwavelength data from both surveys and publications.
-  * `IRSA <http://astroquery.readthedocs.io/en/latest/irsa/irsa.html>`_:               NASA/IPAC Infrared Science Archive. Science products for all of NASA's infrared and sub-mm missions.
-  * `UKIDSS <http://astroquery.readthedocs.io/en/latest/ukidss/ukidss.html>`_:           UKIRT Infrared Deep Sky Survey. JHK images of 7500 sq deg. in the northern sky.
-  * `MAGPIS <http://astroquery.readthedocs.io/en/latest/magpis/magpis.html>`_:           Multi-Array Galactic Plane Imaging Survey. 6 and 20-cm radio images of the Galactic plane from the VLA.
-  * `NRAO <http://astroquery.readthedocs.io/en/latest/nrao/nrao.html>`_:               Science data archive of the National Radio Astronomy Observatory. VLA, JVLA, VLBA and GBT data products.
-  * `Besancon <http://astroquery.readthedocs.io/en/latest/besancon/besancon.html>`_:       Model of stellar population synthesis in the Galaxy.
-  * `NIST <http://astroquery.readthedocs.io/en/latest/nist/nist.html>`_:               National Institute of Standards and Technology (NIST) atomic lines database.
-  * `Fermi <http://astroquery.readthedocs.io/en/latest/fermi/fermi.html>`_:             Fermi gamma-ray telescope archive.
-  * `SDSS <http://astroquery.readthedocs.io/en/latest/sdss/sdss.html>`_:               Sloan Digital Sky Survey data, including optical images, spectra, and spectral templates.
-  * `Alfalfa <http://astroquery.readthedocs.io/en/latest/alfalfa/alfalfa.html>`_:         Arecibo Legacy Fast ALFA survey; extragalactic HI radio data.
-  * `SHA <http://astroquery.readthedocs.io/en/latest/sha/sha.html>`_:                 Spitzer Heritage Archive; infrared data products from the Spitzer Space Telescope
-  * `Lamda <http://astroquery.readthedocs.io/en/latest/lamda/lamda.html>`_:             Leiden Atomic and Molecular Database; energy levels, radiative transitions, and collisional rates for astrophysically relevant atoms and molecules.
-  * `Ogle <http://astroquery.readthedocs.io/en/latest/ogle/ogle.html>`_:               Optical Gravitational Lensing Experiment III; information on interstellar extinction towards the Galactic bulge.
-  * `Splatalogue <http://astroquery.readthedocs.io/en/latest/splatalogue/splatalogue.html>`_: National Radio Astronomy Observatory (NRAO)-maintained (mostly) molecular radio and millimeter line list service.
-  * `CosmoSim <http://astroquery.readthedocs.io/en/latest/cosmosim/cosmosim.html>`_: The CosmoSim database provides results from cosmological simulations performed within different projects: the MultiDark project, the BolshoiP project, and the CLUES project.
-  * `ESO Archive <http://astroquery.readthedocs.io/en/latest/eso/eso.html>`_
+The following modules have been completed using a common API:
+
   * `ALMA Archive <http://astroquery.readthedocs.io/en/latest/alma/alma.html>`_
-  * `GAMA database <http://astroquery.readthedocs.io/en/latest/gama/gama.html>`_
-  * `NVAS archive <http://astroquery.readthedocs.io/en/latest/nvas/nvas.html>`_
-  * `Open Expolanet Catalog (OEC) <http://astroquery.readthedocs.io/en/latest/open_exoplanet_catalogue/open_exoplanet_catalogue.html>`_
-  * `JPL Horizons <http://astroquery.readthedocs.io/en/latest/jplhorizons/jplhorizons.html>`_: JPL Solar System Dynamics Horizons Service
-  * `OAC API <http://astroquery.readthedocs.io/en/latest/oac/oac.html>`_: Open Astronomy Catalog REST API Service
-  * `Gaia <http://astroquery.readthedocs.io/en/latest/gaia/gaia.html>`_: European Space Agency Gaia Archive
-  * `Vamdc <http://astroquery.readthedocs.io/en/latest/vamdc/vamdc.html>`_: VAMDC molecular line database.
-  * `Minor Planet Center <http://astroquery.readthedocs.io/en/latest/mpc/mpc.html>`_:
-  * `xMatch <http://astroquery.readthedocs.io/en/latest/xmatch/xmatch.html>`_:  Cross-identify sources between very large data sets or between a user-uploaded list and a large catalogue.
   * `Atomic Line List <http://astroquery.readthedocs.io/en/latest/atomic/atomic.html>`_: A collection of more than 900,000 atomic transitions.
-  * `Skyview <http://astroquery.readthedocs.io/en/latest/skyview/skyview.html>`_: NASA SkyView service for imaging surveys.
-  * `NASA ADS <http://astroquery.readthedocs.io/en/latest/nasa_ads/nasa_ads.html>`_: SAO/NASA Astrophysics Data System.
+  * `Besancon <http://astroquery.readthedocs.io/en/latest/besancon/besancon.html>`_: Model of stellar population synthesis in the Galaxy.
+  * `ESASky <http://astroquery.readthedocs.io/en/latest/esasky/esasky.html>`_: ESASky is a science driven discovery portal providing easy visualizations and full access to the entire sky as observed with ESA Space astronomy missions.
+  * `ESO Archive <http://astroquery.readthedocs.io/en/latest/eso/eso.html>`_
+  * `Gaia <http://astroquery.readthedocs.io/en/latest/gaia/gaia.html>`_: European Space Agency Gaia Archive.
+  * `GAMA database <http://astroquery.readthedocs.io/en/latest/gama/gama.html>`_
   * `HEASARC <http://astroquery.readthedocs.io/en/latest/heasarc/heasarc.html>`_: NASA's High Energy Astrophysics Science Archive Research Center.
-  * `VO Simple Cone Search <http://astroquery.readthedocs.io/en/latest/vo_conesearch/vo_conesearch.html>`_:
+  * `IBE <http://astroquery.readthedocs.io/en/latest/ibe/ibe.html>`_: IRSA Image Server program interface (IBE) Query Tool provides access to the 2MASS, WISE, and PTF image archives.
+  * `IRSA <http://astroquery.readthedocs.io/en/latest/irsa/irsa.html>`_: NASA/IPAC Infrared Science Archive. Science products for all of NASA's infrared and sub-mm missions.
+  * `IRSA dust <http://astroquery.readthedocs.io/en/latest/irsa/irsa_dust.html>`_: Galactic dust reddening and extinction maps from IRAS 100 um data.
+  * `MAGPIS <http://astroquery.readthedocs.io/en/latest/magpis/magpis.html>`_: Multi-Array Galactic Plane Imaging Survey. 6 and 20-cm radio images of the Galactic plane from the VLA.
   * `MAST <http://astroquery.readthedocs.io/en/latest/mast/mast.html>`_: Barbara A. Mikulski Archive for Space Telescopes.
+  * `Minor Planet Center <http://astroquery.readthedocs.io/en/latest/mpc/mpc.html>`_
+  * `NASA ADS <http://astroquery.readthedocs.io/en/latest/nasa_ads/nasa_ads.html>`_: SAO/NASA Astrophysics Data System.
+  * `NED <http://astroquery.readthedocs.io/en/latest/ned/ned.html>`_: NASA/IPAC Extragalactic Database. Multiwavelength data from both surveys and publications.
+  * `NIST <http://astroquery.readthedocs.io/en/latest/nist/nist.html>`_: National Institute of Standards and Technology (NIST) atomic lines database.
+  * `NRAO <http://astroquery.readthedocs.io/en/latest/nrao/nrao.html>`_: Science data archive of the National Radio Astronomy Observatory. VLA, JVLA, VLBA and GBT data products.
+  * `NVAS archive <http://astroquery.readthedocs.io/en/latest/nvas/nvas.html>`_
+  * `Simbad <http://astroquery.readthedocs.io/en/latest/simbad/simbad.html>`_: Basic data, cross-identifications, bibliography and measurements for astronomical objects outside the solar system.
+  * `Skyview <http://astroquery.readthedocs.io/en/latest/skyview/skyview.html>`_: NASA SkyView service for imaging surveys.
+  * `Splatalogue <http://astroquery.readthedocs.io/en/latest/splatalogue/splatalogue.html>`_: National Radio Astronomy Observatory (NRAO)-maintained (mostly) molecular radio and millimeter line list service.
+  * `UKIDSS <http://astroquery.readthedocs.io/en/latest/ukidss/ukidss.html>`_: UKIRT Infrared Deep Sky Survey. JHK images of 7500 sq deg. in the northern sky.
+  * `Vamdc <http://astroquery.readthedocs.io/en/latest/vamdc/vamdc.html>`_: VAMDC molecular line database.
+  * `Vizier <http://astroquery.readthedocs.io/en/latest/vizier/vizier.html>`_: Set of 11,000+ published, multiwavelength catalogues hosted by the CDS.
+  * `VO Simple Cone Search <http://astroquery.readthedocs.io/en/latest/vo_conesearch/vo_conesearch.html>`_
+  * `xMatch <http://astroquery.readthedocs.io/en/latest/xmatch/xmatch.html>`_:  Cross-identify sources between very large data sets or between a user-uploaded list and a large catalogue.
+
+These others are functional, but do not follow a common or consistent API:
+
+  * `Alfalfa <http://astroquery.readthedocs.io/en/latest/alfalfa/alfalfa.html>`_: Arecibo Legacy Fast ALFA survey; extragalactic HI radio data.
+  * `CosmoSim <http://astroquery.readthedocs.io/en/latest/cosmosim/cosmosim.html>`_: The CosmoSim database provides results from cosmological simulations performed within different projects: the MultiDark project, the BolshoiP project, and the CLUES project.
+  * `Exoplanet Orbit Database  <http://astroquery.readthedocs.io/en/latest/exoplanet_orbit_database/exoplanet_orbit_database.html>`_
+  * `Fermi <http://astroquery.readthedocs.io/en/latest/fermi/fermi.html>`_: Fermi gamma-ray telescope archive.
   * `HITRAN <http://astroquery.readthedocs.io/en/latest/hitran/hitran.html>`_: Access to the high-resolution transmission molecular absorption database.
-  * `NASA Exoplanet Archive  <http://astroquery.readthedocs.io/en/latest/nasa_exoplanet_archive/nasa_exoplanet_archive.html>`_:
-  * `Exoplanet Orbit Database  <http://astroquery.readthedocs.io/en/latest/exoplanet_orbit_database/exoplanet_orbit_database.html>`_:
+  * `JPL Horizons <http://astroquery.readthedocs.io/en/latest/jplhorizons/jplhorizons.html>`_: JPL Solar System Dynamics Horizons Service.
+  * `Lamda <http://astroquery.readthedocs.io/en/latest/lamda/lamda.html>`_: Leiden Atomic and Molecular Database; energy levels, radiative transitions, and collisional rates for astrophysically relevant atoms and molecules.
+  * `NASA Exoplanet Archive  <http://astroquery.readthedocs.io/en/latest/nasa_exoplanet_archive/nasa_exoplanet_archive.html>`_
+  * `OAC API <http://astroquery.readthedocs.io/en/latest/oac/oac.html>`_: Open Astronomy Catalog REST API Service.
+  * `Ogle <http://astroquery.readthedocs.io/en/latest/ogle/ogle.html>`_: Optical Gravitational Lensing Experiment III; information on interstellar extinction towards the Galactic bulge.
+  * `Open Expolanet Catalog (OEC) <http://astroquery.readthedocs.io/en/latest/open_exoplanet_catalogue/open_exoplanet_catalogue.html>`_
+  * `SDSS <http://astroquery.readthedocs.io/en/latest/sdss/sdss.html>`_: Sloan Digital Sky Survey data, including optical images, spectra, and spectral templates.
+  * `SHA <http://astroquery.readthedocs.io/en/latest/sha/sha.html>`_: Spitzer Heritage Archive; infrared data products from the Spitzer Space Telescope.
 
 Additional Links
 ----------------

--- a/README.rst
+++ b/README.rst
@@ -110,6 +110,18 @@ List of Modules
   * `JPL Horizons <http://astroquery.readthedocs.io/en/latest/jplhorizons/jplhorizons.html>`_: JPL Solar System Dynamics Horizons Service
   * `OAC API <http://astroquery.readthedocs.io/en/latest/oac/oac.html>`_: Open Astronomy Catalog REST API Service
   * `Gaia <http://astroquery.readthedocs.io/en/latest/gaia/gaia.html>`_: European Space Agency Gaia Archive
+  * `Vamdc <http://astroquery.readthedocs.io/en/latest/vamdc/vamdc.html>`_: VAMDC molecular line database.
+  * `Minor Planet Center <http://astroquery.readthedocs.io/en/latest/mpc/mpc.html>`_:
+  * `xMatch <http://astroquery.readthedocs.io/en/latest/xmatch/xmatch.html>`_:  Cross-identify sources between very large data sets or between a user-uploaded list and a large catalogue.
+  * `Atomic Line List <http://astroquery.readthedocs.io/en/latest/atomic/atomic.html>`_: A collection of more than 900,000 atomic transitions.
+  * `Skyview <http://astroquery.readthedocs.io/en/latest/skyview/skyview.html>`_: NASA SkyView service for imaging surveys.
+  * `NASA ADS <http://astroquery.readthedocs.io/en/latest/nasa_ads/nasa_ads.html>`_: SAO/NASA Astrophysics Data System.
+  * `HEASARC <http://astroquery.readthedocs.io/en/latest/heasarc/heasarc.html>`_: NASA's High Energy Astrophysics Science Archive Research Center.
+  * `VO Simple Cone Search <http://astroquery.readthedocs.io/en/latest/vo_conesearch/vo_conesearch.html>`_:
+  * `MAST <http://astroquery.readthedocs.io/en/latest/mast/mast.html>`_: Barbara A. Mikulski Archive for Space Telescopes.
+  * `HITRAN <http://astroquery.readthedocs.io/en/latest/hitran/hitran.html>`_: Access to the high-resolution transmission molecular absorption database.
+  * `NASA Exoplanet Archive  <http://astroquery.readthedocs.io/en/latest/nasa_exoplanet_archive/nasa_exoplanet_archive.html>`_:
+  * `Exoplanet Orbit Database  <http://astroquery.readthedocs.io/en/latest/exoplanet_orbit_database/exoplanet_orbit_database.html>`_:
 
 Additional Links
 ----------------

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -220,6 +220,7 @@ These others are functional, but do not follow a common & consistent API:
   nasa_exoplanet_archive/nasa_exoplanet_archive.rst
   exoplanet_orbit_database/exoplanet_orbit_database.rst
   oac/oac.rst
+  jplhorizons/jplhorizons.rst
 
 Catalog, Archive, and Other
 ===========================

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -175,52 +175,52 @@ The following modules have been completed using a common API:
 .. toctree::
   :maxdepth: 1
 
-  simbad/simbad.rst
-  vizier/vizier.rst
+  alma/alma.rst
+  atomic/atomic.rst
+  besancon/besancon.rst
   esasky/esasky.rst
-  irsa/irsa_dust.rst
-  ned/ned.rst
-  splatalogue/splatalogue.rst
-  vamdc/vamdc.rst
+  eso/eso.rst
+  gaia/gaia.rst
+  gama/gama.rst
+  heasarc/heasarc.rst
   ibe/ibe.rst
   irsa/irsa.rst
-  ukidss/ukidss.rst
+  irsa/irsa_dust.rst
   magpis/magpis.rst
-  mpc/mpc.rst
-  nrao/nrao.rst
-  besancon/besancon.rst
-  nist/nist.rst
-  nvas/nvas.rst
-  gama/gama.rst
-  eso/eso.rst
-  xmatch/xmatch.rst
-  atomic/atomic.rst
-  alma/alma.rst
-  skyview/skyview.rst
-  nasa_ads/nasa_ads.rst
-  heasarc/heasarc.rst
-  gaia/gaia.rst
-  vo_conesearch/vo_conesearch.rst
   mast/mast.rst
+  mpc/mpc.rst
+  nasa_ads/nasa_ads.rst
+  ned/ned.rst
+  nist/nist.rst
+  nrao/nrao.rst
+  nvas/nvas.rst
+  simbad/simbad.rst
+  skyview/skyview.rst
+  splatalogue/splatalogue.rst
+  ukidss/ukidss.rst
+  vamdc/vamdc.rst
+  vizier/vizier.rst
+  vo_conesearch/vo_conesearch.rst
+  xmatch/xmatch.rst
 
 These others are functional, but do not follow a common & consistent API:
 
 .. toctree::
   :maxdepth: 1
 
-  fermi/fermi.rst
-  sdss/sdss.rst
   alfalfa/alfalfa.rst
-  sha/sha.rst
+  cosmosim/cosmosim.rst
+  exoplanet_orbit_database/exoplanet_orbit_database.rst
+  fermi/fermi.rst
+  hitran/hitran.rst
+  jplhorizons/jplhorizons.rst
   lamda/lamda.rst
+  nasa_exoplanet_archive/nasa_exoplanet_archive.rst
+  oac/oac.rst
   ogle/ogle.rst
   open_exoplanet_catalogue/open_exoplanet_catalogue.rst
-  cosmosim/cosmosim.rst
-  hitran/hitran.rst
-  nasa_exoplanet_archive/nasa_exoplanet_archive.rst
-  exoplanet_orbit_database/exoplanet_orbit_database.rst
-  oac/oac.rst
-  jplhorizons/jplhorizons.rst
+  sdss/sdss.rst
+  sha/sha.rst
 
 Catalog, Archive, and Other
 ===========================


### PR DESCRIPTION
This PR adds missing modules to and from module lists in the documentation landing page and in the README file. And alphabetically reorders both lists. After the PR info is the same in both places.