### PR TITLE
WFAU: select attributes and put constrains in query_region

### DIFF
--- a/astroquery/ukidss/tests/test_ukidss_remote.py
+++ b/astroquery/ukidss/tests/test_ukidss_remote.py
@@ -50,3 +50,15 @@ class TestUkidss:
             radius=6 * u.arcsec, programme_id='GPS')
         assert isinstance(table, Table)
         assert len(table) > 0
+
+    def test_query_region_constraints(self):
+        crd = SkyCoord(l=10.625, b=-0.38, unit=(u.deg, u.deg), frame='galactic')
+        rad = 6 * u.arcsec
+        constraints = '(priOrSec<=0 OR priOrSec=frameSetID)'
+        table_noconstraint = ukidss.core.Ukidss.query_region(
+            crd, radius=rad, programme_id='GPS')
+        table_constraint = ukidss.core.Ukidss.query_region(
+            crd, radius=rad, programme_id='GPS', constraints=constraints)
+
+        assert isinstance(table_constraint, Table)
+        assert len(table_noconstraint) >= len(table_constraint)

--- a/astroquery/vsa/tests/test_vista_remote.py
+++ b/astroquery/vsa/tests/test_vista_remote.py
@@ -31,10 +31,9 @@ class TestVista:
     @pytest.mark.dependency(depends=["vsa_up"])
     def test_get_images(self):
 
-        crd = SkyCoord(l=336.489, b=-1.48, unit=(u.deg, u.deg),
-                       frame='galactic')
-        images = vista.get_images(crd, frame_type='tilestack', image_width=5 *
-                                  u.arcmin, waveband='H')
+        crd = SkyCoord(l=336.489, b=-1.48, unit=(u.deg, u.deg), frame='galactic')
+        images = vista.get_images(crd, frame_type='tilestack',
+                                  image_width=5 * u.arcmin, waveband='H')
         assert images is not None
 
     @pytest.mark.dependency(depends=["vsa_up"])

--- a/astroquery/vsa/tests/test_vista_remote.py
+++ b/astroquery/vsa/tests/test_vista_remote.py
@@ -62,3 +62,14 @@ class TestVista:
         table = vista.query_region(crd, radius=6 * u.arcsec, programme_id='VVV')
         assert isinstance(table, Table)
         assert len(table) > 0
+
+    @pytest.mark.dependency(depends=["vsa_up"])
+    def test_query_region_constraints(self):
+        crd = SkyCoord(l=350.488, b=0.949, unit=(u.deg, u.deg), frame='galactic')
+        rad = 6 * u.arcsec
+        constraints = '(priOrSec<=0 OR priOrSec=frameSetID)'
+        table_noconstraint = vista.query_region(crd, radius=rad, programme_id='VVV')
+        table_constraint = vista.query_region(crd, radius=rad, programme_id='VVV',
+                                              constraints=constraints)
+        assert isinstance(table_constraint, Table)
+        assert len(table_noconstraint) >= len(table_constraint)

--- a/astroquery/wfau/core.py
+++ b/astroquery/wfau/core.py
@@ -437,7 +437,7 @@ class BaseWFAUClass(QueryWithLogin):
     def query_region(self, coordinates, radius=1 * u.arcmin,
                      programme_id=None, database=None,
                      verbose=False, get_query_payload=False, system='J2000',
-                     columns=['default'], column_filters=''):
+                     attributes=['default'], constraints=''):
         """
         Used to query a region around a known identifier or given
         coordinates from the catalog.
@@ -469,11 +469,12 @@ class BaseWFAUClass(QueryWithLogin):
         system : 'J2000' or 'Galactic'
             The system in which to perform the query. Can affect the output
             data columns.
-        columns : list, optional.
-            Columns to include. Default to 'default'.
-        column_filters : str, optional
-            Filters to apply to the search (SQL condition). Default is empty
-            (no filters applied).
+        attributes : list, optional.
+            Attributes to select from the table.  See, e.g.,
+            http://horus.roe.ac.uk/vsa/crossID_notes.html
+        constraints : str, optional
+            SQL constraints to the search. Default is empty (no constrains 
+            applied).
 
         Returns
         -------
@@ -494,8 +495,8 @@ class BaseWFAUClass(QueryWithLogin):
                                            programme_id=programme_id,
                                            database=database,
                                            get_query_payload=get_query_payload,
-                                           system=system, columns=columns,
-                                           column_filters=column_filters)
+                                           system=system, attributes=attributes,
+                                           constraints=constraints)
         if get_query_payload:
             return response
 
@@ -505,8 +506,8 @@ class BaseWFAUClass(QueryWithLogin):
     def query_region_async(self, coordinates, radius=1 * u.arcmin,
                            programme_id=None,
                            database=None, get_query_payload=False,
-                           system='J2000', columns=['default'],
-                           column_filters=''):
+                           system='J2000', attributes=['default'],
+                           constraints=''):
         """
         Serves the same purpose as `query_region`. But
         returns the raw HTTP response rather than the parsed result.
