### PR TITLE
Add refplane kwarg + documentation to jpl horizons vectors_async method

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -8,6 +8,8 @@
 - SDSS: Update to SDSS-IV URLs and general clean-up. [#1308]
 - NIST: Fixed an upstream issue where js was included in returned data [#1359]
 - MAST: Update query_criteria keyword obstype->intentType [#1366]
+- JPLHorizons: Add ``refplane`` keyword to ``vectors_async`` to return data for
+  different available reference planes [#1335]
 
 0.3.9 (2018-12-06)
 ------------------

--- a/astroquery/jplhorizons/core.py
+++ b/astroquery/jplhorizons/core.py
@@ -807,9 +807,9 @@ class HorizonsClass(BaseQuery):
 
         return response
 
-    def vectors_async(self, get_query_payload=False, refplane='ecliptic',
+    def vectors_async(self, get_query_payload=False,
                       closest_apparition=False, no_fragments=False,
-                      get_raw_response=False, cache=True):
+                      get_raw_response=False, cache=True, refplane='ecliptic'):
         """
         Query JPL Horizons for state vectors. The ``location``
         parameter in ``HorizonsClass`` refers in this case to the center
@@ -885,15 +885,15 @@ class HorizonsClass(BaseQuery):
         get_query_payload : boolean, optional
             When set to `True` the method returns the HTTP request
             parameters as a dict, default: False
+        get_raw_response: boolean, optional
+            Return raw data as obtained by JPL Horizons without parsing the
+            data into a table, default: False
         refplane : string
             Reference plane for all output quantities: ``'ecliptic'``
             (ecliptic and mean equinox of reference epoch), ``'earth'``
             (Earth mean equator and equinox of reference epoch), or
             ``'body'`` (body mean equator and node of date); default:
             ``'ecliptic'``
-        get_raw_response: boolean, optional
-            Return raw data as obtained by JPL Horizons without parsing the
-            data into a table, default: False
 
 
         Returns

--- a/astroquery/jplhorizons/core.py
+++ b/astroquery/jplhorizons/core.py
@@ -807,7 +807,7 @@ class HorizonsClass(BaseQuery):
 
         return response
 
-    def vectors_async(self, get_query_payload=False,
+    def vectors_async(self, get_query_payload=False, refplane='ecliptic',
                       closest_apparition=False, no_fragments=False,
                       get_raw_response=False, cache=True):
         """
@@ -885,6 +885,12 @@ class HorizonsClass(BaseQuery):
         get_query_payload : boolean, optional
             When set to `True` the method returns the HTTP request
             parameters as a dict, default: False
+        refplane : string
+            Reference plane for all output quantities: ``'ecliptic'``
+            (ecliptic and mean equinox of reference epoch), ``'earth'``
+            (Earth mean equator and equinox of reference epoch), or
+            ``'body'`` (body mean equator and node of date); default:
+            ``'ecliptic'``
         get_raw_response: boolean, optional
             Return raw data as obtained by JPL Horizons without parsing the
             data into a table, default: False
@@ -968,7 +974,8 @@ class HorizonsClass(BaseQuery):
             ('COMMAND', '"' + commandline + '"'),
             ('CENTER', ("'" + str(self.location) + "'")),
             ('CSV_FORMAT', ('"YES"')),
-            ('REF_PLANE', 'ECLIPTIC'),
+            ('REF_PLANE', {'ecliptic': 'ECLIPTIC', 'earth': 'FRAME',
+                           'body': "'BODY EQUATOR'"}[refplane]),
             ('REF_SYSTEM', 'J2000'),
             ('TP_TYPE', 'ABSOLUTE'),
             ('LABELS', 'YES'),


### PR DESCRIPTION
Added `refplane` as a keyword arg that is passed to the request payload in the `vectors_async` method. I repurposed the code + documentation from the `elements` method.