### PR TITLE
Fix airmass column issues with jplhorizons.

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -41,7 +41,8 @@
 - MAST: Adding Tesscut interface for accessing TESS cutouts. [#1264]
 - MAST: Add functionality for switching to auth.mast when it goes live [#1256]
 - MAST: Support downloading data from multiple missions from the cloud [#1275]
-- JPLHorizons: Fix queries for major solar system bodies when
+- JPLHorizons: Fix queries for major solar system bodies when sub-observer or sub-solar positions are requested. [#1268]
+- JPLHorizons: Fix bug with airmass column. [#1284]
 
 
 0.3.8 (2018-04-27)

--- a/astroquery/jplhorizons/core.py
+++ b/astroquery/jplhorizons/core.py
@@ -8,7 +8,7 @@ from numpy import ndarray
 from collections import OrderedDict
 
 # 2. third party imports
-from astropy.table import Column
+from astropy.table import Table, Column
 from astropy.io import ascii
 from astropy.time import Time
 
@@ -1130,6 +1130,8 @@ class HorizonsClass(BaseQuery):
                           names=headerline,
                           fill_values=[('.n.a.', '0'),
                                        ('n.a.', '0')])
+        # force to a masked table
+        data = Table(data, masked=True)
 
         # convert data to QTable
         # from astropy.table import QTable
@@ -1167,7 +1169,7 @@ class HorizonsClass(BaseQuery):
                                    name='phasecoeff'), index=7)
 
         # replace missing airmass values with 999 (not observable)
-        if self.query_type is 'ephemerides':
+        if self.query_type is 'ephemerides' and 'a-mass' in data.colnames:
             data['a-mass'] = data['a-mass'].filled(999)
 
         # set column definition dictionary

--- a/astroquery/jplhorizons/tests/test_jplhorizons_remote.py
+++ b/astroquery/jplhorizons/tests/test_jplhorizons_remote.py
@@ -323,3 +323,28 @@ class TestHorizonsClass:
         target = jplhorizons.Horizons(id='301', location='688', epochs=epochs)
         eph = target.ephemerides(quantities=quantities)
         assert len(eph) == 2
+
+    def test_airmass(self):
+        """Regression test for "Airmass issues with jplhorizons #"
+
+        Horizons.ephemerides would crash when Horizons returned tables
+        with no masked data.  The error occurs when attempting to fill
+        bad values in the 'a-mass' column:
+        ``data['a-mass'].filled(99)``.  However, with no masked data,
+        ascii.read returns a normal Table, and the 'a-mass' column was
+        missing the ``filled`` method.
+
+        In addition, the same lines would crash if airmass was not
+        requested in the returned table.
+
+        """
+
+        # verify data['a-mass'].filled(99) works:
+        target = jplhorizons.Horizons('Ceres', location='I41',
+                                      epochs=[2458300.5])
+        eph = target.ephemerides(quantities='1,8')
+        assert len(eph) == 1
+
+        # skip data['a-mass'].filled(99) if 'a-mass' not returned
+        eph = target.ephemerides(quantities='1')
+        assert len(eph) == 1

--- a/astroquery/jplhorizons/tests/test_jplhorizons_remote.py
+++ b/astroquery/jplhorizons/tests/test_jplhorizons_remote.py
@@ -325,7 +325,7 @@ class TestHorizonsClass:
         assert len(eph) == 2
 
     def test_airmass(self):
-        """Regression test for "Airmass issues with jplhorizons #"
+        """Regression test for "Airmass issues with jplhorizons #1284"
 
         Horizons.ephemerides would crash when Horizons returned tables
         with no masked data.  The error occurs when attempting to fill


### PR DESCRIPTION
``Horizons.ephemerides`` would crash when Horizons returned tables with no masked data.  The error occurs when attempting to fill bad values in the 'a-mass' column: ``data['a-mass'].filled(99)``.  However, with no masked data, ``ascii.read`` returns a normal ``Table``, and the 'a-mass' column is missing the ``filled`` method.

In addition, the same lines would crash if airmass was not requested in the returned table.

This PR address both issues.

```python
>>> from astroquery.jplhorizons import Horizons
>>> q = Horizons('Ceres', location='I41', epochs=[2458300.5])
>>> eph = q.ephemerides(quantities='1,8')
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/home/msk/local/lib/python3.6/site-packages/astroquery-0.3.9.dev4979-py3.6.egg/astroquery/utils/class_or_instance.py", line 25, in f
    return self.fn(obj, *args, **kwds)
  File "/home/msk/local/lib/python3.6/site-packages/astroquery-0.3.9.dev4979-py3.6.egg/astroquery/utils/process_asyncs.py", line 29, in newmethod
    result = self._parse_result(response, verbose=verbose)
  File "/home/msk/local/lib/python3.6/site-packages/astroquery-0.3.9.dev4979-py3.6.egg/astroquery/jplhorizons/core.py", line 1223, in _parse_result
    data = self._parse_horizons(response.text)
  File "/home/msk/local/lib/python3.6/site-packages/astroquery-0.3.9.dev4979-py3.6.egg/astroquery/jplhorizons/core.py", line 1171, in _parse_horizons
    data['a-mass'] = data['a-mass'].filled(999)
AttributeError: 'Column' object has no attribute 'filled'
```

```python
>>> from astroquery.jplhorizons import Horizons
>>> q = Horizons('Ceres', location='I41', epochs=[2458300.5])
>>> eph = q.ephemerides(quantities='1')
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/home/msk/local/lib/python3.6/site-packages/astroquery-0.3.9.dev4979-py3.6.egg/astroquery/utils/class_or_instance.py", line 25, in f
    return self.fn(obj, *args, **kwds)
  File "/home/msk/local/lib/python3.6/site-packages/astroquery-0.3.9.dev4979-py3.6.egg/astroquery/utils/process_asyncs.py", line 29, in newmethod
    result = self._parse_result(response, verbose=verbose)
  File "/home/msk/local/lib/python3.6/site-packages/astroquery-0.3.9.dev4979-py3.6.egg/astroquery/jplhorizons/core.py", line 1223, in _parse_result
    data = self._parse_horizons(response.text)
  File "/home/msk/local/lib/python3.6/site-packages/astroquery-0.3.9.dev4979-py3.6.egg/astroquery/jplhorizons/core.py", line 1171, in _parse_horizons
    data['a-mass'] = data['a-mass'].filled(999)
  File "/home/msk/local/lib/python3.6/site-packages/astropy-3.0.dev20600-py3.6-linux-x86_64.egg/astropy/table/table.py", line 1214, in __getitem__
    return self.columns[item]
  File "/home/msk/local/lib/python3.6/site-packages/astropy-3.0.dev20600-py3.6-linux-x86_64.egg/astropy/table/table.py", line 106, in __getitem__
    return OrderedDict.__getitem__(self, item)
KeyError: 'a-mass'
```