@@ -532,11 +533,12 @@ class BaseWFAUClass(QueryWithLogin):
         get_query_payload : bool, optional
             If `True` then returns the dictionary sent as the HTTP request.
             Defaults to `False`.
-        columns : list, optional.
-            Columns to include. Default to 'default'.
-        column_filters : str, optional
-            Filters to apply to the search (SQL condition). Default is empty
-            (no filters applied).
+        attributes : list, optional.
+            Attributes to select from the table.  See, e.g.,
+            http://horus.roe.ac.uk/vsa/crossID_notes.html
+        constraints : str, optional
+            SQL constraints to the search. Default is empty (no constrains 
+            applied).
 
         Returns
         -------
@@ -568,8 +570,8 @@ class BaseWFAUClass(QueryWithLogin):
         request_payload['format'] = 'VOT'
         request_payload['compress'] = 'NONE'
         request_payload['rows'] = 1
-        request_payload['select'] = ','.join(columns)
-        request_payload['where'] = column_filters
+        request_payload['select'] = ','.join(attributes)
+        request_payload['where'] = constraints
 
         # for some reason, this is required on the VISTA website
         if self.archive is not None:

--- a/astroquery/wfau/core.py
+++ b/astroquery/wfau/core.py
@@ -872,11 +872,11 @@ def clean_catalog(wfau_catalog, clean_band='K_1', badclass=-9999,
     """
 
     band = clean_band
-    mask = ((wfau_catalog[band + 'ERRBITS'] <= maxerrbits)
-            * (wfau_catalog[band + 'ERRBITS'] >= minerrbits)
-            * ((wfau_catalog['PRIORSEC'] == wfau_catalog['FRAMESETID'])
-            + (wfau_catalog['PRIORSEC'] == 0))
-            * (wfau_catalog[band + 'PPERRBITS'] < maxpperrbits)
+    mask = ((wfau_catalog[band + 'ERRBITS'] <= maxerrbits) *
+            (wfau_catalog[band + 'ERRBITS'] >= minerrbits) *
+            ((wfau_catalog['PRIORSEC'] == wfau_catalog['FRAMESETID']) +
+             (wfau_catalog['PRIORSEC'] == 0)) *
+            (wfau_catalog[band + 'PPERRBITS'] < maxpperrbits)
             )
     if band + 'CLASS' in wfau_catalog.colnames:
         mask *= (wfau_catalog[band + 'CLASS'] != badclass)

--- a/astroquery/wfau/core.py
+++ b/astroquery/wfau/core.py
@@ -436,7 +436,8 @@ class BaseWFAUClass(QueryWithLogin):
 
     def query_region(self, coordinates, radius=1 * u.arcmin,
                      programme_id=None, database=None,
-                     verbose=False, get_query_payload=False, system='J2000'):
+                     verbose=False, get_query_payload=False, system='J2000',
+                     columns=['default'], column_filters=''):
         """
         Used to query a region around a known identifier or given
         coordinates from the catalog.
@@ -468,6 +469,11 @@ class BaseWFAUClass(QueryWithLogin):
         system : 'J2000' or 'Galactic'
             The system in which to perform the query. Can affect the output
             data columns.
+        columns : list, optional.
+            Columns to include. Default to 'default'.
+        column_filters : str, optional
+            Filters to apply to the search (SQL condition). Default is empty
+            (no filters applied).
 
         Returns
         -------
@@ -488,7 +494,8 @@ class BaseWFAUClass(QueryWithLogin):
                                            programme_id=programme_id,
                                            database=database,
                                            get_query_payload=get_query_payload,
-                                           system=system)
+                                           system=system, columns=columns,
+                                           column_filters=column_filters)
         if get_query_payload:
             return response
 
