### PR TITLE
Skip deployment if [nodeploy] is in commit message.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -162,6 +162,7 @@ matrix:
               secure: DtqyQkllGcWuKOVMsu9RWRiobeL8bdpMxwdSYpob4Cqj0D2hLLx3w50qr0qpDCFzioB3rXnhbtPKEzHB+4fTFT/Rjito32fFPUtee2Rw4SCe4YIlS0ksPOTmxkeoh2TQLIYcNPPoI7UpUX6uC65nzgCUTmZVoiCweQE+i5GhEBI=
             on:
               branch: master
+          before_install: if [[ ! -z $(echo $TRAVIS_COMMIT_MESSAGE | grep -E "\[nodeploy\]") ]]; then echo "Skipping deployment as indicated by commit message"; travis_terminate 0; fi
 
 install:
     - git clone git://github.com/astropy/ci-helpers.git


### PR DESCRIPTION
In theory, the stage conditional should be able to deal with regular expressions (https://docs.travis-ci.com/user/conditional-builds-stages-jobs/#Conditional-Stages), but it seems to be broken as I could manage to get it properly parse the commit message there. 
So for now, we have to start up the job for all cases and process the commit message in the `before_install` section.

So, as a summary, use `[nodeploy]` in the commit message to avoid the commit to the master branch being deployed.