### PR TITLE
Adding new eso instruments to list

### DIFF
--- a/astroquery/eso/tests/test_eso_remote.py
+++ b/astroquery/eso/tests/test_eso_remote.py
@@ -165,7 +165,7 @@ class TestEso:
         tbl = eso.query_apex_quicklooks(prog_id='095.F-9802')
         tblb = eso.query_apex_quicklooks('095.F-9802')
 
-        assert len(tbl) == 4
+        assert len(tbl) == 10
         assert set(tbl['Release Date']) == {'2015-07-17', '2015-07-18',
                                             '2015-09-15', '2015-09-18'}
 

--- a/astroquery/eso/tests/test_eso_remote.py
+++ b/astroquery/eso/tests/test_eso_remote.py
@@ -13,7 +13,7 @@ instrument_list = [u'fors1', u'fors2', u'sphere', u'vimos', u'omegacam',
                    u'hawki', u'isaac', u'naco', u'visir', u'vircam', u'apex',
                    u'giraffe', u'uves', u'xshooter', u'muse', u'crires',
                    u'kmos', u'sinfoni', u'amber', u'midi', u'pionier',
-                   u'gravity']
+                   u'gravity', u'espresso', u'wlgsu', u'matisse']
 
 # Some tests take too long, leading to travis timeouts
 # TODO: make this a configuration item


### PR DESCRIPTION
@keflavich - There is another test failing, it seems your observing program suddenly has more data in the archive!??! I really don't understand why, but you may have better ideas:

```
======================================================================================= test session starts ========================================================================================
platform darwin -- Python 3.7.0, pytest-3.9.3, py-1.6.0, pluggy-0.7.1

Running tests with astroquery version 0.3.10.dev5279_testrun.
Running tests in astroquery/eso docs/eso.

Date: 2019-04-02T19:50:47

Platform: Darwin-17.7.0-x86_64-i386-64bit

Executable: /usr/local/opt/python/bin/python3.7

Full Python Version: 
3.7.0 (default, Sep 18 2018, 18:47:22) 
[Clang 9.1.0 (clang-902.0.39.2)]

encodings: sys: utf-8, locale: UTF-8, filesystem: utf-8
byteorder: little
float info: dig: 15, mant_dig: 15

Numpy: 1.16.0
Matplotlib: 3.0.2.post1886+g0f927c135
Pandas: 0.23.4
Astropy: 3.1.2
APLpy: not available
pyregion: not available
astropy_helpers: 2.0.8
Using Astropy options: remote_data: any.

rootdir: /private/var/folders/dc/hsm7tqpx2d57n7vb3k1l81xw0000gq/T/astroquery-test-6ijpuwi9/lib/python3.7/site-packages, inifile: setup.cfg
plugins: xonsh-0.8.3, xdist-1.26.1, remotedata-0.3.1, openfiles-0.3.0, forked-1.0.2, dependency-0.4.0, cov-2.6.0, arraydiff-0.3, doctestplus-0.3.0.dev0
collected 43 items                                                                                                                                                                                 

astroquery/eso/tests/test_eso.py ...                                                                                                                                                         [  6%]
astroquery/eso/tests/test_eso_remote.py ......sss........................F..ss.                                                                                                              [ 97%]
docs/eso/eso.rst .                                                                                                                                                                           [100%]

============================================================================================= FAILURES =============================================================================================
___________________________________________________________________________________ TestEso.test_apex_retrieval ____________________________________________________________________________________

self = <astroquery.eso.tests.test_eso_remote.TestEso object at 0x121866278>

    def test_apex_retrieval(self):
        eso = Eso()
    
        tbl = eso.query_apex_quicklooks(prog_id='095.F-9802')
        tblb = eso.query_apex_quicklooks('095.F-9802')
    
>       assert len(tbl) == 4
E       assert 10 == 4
E        +  where 10 = len(<Table length=10>\n         Product ID         Observation Date ...  APEX Project ID  \n           str27                ...15JUL16.TAR       2015-07-15 ... E-095.F-9802A-2015\nE-095.F-9802A.2015JUL15.TAR       2015-07-10 ... E-095.F-9802A-2015)

astroquery/eso/tests/test_eso_remote.py:168: AssertionError
========================================================================= 1 failed, 37 passed, 5 skipped in 188.01 seconds =========================================================================

```