### PR TITLE
Silence download progress bar according to log level

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -10,6 +10,8 @@
 - NASA_ADS: Use new API [#1162]
 - VO_CONESEARCH: Service validator now uses new STScI VAO TAP registry. [#1114]
 - Nasa Exoplanet Arhive: Add option to return all columns. [#1183]
+- File download progress bar no longer displays when Astropy log level
+  is set to "WARNING", "ERROR", or "CRITICAL". [#1188]
 
 
 0.3.8 (2018-04-27)

--- a/astroquery/query.py
+++ b/astroquery/query.py
@@ -4,12 +4,13 @@ from __future__ import (absolute_import, division, print_function,
 import abc
 import pickle
 import hashlib
+import io
 import os
 import requests
 
 from astropy.extern import six
 from astropy.config import paths
-from astropy import log
+from astropy.logger import log
 import astropy.units as u
 from astropy.utils.console import ProgressBarOrSpinner
 import astropy.utils.data
@@ -274,9 +275,16 @@ class BaseQuery(object):
 
         bytes_read = 0
 
+        # Only show progress bar if logging level is INFO or lower.
+        if log.getEffectiveLevel() <= 20:
+            progress_stream = None  # Astropy default
+        else:
+            progress_stream = io.StringIO()
+
         with ProgressBarOrSpinner(
-            length, ('Downloading URL {0} to {1} ...'
-                     .format(url, local_filepath))) as pb:
+                length, ('Downloading URL {0} to {1} ...'
+                         .format(url, local_filepath)),
+                file=progress_stream) as pb:
             with open(local_filepath, open_mode) as f:
                 for block in response.iter_content(blocksize):
                     f.write(block)


### PR DESCRIPTION
Fix #1179 
Close astropy/astropy#7626

Also see:
KeplerGO/lightkurve#150
KeplerGO/lightkurve#165

*After* this patch (using MAST download example from doc):
```python
>>> from astroquery.mast import Observations
>>> obsid = '3000007760'
>>> dataProductsByID = Observations.get_product_list(obsid)
>>> # This is INFO level, the default
>>> manifest = Observations.download_products(dataProductsByID)
Downloading URL https://mast.stsci.edu/api/v0/download/file?uri=mast:IUE/url/pub/iue/data/lwp/13000/lwp13058.mxlo.gz to ./mastDownload/IUE/lwp13058/lwp13058.mxlo.gz ...
|==============================================================|  18k/ 18k (100.00%)         0s
Downloading URL https://mast.stsci.edu/api/v0/download/file?uri=mast:IUE/url/pub/vospectra/iue2/lwp13058mxlo_vo.fits to ./mastDownload/IUE/lwp13058/lwp13058mxlo_vo.fits ...
|==============================================================|  48k/ 48k (100.00%)         0s
>>> manifest = Observations.download_products(dataProductsByID)
INFO: Found cached file ./mastDownload/IUE/lwp13058/lwp13058.mxlo.gz with expected size 18206. [astroquery.query]
INFO: Found cached file ./mastDownload/IUE/lwp13058/lwp13058mxlo_vo.fits with expected size 48960. [astroquery.query]
>>> from astropy.logger import log
>>> log.setLevel('ERROR')  # Shuddup and dance with me
>>> manifest = Observations.download_products(dataProductsByID, cache=False)  # Ignore cache
>>> manifest = Observations.download_products(dataProductsByID)
```

Kepler people (@texadactyl, @christinahedges, @gully, or @barentsen), feel free to take this patch for a spin before merge.