@@ -498,7 +505,8 @@ class BaseWFAUClass(QueryWithLogin):
     def query_region_async(self, coordinates, radius=1 * u.arcmin,
                            programme_id=None,
                            database=None, get_query_payload=False,
-                           system='J2000'):
+                           system='J2000', columns=['default'],
+                           column_filters=''):
         """
         Serves the same purpose as `query_region`. But
         returns the raw HTTP response rather than the parsed result.
@@ -524,6 +532,11 @@ class BaseWFAUClass(QueryWithLogin):
         get_query_payload : bool, optional
             If `True` then returns the dictionary sent as the HTTP request.
             Defaults to `False`.
+        columns : list, optional.
+            Columns to include. Default to 'default'.
+        column_filters : str, optional
+            Filters to apply to the search (SQL condition). Default is empty
+            (no filters applied).
 
         Returns
         -------
@@ -555,8 +568,8 @@ class BaseWFAUClass(QueryWithLogin):
         request_payload['format'] = 'VOT'
         request_payload['compress'] = 'NONE'
         request_payload['rows'] = 1
-        request_payload['select'] = 'default'
-        request_payload['where'] = ''
+        request_payload['select'] = ','.join(columns)
+        request_payload['where'] = column_filters
 
         # for some reason, this is required on the VISTA website
         if self.archive is not None:

--- a/astroquery/wfau/core.py
+++ b/astroquery/wfau/core.py
@@ -473,7 +473,7 @@ class BaseWFAUClass(QueryWithLogin):
             Attributes to select from the table.  See, e.g.,
             http://horus.roe.ac.uk/vsa/crossID_notes.html
         constraints : str, optional
-            SQL constraints to the search. Default is empty (no constrains 
+            SQL constraints to the search. Default is empty (no constrains
             applied).
 
         Returns
@@ -537,7 +537,7 @@ class BaseWFAUClass(QueryWithLogin):
             Attributes to select from the table.  See, e.g.,
             http://horus.roe.ac.uk/vsa/crossID_notes.html
         constraints : str, optional
-            SQL constraints to the search. Default is empty (no constrains 
+            SQL constraints to the search. Default is empty (no constrains
             applied).
 
         Returns
@@ -872,11 +872,11 @@ def clean_catalog(wfau_catalog, clean_band='K_1', badclass=-9999,
     """
 
     band = clean_band
-    mask = ((wfau_catalog[band + 'ERRBITS'] <= maxerrbits) *
-            (wfau_catalog[band + 'ERRBITS'] >= minerrbits) *
-            ((wfau_catalog['PRIORSEC'] == wfau_catalog['FRAMESETID']) +
-             (wfau_catalog['PRIORSEC'] == 0)) *
-            (wfau_catalog[band + 'PPERRBITS'] < maxpperrbits)
+    mask = ((wfau_catalog[band + 'ERRBITS'] <= maxerrbits)
+            * (wfau_catalog[band + 'ERRBITS'] >= minerrbits)
+            * ((wfau_catalog['PRIORSEC'] == wfau_catalog['FRAMESETID'])
+            + (wfau_catalog['PRIORSEC'] == 0))
+            * (wfau_catalog[band + 'PPERRBITS'] < maxpperrbits)
             )
     if band + 'CLASS' in wfau_catalog.colnames:
         mask *= (wfau_catalog[band + 'CLASS'] != badclass)


### PR DESCRIPTION
This adds two new optional parameters in the ``query_region`` (and ``query_region_async``) method of WFAU services. The first one, _attributes_, allows selecting the columns of the returned table. With the second one, _constraints_, the user can pass an SQL condition to impose additional constraints in the search.

An example of use:

```
from astroquery.ukidss import Ukidss
from astropy.coordinates import SkyCoord

data = Ukidss.query_region(SkyCoord(12.0, 5.0, unit='deg'), programme_id='LAS', 
                           attributes=['RA', 'Dec', 'sigRa', 'sigDec'], 
                           constraints='(priOrSec<=0 OR priOrSec=frameSetID)')
```