### PR TITLE
DOC: Update setup.cfg to use build_docs

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,4 +1,4 @@
-[build_sphinx]
+[build_docs]
 source-dir = docs
 build-dir = docs/_build
 all_files = 1

--- a/setup.cfg
+++ b/setup.cfg
@@ -3,6 +3,11 @@ source-dir = docs
 build-dir = docs/_build
 all_files = 1
 
+[build_sphinx]
+source-dir = docs
+build-dir = docs/_build
+all_files = 1
+
 [upload_docs]
 upload-dir = docs/_build/html
 show-response = 1


### PR DESCRIPTION
I see that you are running `python setup.py build_docs` in Travis CI. Is there a reason why you still need `build_sphinx` in `setup.cfg`?