### PR TITLE
Clarifying pip install instructions

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -43,6 +43,7 @@
 - MAST: Support downloading data from multiple missions from the cloud [#1275]
 - JPLHorizons: Fix queries for major solar system bodies when sub-observer or sub-solar positions are requested. [#1268]
 - JPLHorizons: Fix bug with airmass column. [#1284]
+- docs: Clarifying install instructions [#1270]
 
 
 0.3.8 (2018-04-27)

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -33,7 +33,8 @@ The latest version of astroquery can be pip installed.
 
 \*Note that if an environment already has a release version of astroquery installed
 when this command is run, it will not install the latest release.
-In this case astroquery will need to be uninstalled before the pip command is run.
+In this case astroquery will need to be uninstalled (``pip uninstall astroquery``
+or ``conda uninstall astroquery``) before the pip command is run.
 
 .. code-block:: bash
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -37,7 +37,7 @@ In this case astroquery will need to be uninstalled before the pip command is ru
 
 .. code-block:: bash
 
-    $ pip install --pre astroquery    
+    $ pip install --pre astroquery
 
 We also keep doing regular, tagged version for maintanence purposes. These
 can be then conda installed from the ``astropy`` conda channel.

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -31,9 +31,13 @@ that a release will be instantaniously available after each set of changes
 made to the code.
 The latest version of astroquery can be pip installed.
 
+\*Note that if an environment already has a release version of astroquery installed
+when this command is run, it will not install the latest release.
+In this case astroquery will need to be uninstalled before the pip command is run.
+
 .. code-block:: bash
 
-    $ pip install --pre astroquery
+    $ pip install --pre astroquery    
 
 We also keep doing regular, tagged version for maintanence purposes. These
 can be then conda installed from the ``astropy`` conda channel.

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -31,10 +31,8 @@ that a release will be instantaniously available after each set of changes
 made to the code.
 The latest version of astroquery can be pip installed.
 
-\*Note that if an environment already has a release version of astroquery installed
-when this command is run, it will not install the latest release.
-In this case astroquery will need to be uninstalled (``pip uninstall astroquery``
-or ``conda uninstall astroquery``) before the pip command is run.
+\*Note: If an environment already has an older version of astroquery installed
+add ``--upgrade`` to make sure the latest version is installed.
 
 .. code-block:: bash
 


### PR DESCRIPTION
I noticed that if I try to use the `pip install --pre astroquery` command in an environment that already has astroquery 3.8 installed it has no affect.  I have to uninstall astroquery first.  This PR adds a clarifying comment to that affect to the install instructions.