### PR TITLE
Correct object-notes to object_notes

### DIFF
--- a/docs/ned/ned.rst
+++ b/docs/ned/ned.rst
@@ -231,7 +231,7 @@ Fetching other data tables for an object
 
 Several other data tables for an object may be fetched via the :meth:`~astroquery.ned.NedClass.get_table`
 queries. These take a keyword argument ``table``, which may be set to one of
-``photometry``, ``diameters``, ``redshifts``, ``references`` or ``object-notes``. For
+``photometry``, ``diameters``, ``redshifts``, ``references`` or ``object_notes``. For
 instance the ``table=photometry`` will fetch all the relevant photometric data
 for the specified object. We look at a simple example:
 


### PR DESCRIPTION
Fixes #1195 

Corrects "object-notes" to "object_notes" [underscore instead of dash]