### PR TITLE
More remote fixes: xfails, server status checks

### DIFF
--- a/astroquery/nrao/core.py
+++ b/astroquery/nrao/core.py
@@ -460,7 +460,7 @@ class NraoClass(QueryWithLogin):
                                   " and the error in self.table_parse_error.")
 
     def _parse_html_result(self, response, verbose=False):
-        # pares the HTML return...
+        # parse the HTML return...
         root = BeautifulSoup(response.content, 'html5lib')
 
         htmltable = root.findAll('table')
@@ -473,7 +473,7 @@ class NraoClass(QueryWithLogin):
         if six.PY2:
             from astropy.io.ascii import html
             from astropy.io.ascii.core import convert_numpy
-            htmlreader = html.HTML()
+            htmlreader = html.HTML({'parser':'html5lib'})
             htmlreader.outputter.default_converters.append(convert_numpy(np.unicode))
             table = htmlreader.read(string_to_parse)
         else:

--- a/astroquery/nrao/core.py
+++ b/astroquery/nrao/core.py
@@ -235,8 +235,8 @@ class NraoClass(QueryWithLogin):
             PASSWD="",  # TODO: implement login...
             SUBMIT="Submit Query")
 
-        if (request_payload['QUERYTYPE'] == "ARCHIVE" and
-            request_payload['PROTOCOL'] != 'HTML'):
+        if ((request_payload['QUERYTYPE'] == "ARCHIVE" and
+             request_payload['PROTOCOL'] != 'HTML')):
             warnings.warn("Changing protocol to HTML: ARCHIVE queries do not"
                           " support votable returns")
             request_payload['PROTOCOL'] = 'HTML'
@@ -277,7 +277,8 @@ class NraoClass(QueryWithLogin):
 
         # Developer notes:
         # Login via https://my.nrao.edu/cas/login
-        # # this can be added to auto-redirect back to the query tool: ?service=https://archive.nrao.edu/archive/advquery.jsp
+        # # this can be added to auto-redirect back to the query tool:
+        # ?service=https://archive.nrao.edu/archive/advquery.jsp
 
         if username is None:
             if not self.USERNAME:
@@ -473,7 +474,7 @@ class NraoClass(QueryWithLogin):
         if six.PY2:
             from astropy.io.ascii import html
             from astropy.io.ascii.core import convert_numpy
-            htmlreader = html.HTML({'parser':'html5lib'})
+            htmlreader = html.HTML({'parser': 'html5lib'})
             htmlreader.outputter.default_converters.append(convert_numpy(np.unicode))
             table = htmlreader.read(string_to_parse)
         else:

--- a/astroquery/xmatch/tests/test_xmatch_remote.py
+++ b/astroquery/xmatch/tests/test_xmatch_remote.py
@@ -15,6 +15,7 @@ from ...xmatch import XMatch
 
 DATA_DIR = os.path.join(os.path.dirname(__file__), 'data')
 
+
 @remote_data
 @pytest.mark.dependency(name='xmatch_up')
 def test_is_vsa_up():
@@ -41,13 +42,11 @@ class TestXMatch:
         assert 'II/311/wise' in tables
         assert 'II/246/out' in tables
 
-
     def test_xmatch_is_avail_table(self, xmatch):
         assert xmatch.is_table_available('II/311/wise')
         assert xmatch.is_table_available('II/246/out')
         assert xmatch.is_table_available('vizier:II/311/wise')
         assert not xmatch.is_table_available('blablabla')
-
 
     def test_xmatch_query(self, xmatch):
         with open(os.path.join(DATA_DIR, 'posList.csv'), 'r') as pos_list:
@@ -67,7 +66,6 @@ class TestXMatch:
         http_test_table = self.http_test()
         assert all(table == http_test_table)
 
-
     def test_xmatch_query_astropy_table(self, xmatch):
         datapath = os.path.join(DATA_DIR, 'posList.csv')
         input_table = Table.read(datapath, format='ascii.csv')
@@ -86,7 +84,6 @@ class TestXMatch:
 
         http_test_table = self.http_test()
         assert all(table == http_test_table)
-
 
     def http_test(self):
         # this can be used to check that the API is still functional & doing as expected

