### PR TITLE
Change internal order of coordinate resolution in parse_coordinates

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -28,6 +28,10 @@
 - MAST: Fixing mrp_only but and changing default to False [#1238]
 - SPLATALOGUE: Minor - utils & tests updated to match upstream change [#1236]
 - FERMI: Switch to HTTPS [#1241]
+- utils: fix bug in ``parse_coordinates``, now strings that can be
+  interpreted as coordinates are not sent through Sesame. When unit is not
+  provided, degrees is now explicitely assumed. [#1252]
+
 
 0.3.8 (2018-04-27)
 ------------------

--- a/astroquery/utils/commons.py
+++ b/astroquery/utils/commons.py
@@ -155,17 +155,27 @@ def parse_coordinates(coordinates):
     """
     if isinstance(coordinates, six.string_types):
         try:
-            c = ICRSCoord.from_name(coordinates)
-        except coord.name_resolve.NameResolveError:
-            try:
-                c = ICRSCoordGenerator(coordinates)
-                warnings.warn("Coordinate string is being interpreted as an "
-                              "ICRS coordinate.")
-            except u.UnitsError:
-                warnings.warn("Only ICRS coordinates can be entered as "
-                              "strings.\n For other systems please use the "
-                              "appropriate astropy.coordinates object.")
-                raise u.UnitsError
+            c = ICRSCoordGenerator(coordinates)
+            warnings.warn("Coordinate string is being interpreted as an "
+                          "ICRS coordinate.")
+
+        except u.UnitsError:
+            warnings.warn("Only ICRS coordinates can be entered as "
+                          "strings.\n For other systems please use the "
+                          "appropriate astropy.coordinates object.")
+            raise u.UnitsError
+        except ValueError as err:
+            if isinstance(err.args[1], u.UnitsError):
+                try:
+                    c = ICRSCoordGenerator(coordinates, unit='deg')
+                    warnings.warn("Coordinate string is being interpreted as an "
+                                  "ICRS coordinate provided in degrees.")
+
+                except ValueError:
+                    c = ICRSCoord.from_name(coordinates)
+            else:
+                c = ICRSCoord.from_name(coordinates)
+
     elif isinstance(coordinates, CoordClasses):
         if hasattr(coordinates, 'frame'):
             c = coordinates

--- a/astroquery/utils/tests/test_utils.py
+++ b/astroquery/utils/tests/test_utils.py
@@ -73,6 +73,13 @@ def test_parse_coordinates_3():
         commons.parse_coordinates(9.8 * u.kg)
 
 
+def test_parse_coordinates_4():
+    # Regression test for #1251
+    coordinates = "251.51 32.36"
+    c = commons.parse_coordinates(coordinates)
+    assert c.to_string() == coordinates
+
+
 def test_send_request_post(monkeypatch):
     def mock_post(url, data, timeout, headers={}, status_code=200):
         class SpecialMockResponse(object):


### PR DESCRIPTION
This is to fix #1251. 

The most significant change is that degrees now explicitly assumed if the initializer cannot figure it out from the string itself (previously it was left to Sesame to decide how to parse it).