### PR TITLE
Limit keyring version for legacy Python

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -72,7 +72,7 @@ matrix:
         - os: linux
           stage: Tests with other Python/Numpy versions, remote data
           env: EVENT_TYPE='push cron' PYTHON_VERSION=2.7
-               SETUP_CMD='test --remote-data -V' CONDA_DEPENDENCIES=$CONDA_DEPENDENCIES_REMOTE
+               SETUP_CMD='test --remote-data -V' CONDA_DEPENDENCIES=$CONDA_DEPENDENCIES_REMOTE KEYRING_VERSION='<12.0'
 
         # No need to run it from cron
         # Try MacOS X
@@ -96,7 +96,7 @@ matrix:
         # time. We don't expect any of these to fail in master for cron jobs.
         - os: linux
           stage: Tests with other Python/Numpy versions, remote data
-          env: PYTHON_VERSION=2.7 NUMPY_VERSION=1.9
+          env: PYTHON_VERSION=2.7 NUMPY_VERSION=1.9  KEYRING_VERSION='<12.0'
         - os: linux
           stage: Tests with other Python/Numpy versions, remote data
           env: PYTHON_VERSION=3.4 NUMPY_VERSION=1.10
@@ -129,7 +129,7 @@ matrix:
         # Try with optional dependencies disabled
         - os: linux
           stage: Test docs, astropy dev, and without optional dependencies
-          env: PYTHON_VERSION=2.7
+          env: PYTHON_VERSION=2.7  KEYRING_VERSION='<12.0'
                CONDA_DEPENDENCIES='requests beautifulsoup4 html5lib keyring'
         - os: linux
           stage: Test docs, astropy dev, and without optional dependencies

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -12,7 +12,7 @@ environment:
                         # to the matrix section.
       CONDA_DEPENDENCIES: "requests beautifulsoup4 matplotlib html5lib keyring aplpy"
       PIP_DEPENDENCIES: "pyregion"
-      CONDA_CHANNELS: "astropy conda-forge"
+      CONDA_CHANNELS: "astropy"
       ASTROPY_USE_SYSTEM_PYTEST: 1
 
   matrix:


### PR DESCRIPTION
This should fix the travis issues we see. I didn't have the time to look into more details why the more recent version stopped working on Python 2, it may be a keyring issue or a conda issue, but almost certainly not an issue in astroquery so I suggest we live with the workaround for now (and if users run into the same thing with 2.7, we advise them to use an <12.0 version).

This should close #1097 