### PR TITLE
Retrieve wavenumbers from NIST queries.

### DIFF
--- a/astroquery/nist/core.py
+++ b/astroquery/nist/core.py
@@ -120,6 +120,7 @@ class NistClass(BaseQuery):
         request_payload["J_out"] = "on"
         request_payload["page_size"] = 15
         request_payload["remove_js"] = "on"
+        request_payload["show_wn"] = 1
         return request_payload
 
     @prepend_docstr_nosections("\n" + _args_to_payload.__doc__)


### PR DESCRIPTION
This change causes the request to NIST to include a request for the wavenumber of each transition. While this number can be computed as the difference between the upper and lower energy wavenumbers, it's convenient to have it as a separate column (where it can also serve as a checksum to compare the energies to if desired).

I ran the NIST-specific tests with pytest and they passed, but wasn't able to run all tests as it asked for a password from "aginsburg" so I'm not sure if I messed something up in installation. I use the modified code in my own research (the need for which prompted the change) and it's worked fine for me so far, for what that's worth. Apologies if I'm doing this wrong, it's my first real pull request.