### PR TITLE
Dace service

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -6,6 +6,7 @@
 - HEASARC: Fixing error handling to filter out only the query errors. [#1338]
 - CDS: Apply MOCPy v0.5.* API changes. [#1343]
 - SDSS: Update to SDSS-IV URLs and general clean-up. [#1308]
+- DACE: add DACE Service in astroquery. See https://dace.unige.ch/ for details. [#1370]
 
 0.3.9 (2018-12-06)
 ------------------

--- a/astroquery/dace/__init__.py
+++ b/astroquery/dace/__init__.py
@@ -1,0 +1,38 @@
+# Licensed under a 3-clause BSD style license - see LICENSE.rst
+
+"""
+Dace API
+--------
+
+:author: Julien Burnier (julien.burnier@unige.ch)
+"""
+
+# Make the URL of the server, timeout and other items configurable
+# See <http://docs.astropy.org/en/latest/config/index.html#developer-usage>
+# for docs and examples on how to do this
+# Below is a common use case
+from astropy import config as _config
+
+
+class Conf(_config.ConfigNamespace):
+    """
+    Configuration parameters for `astroquery.template_module`.
+    """
+    server = _config.ConfigItem(
+        ['https://dace-api.unige.ch/'],
+        'Dace')
+
+    timeout = _config.ConfigItem(
+        30,
+        'Time limit for connecting to template_module server.')
+
+
+conf = Conf()
+
+# Now import your public class
+# Should probably have the same name as your module
+from .core import Dace, DaceClass
+
+__all__ = ['Dace', 'DaceClass',
+           'Conf', 'conf',
+           ]

--- a/astroquery/dace/__init__.py
+++ b/astroquery/dace/__init__.py
@@ -7,16 +7,12 @@ Dace API
 :author: Julien Burnier (julien.burnier@unige.ch)
 """
 
-# Make the URL of the server, timeout and other items configurable
-# See <http://docs.astropy.org/en/latest/config/index.html#developer-usage>
-# for docs and examples on how to do this
-# Below is a common use case
 from astropy import config as _config
 
 
 class Conf(_config.ConfigNamespace):
     """
-    Configuration parameters for `astroquery.template_module`.
+    Configuration parameters for `astroquery.dace`.
     """
     server = _config.ConfigItem(
         ['https://dace-api.unige.ch/'],
@@ -24,13 +20,11 @@ class Conf(_config.ConfigNamespace):
 
     timeout = _config.ConfigItem(
         30,
-        'Time limit for connecting to template_module server.')
+        'Time limit for connecting to DACE server.')
 
 
 conf = Conf()
 
-# Now import your public class
-# Should probably have the same name as your module
 from .core import Dace, DaceClass
 
 __all__ = ['Dace', 'DaceClass',

--- a/astroquery/dace/core.py
+++ b/astroquery/dace/core.py
@@ -44,14 +44,14 @@ class DaceClass(BaseQuery):
     def _parse_result(self, response, verbose=False):
         try:
             json_data = response.json()
-            dace_dict = self._transform_data_as_dict(json_data)
+            dace_dict = self.transform_data_as_dict(json_data)
             return Table(dace_dict)
         except Exception as ex:
             raise ParseException(
                 "Failed to parse DACE result! Exception : {} \nRaw content : {}".format(ex, response.text))
 
     @staticmethod
-    def _transform_data_as_dict(json_data):
+    def transform_data_as_dict(json_data):
         """
         Internally DACE data are provided using protobuff. The format is a list of parameters. Here we parse
         these data to give to the user something more readable and ignore the internal stuff

--- a/astroquery/dace/core.py
+++ b/astroquery/dace/core.py
@@ -13,20 +13,19 @@ class ParseException(Exception):
     """Raised when parsing Dace data fails"""
 
 
-"""
-DACE class to access DACE (Data Analysis Center for Exoplanets) data based in Geneva Observatory  
-"""
-
-
 @async_to_sync
 class DaceClass(BaseQuery):
+    """
+    DACE class to access DACE (Data Analysis Center for Exoplanets) data based in Geneva Observatory
+    """
+
     __DACE_URL = conf.server
     __DACE_TIMEOUT = conf.timeout
     __OBSERVATION_ENDPOINT = 'ObsAPI/observation/'
     __RADIAL_VELOCITIES_ENDPOINT = __OBSERVATION_ENDPOINT + 'radialVelocities/'
     __HEADERS = {'Accept': 'application/json'}
 
-    def query_radial_velocities(self, object_name):
+    def query_radial_velocities_async(self, object_name):
         """
         Get radial velocities data for an object_name. For example : HD40307
 
@@ -36,13 +35,12 @@ class DaceClass(BaseQuery):
 
         Return
         ------
-        table : ~astropy.table.Table Table containing radial velocities data for the object_name given
+        Raw HTTP response
         """
-        response = self._request("GET", ''.join([self.__DACE_URL, self.__RADIAL_VELOCITIES_ENDPOINT, object_name]),
-                                 timeout=self.__DACE_TIMEOUT, headers=self.__HEADERS)
-        return self._parse_result(response)
+        return self._request("GET", ''.join([self.__DACE_URL, self.__RADIAL_VELOCITIES_ENDPOINT, object_name]),
+                             timeout=self.__DACE_TIMEOUT, headers=self.__HEADERS)
 
-    def _parse_result(self, response):
+    def _parse_result(self, response, verbose=False):
         try:
             json_data = response.json()
             dace_dict = self._transform_data_as_dict(json_data)
@@ -75,6 +73,3 @@ class DaceClass(BaseQuery):
 
 
 Dace = DaceClass()
-
-# Next you should write the docs in astroquery/docs/module_name
-# using Sphinx.

--- a/astroquery/dace/core.py
+++ b/astroquery/dace/core.py
@@ -31,11 +31,12 @@ class DaceClass(BaseQuery):
 
         Parameters
         ----------
-        object_name : the target you want radial velocities data
+        object_name : str
+            The target you want radial velocities data
 
         Return
         ------
-        Raw HTTP response
+        response : a ``requests.Response`` from DACE
         """
         return self._request("GET", ''.join([self.__DACE_URL, self.__RADIAL_VELOCITIES_ENDPOINT, object_name]),
                              timeout=self.__DACE_TIMEOUT, headers=self.__HEADERS)
@@ -47,7 +48,7 @@ class DaceClass(BaseQuery):
             return Table(dace_dict)
         except Exception as ex:
             raise ParseException(
-                "Failed to parse DACE result! Exception : " + str(ex) + "\n" + "Raw content : " + response.text)
+                "Failed to parse DACE result! Exception : {} \nRaw content : {}".format(ex, response.text))
 
     @staticmethod
     def _transform_data_as_dict(json_data):

--- a/astroquery/dace/core.py
+++ b/astroquery/dace/core.py
@@ -1,6 +1,7 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 from __future__ import print_function
 from collections import defaultdict
+from json import JSONDecodeError
 from astropy.table import Table
 from ..query import BaseQuery
 from ..utils import async_to_sync
@@ -46,9 +47,8 @@ class DaceClass(BaseQuery):
             json_data = response.json()
             dace_dict = self.transform_data_as_dict(json_data)
             return Table(dace_dict)
-        except Exception as ex:
-            raise ParseException(
-                "Failed to parse DACE result! Exception : {} \nRaw content : {}".format(ex, response.text))
+        except JSONDecodeError as error:
+            raise ParseException("Failed to parse DACE result. Request response : {}".format(response.text)) from error
 
     @staticmethod
     def transform_data_as_dict(json_data):

--- a/astroquery/dace/core.py
+++ b/astroquery/dace/core.py
@@ -57,19 +57,21 @@ class DaceClass(BaseQuery):
         these data to give to the user something more readable and ignore the internal stuff
         """
         data = defaultdict(list)
-        parameters = json_data['parameters']
+        parameters = json_data.get('parameters')
         for parameter in parameters:
-            variable_name = parameter['variableName']
-            data[variable_name].extend(parameter['doubleValues']) if 'doubleValues' in parameter \
-                else None
-            data[variable_name].extend(parameter['intValues']) if 'intValues' in parameter \
-                else None
-            data[variable_name].extend(parameter['stringValues']) if 'stringValues' in parameter \
-                else None
-            data[variable_name].extend(parameter['boolValues']) if 'boolValues' in parameter \
-                else None
-            data[variable_name + '_err'].extend(parameter['minErrorValues']) \
-                if 'minErrorValues' in parameter else []  # min or max is symmetric
+            variable_name = parameter.get('variableName')
+            double_values = parameter.get('doubleValues')
+            int_values = parameter.get('intValues')
+            string_values = parameter.get('stringValues')
+            bool_values = parameter.get('boolValues')
+            # Only one type of values can be present. So we look for the next occurence not None
+            values = next(values_list for values_list in [double_values, int_values, string_values, bool_values] if
+                          values_list is not None)
+            data[variable_name].extend(values)
+
+            error_values = parameter.get('minErrorValues')  # min or max is symmetric
+            if error_values is not None:
+                data[variable_name + '_err'].extend(error_values)
         return data
 
 

--- a/astroquery/dace/core.py
+++ b/astroquery/dace/core.py
@@ -51,7 +51,8 @@ class DaceClass(BaseQuery):
             raise ParseException(
                 "Failed to parse DACE result! Exception : " + str(ex) + "\n" + "Raw content : " + response.text)
 
-    def _transform_data_as_dict(self, json_data):
+    @staticmethod
+    def _transform_data_as_dict(json_data):
         """
         Internally DACE data are provided using protobuff. The format is a list of parameters. Here we parse
         these data to give to the user something more readable and ignore the internal stuff

--- a/astroquery/dace/core.py
+++ b/astroquery/dace/core.py
@@ -1,0 +1,79 @@
+# Licensed under a 3-clause BSD style license - see LICENSE.rst
+from __future__ import print_function
+from collections import defaultdict
+from astropy.table import Table
+from ..query import BaseQuery
+from ..utils import async_to_sync
+from . import conf
+
+__all__ = ['Dace', 'DaceClass']
+
+
+class ParseException(Exception):
+    """Raised when parsing Dace data fails"""
+
+
+"""
+DACE class to access DACE (Data Analysis Center for Exoplanets) data based in Geneva Observatory  
+"""
+
+
+@async_to_sync
+class DaceClass(BaseQuery):
+    __DACE_URL = conf.server
+    __DACE_TIMEOUT = conf.timeout
+    __OBSERVATION_ENDPOINT = 'ObsAPI/observation/'
+    __RADIAL_VELOCITIES_ENDPOINT = __OBSERVATION_ENDPOINT + 'radialVelocities/'
+    __HEADERS = {'Accept': 'application/json'}
+
+    def query_radial_velocities(self, object_name):
+        """
+        Get radial velocities data for an object_name. For example : HD40307
+
+        Parameters
+        ----------
+        object_name : the target you want radial velocities data
+
+        Return
+        ------
+        table : ~astropy.table.Table Table containing radial velocities data for the object_name given
+        """
+        response = self._request("GET", ''.join([self.__DACE_URL, self.__RADIAL_VELOCITIES_ENDPOINT, object_name]),
+                                 timeout=self.__DACE_TIMEOUT, headers=self.__HEADERS)
+        return self._parse_result(response)
+
+    def _parse_result(self, response):
+        try:
+            json_data = response.json()
+            dace_dict = self._transform_data_as_dict(json_data)
+            return Table(dace_dict)
+        except Exception as ex:
+            raise ParseException(
+                "Failed to parse DACE result! Exception : " + str(ex) + "\n" + "Raw content : " + response.text)
+
+    def _transform_data_as_dict(self, json_data):
+        """
+        Internally DACE data are provided using protobuff. The format is a list of parameters. Here we parse
+        these data to give to the user something more readable and ignore the internal stuff
+        """
+        data = defaultdict(list)
+        parameters = json_data['parameters']
+        for parameter in parameters:
+            variable_name = parameter['variableName']
+            data[variable_name].extend(parameter['doubleValues']) if 'doubleValues' in parameter \
+                else None
+            data[variable_name].extend(parameter['intValues']) if 'intValues' in parameter \
+                else None
+            data[variable_name].extend(parameter['stringValues']) if 'stringValues' in parameter \
+                else None
+            data[variable_name].extend(parameter['boolValues']) if 'boolValues' in parameter \
+                else None
+            data[variable_name + '_err'].extend(parameter['minErrorValues']) \
+                if 'minErrorValues' in parameter else []  # min or max is symmetric
+        return data
+
+
+Dace = DaceClass()
+
+# Next you should write the docs in astroquery/docs/module_name
+# using Sphinx.

--- a/astroquery/dace/tests/data/parameter_list.json
+++ b/astroquery/dace/tests/data/parameter_list.json
@@ -1,0 +1,62 @@
+{
+  "parameters": [
+    {
+      "variableName": "ccf_noise",
+      "label": "CCF Noise",
+      "unit": "",
+      "doubleValues": [
+        0.005320016177906,
+        0.00393390440796704,
+        0.0032324617496158
+      ]
+    },
+    {
+      "variableName": "ins_name",
+      "label": "Instrument Name",
+      "unit": "",
+      "stringValues": [
+        "CORALIE98",
+        "CORALIE98",
+        "HARPS"
+      ]
+    },
+    {
+      "variableName": "drs_qc",
+      "label": "DRS Quality check",
+      "unit": "",
+      "boolValues": [
+        true,
+        true,
+        false
+      ]
+    },
+    {
+      "variableName": "rjd",
+      "label": "Barycentric Reduced Julian Day",
+      "unit": "RJD",
+      "intValues": [
+        51031,
+        51039,
+        51088
+      ]
+    },
+    {
+      "variableName": "rv",
+      "label": "Radial Velocity",
+      "unit": "MPS",
+      "doubleValues": [
+        31300.4226771379,
+        31295.5671320506,
+        31294.3391634734
+      ],
+      "minErrorValues": [
+        5.420218247708816,
+        4.0697289792344185,
+        3.4386352834851026
+      ]
+    }
+  ]
+}
+
+
+

--- a/astroquery/dace/tests/setup_package.py
+++ b/astroquery/dace/tests/setup_package.py
@@ -1,0 +1,9 @@
+# Licensed under a 3-clause BSD style license - see LICENSE.rst
+from __future__ import absolute_import
+
+import os
+
+
+def get_package_data():
+    paths = [os.path.join('data', '*.json')]
+    return {'astroquery.dace.tests': paths}

--- a/astroquery/dace/tests/test_dace.py
+++ b/astroquery/dace/tests/test_dace.py
@@ -1,0 +1,31 @@
+import os
+import unittest
+import json
+from astroquery.dace import Dace
+
+DATA_FILES = {
+    'parameter_list': 'parameter_list.json',
+}
+
+
+class TestDaceClass(unittest.TestCase):
+    def test_transform_data_as_dict(self):
+        expected_parameter_dict = {'ccf_noise': [0.005320016177906, 0.00393390440796704, 0.0032324617496158],
+                                   'ins_name': ['CORALIE98', 'CORALIE98', 'HARPS'],
+                                   'drs_qc': [True, True, False],
+                                   'rjd': [51031, 51039, 51088],
+                                   'rv': [31300.4226771379, 31295.5671320506, 31294.3391634734],
+                                   'rv_err': [5.420218247708816, 4.0697289792344185, 3.4386352834851026]}
+        with open(self._data_path('parameter_list.json'), 'r') as file:
+            parameter_list = json.load(file)
+        parameter_dict = Dace.transform_data_as_dict(parameter_list)
+        assert parameter_dict == expected_parameter_dict
+
+    @staticmethod
+    def _data_path(filename):
+        data_dir = os.path.join(os.path.dirname(__file__), 'data')
+        return os.path.join(data_dir, filename)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/astroquery/dace/tests/test_dace_remote.py
+++ b/astroquery/dace/tests/test_dace_remote.py
@@ -11,6 +11,8 @@ class TestDaceClass(unittest.TestCase):
     def test_should_get_radial_velocities(self):
         radial_velocities_table = Dace.query_radial_velocities('HD40307')
         assert radial_velocities_table is not None and 'rv' in radial_velocities_table.colnames
+        # HARPS is a spectrograph and has to be present for this target because HD40307 has been observed and
+        # processed by this instrument
         assert 'HARPS' in radial_velocities_table['ins_name']
         assert HARPS_PUBLICATION in radial_velocities_table['pub_bibcode']
         public_harps_data = [row for row in radial_velocities_table['pub_bibcode'] if HARPS_PUBLICATION in row]

--- a/astroquery/dace/tests/test_dace_remote.py
+++ b/astroquery/dace/tests/test_dace_remote.py
@@ -7,9 +7,8 @@ from astroquery.dace import Dace
 class TestDaceClass(unittest.TestCase):
 
     def test_should_get_radial_velocities(self):
-        radial_velocities = Dace.query_radial_velocities('HD40307')
-        assert radial_velocities is not None and 'rv' in radial_velocities.colnames
-
+        radial_velocities_table = Dace.query_radial_velocities('HD40307')
+        assert radial_velocities_table is not None and 'rv' in radial_velocities_table.colnames
 
 if __name__ == "__main__":
     unittest.main()

--- a/astroquery/dace/tests/test_dace_remote.py
+++ b/astroquery/dace/tests/test_dace_remote.py
@@ -2,6 +2,8 @@ import unittest
 from astropy.tests.helper import remote_data
 from astroquery.dace import Dace
 
+HARPS_PUBLICATION = '2009A&A...493..639M'
+
 
 @remote_data
 class TestDaceClass(unittest.TestCase):
@@ -9,6 +11,10 @@ class TestDaceClass(unittest.TestCase):
     def test_should_get_radial_velocities(self):
         radial_velocities_table = Dace.query_radial_velocities('HD40307')
         assert radial_velocities_table is not None and 'rv' in radial_velocities_table.colnames
+        assert 'HARPS' in radial_velocities_table['ins_name']
+        assert HARPS_PUBLICATION in radial_velocities_table['pub_bibcode']
+        public_harps_data = [row for row in radial_velocities_table['pub_bibcode'] if HARPS_PUBLICATION in row]
+        assert len(public_harps_data) > 100
 
 
 if __name__ == "__main__":

--- a/astroquery/dace/tests/test_dace_remote.py
+++ b/astroquery/dace/tests/test_dace_remote.py
@@ -1,4 +1,3 @@
-import pytest
 import unittest
 from astropy.tests.helper import remote_data
 from astroquery.dace import Dace
@@ -9,8 +8,7 @@ class TestDaceClass(unittest.TestCase):
 
     def test_should_get_radial_velocities(self):
         radial_velocities = Dace.query_radial_velocities('HD40307')
-        assert radial_velocities is not None
-        assert 'rv' in radial_velocities.colnames
+        assert radial_velocities is not None and 'rv' in radial_velocities.colnames
 
 
 if __name__ == "__main__":

--- a/astroquery/dace/tests/test_dace_remote.py
+++ b/astroquery/dace/tests/test_dace_remote.py
@@ -1,6 +1,4 @@
-import os
 import unittest
-import json
 from astropy.tests.helper import remote_data
 from astroquery.dace import Dace
 
@@ -8,7 +6,7 @@ HARPS_PUBLICATION = '2009A&A...493..639M'
 
 
 @remote_data
-class TestDaceClass(unittest.TestCase):
+class TestDaceClassRemote(unittest.TestCase):
 
     def test_should_get_radial_velocities(self):
         radial_velocities_table = Dace.query_radial_velocities('HD40307')
@@ -20,23 +18,6 @@ class TestDaceClass(unittest.TestCase):
         public_harps_data = [row for row in radial_velocities_table['pub_bibcode'] if HARPS_PUBLICATION in row]
         assert len(public_harps_data) > 100
         assert len(radial_velocities_table['rv_err']) > 100
-
-    def test_transform_data_as_dict(self):
-        expected_parameter_dict = {'ccf_noise': [0.005320016177906, 0.00393390440796704, 0.0032324617496158],
-                                   'ins_name': ['CORALIE98', 'CORALIE98', 'HARPS'],
-                                   'drs_qc': [True, True, False],
-                                   'rjd': [51031, 51039, 51088],
-                                   'rv': [31300.4226771379, 31295.5671320506, 31294.3391634734],
-                                   'rv_err': [5.420218247708816, 4.0697289792344185, 3.4386352834851026]}
-        with open(self._data_path('parameter_list.json'), 'r') as file:
-            parameter_list = json.load(file)
-        parameter_dict = Dace._transform_data_as_dict(parameter_list)
-        assert parameter_dict == expected_parameter_dict
-
-    @staticmethod
-    def _data_path(filename):
-        data_dir = os.path.join(os.path.dirname(__file__), 'data')
-        return os.path.join(data_dir, filename)
 
 
 if __name__ == "__main__":

--- a/astroquery/dace/tests/test_dace_remote.py
+++ b/astroquery/dace/tests/test_dace_remote.py
@@ -1,4 +1,6 @@
+import os
 import unittest
+import json
 from astropy.tests.helper import remote_data
 from astroquery.dace import Dace
 
@@ -17,6 +19,24 @@ class TestDaceClass(unittest.TestCase):
         assert HARPS_PUBLICATION in radial_velocities_table['pub_bibcode']
         public_harps_data = [row for row in radial_velocities_table['pub_bibcode'] if HARPS_PUBLICATION in row]
         assert len(public_harps_data) > 100
+        assert len(radial_velocities_table['rv_err']) > 100
+
+    def test_transform_data_as_dict(self):
+        expected_parameter_dict = {'ccf_noise': [0.005320016177906, 0.00393390440796704, 0.0032324617496158],
+                                   'ins_name': ['CORALIE98', 'CORALIE98', 'HARPS'],
+                                   'drs_qc': [True, True, False],
+                                   'rjd': [51031, 51039, 51088],
+                                   'rv': [31300.4226771379, 31295.5671320506, 31294.3391634734],
+                                   'rv_err': [5.420218247708816, 4.0697289792344185, 3.4386352834851026]}
+        with open(self._data_path('parameter_list.json'), 'r') as file:
+            parameter_list = json.load(file)
+        parameter_dict = Dace._transform_data_as_dict(parameter_list)
+        assert parameter_dict == expected_parameter_dict
+
+    @staticmethod
+    def _data_path(filename):
+        data_dir = os.path.join(os.path.dirname(__file__), 'data')
+        return os.path.join(data_dir, filename)
 
 
 if __name__ == "__main__":

--- a/astroquery/dace/tests/test_dace_remote.py
+++ b/astroquery/dace/tests/test_dace_remote.py
@@ -10,5 +10,6 @@ class TestDaceClass(unittest.TestCase):
         radial_velocities_table = Dace.query_radial_velocities('HD40307')
         assert radial_velocities_table is not None and 'rv' in radial_velocities_table.colnames
 
+
 if __name__ == "__main__":
     unittest.main()

--- a/astroquery/dace/tests/test_dace_remote.py
+++ b/astroquery/dace/tests/test_dace_remote.py
@@ -1,0 +1,17 @@
+import pytest
+import unittest
+from astropy.tests.helper import remote_data
+from astroquery.dace import Dace
+
+
+@remote_data
+class TestDaceClass(unittest.TestCase):
+
+    def test_should_get_radial_velocities(self):
+        radial_velocities = Dace.query_radial_velocities('HD40307')
+        assert radial_velocities is not None
+        assert 'rv' in radial_velocities.colnames
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/docs/dace/dace.rst
+++ b/docs/dace/dace.rst
@@ -1,0 +1,37 @@
+.. doctest-skip-all
+
+.. _astroquery.dace:
+
+************************
+DACE (`astroquery.dace`)
+************************
+
+This module let you query DACE (Data Analysis Center for Exoplanets) data. This project is developed
+at Observatory of Geneva and can be accessed online at https://dace.unige.ch
+
+
+API
+===
+
+Query radial velocities
+-----------------------
+If you need to get radial velocities data for an object you can do the following and get a `~astropy.table.Table` :
+
+.. code-block:: python
+
+    >>> from astroquery.dace import Dace
+    >>> radial_velocities_table = Dace.query_radial_velocities('HD40307')
+    >>> print(radial_velocities_table)
+
+          rjd                 rv               rv_err        ins_name
+    ------------------ ------------------ ------------------ --------- ...
+    51131.82401522994   31300.4226771379  5.420218247708816 CORALIE98
+    51139.809670339804   31295.5671320506 4.0697289792344185 CORALIE98
+    51188.67579095997   31294.3391634734 3.4386352834851026 CORALIE98
+    51259.531961040106   31298.3278930888 7.0721030870398245 CORALIE98
+
+               ...                ...                ...       ...
+    56403.48691046983   31333.3379143329 0.5476157667089154   HARPS03
+    56596.82446234021   31334.9563430348  0.508056405864858   HARPS03
+    56602.871036310215   31337.4095684621 0.4167374664543639   HARPS03
+

--- a/docs/dace/dace.rst
+++ b/docs/dace/dace.rst
@@ -35,3 +35,8 @@ If you need to get radial velocities data for an object you can do the following
     56596.82446234021   31334.9563430348  0.508056405864858   HARPS03
     56602.871036310215   31337.4095684621 0.4167374664543639   HARPS03
 
+Reference/API
+=============
+
+.. automodapi:: astroquery.dace
+    :no-inheritance-diagram:

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -179,6 +179,7 @@ The following modules have been completed using a common API:
   vo_conesearch/vo_conesearch.rst
   vsa/vsa.rst
   xmatch/xmatch.rst
+  dace/dace.rst
 
 
 These others are functional, but do not follow a common & consistent API:


### PR DESCRIPTION
Hello,

In Geneva Observatory, we would like to add our API DACE (Data Analysis Center for Exoplanets : https://dace.unige.ch) in astroquery. This is a first small version giving only public data of radial velocities of observed objects (stars, etc.). Next step will be to implement authentication, other useful APIs for astrophysicists and query_object(objectname, ...) (according to your requirements) but will need extra dev on our side. For now we don't have query_regions and get_images but can happen in the future.
This is my first contribution so don't hesitate to tell me if something is missing.

Have a nice day,

Julien 