--- a/astroquery/xmatch/tests/test_xmatch_remote.py
+++ b/astroquery/xmatch/tests/test_xmatch_remote.py
@@ -2,6 +2,8 @@
 import os.path
 import os
 import pytest
+import requests
+from requests import ReadTimeout
 
 from astropy.tests.helper import remote_data
 from astropy.table import Table
@@ -13,75 +15,86 @@ from ...xmatch import XMatch
 
 DATA_DIR = os.path.join(os.path.dirname(__file__), 'data')
 
-
-# fixture only used here to save creating XMatch instances in each
-# of the following test functions
-@pytest.fixture
-def xmatch():
-    return XMatch()
+@remote_data
+@pytest.mark.dependency(name='xmatch_up')
+def test_is_vsa_up():
+    try:
+        requests.get("http://cdsxmatch.u-strasbg.fr/xmatch/api/v1/sync")
+    except Exception as ex:
+        pytest.xfail("XMATCH appears to be down.  Exception was: {0}".format(ex))
 
 
 @remote_data
-def test_xmatch_avail_tables(xmatch):
-    tables = xmatch.get_available_tables()
-    assert tables
-    # those example tables are from
-    # http://cdsxmatch.u-strasbg.fr/xmatch/doc/API-calls.html
-    assert 'II/311/wise' in tables
-    assert 'II/246/out' in tables
+@pytest.mark.dependency(depends=["xmatch_up"])
+class TestXMatch:
+    # fixture only used here to save creating XMatch instances in each
+    # of the following test functions
+    @pytest.fixture
+    def xmatch(self):
+        return XMatch()
+
+    def test_xmatch_avail_tables(self, xmatch):
+        tables = xmatch.get_available_tables()
+        assert tables
+        # those example tables are from
+        # http://cdsxmatch.u-strasbg.fr/xmatch/doc/API-calls.html
+        assert 'II/311/wise' in tables
+        assert 'II/246/out' in tables
 
 
-@remote_data
-def test_xmatch_is_avail_table(xmatch):
-    assert xmatch.is_table_available('II/311/wise')
-    assert xmatch.is_table_available('II/246/out')
-    assert xmatch.is_table_available('vizier:II/311/wise')
-    assert not xmatch.is_table_available('blablabla')
+    def test_xmatch_is_avail_table(self, xmatch):
+        assert xmatch.is_table_available('II/311/wise')
+        assert xmatch.is_table_available('II/246/out')
+        assert xmatch.is_table_available('vizier:II/311/wise')
+        assert not xmatch.is_table_available('blablabla')
 
 
-@remote_data
-def test_xmatch_query(xmatch):
-    with open(os.path.join(DATA_DIR, 'posList.csv'), 'r') as pos_list:
-        table = xmatch.query(
-            cat1=pos_list, cat2='vizier:II/246/out', max_distance=5 * arcsec,
-            colRA1='ra', colDec1='dec')
-    assert isinstance(table, Table)
-    assert table.colnames == [
-        'angDist', 'ra', 'dec', 'my_id', '2MASS', 'RAJ2000', 'DEJ2000',
-        'errHalfMaj', 'errHalfMin', 'errPosAng', 'Jmag', 'Hmag', 'Kmag',
-        'e_Jmag', 'e_Hmag', 'e_Kmag', 'Qfl', 'Rfl', 'X', 'MeasureJD']
-    assert len(table) == 11
+    def test_xmatch_query(self, xmatch):
+        with open(os.path.join(DATA_DIR, 'posList.csv'), 'r') as pos_list:
+            try:
+                table = xmatch.query(
+                    cat1=pos_list, cat2='vizier:II/246/out', max_distance=5 * arcsec,
+                    colRA1='ra', colDec1='dec')
+            except ReadTimeout:
+                pytest.xfail("xmatch query timed out.")
+        assert isinstance(table, Table)
+        assert table.colnames == [
+            'angDist', 'ra', 'dec', 'my_id', '2MASS', 'RAJ2000', 'DEJ2000',
+            'errHalfMaj', 'errHalfMin', 'errPosAng', 'Jmag', 'Hmag', 'Kmag',
+            'e_Jmag', 'e_Hmag', 'e_Kmag', 'Qfl', 'Rfl', 'X', 'MeasureJD']
+        assert len(table) == 11
 
