### PR TITLE
Added access to member_ouss_id

### DIFF
--- a/astroquery/alma/core.py
+++ b/astroquery/alma/core.py
@@ -885,7 +885,7 @@ class AlmaClass(QueryWithLogin):
             # allowed
             self._valid_params.append('download')
             self._valid_params.append('format')
-            self._valid_params.append('member_ouss_id')
+            self._valid_params.append('member_ous_id')
         invalid_params = [k for k in payload if k not in self._valid_params]
         if len(invalid_params) > 0:
             raise InvalidQueryError("The following parameters are not accepted"

--- a/astroquery/alma/core.py
+++ b/astroquery/alma/core.py
@@ -885,6 +885,7 @@ class AlmaClass(QueryWithLogin):
             # allowed
             self._valid_params.append('download')
             self._valid_params.append('format')
+            self._valid_params.append('member_ouss_id')
         invalid_params = [k for k in payload if k not in self._valid_params]
         if len(invalid_params) > 0:
             raise InvalidQueryError("The following parameters are not accepted"

--- a/astroquery/alma/tests/test_alma_remote.py
+++ b/astroquery/alma/tests/test_alma_remote.py
@@ -175,6 +175,10 @@ class TestAlma:
         # May 9, 2018: 162
         assert len(result) == 162
 
+        result = alma.query(payload={'member_ous_id': 'uid://A001/X11a2/X11'},
+                            public=False, science=True)
+        assert len(result) == 1
+
     # As of April 2017, these data are *MISSING FROM THE ARCHIVE*.
     # This has been reported, as it is definitely a bug.
     @pytest.mark.xfail

--- a/astroquery/alma/tests/test_alma_remote.py
+++ b/astroquery/alma/tests/test_alma_remote.py
@@ -176,7 +176,7 @@ class TestAlma:
         assert len(result) == 162
 
         result = alma.query(payload={'member_ous_id': 'uid://A001/X11a2/X11'},
-                            public=False, science=True)
+                            science=True)
         assert len(result) == 1
 
     # As of April 2017, these data are *MISSING FROM THE ARCHIVE*.


### PR DESCRIPTION
Our users at the CADC would like to be able to query alma on the member_ouss_id attribute. Although not available on the public query page, the attribute is supported on the back end and this patch allows it to be used as a constraint.