### PR TITLE
Fixing dev version number for deployment for doing a full clone

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -154,6 +154,8 @@ matrix:
                SETUP_CMD='' EVENT_TYPE='push pull_request'
 
         - stage: Deploy
+          git:
+            depth: False
           env: SETUP_CMD='sdist' EVENT_TYPE='push'
           deploy:
             provider: pypi


### PR DESCRIPTION
this should fix the dev version to get the 5000+ number that is incremental, rather than oscillating around ~500.