### PR TITLE
GAIA: "Fix" units with .'s and quotes in them

### DIFF
--- a/astroquery/utils/tap/model/modelutils.py
+++ b/astroquery/utils/tap/model/modelutils.py
@@ -16,6 +16,7 @@ Created on 30 jun. 2016
 """
 import os
 from astropy.table import Table as APTable
+from astropy import units as u
 
 
 def check_file_exists(file_name):
@@ -26,8 +27,20 @@ def check_file_exists(file_name):
     return os.path.exists(file_name)
 
 
-def read_results_table_from_file(file_name, output_format):
+def read_results_table_from_file(file_name, output_format, correct_units=True):
     if check_file_exists(file_name):
-        return APTable.read(file_name, format=output_format)
+        result = APTable.read(file_name, format=output_format)
+        if correct_units:
+            for cn in result.colnames:
+                col = result[cn]
+                if isinstance(col.unit, u.UnrecognizedUnit):
+                    try:
+                        col.unit = u.Unit(col.unit.name.replace(".", " ").replace("'",""))
+                    except:
+                        pass
+                elif isinstance(col.unit, str):
+                    col.unit = col.unit.replace(".", " ").replace("'","")
+        
+        return result
     else:
         return None

--- a/astroquery/utils/tap/model/modelutils.py
+++ b/astroquery/utils/tap/model/modelutils.py
@@ -40,7 +40,7 @@ def read_results_table_from_file(file_name, output_format, correct_units=True):
                         pass
                 elif isinstance(col.unit, str):
                     col.unit = col.unit.replace(".", " ").replace("'", "")
-        
+
         return result
     else:
         return None

--- a/astroquery/utils/tap/model/modelutils.py
+++ b/astroquery/utils/tap/model/modelutils.py
@@ -35,11 +35,11 @@ def read_results_table_from_file(file_name, output_format, correct_units=True):
                 col = result[cn]
                 if isinstance(col.unit, u.UnrecognizedUnit):
                     try:
-                        col.unit = u.Unit(col.unit.name.replace(".", " ").replace("'",""))
-                    except:
+                        col.unit = u.Unit(col.unit.name.replace(".", " ").replace("'", ""))
+                    except Exception as ex:
                         pass
                 elif isinstance(col.unit, str):
-                    col.unit = col.unit.replace(".", " ").replace("'","")
+                    col.unit = col.unit.replace(".", " ").replace("'", "")
         
         return result
     else:

--- a/astroquery/utils/tap/xmlparser/utils.py
+++ b/astroquery/utils/tap/xmlparser/utils.py
@@ -46,11 +46,11 @@ def read_http_response(response, outputFormat, correct_units=True):
             col = result[cn]
             if isinstance(col.unit, u.UnrecognizedUnit):
                 try:
-                    col.unit = u.Unit(col.unit.name.replace(".", " ").replace("'",""))
-                except:
+                    col.unit = u.Unit(col.unit.name.replace(".", " ").replace("'", ""))
+                except Exception as ex:
                     pass
             elif isinstance(col.unit, str):
-                col.unit = col.unit.replace(".", " ").replace("'","")
+                col.unit = col.unit.replace(".", " ").replace("'", "")
 
     return result
         

--- a/astroquery/utils/tap/xmlparser/utils.py
+++ b/astroquery/utils/tap/xmlparser/utils.py
@@ -16,6 +16,7 @@ Created on 30 jun. 2016
 """
 
 import io
+from astropy import units as u
 from astropy.table import Table as APTable
 import six
 
@@ -29,16 +30,30 @@ def util_create_string_from_buffer(buffer):
         return ''.join(map(str, buffer))
 
 
-def read_http_response(response, outputFormat):
+def read_http_response(response, outputFormat, correct_units=True):
     astropyFormat = get_suitable_astropy_format(outputFormat)
     if six.PY2:
         # 2.7
-        return APTable.read(response, format=astropyFormat)
+        result = APTable.read(response, format=astropyFormat)
     else:
         # 3.0
         # If we want to use astropy.table, we have to read the data
         data = io.BytesIO(response.read())
-        return APTable.read(data, format=astropyFormat)
+        result = APTable.read(data, format=astropyFormat)
+
+    if correct_units:
+        for cn in result.colnames:
+            col = result[cn]
+            if isinstance(col.unit, u.UnrecognizedUnit):
+                try:
+                    col.unit = u.Unit(col.unit.name.replace(".", " ").replace("'",""))
+                except:
+                    pass
+            elif isinstance(col.unit, str):
+                col.unit = col.unit.replace(".", " ").replace("'","")
+
+    return result
+        
 
 
 def get_suitable_astropy_format(outputFormat):

--- a/astroquery/utils/tap/xmlparser/utils.py
+++ b/astroquery/utils/tap/xmlparser/utils.py
@@ -53,7 +53,6 @@ def read_http_response(response, outputFormat, correct_units=True):
                 col.unit = col.unit.replace(".", " ").replace("'", "")
 
     return result
-        
 
 
 def get_suitable_astropy_format(outputFormat):


### PR DESCRIPTION
This is a hack to fix some units, like `mas.yr**-1` and `'electron'.s**-1`.  It doesn't work for all the GAIA units, but it works for many.

cc @eteq, @tomdonaldson, @jcsegovia 