### PR TITLE
Fix catalog parsing in `Vizier._args_to_payload`

### DIFF
--- a/astroquery/vizier/core.py
+++ b/astroquery/vizier/core.py
@@ -443,7 +443,7 @@ class VizierClass(BaseQuery):
         return response
 
     def query_constraints_async(self, catalog=None, return_type='votable',
-                                cache=True,
+                                cache=True, get_query_payload=False,
                                 **kwargs):
         """
         Send a query to Vizier in which you specify constraints with
@@ -502,6 +502,8 @@ class VizierClass(BaseQuery):
             catalog=catalog,
             column_filters=kwargs,
             center={'-c.rd': 180})
+        if get_query_payload:
+            return data_payload
         response = self._request(
             method='POST', url=self._server_to_url(return_type=return_type),
             data=data_payload, timeout=self.TIMEOUT, cache=cache)
@@ -515,7 +517,7 @@ class VizierClass(BaseQuery):
         body = OrderedDict()
         center = kwargs.get('center')
         # process: catalog
-        catalog = kwargs.get('catalog', self.catalog)
+        catalog = kwargs.get('catalog') or self.catalog
 
         if catalog is not None:
             if isinstance(catalog, six.string_types):

--- a/astroquery/vizier/tests/test_vizier.py
+++ b/astroquery/vizier/tests/test_vizier.py
@@ -170,8 +170,11 @@ def test_get_catalogs(patch_post):
 
 def test_catalog_consistency_issue1326(patch_post):
     # regression test for issue 1326
-    result1 = vizier.core.Vizier(catalog='J/ApJ/706/83').query_constraints_async(testconstraint='blah', get_query_payload=True)
-    result2 = vizier.core.Vizier().query_constraints_async(testconstraint='blah', catalog='J/ApJ/706/83', get_query_payload=True)
+    result1 = vizier.core.Vizier(catalog='J/ApJ/706/83').query_constraints_async(testconstraint='blah',
+                                                                                 get_query_payload=True)
+    result2 = vizier.core.Vizier().query_constraints_async(testconstraint='blah',
+                                                           catalog='J/ApJ/706/83',
+                                                           get_query_payload=True)
 
     assert result1 == result2
 

--- a/astroquery/vizier/tests/test_vizier.py
+++ b/astroquery/vizier/tests/test_vizier.py
@@ -167,6 +167,7 @@ def test_get_catalogs(patch_post):
     result = vizier.core.Vizier.get_catalogs('J/ApJ/706/83')
     assert isinstance(result, commons.TableList)
 
+
 def test_catalog_consistency_issue1326(patch_post):
     # regression test for issue 1326
     result1 = vizier.core.Vizier(catalog='J/ApJ/706/83').query_constraints_async(testconstraint='blah', get_query_payload=True)

--- a/astroquery/vizier/tests/test_vizier.py
+++ b/astroquery/vizier/tests/test_vizier.py
@@ -167,6 +167,13 @@ def test_get_catalogs(patch_post):
     result = vizier.core.Vizier.get_catalogs('J/ApJ/706/83')
     assert isinstance(result, commons.TableList)
 
+def test_catalog_consistency_issue1326(patch_post):
+    # regression test for issue 1326
+    result1 = vizier.core.Vizier(catalog='J/ApJ/706/83').query_constraints_async(testconstraint='blah', get_query_payload=True)
+    result2 = vizier.core.Vizier().query_constraints_async(testconstraint='blah', catalog='J/ApJ/706/83', get_query_payload=True)
+
+    assert result1 == result2
+
 
 class TestVizierKeywordClass:
 


### PR DESCRIPTION
Fix for Issue #1326.

The bug was that we were using dict.get('key', 'default'), but if dict had {'key': None}, None would be used instead of 'default'.  The regression test is a simple one but required adding get_query_payload.