### PR TITLE
Stop pep8 warning us about warning 504

### DIFF
--- a/.pep8speaks.yml
+++ b/.pep8speaks.yml
@@ -5,6 +5,8 @@ pycodestyle:
     - E741  # l and b are valid variable names for the galactic frame
     - E226  # Don't force "missing whitespace around arithmetic operator"
     - E402  # .conf has to be set in the __init__.py modules imports
+    - W504  # we need to have line breaks after binary operators,
+            # lines become unreadable otherwise
 
   exclude:
     - ez_setup.py


### PR DESCRIPTION
It's fine to end a line with a binary operator.  

Note that I also made this change in #1283, but I really, really want this warning to die, so I'm making it an independent PR.

NO MORE 504!