### PR TITLE
Index cleanup

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -105,7 +105,7 @@ matrix:
         - os: linux
           stage: Tests with other Python/Numpy versions
           env: PYTHON_VERSION=3.5.5 NUMPY_VERSION=1.12 KEYRING_VERSION='<12.0'
-               ASTROPY_VERSION=3.0
+               ASTROPY_VERSION=3.0 APLPY_VERSION='<2.0'
 
         - os: linux
           stage: Tests with other Python/Numpy versions

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -282,12 +282,11 @@ Simulation services query databases of simulated or synthetic data
   besancon/besancon.rst
   cosmosim/cosmosim.rst
 
-Other
------
+Line List Services
+------------------
 
-There are other astronomically significant services, e.g. line list and
-atomic/molecular cross section and collision rate services, that don't fit the
-above categories.
+There are several web services that provide atomic or molecular line lists, as
+well as  cross section and collision rates.  Those services are:
 
 .. toctree::
   :maxdepth: 1
@@ -296,9 +295,18 @@ above categories.
   lamda/lamda.rst
   nist/nist.rst
   splatalogue/splatalogue.rst
-  nasa_ads/nasa_ads.rst
   vamdc/vamdc.rst
   hitran/hitran.rst
+
+Other
+-----
+
+There are other astronomically significant services, that don't fit the
+above categories. Those services are here:
+
+.. toctree::
+  :maxdepth: 1
+  nasa_ads/nasa_ads.rst
   utils/tap.rst
   jplhorizons/jplhorizons.rst
   jplsbdb/jplsbdb.rst

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -274,7 +274,7 @@ generally return a table listing the available data first.
 Simulations
 -----------
 
-Simulation services query databases of simulated or synthetic data
+These services query databases of simulated or synthetic data:
 
 .. toctree::
   :maxdepth: 1

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -306,6 +306,7 @@ above categories. Those services are here:
 
 .. toctree::
   :maxdepth: 1
+  
   nasa_ads/nasa_ads.rst
   utils/tap.rst
   jplhorizons/jplhorizons.rst


### PR DESCRIPTION
Inspired by a discussion with @tddesjardins  and  @crawfordsm : since it turns out about half of the of the "other" items in the index are now line list services, and they have names that are not really clearly line lists, I added another category specifically for "line lister services" (although we could call it something else if there's a more general term).