### PR TITLE
NRAO: Fix case handling in parameter validation

### DIFF
--- a/.pep8speaks.yml
+++ b/.pep8speaks.yml
@@ -5,8 +5,7 @@ pycodestyle:
     - E741  # l and b are valid variable names for the galactic frame
     - E226  # Don't force "missing whitespace around arithmetic operator"
     - E402  # .conf has to be set in the __init__.py modules imports
-    - W504  # we need to have line breaks after binary operators,
-            # lines become unreadable otherwise
+    - W504  # we've been perpetually annoyed by W504 "line break after binary operator", since there's often no real alternative
 
   exclude:
     - ez_setup.py

--- a/astroquery/nrao/core.py
+++ b/astroquery/nrao/core.py
@@ -77,6 +77,8 @@ class NraoClass(QueryWithLogin):
 
     telescope_config = ['ALL', 'A', 'AB', 'BnA', 'B', 'BC', 'CnB', 'C',
                         'CD', 'DnC', 'D', 'DA']
+    # we only ever use uppercase versions
+    telescope_config = [x.upper() for x in telescope_config]
 
     obs_bands = ['ALL', 'all', '4', 'P', 'L', 'S', 'C', 'X', 'U', 'K', 'Ka', 'Q', 'W']
 

--- a/astroquery/nrao/core.py
+++ b/astroquery/nrao/core.py
@@ -46,10 +46,10 @@ def _validate_params(func):
                                  .format(Nrao.telescope_config))
         if isinstance(obs_band, (list, tuple)):
             for ob in obs_band:
-                if ob not in Nrao.obs_bands:
+                if ob.upper() not in Nrao.obs_bands:
                     raise ValueError("'obs_band' must be one of {!s}"
                                      .format(Nrao.obs_bands))
-        elif obs_band not in Nrao.obs_bands:
+        elif obs_band.upper() not in Nrao.obs_bands:
             raise ValueError("'obs_band' must be one of {!s}"
                              .format(Nrao.obs_bands))
         if sub_array not in Nrao.subarrays and sub_array != 'all':
@@ -77,10 +77,12 @@ class NraoClass(QueryWithLogin):
 
     telescope_config = ['ALL', 'A', 'AB', 'BnA', 'B', 'BC', 'CnB', 'C',
                         'CD', 'DnC', 'D', 'DA']
-    # we only ever use uppercase versions
-    telescope_config = [x.upper() for x in telescope_config]
 
     obs_bands = ['ALL', 'all', '4', 'P', 'L', 'S', 'C', 'X', 'U', 'K', 'Ka', 'Q', 'W']
+
+    # we only ever use uppercase versions
+    telescope_config = [x.upper() for x in telescope_config]
+    obs_bands = [x.upper() for x in obs_bands]
 
     subarrays = ['ALL', 1, 2, 3, 4, 5]
 

--- a/astroquery/nrao/tests/test_nrao.py
+++ b/astroquery/nrao/tests/test_nrao.py
@@ -106,6 +106,7 @@ def test_query_region_multiconfig(patch_post, patch_parse_coordinates):
     )
     assert isinstance(result, Table)
 
+
 def test_query_region_lowercase(patch_post, patch_parse_coordinates):
     # regression test for issue 1282
     # test that the checker allows BnA, etc.

--- a/astroquery/nrao/tests/test_nrao.py
+++ b/astroquery/nrao/tests/test_nrao.py
@@ -105,3 +105,18 @@ def test_query_region_multiconfig(patch_post, patch_parse_coordinates):
         telescope_config=['A', 'AB', 'B', 'BC', 'C', 'CD', 'D'],
     )
     assert isinstance(result, Table)
+
+def test_query_region_lowercase(patch_post, patch_parse_coordinates):
+    # regression test for issue 1282
+    # test that the checker allows BnA, etc.
+    result = nrao.core.Nrao.query_region(
+        commons.ICRSCoordGenerator("05h35.8m 35d43m"), querytype='ARCHIVE',
+        telescope_config=['A', 'BnA', 'AB', 'B', 'BC', 'C', 'CD', 'D'],
+    )
+    assert isinstance(result, Table)
+
+    result = nrao.core.Nrao.query_region(
+        commons.ICRSCoordGenerator("05h35.8m 35d43m"), querytype='ARCHIVE',
+        obs_band=['K', 'Ka'],
+    )
+    assert isinstance(result, Table)


### PR DESCRIPTION
The NRAO module was doing parameter validation incorrectly, checking for 'BnA' in a list that was forced to be all uppercase.  This adds a regression test.

Addresses issue #1282