### PR TITLE
The deploy job should not even come up for cron runs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,7 +24,7 @@ stages:
      if: type = cron
    - name: Tests with other Python/Numpy versions
    - name: Deploy
-     if: ((branch = master) AND type != pull_request)
+     if: ((branch = master) AND type != pull_request AND type != cron)
    - name: Remote data tests
      if: type != pull_request
 


### PR DESCRIPTION
Currently it's cancelled from within `ci-helpers`, but jobs from that stage shouldn't even start up.