### PR TITLE
MAST: Fixing bug and changing confusing default

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -25,6 +25,7 @@
   location and additional ephemerides information added [#1207]
 - MAST: Fixing bug in catalog criteria querues, and updating remote tests. [#1223]
 - JPLSDB: New module for querying JPL's Small Body Database Browser [#1214]
+- MAST: Fixing mrp_only but and changing default to False [#1238]
 
 0.3.8 (2018-04-27)
 ------------------

--- a/astroquery/mast/core.py
+++ b/astroquery/mast/core.py
@@ -1308,7 +1308,7 @@ class ObservationsClass(MastClass):
         log.info("Using the S3 HST public dataset")
         log.warning("Your AWS account will be charged for access to the S3 bucket")
         log.info("See Request Pricing in https://aws.amazon.com/s3/pricing/ for details")
-        log.info("If you have not configured boto3, follow the instructions here: " + \
+        log.info("If you have not configured boto3, follow the instructions here: "
                  "https://boto3.readthedocs.io/en/latest/guide/configuration.html")
 
     def disable_s3_hst_dataset(self):
@@ -1914,11 +1914,11 @@ class CatalogsClass(MastClass):
             pathList = []
             for spec in spectra:
                 if spec['SpectrumType'] < 2:
-                    urlList.append('https://hla.stsci.edu/cgi-bin/getdata.cgi?config=ops&dataset=' + \
+                    urlList.append('https://hla.stsci.edu/cgi-bin/getdata.cgi?config=ops&dataset='
                                    spec['DatasetName'])
 
                 else:
-                    urlList.append('https://hla.stsci.edu/cgi-bin/ecfproxy?file_id=' + \
+                    urlList.append('https://hla.stsci.edu/cgi-bin/ecfproxy?file_id='
                                    spec['DatasetName'] + '.fits')
 
                 pathList.append(downloadFile + "/HSC/" + spec['DatasetName'] + '.fits')

--- a/astroquery/mast/core.py
+++ b/astroquery/mast/core.py
@@ -1914,12 +1914,12 @@ class CatalogsClass(MastClass):
             pathList = []
             for spec in spectra:
                 if spec['SpectrumType'] < 2:
-                    urlList.append('https://hla.stsci.edu/cgi-bin/getdata.cgi?config=ops&dataset=' +
-                                   spec['DatasetName'])
+                    urlList.append('https://hla.stsci.edu/cgi-bin/getdata.cgi?config=ops&dataset='
+                                   + spec['DatasetName'])
 
                 else:
-                    urlList.append('https://hla.stsci.edu/cgi-bin/ecfproxy?file_id=' +
-                                   spec['DatasetName'] + '.fits')
+                    urlList.append('https://hla.stsci.edu/cgi-bin/ecfproxy?file_id='
+                                   + spec['DatasetName'] + '.fits')
 
                 pathList.append(downloadFile + "/HSC/" + spec['DatasetName'] + '.fits')
 

--- a/astroquery/mast/core.py
+++ b/astroquery/mast/core.py
@@ -1199,7 +1199,7 @@ class ObservationsClass(MastClass):
         **filters :
             Filters to be applied.  Valid filters are all products fields listed
             `here <https://masttest.stsci.edu/api/v0/_productsfields.html>`__.
-            The column name is the keyword, with the argument being one or more acceptable values 
+            The column name is the keyword, with the argument being one or more acceptable values
             for that parameter.
             Filter behavior is AND between the filters and OR within a filter set.
             For example: productType="SCIENCE",extension=["fits","jpg"]
@@ -1308,7 +1308,7 @@ class ObservationsClass(MastClass):
         log.info("Using the S3 HST public dataset")
         log.warning("Your AWS account will be charged for access to the S3 bucket")
         log.info("See Request Pricing in https://aws.amazon.com/s3/pricing/ for details")
-        log.info("If you have not configured boto3, follow the instructions here: " +
+        log.info("If you have not configured boto3, follow the instructions here: " + \
                  "https://boto3.readthedocs.io/en/latest/guide/configuration.html")
 
     def disable_s3_hst_dataset(self):
@@ -1914,11 +1914,11 @@ class CatalogsClass(MastClass):
             pathList = []
             for spec in spectra:
                 if spec['SpectrumType'] < 2:
-                    urlList.append('https://hla.stsci.edu/cgi-bin/getdata.cgi?config=ops&dataset=' +
+                    urlList.append('https://hla.stsci.edu/cgi-bin/getdata.cgi?config=ops&dataset=' + \
                                    spec['DatasetName'])
 
                 else:
-                    urlList.append('https://hla.stsci.edu/cgi-bin/ecfproxy?file_id=' +
+                    urlList.append('https://hla.stsci.edu/cgi-bin/ecfproxy?file_id=' + \
                                    spec['DatasetName'] + '.fits')
 
                 pathList.append(downloadFile + "/HSC/" + spec['DatasetName'] + '.fits')

--- a/astroquery/mast/core.py
+++ b/astroquery/mast/core.py
@@ -1914,12 +1914,12 @@ class CatalogsClass(MastClass):
             pathList = []
             for spec in spectra:
                 if spec['SpectrumType'] < 2:
-                    urlList.append('https://hla.stsci.edu/cgi-bin/getdata.cgi?config=ops&dataset='
-                                   + spec['DatasetName'])
+                    urlList.append('https://hla.stsci.edu/cgi-bin/getdata.cgi?config=ops&dataset={0}'
+                                   .format(spec['DatasetName']))
 
                 else:
-                    urlList.append('https://hla.stsci.edu/cgi-bin/ecfproxy?file_id='
-                                   + spec['DatasetName'] + '.fits')
+                    urlList.append('https://hla.stsci.edu/cgi-bin/ecfproxy?file_id={0}'
+                                   .format(spec['DatasetName']) + '.fits')
 
                 pathList.append(downloadFile + "/HSC/" + spec['DatasetName'] + '.fits')
 

--- a/astroquery/mast/core.py
+++ b/astroquery/mast/core.py
@@ -1914,11 +1914,11 @@ class CatalogsClass(MastClass):
             pathList = []
             for spec in spectra:
                 if spec['SpectrumType'] < 2:
-                    urlList.append('https://hla.stsci.edu/cgi-bin/getdata.cgi?config=ops&dataset='
+                    urlList.append('https://hla.stsci.edu/cgi-bin/getdata.cgi?config=ops&dataset=' +
                                    spec['DatasetName'])
 
                 else:
-                    urlList.append('https://hla.stsci.edu/cgi-bin/ecfproxy?file_id='
+                    urlList.append('https://hla.stsci.edu/cgi-bin/ecfproxy?file_id=' +
                                    spec['DatasetName'] + '.fits')
 
                 pathList.append(downloadFile + "/HSC/" + spec['DatasetName'] + '.fits')

--- a/astroquery/mast/core.py
+++ b/astroquery/mast/core.py
@@ -1184,7 +1184,7 @@ class ObservationsClass(MastClass):
 
         return self.service_request_async(service, params)
 
-    def filter_products(self, products, mrp_only=True, **filters):
+    def filter_products(self, products, mrp_only=False, extension=None, **filters):
         """
         Takes an `astropy.table.Table` of MAST observation data products and filters it based on given filters.
 
@@ -1193,13 +1193,14 @@ class ObservationsClass(MastClass):
         products : `astropy.table.Table`
             Table containing data products to be filtered.
         mrp_only : bool, optional
-            Default True. When set to true only "Minimum Recommended Products" will be returned.
+            Default False. When set to true only "Minimum Recommended Products" will be returned.
+        extension : string, optional
+            Default None. Option to filter by file extension.
         **filters :
             Filters to be applied.  Valid filters are all products fields listed
-            `here <https://masttest.stsci.edu/api/v0/_productsfields.html>`__ and 'extension'
-            which is the desired file extension.
-            The Column Name (or 'extension') is the keyword, with the argument being one or
-            more acceptable values for that parameter.
+            `here <https://masttest.stsci.edu/api/v0/_productsfields.html>`__.
+            The column name is the keyword, with the argument being one or more acceptable values 
+            for that parameter.
             Filter behavior is AND between the filters and OR within a filter set.
             For example: productType="SCIENCE",extension=["fits","jpg"]
 
@@ -1208,12 +1209,20 @@ class ObservationsClass(MastClass):
         response : `~astropy.table.Table`
         """
 
-        # Dealing with mrp first, b/c it's special
-        if mrp_only:
-            products.remove_rows(np.where(products['productGroupDescription'] != "Minimum Recommended Products"))
-
         filterMask = np.full(len(products), True, dtype=bool)
 
+        # Applying the special filters (mrp_only and extension)
+        if mrp_only:
+            filterMask &= (products['productGroupDescription'] == "Minimum Recommended Products")
+
+        if extension:
+            mask = np.full(len(products), False, dtype=bool)
+            for elt in extension:
+                mask |= [False if isinstance(x, np.ma.core.MaskedConstant) else x.endswith(elt)
+                         for x in products["productFilename"]]
+            filterMask &= mask
+
+        # Applying the rest of the filters
         for colname, vals in filters.items():
 
             if type(vals) == str:
@@ -1221,11 +1230,7 @@ class ObservationsClass(MastClass):
 
             mask = np.full(len(products), False, dtype=bool)
             for elt in vals:
-                if colname == 'extension':  # extension is not actually a column
-                    mask |= [False if isinstance(x, np.ma.core.MaskedConstant) else x.endswith(elt)
-                             for x in products["productFilename"]]
-                else:
-                    mask |= (products[colname] == elt)
+                mask |= (products[colname] == elt)
 
             filterMask &= mask
 
@@ -1495,7 +1500,7 @@ class ObservationsClass(MastClass):
         return manifest
 
     def download_products(self, products, download_dir=None,
-                          cache=True, curl_flag=False, mrp_only=True, **filters):
+                          cache=True, curl_flag=False, mrp_only=False, **filters):
         """
         Download data products.
 
@@ -1513,7 +1518,7 @@ class ObservationsClass(MastClass):
             Default is False.  If true instead of downloading files directly, a curl script
             will be downloaded that can be used to download the data files at a later time.
         mrp_only : bool, optional
-            Default True. When set to true only "Minimum Recommended Products" will be returned.
+            Default False. When set to true only "Minimum Recommended Products" will be returned.
         **filters :
             Filters to be applied.  Valid filters are all products fields listed
             `here <https://masttest.stsci.edu/api/v0/_productsfields.html>`__ and 'extension'

--- a/docs/mast/mast.rst
+++ b/docs/mast/mast.rst
@@ -244,7 +244,6 @@ with a `~astropy.table.Table` of data products, or a list (or single) obsid as t
 
                 >>> from astroquery.mast import Observations
                 >>> Observations.download_products('2003839997',
-                                                   mrp_only=False,
                                                    productType="SCIENCE",
                                                    curl_flag=True)
                                                    
@@ -258,8 +257,6 @@ Filter keyword arguments can be applied to download only data products that meet
 Available filters are "mrp_only" (Minimum Recommended Products), "extension" (file extension),
 and all products fields listed `here <https://mast.stsci.edu/api/v0/_productsfields.html>`_.
 
-**Important: mrp_only defaults to True.**
-
 The ‘AND' operation is performed for a list of filters, and the ‘OR' operation is performed within a filter set.
 The below example illustrates downloading all product files with the extension "fits" that are either "RAW" or "UNCAL."
 
@@ -267,7 +264,6 @@ The below example illustrates downloading all product files with the extension "
 
                 >>> from astroquery.mast import Observations
                 >>> Observations.download_products('2003839997',
-                                                   mrp_only=False,
                                                    productSubGroupDescription=["RAW", "UNCAL"],
                                                    extension="fits")
                 Downloading URL https://mast.stsci.edu/api/v0/download/file/HST/product/ib3p11p7q_raw.fits to ./mastDownload/HST/IB3P11P7Q/ib3p11p7q_raw.fits ... [Done]
@@ -286,7 +282,6 @@ Product filtering can also be applied directly to a table of products without pr
                 31
                 
                 >>> dataProductsByID = Observations.filter_products(dataProductsByID,
-                                                                    mrp_only=False,
                                                                     productSubGroupDescription=["RAW", "UNCAL"],
                                                                     extenstion="fits")
                 >>> print(len(dataProductsByID))


### PR DESCRIPTION
This PR encompasses three small changes:
- Change mrp_only default from True to False.
   This is where when downloading files, by default only files marked "Minimum Recommended Products" are downloaded. Users find this confusing so we're changing the default to False. 
- Fix a bug where when applying the mrp_only filter the original products table was itself altered rather than just having the filtered table returned as should be the case.
- Pulled out the extension from the general kwargs **filters. This changes nothing operationally, it's just a change for clarity.