### PR TITLE
Updating version dependencies

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -50,8 +50,8 @@ website <http://simbad.u-strasbg.fr/simbad/>`_, use the ``simbad`` sub-package:
 Installation and Requirements
 -----------------------------
 
-Astroquery works with Python 2.7 and 3.3 or later.
-As an `astropy`_ affiliate, astroquery requires `astropy`_ version 1.3 or later.
+Astroquery works with Python 2.7 and 3.5 or later.
+As an `astropy`_ affiliate, astroquery requires `astropy`_ version 2.0 or later.
 
 astroquery uses the `requests <http://docs.python-requests.org/en/latest/>`_
 module to communicate with the internet.  `BeautifulSoup
@@ -149,7 +149,7 @@ These others are functional, but do not follow a common or consistent API:
   * `Fermi <http://astroquery.readthedocs.io/en/latest/fermi/fermi.html>`_: Fermi gamma-ray telescope archive.
   * `HITRAN <http://astroquery.readthedocs.io/en/latest/hitran/hitran.html>`_: Access to the high-resolution transmission molecular absorption database.
   * `JPL Horizons <http://astroquery.readthedocs.io/en/latest/jplhorizons/jplhorizons.html>`_: JPL Solar System Dynamics Horizons Service.
-  * `JPL SBDB <http://astroquery.readthedocs.io/en/latest/jplsbdb/jplsbdb.html>`_: JPL Solar System Dynamics Small-Body Database Browser Service.  
+  * `JPL SBDB <http://astroquery.readthedocs.io/en/latest/jplsbdb/jplsbdb.html>`_: JPL Solar System Dynamics Small-Body Database Browser Service.
   * `Lamda <http://astroquery.readthedocs.io/en/latest/lamda/lamda.html>`_: Leiden Atomic and Molecular Database; energy levels, radiative transitions, and collisional rates for astrophysically relevant atoms and molecules.
   * `NASA Exoplanet Archive  <http://astroquery.readthedocs.io/en/latest/nasa_exoplanet_archive/nasa_exoplanet_archive.html>`_
   * `OAC API <http://astroquery.readthedocs.io/en/latest/oac/oac.html>`_: Open Astronomy Catalog REST API Service.

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -64,12 +64,12 @@ The development version can be obtained and installed from github:
 Requirements
 ------------
 
-Astroquery works with Python 2.7 and 3.4 or later.
+Astroquery works with Python 2.7 and 3.5 or later.
 
 The following packages are required for astroquery installation & use:
 
-* `numpy <http://www.numpy.org>`_ >= 1.10
-* `astropy <http://www.astropy.org>`__ (>=1.3)
+* `numpy <http://www.numpy.org>`_ >= 1.12
+* `astropy <http://www.astropy.org>`__ (>=2.0)
 * `requests <http://docs.python-requests.org/en/latest/>`_
 * `keyring <https://pypi.python.org/pypi/keyring>`_
 * `Beautiful Soup <https://www.crummy.com/software/BeautifulSoup/>`_

--- a/pip-requirements
+++ b/pip-requirements
@@ -1,5 +1,5 @@
-numpy>=1.10.0
-astropy>=1.3
+numpy>=1.12
+astropy>=2.0
 requests>=2.4.3
 keyring>=4.0
 beautifulsoup4>=4.3.2

--- a/setup.cfg
+++ b/setup.cfg
@@ -13,7 +13,7 @@ upload-dir = docs/_build/html
 show-response = 1
 
 [tool:pytest]
-minversion = 2.2
+minversion = 3.0
 norecursedirs = build docs/_build docs/gallery-examples
 doctest_plus = enabled
 addopts = -p no:warnings

--- a/setup.py
+++ b/setup.py
@@ -114,7 +114,7 @@ for root, dirs, files in os.walk(PACKAGENAME):
                     os.path.relpath(root, PACKAGENAME), filename))
 package_info['package_data'][PACKAGENAME].extend(c_files)
 
-required_packages = ['astropy>=1.3', 'requests>=2.4.3', 'keyring>=4.0',
+required_packages = ['astropy>=2.0', 'requests>=2.4.3', 'keyring>=4.0',
                      'beautifulsoup4>=4.3.2', 'html5lib>=0.999', 'six']
 
 extras_require = {


### PR DESCRIPTION
In #1308 testing for some old versions of dependencies has been dropped, this PR merely updates the docs and requirement files to reflect on that. As always, it's possible that most of the functionality still works with older versions, but we neither can guarantee that nor have capacity for fix any issues for those.