### PR TITLE
Make the `all_columns` parameter work for `query_planet`.

### DIFF
--- a/astroquery/nasa_exoplanet_archive/nasa_exoplanet_archive.py
+++ b/astroquery/nasa_exoplanet_archive/nasa_exoplanet_archive.py
@@ -101,8 +101,7 @@ class NasaExoplanetArchiveClass(object):
 
         return self._table
 
-    def query_planet(self, planet_name, table_path=None,
-                     all_columns=False):
+    def query_planet(self, planet_name, **kwargs):
         """
         Get table of exoplanet properties.
 
@@ -110,12 +109,8 @@ class NasaExoplanetArchiveClass(object):
         ----------
         planet_name : str
             Name of planet
-        table_path : str (optional)
-            Path to a local table file. Default `None` will trigger a
-            download of the table from the internet.
-        all_columns : bool (optional)
-            Return all available columns. The default returns only the
-            columns in the default category at the link above.
+        kwargs : dict (optional)
+            Extra keyword arguments passed to ``get_confirmed_planets_table``.
 
         Return
         ------
@@ -123,7 +118,7 @@ class NasaExoplanetArchiveClass(object):
             Table of one exoplanet's properties.
         """
 
-        exoplanet_table = self.get_confirmed_planets_table(table_path=table_path)
+        exoplanet_table = self.get_confirmed_planets_table(**kwargs)
         return exoplanet_table.loc[planet_name.strip().lower().replace(' ', '')]
 
 

--- a/astroquery/nasa_exoplanet_archive/tests/test_nasa_exoplanet_archive_remote.py
+++ b/astroquery/nasa_exoplanet_archive/tests/test_nasa_exoplanet_archive_remote.py
@@ -81,6 +81,18 @@ def test_hd209458b_exoplanet_archive():
     assert not params['pl_kepflag']
     assert not params['pl_ttvflag']
 
+    # Default columns don't include planet columns
+    assert 'pl_tranflag' not in params.columns
+
+
+@remote_data
+def test_exoplanet_archive_query_plant_all_columns():
+    # Same test as above but get all the columns
+    params = NasaExoplanetArchive.query_planet('HD 209458 b ', cache=False, all_columns=True)
+
+    # Check some planets are in the table
+    assert 'pl_tranflag' in params.columns
+
 
 @pytest.mark.skipif('APY_LT12')
 def test_hd209458b_exoplanets_archive_apy_lt12():

--- a/astroquery/nasa_exoplanet_archive/tests/test_nasa_exoplanet_archive_remote.py
+++ b/astroquery/nasa_exoplanet_archive/tests/test_nasa_exoplanet_archive_remote.py
@@ -90,7 +90,7 @@ def test_exoplanet_archive_query_plant_all_columns():
     # Same test as above but get all the columns
     params = NasaExoplanetArchive.query_planet('HD 209458 b ', cache=False, all_columns=True)
 
-    # Check some planets are in the table
+    # Check non-default column in table
     assert 'pl_tranflag' in params.columns
 
 


### PR DESCRIPTION
This adjusts `query_planet` to pass any additional keyword argmunets to the underlying `get_confirmed_planets_table` method.

This seems like the logical way to fix the problem in #1317 but might not be preferred.