### PR TITLE
Add option to skip deduplication

### DIFF
--- a/astroquery/eso/core.py
+++ b/astroquery/eso/core.py
@@ -615,7 +615,7 @@ class EsoClass(QueryWithLogin):
         return datasets_to_download, files
 
     def retrieve_data(self, datasets, continuation=False, destination=None,
-                      with_calib='none', deduplicate=True):
+                      with_calib='none', request_all_objects=False):
         """
         Retrieve a list of datasets form the ESO archive.
 
@@ -634,6 +634,12 @@ class EsoClass(QueryWithLogin):
         with_calib : string
             Retrieve associated calibration files: 'none' (default), 'raw' for
             raw calibrations, or 'processed' for processed calibrations.
+        request_all_objects : bool
+            When retrieving associated calibrations (``with_calib != 'none'),
+            this allows to request all the objects included the already
+            downloaded ones, to be sure to retrieve all calibration files.
+            This is useful when the download was interrupted. `False` by
+            default.
 
         Returns
         -------
@@ -663,12 +669,12 @@ class EsoClass(QueryWithLogin):
             raise TypeError("Datasets must be given as a list of strings.")
 
         # First: Detect datasets already downloaded
-        if deduplicate:
+        if with_calib != 'none' and request_all_objects:
+            datasets_to_download, files = list(datasets), []
+        else:
             log.info("Detecting already downloaded datasets...")
             datasets_to_download, files = self._check_existing_files(
                 datasets, continuation=continuation, destination=destination)
-        else:
-            datasets_to_download, files = list(datasets), []
 
         # Second: Check that the datasets to download are in the archive
         log.info("Checking availability of datasets to download...")

--- a/astroquery/eso/core.py
+++ b/astroquery/eso/core.py
@@ -635,7 +635,7 @@ class EsoClass(QueryWithLogin):
             Retrieve associated calibration files: 'none' (default), 'raw' for
             raw calibrations, or 'processed' for processed calibrations.
         request_all_objects : bool
-            When retrieving associated calibrations (``with_calib != 'none'),
+            When retrieving associated calibrations (``with_calib != 'none'``),
             this allows to request all the objects included the already
             downloaded ones, to be sure to retrieve all calibration files.
             This is useful when the download was interrupted. `False` by

--- a/astroquery/eso/core.py
+++ b/astroquery/eso/core.py
@@ -615,7 +615,7 @@ class EsoClass(QueryWithLogin):
         return datasets_to_download, files
 
     def retrieve_data(self, datasets, continuation=False, destination=None,
-                      with_calib='none'):
+                      with_calib='none', deduplicate=True):
         """
         Retrieve a list of datasets form the ESO archive.
 
@@ -663,9 +663,12 @@ class EsoClass(QueryWithLogin):
             raise TypeError("Datasets must be given as a list of strings.")
 
         # First: Detect datasets already downloaded
-        log.info("Detecting already downloaded datasets...")
-        datasets_to_download, files = self._check_existing_files(
-            datasets, continuation=continuation, destination=destination)
+        if deduplicate:
+            log.info("Detecting already downloaded datasets...")
+            datasets_to_download, files = self._check_existing_files(
+                datasets, continuation=continuation, destination=destination)
+        else:
+            datasets_to_download, files = list(datasets), []
 
         # Second: Check that the datasets to download are in the archive
         log.info("Checking availability of datasets to download...")

--- a/astroquery/eso/tests/test_eso_remote.py
+++ b/astroquery/eso/tests/test_eso_remote.py
@@ -128,6 +128,9 @@ class TestEso:
         assert "MIDI.2014-07-25T02:03:11.561" in result[0]
         result = eso.retrieve_data("MIDI.2014-07-25T02:03:11.561")
         assert isinstance(result, six.string_types)
+        result = eso.retrieve_data("MIDI.2014-07-25T02:03:11.561",
+                                   deduplicate=False)
+        assert isinstance(result, six.string_types)
 
     @pytest.mark.skipif('not Eso.USERNAME')
     def test_retrieve_data_twice(self):

--- a/astroquery/eso/tests/test_eso_remote.py
+++ b/astroquery/eso/tests/test_eso_remote.py
@@ -129,7 +129,7 @@ class TestEso:
         result = eso.retrieve_data("MIDI.2014-07-25T02:03:11.561")
         assert isinstance(result, six.string_types)
         result = eso.retrieve_data("MIDI.2014-07-25T02:03:11.561",
-                                   deduplicate=False)
+                                   request_all_objects=True)
         assert isinstance(result, six.string_types)
 
     @pytest.mark.skipif('not Eso.USERNAME')


### PR DESCRIPTION
Following #1184: we encounter one issue when someone interrupts the download, and one OBJECT was retrieved but not all its associated calibration files, then at the next retrieval the files for this object are not requested.
I don't want to completely skip the deduplication when requesting calibrations, because often it will be useful to have it, so I added an option which can be more general, to manually skip the deduplication.

cc @keflavich 