### PR TITLE
Pin mpl to previous build as latest one doesn't work with np 1.9

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -105,6 +105,8 @@ matrix:
           env: PYTHON_VERSION=2.7 NUMPY_VERSION=1.9  KEYRING_VERSION='<12.0'
                CONDA_DEPENDENCIES="`echo $CONDA_DEPENDENCIES | sed 's/ regions//'`"
                PIP_DEPENDENCIES="`echo $PIP_DEPENDENCIES regions`"  # There is an issue with the conda packaging of regions for np 1.9
+          before_script: conda install matplotlib=2.2.2=py27h0e671d2_0
+
         - os: linux
           stage: Tests with other Python/Numpy versions
           env: PYTHON_VERSION=3.4 NUMPY_VERSION=1.10


### PR DESCRIPTION
This should fix the issues we see currently.

I'll manually cancel all but the affected job in the matrix.