### PR TITLE
Doc fix: PsAMV from Horizons is the negative velocity vector.

### DIFF
--- a/astroquery/jplhorizons/core.py
+++ b/astroquery/jplhorizons/core.py
@@ -218,7 +218,7 @@ class HorizonsClass(BaseQuery):
         +------------------+-----------------------------------------------+
         | sunTargetPA      | -Sun vector PA (float, deg, EoN, "PsAng")     |
         +------------------+-----------------------------------------------+
-        | velocityPA       | velocity vector PA (float, deg, EoN, "PsAMV") |
+        | velocityPA       | -velocity vector PA (float, deg, EoN, "PsAMV")|
         +------------------+-----------------------------------------------+
         | GlxLon           | galactic longitude (float, deg, "GlxLon")     |
         +------------------+-----------------------------------------------+


### PR DESCRIPTION
Hello,

According to JPL Horizons, PsAMV is the negative velocity vector.  This PR fixes the definition for velocityPA in `jplhorizons.HorizonsClass.ephemeris_async` to match the definition of PsAMV. 

From https://ssd.jpl.nasa.gov/?horizons_doc :  "The position angles of the extended Sun->target radius vector ("PsAng") and the negative of the target's heliocentric velocity vector ("PsAMV"), as seen in the plane-of-sky of the observer, measured CCW from reference frame North Celestial Pole. Small-bodies only."

Cheers,
Mike