### PR TITLE
Fix crash with beautifulsoup 4.7+

### DIFF
--- a/astroquery/eso/core.py
+++ b/astroquery/eso/core.py
@@ -764,7 +764,7 @@ class EsoClass(QueryWithLogin):
                 # The benefit of this is also that in the download script the
                 # list of files is de-duplicated, whereas on the web page the
                 # calibration files would be duplicated for each exposure.
-                link = root.select('a[href$=/script]')[0]
+                link = root.select('a[href$="/script"]')[0]
                 if 'downloadRequest' not in link.text:
                     # Make sure that we found the correct link
                     raise RemoteServiceError(


### PR DESCRIPTION
beautifulsoup 4.7 switched to soupsieve for css selectors, which is
causing a crash with the `[href$=/script]` selector. This was allowed
before but is not standard, so soupsieve will not support it.

https://groups.google.com/forum/#!topic/beautifulsoup/LXbShO5rL74 (see also the traceback there)