### PR TITLE
Temporarily imit keyring version for all <3.6 python versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -48,6 +48,7 @@ env:
         - EVENT_TYPE='pull_request push'
         - ASTROPY_USE_SYSTEM_PYTEST=1
         - SPHINX_VERSION='>=1.6'
+        - DEBUG=true
 
     matrix:
         - PYTHON_VERSION=2.7 SETUP_CMD='egg_info'
@@ -102,7 +103,8 @@ matrix:
           env: PYTHON_VERSION=3.4 NUMPY_VERSION=1.10
         - os: linux
           stage: Tests with other Python/Numpy versions, remote data
-          env: PYTHON_VERSION=3.5 NUMPY_VERSION=1.11
+          env: PYTHON_VERSION=3.5 NUMPY_VERSION=1.11 KEYRING_VERSION='<12.0'
+
         - os: linux
           stage: Tests with other Python/Numpy versions, remote data
           env: NUMPY_VERSION=1.12 ASTROPY_VERSION=1.3 PYTEST_VERSION='<3.2'

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -19,6 +19,7 @@ environment:
       - PYTHON_VERSION: "2.7"
         ASTROPY_VERSION: "LTS"
         NUMPY_VERSION: "1.13"
+        KEYRING_VERSION: "<12"
 
       - PYTHON_VERSION: "3.6"
         ASTROPY_VERSION: "stable"


### PR DESCRIPTION
Well, apparently it was the same issue as the ones in #1103 

The limits btw may be removed soon as the fix is already been merged, see #1122 