### PR TITLE
STScI DSI-68: Expose direct HST S3 urls

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,7 +1,7 @@
 0.3.9 (unreleased)
 ------------------
 
-- none yet
+- MAST: Enable converting list of products into S3 uris [#1126]
 
 0.3.8 (2018-04-27)
 ------------------

--- a/astroquery/mast/core.py
+++ b/astroquery/mast/core.py
@@ -824,6 +824,7 @@ class ObservationsClass(MastClass):
 
         self._boto3 = None
         self._botocore = None
+        self._hst_bucket = "stpubdata"
 
     def list_missions(self):
         """
@@ -1322,15 +1323,19 @@ class ObservationsClass(MastClass):
         self._boto3 = None
         self._botocore = None
 
-    def _download_from_s3(self, dataProduct, localPath, cache=True):
-        # The following is a mishmash of BaseQuery._download_file and s3 access through boto
+    def get_hst_s3_uris(self, dataProducts, includeBucket=True):
+        """ Takes an `astropy.table.Table` of data products and turns them into s3 uris. """
 
-        bkt_name = 'stpubdata'
+        return [self.get_hst_s3_uri(dataProduct, includeBucket) for dataProduct in dataProducts]
+
+    def get_hst_s3_uri(self, dataProduct, includeBucket=True):
+        """ Turns a dataProduct into a S3 URI """
+
+        if self._boto3 is None:
+            raise Exception("Must enable s3 hst dataset before attempting to query the s3 information")
 
         # This is a cheap operation and does not perform any actual work yet
-        s3 = self._boto3.resource('s3')
         s3_client = self._boto3.client('s3')
-        bkt = s3.Bucket(bkt_name)
 
         dataUri = dataProduct['dataURI']
         filename = dataUri.split("/")[-1]
@@ -1354,33 +1359,43 @@ class ObservationsClass(MastClass):
         # So in conclusion we can't trust the last char obs_id from the file or from the database
         # So with that in mind, hold your nose when reading the following:
 
-        info_lookup = None
+        paths = []
+
         sane_path = os.path.join("hst", "public", obs_id[:4], obs_id, filename)
-        try:
-            info_lookup = s3_client.head_object(Bucket=bkt_name, Key=sane_path, RequestPayer='requester')
-            bucketPath = sane_path
-        except self._botocore.exceptions.ClientError as e:
-            if e.response['Error']['Code'] != "404":
-                raise
+        paths += [sane_path]
 
-        if info_lookup is None:
-            # Unfortunately our file placement logic is anything but sane
-            # We put files in folders that don't make sense
-            for ch in (string.digits + string.ascii_lowercase):
-                # The last char of the obs_folder (observation id) can be any lowercase or numeric char
-                insane_obs = obs_id[:-1] + ch
-                insane_path = os.path.join("hst", "public", insane_obs[:4], insane_obs, filename)
+        # Unfortunately our file placement logic is anything but sane
+        # We put files in folders that don't make sense
+        for ch in (string.digits + string.ascii_lowercase):
+            # The last char of the obs_folder (observation id) can be any lowercase or numeric char
+            insane_obs = obs_id[:-1] + ch
+            insane_path = os.path.join("hst", "public", insane_obs[:4], insane_obs, filename)
+            paths += [insane_path]
 
-                try:
-                    info_lookup = s3_client.head_object(Bucket=bkt_name, Key=insane_path, RequestPayer='requester')
-                    bucketPath = insane_path
-                    break
-                except self._botocore.exceptions.ClientError as e:
-                    if e.response['Error']['Code'] != "404":
-                        raise
+        for path in paths:
+            try:
+                s3_client.head_object(Bucket=self._hst_bucket, Key=path, RequestPayer='requester')
+                if includeBucket:
+                    path = "s3://%s/%s" % (self._hst_bucket, path)
+                return path
+            except self._botocore.exceptions.ClientError as e:
+                if e.response['Error']['Code'] != "404":
+                    raise
 
-        if info_lookup is None:
-            raise Exception("Unable to locate file!")
+        raise Exception("Unable to locate file!")
+
+    def _download_from_s3(self, dataProduct, localPath, cache=True):
+        # The following is a mishmash of BaseQuery._download_file and s3 access through boto
+
+        self._hst_bucket = 'stpubdata'
+
+        # This is a cheap operation and does not perform any actual work yet
+        s3 = self._boto3.resource('s3')
+        s3_client = self._boto3.client('s3')
+        bkt = s3.Bucket(self._hst_bucket)
+
+        bucketPath = self.get_hst_s3_uri(dataProduct, False)
+        info_lookup = s3_client.head_object(Bucket=self._hst_bucket, Key=bucketPath, RequestPayer='requester')
 
         # Unfortunately, we can't use the reported file size in the reported product.  STScI's backing
         # archive database (CAOM) is frequently out of date and in many cases omits the required information.
@@ -1403,7 +1418,7 @@ class ObservationsClass(MastClass):
                     return
 
         with ProgressBarOrSpinner(length, ('Downloading URL s3://{0}/{1} to {2} ...'.format(
-                bkt_name, bucketPath, localPath))) as pb:
+                self._hst_bucket, bucketPath, localPath))) as pb:
 
             # Bytes read tracks how much data has been received so far
             # This variable will be updated in multiple threads below

--- a/astroquery/mast/core.py
+++ b/astroquery/mast/core.py
@@ -1323,12 +1323,12 @@ class ObservationsClass(MastClass):
         self._boto3 = None
         self._botocore = None
 
-    def get_hst_s3_uris(self, dataProducts, includeBucket=True):
+    def get_hst_s3_uris(self, dataProducts, includeBucket=True, fullUrl=False):
         """ Takes an `astropy.table.Table` of data products and turns them into s3 uris. """
 
-        return [self.get_hst_s3_uri(dataProduct, includeBucket) for dataProduct in dataProducts]
+        return [self.get_hst_s3_uri(dataProduct, includeBucket, fullUrl) for dataProduct in dataProducts]
 
-    def get_hst_s3_uri(self, dataProduct, includeBucket=True):
+    def get_hst_s3_uri(self, dataProduct, includeBucket=True, fullUrl=False):
         """ Turns a dataProduct into a S3 URI """
 
         if self._boto3 is None:
@@ -1377,6 +1377,8 @@ class ObservationsClass(MastClass):
                 s3_client.head_object(Bucket=self._hst_bucket, Key=path, RequestPayer='requester')
                 if includeBucket:
                     path = "s3://%s/%s" % (self._hst_bucket, path)
+                elif fullUrl:
+                    path = "http://s3.amazonaws.com/%s/%s" % (self._hst_bucket, path)
                 return path
             except self._botocore.exceptions.ClientError as e:
                 if e.response['Error']['Code'] != "404":

--- a/astroquery/mast/core.py
+++ b/astroquery/mast/core.py
@@ -1332,7 +1332,7 @@ class ObservationsClass(MastClass):
         """ Turns a dataProduct into a S3 URI """
 
         if self._boto3 is None:
-            raise Exception("Must enable s3 hst dataset before attempting to query the s3 information")
+            raise AtrributeError("Must enable s3 hst dataset before attempting to query the s3 information")
 
         # This is a cheap operation and does not perform any actual work yet
         s3_client = self._boto3.client('s3')


### PR DESCRIPTION
This will make integration with tools like Lambda simpler.

```
from astroquery.mast import Observations
obsTable = Observations.query_object("M101",radius=0.02)
hstObs = obsTable[obsTable["obs_collection"]=="HST"]
products = Observations.get_product_list(hstObs[:4])
Observations.enable_s3_hst_dataset()

Observations.get_hst_s3_uris(products)
['s3://stpubdata/hst/public/ib3p/ib3p11010/ib3p11010_asn.fits', 's3://stpubdata/hst/public/ib3p/ib3p11010/ib3p11010_drc.fits', 's3://stpubdata/hst/public/ib3p/ib3p11010/ib3p11010_drz.fits', 's3://stpubdata/hst/public/icae/icae03010/icae03010_asn.fits', 's3://stpubdata/hst/public/icae/icae03010/icae03010_drc.fits', 's3://stpubdata/hst/public/icae/icae03010/icae03010_drz.fits', 's3://stpubdata/hst/public/icae/icae03020/icae03020_asn.fits', 's3://stpubdata/hst/public/icae/icae03020/icae03020_drc.fits', 's3://stpubdata/hst/public/icae/icae03020/icae03020_drz.fits', 's3://stpubdata/hst/public/icae/icae03030/icae03030_asn.fits', 's3://stpubdata/hst/public/icae/icae03030/icae03030_drc.fits', 's3://stpubdata/hst/public/icae/icae03030/icae03030_drz.fits']

Observations.get_hst_s3_uri(products[0])
's3://stpubdata/hst/public/ib3p/ib3p11010/ib3p11010_asn.fits'

Observations.get_hst_s3_uri(products[0], includeBucket=False)
'hst/public/ib3p/ib3p11010/ib3p11010_asn.fits'
```

CC @arfon