### PR TITLE
Detect ESO logout and authenticate again to retrieve data

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,6 +1,7 @@
 0.3.10 (unreleased)
 -------------------
 
+- ESO: Try to re-authenticate when logged out from the ESO server. [#1315]
 
 
 

--- a/astroquery/eso/core.py
+++ b/astroquery/eso/core.py
@@ -616,7 +616,8 @@ class EsoClass(QueryWithLogin):
 
             # trying to detect the failing authentication:
             # - content type should not be html
-            if resp.headers['Content-Type'] == 'text/html;charset=UTF-8':
+            if (resp.headers['Content-Type'] == 'text/html;charset=UTF-8' and
+                    resp.url.startswith('https://www.eso.org/sso/login')):
                 if trials == 1:
                     log.warning("Session expired, trying to re-authenticate")
                     self.login()

--- a/astroquery/query.py
+++ b/astroquery/query.py
@@ -340,6 +340,7 @@ class BaseQuery(object):
                         pb.update(bytes_read)
 
         response.close()
+        return response
 
 
 class suspend_cache:


### PR DESCRIPTION
Should fix #1272. It works locally if I delete the cookies before doing doing the request.

This will work only if the password is stored in a keyring, and raise an error otherwise. I wrapped `_download_file` to detect if we get an html response, which I then interpret as login page as I don't think that we are supposed to get html here otherwise, but maybe we need a better way to detect that it is really a login page. We could look at the content, or at the number of redirections.