### PR TITLE
Fix several bugs in atomic

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,6 +1,7 @@
 0.3.9 (unreleased)
 ------------------
 
+- ATOMIC: fix several bugs for using Quantited for the range parameters. [#1187]
 - ESASKY: get_maps() accepts dict or list of (name, Table) pairs as input
   table list. [#1167]
 - HITRAN: use class-based API [#824]

--- a/astroquery/atomic/core.py
+++ b/astroquery/atomic/core.py
@@ -222,11 +222,11 @@ class AtomicLineListClass(BaseQuery):
         lower_level_erange = lower_level_energy_range
         if lower_level_erange is not None:
             lower_level_erange = lower_level_erange.to(
-                u.cm ** -1, equivalencies=u.spectral()).value()
+                u.cm ** -1, equivalencies=u.spectral()).value
         upper_level_erange = upper_level_energy_range
         if upper_level_erange is not None:
             upper_level_erange = upper_level_erange.to(
-                u.cm ** -1, equivalencies=u.spectral()).value()
+                u.cm ** -1, equivalencies=u.spectral()).value
         input = {
             'wavl': '-'.join(map(str, wlrange_in_angstroms)),
             'wave': 'Angstrom',

--- a/astroquery/atomic/core.py
+++ b/astroquery/atomic/core.py
@@ -196,7 +196,10 @@ class AtomicLineListClass(BaseQuery):
         else:
             raise ValueError('parameter wavelength_type must be either "air" '
                              'or "vacuum".')
-        wlrange = wavelength_range or []
+        if wavelength_range is not None:
+            wlrange = wavelength_range
+        else:
+            wlrange = []
         if len(wlrange) not in (0, 2):
             raise ValueError('Length of `wavelength_range` must be 2 or 0, '
                              'but is: {}'.format(len(wlrange)))

--- a/astroquery/atomic/tests/test_atomic_remote.py
+++ b/astroquery/atomic/tests/test_atomic_remote.py
@@ -71,3 +71,13 @@ def test_empty_result_set():
     assert isinstance(table, Table)
     assert not table
     assert len(table) == 0
+@remote_data
+def test_lower_upper_ranges():
+    result = AtomicLineList.query_object(
+        lower_level_energy_range=u.Quantity((600 * u.cm**(-1), 1000 * u.cm**(-1))),
+        upper_level_energy_range=u.Quantity((15000 * u.cm**(-1), 100000 * u.cm**(-1))),
+        element_spectrum='Ne III')
+    assert isinstance(result, Table)
+
+    assert np.all(result['LAMBDA VAC ANG'] ==
+                  np.array([1814.73, 3968.91, 4013.14]))

--- a/astroquery/atomic/tests/test_atomic_remote.py
+++ b/astroquery/atomic/tests/test_atomic_remote.py
@@ -44,33 +44,35 @@ LAMBDA VAC ANG SPECTRUM  TT CONFIGURATION TERM  J J    A_ki   LEVEL ENERGY  CM 1
 
 
 @remote_data
-def test_query_with_params():
-    table = AtomicLineList.query_object(
+def test_query_with_wavelength_params():
+    result = AtomicLineList.query_object(
         wavelength_range=(15 * u.nm, 200 * u.Angstrom),
         wavelength_type='Air',
         wavelength_accuracy=20,
         element_spectrum='C II-IV')
-    assert isinstance(table, Table)
-    assert table.colnames == ['LAMBDA VAC ANG', 'SPECTRUM', 'TT',
+    assert isinstance(result, Table)
+    assert result.colnames == ['LAMBDA VAC ANG', 'SPECTRUM', 'TT',
                               'CONFIGURATION', 'TERM', 'J J', 'A_ki',
                               'LEVEL ENERGY  CM 1']
-    assert np.all(table['LAMBDA VAC ANG'] ==
+    assert np.all(result['LAMBDA VAC ANG'] ==
                   np.array([196.8874, 197.7992, 199.0122]))
-    assert np.all(table['SPECTRUM'] == np.array(['C IV', 'C IV', 'C IV']))
-    assert np.all(table['TT'] == np.array(['E1', 'E1', 'E1']))
-    assert np.all(table['TERM'] == np.array(['2S-2Po', '2S-2Po', '2S-2Po']))
-    assert np.all(table['J J'] == np.array(['1/2-*', '1/2-*', '1/2-*']))
-    assert np.all(table['LEVEL ENERGY  CM 1'] ==
+    assert np.all(result['SPECTRUM'] == np.array(['C IV', 'C IV', 'C IV']))
+    assert np.all(result['TT'] == np.array(['E1', 'E1', 'E1']))
+    assert np.all(result['TERM'] == np.array(['2S-2Po', '2S-2Po', '2S-2Po']))
+    assert np.all(result['J J'] == np.array(['1/2-*', '1/2-*', '1/2-*']))
+    assert np.all(result['LEVEL ENERGY  CM 1'] ==
                   np.array(['0.00 -   507904.40', '0.00 -   505563.30',
                             '0.00 -   502481.80']))
 
 
 @remote_data
 def test_empty_result_set():
-    table = AtomicLineList.query_object(wavelength_accuracy=0)
-    assert isinstance(table, Table)
-    assert not table
-    assert len(table) == 0
+    result = AtomicLineList.query_object(wavelength_accuracy=0)
+    assert isinstance(result, Table)
+    assert not result
+    assert len(result) == 0
+
+
 @remote_data
 def test_lower_upper_ranges():
     result = AtomicLineList.query_object(


### PR DESCRIPTION
#1186 unearthed some issues with the atomic module:

* `wavelenght_range` is inconsistent with `lower_level_energy_range` and `upper_level_energy_range` by accepting both a Quantity object or a tuple or two Quantities. I feel we should have been more pedantic and only accept one way to do this as even though the docstring is correct it confuses users. I've lest this as is, we may need to open an issue for further discussion.
* specifying `upper/lower_level_energy_range` as a Quantity, a `TypeError` is raised. This is fixed now and test added.
* When supplying a Quantity for `wavelenght_range`, an AstropyDeprecationWarning is raised. This is fixed now by checking whether the kwarg is specified rather than its truth value.

Closes #1186