### PR TITLE
ASB-735: support multiple missions on stpubdata

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -40,8 +40,8 @@
   provided, degrees is now explicitely assumed. [#1252]
 - MAST: Adding Tesscut interface for accessing TESS cutouts. [#1264]
 - MAST: Add functionality for switching to auth.mast when it goes live [#1256]
+- MAST: Support downloading data from multiple missions on S3 [#1275]
 - JPLHorizons: Fix queries for major solar system bodies when
-  sub-observer or sub-solar positions are requested. [#1268]
 
 
 0.3.8 (2018-04-27)

--- a/astroquery/mast/core.py
+++ b/astroquery/mast/core.py
@@ -45,6 +45,7 @@ from ..exceptions import (TimeoutError, InvalidQueryError, RemoteServiceError,
 from . import conf
 from . import fpl
 
+
 __all__ = ['Observations', 'ObservationsClass',
            'Mast', 'MastClass']
 
@@ -1656,7 +1657,7 @@ class ObservationsClass(MastClass):
             url = None
 
             try:
-                if self._boto3 is not None and dataProduct["dataURI"].startswith("mast:HST/product"):
+                if self._boto3 is not None and fpl.has_path(dataProduct):
                     try:
                         self._download_from_s3(dataProduct, localPath, cache)
                     except Exception as ex:

--- a/astroquery/mast/core.py
+++ b/astroquery/mast/core.py
@@ -1496,7 +1496,7 @@ class ObservationsClass(MastClass):
                           "URL": [url]})
         return manifest
 
-    @deprecated(since="11/9/18", alternative="enable_s3_dataset")
+    @deprecated(since="v0.3.9", alternative="enable_s3_dataset")
     def enable_s3_hst_dataset(self):
         return self.enable_s3_dataset()
 
@@ -1516,7 +1516,7 @@ class ObservationsClass(MastClass):
         log.info("If you have not configured boto3, follow the instructions here: "
                  "https://boto3.readthedocs.io/en/latest/guide/configuration.html")
 
-    @deprecated(since="11/9/18", alternative="disable_s3_dataset")
+    @deprecated(since="v0.3.9", alternative="disable_s3_dataset")
     def disable_s3_hst_dataset(self):
         return self.disable_s3_dataset()
 
@@ -1527,7 +1527,7 @@ class ObservationsClass(MastClass):
         self._boto3 = None
         self._botocore = None
 
-    @deprecated(since="11/9/18", alternative="get_s3_uris")
+    @deprecated(since="v0.3.9", alternative="get_s3_uris")
     def get_hst_s3_uris(self, dataProducts, includeBucket=True, fullUrl=False):
         return self.get_s3_uris(self, dataproducts, includeBucket, fullUrl)
 
@@ -1536,7 +1536,7 @@ class ObservationsClass(MastClass):
 
         return [self.get_s3_uri(dataProduct, includeBucket, fullUrl) for dataProduct in dataProducts]
 
-    @deprecated(since="11/9/18", alternative="get_s3_uri")
+    @deprecated(since="v0.3.9", alternative="get_s3_uri")
     def get_hst_s3_uri(self, dataProduct, includeBucket=True, fullUrl=False):
         return self.get_s3_uri(self, dataProduct, includeBucket, fullUrl)
 

--- a/astroquery/mast/fpl.py
+++ b/astroquery/mast/fpl.py
@@ -1,0 +1,55 @@
+# Licensed under a 3-clause BSD style license - see LICENSE.rst
+"""
+MAST File Path Lookup
+=====================
+
+Functions to deal with mapping data products to storage paths
+
+Due to the way that several missions work, we may need to check
+more than one path per product
+"""
+
+def hst_paths(dataProduct):
+    dataUri = dataProduct['dataURI']
+    filename = dataUri.split("/")[-1]
+    obs_id = dataProduct['obs_id']
+
+    obs_id = obs_id.lower()
+
+    # This next part is a bit funky.  Let me explain why:
+    # We have 2 different possible URI schemes for HST:
+    #   mast:HST/product/obs_id_filename.type (old style)
+    #   mast:HST/product/obs_id/obs_id_filename.type (new style)
+    # The first scheme was developed thinking that the obs_id in the filename
+    # would *always* match the actual obs_id folder the file was placed in.
+    # Unfortunately this assumption was false.
+    # We have been trying to switch to the new uri scheme as it specifies the
+    # obs_id used in the folder path correctly.
+    # The cherry on top is that the obs_id in the new style URI is not always correct either!
+    # When we are looking up files we have some code which iterates through all of
+    # the possible permutations of the obs_id's last char which can be *ANYTHING*
+    #
+    # So in conclusion we can't trust the last char obs_id from the file or from the database
+    # So with that in mind, hold your nose when reading the following:
+
+    paths = []
+
+    sane_path = os.path.join("hst", "public", obs_id[:4], obs_id, filename)
+    paths += [sane_path]
+
+    # Unfortunately our file placement logic is anything but sane
+    # We put files in folders that don't make sense
+    for ch in (string.digits + string.ascii_lowercase):
+        # The last char of the obs_folder (observation id) can be any lowercase or numeric char
+        insane_obs = obs_id[:-1] + ch
+        insane_path = os.path.join("hst", "public", insane_obs[:4], insane_obs, filename)
+        paths += [insane_path]
+
+    return paths
+
+
+def paths(dataProduct):
+    if dataProduct['dataURI'].lower().startswith("mast:hst/product"):
+        return fpl.hst_paths(dataProduct)
+
+    return None

--- a/astroquery/mast/fpl.py
+++ b/astroquery/mast/fpl.py
@@ -11,6 +11,7 @@ more than one path per product
 
 import string
 
+
 def hst_paths(dataProduct):
     dataUri = dataProduct['dataURI']
     filename = dataUri.split("/")[-1]
@@ -78,13 +79,14 @@ def _tess_product_paths(file_name):
 
     return ["/".join(parts)]
 
+
 def _tess_report_paths(file_name):
     """ TESS Report File """
     # tess2018206190142-s0001-s0001-0000000349518145-01-00106_dvs.pdf
     #                   sssss eeeee zzzzffffppppllll
     #                   18-23 24-29 30  34  38  42  46
 
-    sssss = file_name[18:23]
+    # sssss = file_name[18:23]
     eeeee = file_name[24:29]
     zzzz = file_name[30:34]
     ffff = file_name[34:38]
@@ -130,11 +132,13 @@ def _tess_ffi_file(file_name):
     ]
     return ["/".join(parts)]
 
+
 _tess_map = {
     _tess_product_paths: ["tp.fits", "lc.fits"],
     _tess_report_paths: ["_dvs.pdf", "_dvr.pdf", "_dvr.xml", "_dvt.fits"],
     _tess_ffi_file: ['ffir.fits', 'ffic.fits', 'col.fits', 'cbv.fits'],
 }
+
 
 def tess_paths(dataProduct):
     dataUri = dataProduct['dataURI']
@@ -148,7 +152,6 @@ def tess_paths(dataProduct):
     return None
 
 
-
 def paths(dataProduct):
     if dataProduct['dataURI'].lower().startswith("mast:hst/product"):
         return hst_paths(dataProduct)
@@ -157,6 +160,7 @@ def paths(dataProduct):
         return tess_paths(dataProduct)
 
     return None
+
 
 def has_path(dataProduct):
     return dataProduct['dataURI'].lower().startswith("mast:hst/product") or \

--- a/astroquery/mast/fpl.py
+++ b/astroquery/mast/fpl.py
@@ -65,6 +65,7 @@ def _tess_product_paths(file_name):
     llll = file_name[36:40]
 
     parts = [
+        "tess",
         "public",
         "tid",
         sssss,
@@ -75,7 +76,7 @@ def _tess_product_paths(file_name):
         file_name
     ]
 
-    return "/".join(parts)
+    return ["/".join(parts)]
 
 def _tess_report_paths(file_name):
     """ TESS Report File """
@@ -91,6 +92,7 @@ def _tess_report_paths(file_name):
     llll = file_name[42:46]
 
     parts = [
+        "tess",
         "public",
         "tid",
         eeeee,
@@ -101,7 +103,7 @@ def _tess_report_paths(file_name):
         file_name
     ]
 
-    return "/".join(parts)
+    return ["/".join(parts)]
 
 
 def _tess_ffi_file(file_name):
@@ -117,6 +119,7 @@ def _tess_ffi_file(file_name):
     camera_chip = file_name[24:27]
 
     parts = [
+        "tess",
         "public",
         "ffi",
         sector,
@@ -125,7 +128,7 @@ def _tess_ffi_file(file_name):
         camera_chip,
         file_name
     ]
-    return "/".join(parts)
+    return ["/".join(parts)]
 
 _tess_map = {
     _tess_product_paths: ["tp.fits", "lc.fits"],


### PR DESCRIPTION
At STScI, we are gearing up to put TESS data on S3.  We would like to get the code in before the TESS data release go-live.

Access to the TESS data will be locked down until the official go live.  Here is a example program showcasing the output.  The product had to be constructed by hand as we do not have the products in our ops database yet.

In addition, we have added the ability to specify a [profile name](https://boto3.amazonaws.com/v1/documentation/api/latest/guide/configuration.html) for the cloud credentials configuration

```python
from astroquery.mast import Observations
products = [{
    "obs_collection": "TESS",
    "obs_id": "206409997",
    "dataURI": "mast:TESS/product/tess2018206045859-s0001-0000000206409997-0120-s_tp.fits",
    "productFilename": "tess2018206045859-s0001-0000000206409997-0120-s_tp.fits"
}]
Observations.enable_cloud_dataset()

manifest = Observations._download_files(products, "mastDownload")
```
```
INFO: Using the S3 STScI public dataset [astroquery.mast.core]
WARNING: Your AWS account will be charged for access to the S3 bucket [astroquery.mast.core]
INFO: See Request Pricing in https://aws.amazon.com/s3/pricing/ for details [astroquery.mast.core]
INFO: If you have not configured boto3, follow the instructions here: https://boto3.readthedocs.io/en/latest/guide/configuration.html [astroquery.mast.core]
Downloading URL s3://stpubdata/tess/public/tid/s0001/0000/0002/0640/9997/tess2018206045859-s0001-0000000206409997-0120-s_tp.fits to mastDownload/TESS/206409997/tess2018206045859-s0001-0000000206409997-0120-s_tp.fits ...
|=========================================================================================================================================================================================================================================|  49M/ 49M (100.00%)         2s
```
