### PR TITLE
Switching to use VOtable format for XMatch

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -185,6 +185,12 @@ mast
 - Changed warning to error for authentication failure. [#1874]
 
 
+xmatch
+^^^^^^
+
+- Minor internal change to use VOTable as the response format that include
+  units, too. [#1375]
+
 
 Infrastructure, Utility and Other Changes and Additions
 -------------------------------------------------------

--- a/astroquery/xmatch/core.py
+++ b/astroquery/xmatch/core.py
@@ -2,11 +2,10 @@
 
 from io import StringIO, BytesIO
 
-from astropy.io import ascii, votable
+from astropy.io import votable
 import astropy.units as u
 from astropy.table import Table
 from requests import HTTPError
-
 
 from astroquery.query import BaseQuery
 from astroquery.exceptions import InvalidQueryError
@@ -78,7 +77,7 @@ class XMatchClass(BaseQuery):
         if get_query_payload:
             return response
 
-        return Table.read(BytesIO(response.content), format='votable')
+        return Table.read(BytesIO(response.content), format='votable', use_names_over_ids=True)
 
     @prepend_docstr_nosections("\n" + query.__doc__)
     def query_async(self, cat1, cat2, max_distance, colRA1=None, colDec1=None,
@@ -189,23 +188,6 @@ class XMatchClass(BaseQuery):
 
         content = response.text
         return content.splitlines()
-
-    def _parse_text(self, text):
-        """
-        Parse a CSV text file that has potentially duplicated header names
-        """
-        header = text.split("\n")[0]
-        colnames = header.split(",")
-        for column in colnames:
-            if colnames.count(column) > 1:
-                counter = 1
-                while colnames.count(column) > 0:
-                    colnames[colnames.index(column)] = column + "_{counter}".format(counter=counter)
-                    counter += 1
-        new_text = ",".join(colnames) + "\n" + "\n".join(text.split("\n")[1:])
-        result = ascii.read(new_text, format='csv', fast_reader=False)
-
-        return result
 
 
 XMatch = XMatchClass()

--- a/astroquery/xmatch/core.py
+++ b/astroquery/xmatch/core.py
@@ -77,7 +77,8 @@ class XMatchClass(BaseQuery):
         if get_query_payload:
             return response
 
-        return Table.read(BytesIO(response.content), format='votable', use_names_over_ids=True)
+        content = BytesIO(response.content)
+        return Table.read(content, format='votable', use_names_over_ids=True)
 
     @prepend_docstr_nosections("\n" + query.__doc__)
     def query_async(self, cat1, cat2, max_distance, colRA1=None, colDec1=None,

--- a/astroquery/xmatch/core.py
+++ b/astroquery/xmatch/core.py
@@ -77,7 +77,8 @@ class XMatchClass(BaseQuery):
                                     **kwargs)
         if get_query_payload:
             return response
-        return self._parse_text(response.text)
+
+        return Table.read(BytesIO(response.content), format='votable')
 
     @prepend_docstr_nosections("\n" + query.__doc__)
     def query_async(self, cat1, cat2, max_distance, colRA1=None, colDec1=None,
@@ -92,12 +93,11 @@ class XMatchClass(BaseQuery):
         if max_distance > 180 * u.arcsec:
             raise ValueError(
                 'max_distance argument must not be greater than 180')
-        payload = {
-            'request': 'xmatch',
-            'distMaxArcsec': max_distance.to(u.arcsec).value,
-            'RESPONSEFORMAT': 'csv',
-            **kwargs
-        }
+        payload = {'request': 'xmatch',
+                   'distMaxArcsec': max_distance.to(u.arcsec).value,
+                   'RESPONSEFORMAT': 'votable',
+                   **kwargs}
+
         kwargs = {}
 
         self._prepare_sending_table(1, payload, kwargs, cat1, colRA1, colDec1)

--- a/astroquery/xmatch/tests/test_xmatch.py
+++ b/astroquery/xmatch/tests/test_xmatch.py
@@ -104,9 +104,3 @@ def test_xmatch_query_cat1_table_local(monkeypatch):
         'errHalfMaj', 'errHalfMin', 'errPosAng', 'Jmag', 'Hmag', 'Kmag',
         'e_Jmag', 'e_Hmag', 'e_Kmag', 'Qfl', 'Rfl', 'X', 'MeasureJD']
     assert len(table) == 11
-
-
-@pytest.mark.parametrize('datafile', DATA_FILES.values())
-def test_parse_text(datafile):
-    xm = XMatch()
-    xm._parse_text(datafile)

--- a/docs/xmatch/xmatch.rst
+++ b/docs/xmatch/xmatch.rst
@@ -55,6 +55,7 @@ in the resulting table for demonstration purposes.  Finally, ``colRa1`` and
     <class 'astropy.table.table.Table'>
     >>> print(table)
     angDist      ra       dec         2MASS       ... Qfl Rfl  X   MeasureJD
+     arcsec                                       ...                  d
     -------- --------- --------- ---------------- ... --- --- --- ------------
     1.352044 267.22029 -20.35869 17485281-2021323 ... EEU 226   2 2450950.8609
     1.578188 267.22029 -20.35869 17485288-2021328 ... UUB 662   2 2450950.8609


### PR DESCRIPTION
Edit: to close #1777


As the reader for the csv format cannot handle column duplications (that is quite likely as both users and catalogues can name their RA/DEC columns as RA/DEC, and there is no renaming on the server side). Until astropy solves this for the ascii reader, and we require that version as minimum version we need to have a workaround.

Here is a failing example:

```
from astropy.table import Table
import astropy.units as u
from  astroquery.xmatch import XMatch

input_table=Table.read("""2.11044940645274 0.688137082702486
    2.11504231688281 0.671688214247088
    2.08882950663451 0.719216362471814
    2.09308610414763 0.708799922876203
    2.09619379588014 0.706120900363544""", names=['ra', 'dec'], format='ascii')

XMatch.query(input_table, 'vizier:II/311/wise', 5*u.arcsec, 'ra', 'dec')
```

The downside of this PR that the votable will remove also columns that are totally fine otherwise (e.g. _2MASS in the example in the current docs)