### PR TITLE
fix jplhorizons queries (fixes #1192)

### DIFF
--- a/astroquery/jplhorizons/__init__.py
+++ b/astroquery/jplhorizons/__init__.py
@@ -17,7 +17,7 @@ class Conf(_config.ConfigNamespace):
 
     # server settings
     horizons_server = _config.ConfigItem(
-        'http://ssd.jpl.nasa.gov/horizons_batch.cgi',
+        'https://ssd.jpl.nasa.gov/horizons_batch.cgi',
         'JPL Horizons')
 
     # implement later: sbdb_server = 'http://ssd-api.jpl.nasa.gov/sbdb.api'


### PR DESCRIPTION
JPL Horizons now requires https - queries are currently not possible. This PR changes http to https in the server url and fixes this problem (#1192).
 