### PR TITLE
Making description less ambiguous 

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -18,7 +18,7 @@ auto_use = True
 
 [metadata]
 package_name = astroquery
-description = Functions and classes to access online data resources
+description = Functions and classes to access online astronomical data resources
 long_description =
 author = Adam Ginsburg
 author_email =


### PR DESCRIPTION
I saw the description on twitter today, and it seemed a bit ambiguous (fair enough astro is in the name of the package...).