-    http_test_table = http_test()
-    assert all(table == http_test_table)
-
-
-@remote_data
-def test_xmatch_query_astropy_table(xmatch):
-    datapath = os.path.join(DATA_DIR, 'posList.csv')
-    input_table = Table.read(datapath, format='ascii.csv')
-    table = xmatch.query(
-        cat1=input_table, cat2='vizier:II/246/out', max_distance=5 * arcsec,
-        colRA1='ra', colDec1='dec')
-    assert isinstance(table, Table)
-    assert table.colnames == [
-        'angDist', 'ra', 'dec', 'my_id', '2MASS', 'RAJ2000', 'DEJ2000',
-        'errHalfMaj', 'errHalfMin', 'errPosAng', 'Jmag', 'Hmag', 'Kmag',
-        'e_Jmag', 'e_Hmag', 'e_Kmag', 'Qfl', 'Rfl', 'X', 'MeasureJD']
-    assert len(table) == 11
-
-    http_test_table = http_test()
-    assert all(table == http_test_table)
+        http_test_table = self.http_test()
+        assert all(table == http_test_table)
 
 
-@remote_data
-def http_test():
-    # this can be used to check that the API is still functional & doing as expected
-    infile = os.path.join(DATA_DIR, 'posList.csv')
-    outfile = os.path.join(DATA_DIR, 'http_result.csv')
-    os.system('curl -X POST -F request=xmatch -F distMaxArcsec=5 -F RESPONSEFORMAT=csv '
-              '-F cat1=@{1} -F colRA1=ra -F colDec1=dec -F cat2=vizier:II/246/out  '
-              'http://cdsxmatch.u-strasbg.fr/xmatch/api/v1/sync > {0}'.
-              format(outfile, infile))
-    table = ascii.read(outfile, format='csv')
-    return table
+    def test_xmatch_query_astropy_table(self, xmatch):
+        datapath = os.path.join(DATA_DIR, 'posList.csv')
+        input_table = Table.read(datapath, format='ascii.csv')
+        try:
+            table = xmatch.query(
+                cat1=input_table, cat2='vizier:II/246/out', max_distance=5 * arcsec,
+                colRA1='ra', colDec1='dec')
+        except ReadTimeout:
+            pytest.xfail("xmatch query timed out.")
+        assert isinstance(table, Table)
+        assert table.colnames == [
+            'angDist', 'ra', 'dec', 'my_id', '2MASS', 'RAJ2000', 'DEJ2000',
+            'errHalfMaj', 'errHalfMin', 'errPosAng', 'Jmag', 'Hmag', 'Kmag',
+            'e_Jmag', 'e_Hmag', 'e_Kmag', 'Qfl', 'Rfl', 'X', 'MeasureJD']
+        assert len(table) == 11
+
+        http_test_table = self.http_test()
+        assert all(table == http_test_table)
+
+
+    def http_test(self):
+        # this can be used to check that the API is still functional & doing as expected
+        infile = os.path.join(DATA_DIR, 'posList.csv')
+        outfile = os.path.join(DATA_DIR, 'http_result.csv')
+        os.system('curl -X POST -F request=xmatch -F distMaxArcsec=5 -F RESPONSEFORMAT=csv '
+                  '-F cat1=@{1} -F colRA1=ra -F colDec1=dec -F cat2=vizier:II/246/out  '
+                  'http://cdsxmatch.u-strasbg.fr/xmatch/api/v1/sync > {0}'.
+                  format(outfile, infile))
+        table = ascii.read(outfile, format='csv')
+        return table


### PR DESCRIPTION
Added some more small fixes.  One is for a py2 non-remote failure for the NRAO
service.  The other is to handle xmatch, which times out every time I try it at
the moment.  Instead of failing, we're catching/xfailing on a timeout error,
since it doesn't indicate an error in the astroquery code.


There are more bugs that need to be caught. =(

@bsipocz - is there a way to trigger the cronjobs for PRs?