### PR TITLE
XMatch: need longer timeout

### DIFF
--- a/astroquery/xmatch/__init__.py
+++ b/astroquery/xmatch/__init__.py
@@ -11,7 +11,7 @@ class Conf(_config.ConfigNamespace):
         'xMatch URL')
 
     timeout = _config.ConfigItem(
-        60,
+        300,
         'time limit for connecting to xMatch server')
 
 


### PR DESCRIPTION
We have a report that astroquery is causing issues with the XMatch service because the timeout is too short.

Rejected jobs should return the following:
```
<INFO name="QUERY_STATUS" value="ERROR">
  Message: Too many jobs are being processed, try later!
</INFO>
```