### PR TITLE
Fix for issue 1327: HEASARC errors too aggressive

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -3,7 +3,7 @@
 
 - ESO: Try to re-authenticate when logged out from the ESO server. [#1315]
 - ADS: Fix an error in one of the default keys, citations->citation [#1337]
-
+- HEASARC: Fixing error handling to filter out only the query errors. [#1338]
 
 
 

--- a/astroquery/heasarc/core.py
+++ b/astroquery/heasarc/core.py
@@ -213,8 +213,8 @@ class HeasarcClass(BaseQuery):
                              "Check that the object name is in GRB, SIMBAD+Sesame, or "
                              "NED format and that the mission name is as listed in "
                              "query_mission_list().")
-        elif "ERROR" in response.text:
-            raise InvalidQueryError("unspecified error from HEASARC database. "
+        elif "Software error:" in response.text:
+            raise InvalidQueryError("Unspecified error from HEASARC database. "
                                     "\nCheck error message: \n{!s}".format(response.text))
 
         try:


### PR DESCRIPTION
In Issue #1327, the HEASARC module was returning an error even though
the query was successful.  This problem occurred because the code is
searching for the word "ERROR" in the returned text, and for some
returns, "ERROR" was included in the text to mean "measurement error",
not "query error".

Keep an eye on this issue in the future, though: there may be other
classes of HEASARC query errors we're not catching now.