### PR TITLE
Fixing kwarg-passing bug

### DIFF
--- a/astroquery/nasa_exoplanet_archive/nasa_exoplanet_archive.py
+++ b/astroquery/nasa_exoplanet_archive/nasa_exoplanet_archive.py
@@ -123,7 +123,8 @@ class NasaExoplanetArchiveClass(object):
             Table of one exoplanet's properties.
         """
 
-        exoplanet_table = self.get_confirmed_planets_table(table_path=table_path)
+        exoplanet_table = self.get_confirmed_planets_table(table_path=table_path,
+                                                           all_columns=all_columns)
         return exoplanet_table.loc[planet_name.strip().lower().replace(' ', '')]
 
 


### PR DESCRIPTION
Presently the `get_planet` method of the `NasaExoplanetArchive` class has a keyword argument for getting `all_columns` of the table, but the user-supplied keyword is not passed on to the `self.get_confirmed_planets_table` method within the function. This PR corrects that small bug. 