### PR TITLE
Set http user-agent when running Travis CI and AppVeyor

### DIFF
--- a/astroquery/tests/test_internet.py
+++ b/astroquery/tests/test_internet.py
@@ -1,14 +1,17 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 from astropy.tests.helper import remote_data
 import requests
+import os
 
 from .. import version
+
+IS_CI = os.environ.get('TRAVIS', False) or os.environ.get('APPVEYOR', False) == 'True'
 
 
 @remote_data
 def test_net_connection():
     R = requests.post('http://httpbin.org/post',
                       headers={'User-Agent':
-                               'astropy:astroquery.{0}'
-                               .format(version.version)})
+                      'astropy:astroquery-ci-tests.{0}'
+                      .format(version.version)})
     R.raise_for_status()


### PR DESCRIPTION
Fixes #1281. 

Create environment variables in the `astroquery/tests/test_internet.py` files for both the Travis CI and AppVeyor, and then checked these are turned on in the respective `.travis.yml` and `appveyor.yml` .yml files by default. Finally, the http user-agent is changed in `astroquery/tests/test_internet.py`. 