### PR TITLE
MAST: remove deprecated code, fix tests, general cleanup

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -12,6 +12,8 @@
   different available reference planes [#1335]
 - ALMA: Fix some broken VOtable returns and a broken login URL [#1369]
 - CADC: Initial version [#1354]
+- MAST: Remove deprecated authorization code, fix unit tests, general code
+  cleanup, documentation additions [#1409]
 
 0.3.9 (2018-12-06)
 ------------------

--- a/astroquery/mast/__init__.py
+++ b/astroquery/mast/__init__.py
@@ -3,7 +3,7 @@
 MAST Query Tool
 ===============
 
-This module contains various methods for querying the MAST Portal.
+Module to query the Barbara A. Mikulski Archive for Space Telescopes (MAST).
 """
 
 from astropy import config as _config

--- a/astroquery/mast/core.py
+++ b/astroquery/mast/core.py
@@ -3,8 +3,7 @@
 MAST Portal
 ===========
 
-Module to query the Barbara A. Mikulski Archive for Space Telescopes (MAST).
-
+This module contains various methods for querying the MAST Portal.
 """
 
 from __future__ import print_function, division

--- a/astroquery/mast/core.py
+++ b/astroquery/mast/core.py
@@ -27,7 +27,6 @@ from astropy.table import Table, Row, vstack, MaskedColumn
 from astropy.logger import log
 
 from astropy.utils import deprecated
-from astropy.utils.decorators import deprecated_renamed_argument
 from astropy.utils.console import ProgressBarOrSpinner
 from astropy.utils.exceptions import AstropyDeprecationWarning
 
@@ -218,8 +217,7 @@ class MastClass(QueryWithLogin):
     def get_token(self):
         return None
 
-    @deprecated_renamed_argument('silent', new_name=None, since="v0.3.9.dev (use 'verbose' instead)")
-    def session_info(self, silent=None, verbose=True):
+    def session_info(self, silent=None, verbose=None):
         """
         Displays information about current MAST user, and returns user info dictionary.
 
@@ -235,6 +233,19 @@ class MastClass(QueryWithLogin):
         response : dict
         """
 
+        # Dealing with deprecated argument
+        if (silent is not None) and (verbose is not None):
+            warnings.warn(("Argument 'silent' has been deprecated, "
+                           "will be ignored in favor of 'verbose'"), AstropyDeprecationWarning)
+        elif silent is not None:
+            warnings.warn(("Argument 'silent' has been deprecated, "
+                           "and will be removed in the future. "
+                           " Use 'verbose' instead."), AstropyDeprecationWarning)
+            verbose = not silent
+        elif (silent is None) and  (verbose is None):
+            verbose = True
+
+        
         # get user information
         self._session.headers["Accept"] = "application/json"
         response = self._session.request("GET", self._SESSION_INFO_URL)

--- a/astroquery/mast/core.py
+++ b/astroquery/mast/core.py
@@ -172,7 +172,7 @@ class MastClass(QueryWithLogin):
             Default is None.
             The token to authenticate the user.
             This can be generated at
-                https://auth.mast.stsci.edu/token?suggested_name=Astroquery&suggested_scope=mast:exclusive_access.
+            https://auth.mast.stsci.edu/token?suggested_name=Astroquery&suggested_scope=mast:exclusive_access.
             If not supplied, it will be prompted for if not in the keyring or set via $MAST_API_TOKEN
         store_token : bool, optional
             Default False.
@@ -1674,7 +1674,7 @@ class CatalogsClass(MastClass):
 
         Parameters
         ----------
-        specrtra : `~astropy.table.Table` or `astropy.table.Row`
+        spectra : `~astropy.table.Table` or `astropy.table.Row`
             One or more HSC spectra to be downloaded.
         download_dir : str, optional
            Specify the base directory to download spectra into.

--- a/astroquery/mast/core.py
+++ b/astroquery/mast/core.py
@@ -64,9 +64,9 @@ def _prepare_service_request_string(json_obj):
     response : str
         URL encoded Mashup Request string.
     """
+
     request_string = json.dumps(json_obj)
-    request_string = urlencode(request_string)
-    return "request="+request_string
+    return 'request={}'.format(urlencode(request_string))
 
 
 def _mashup_json_to_table(json_obj, col_config=None):
@@ -303,6 +303,9 @@ class MastClass(QueryWithLogin):
 
                 if (time.time() - start_time) >= self.TIMEOUT:
                     raise TimeoutError("Timeout limit of {} exceeded.".format(self.TIMEOUT))
+
+                # Raising error based on HTTP status if necessary
+                response.raise_for_status()
 
                 result = response.json()
 
@@ -1252,13 +1255,13 @@ class ObservationsClass(MastClass):
         manifest_array = []
         for data_product in products:
 
-            local_path = base_dir + "/" + data_product['obs_collection'] + "/" + data_product['obs_id']
+            local_path = os.path.join(base_dir, data_product['obs_collection'], data_product['obs_id'])
             data_url = self._MAST_DOWNLOAD_URL + "?uri=" + data_product["dataURI"]
 
             if not os.path.exists(local_path):
                 os.makedirs(local_path)
 
-            local_path += '/' + data_product['productFilename']
+            local_path = os.path.join(local_path, data_product['productFilename'])
 
             status = "COMPLETE"
             msg = None
@@ -1731,7 +1734,7 @@ class CatalogsClass(MastClass):
             response = self.service_request_async(service, params)
             bundler_response = response[0].json()
 
-            local_path = download_dir.rstrip('/') + "/" + download_file + ".sh"
+            local_path = os.path.join(download_dir, "{}.sh".format(download_file))
             self._download_file(bundler_response['url'], local_path, head_safe=True, continuation=False)
 
             status = "COMPLETE"
@@ -1763,8 +1766,6 @@ class CatalogsClass(MastClass):
             manifest_array = []
             for spec in spectra:
 
-                # local_path = base_dir + "/HSC"# + spec['DatasetName'] + ".fits"
-
                 if spec['SpectrumType'] < 2:
                     data_url = 'https://hla.stsci.edu/cgi-bin/getdata.cgi?config=ops&dataset=' \
                               + spec['DatasetName']
@@ -1772,7 +1773,7 @@ class CatalogsClass(MastClass):
                     data_url = 'https://hla.stsci.edu/cgi-bin/ecfproxy?file_id=' \
                               + spec['DatasetName'] + '.fits'
 
-                local_path = base_dir + '/' + spec['DatasetName'] + ".fits"
+                local_path = os.path.join(base_dir, "{}.fits".format(spec['DatasetName']))
 
                 status = "COMPLETE"
                 msg = None

--- a/astroquery/mast/core.py
+++ b/astroquery/mast/core.py
@@ -242,10 +242,9 @@ class MastClass(QueryWithLogin):
                            "and will be removed in the future. "
                            " Use 'verbose' instead."), AstropyDeprecationWarning)
             verbose = not silent
-        elif (silent is None) and  (verbose is None):
+        elif (silent is None) and (verbose is None):
             verbose = True
 
-        
         # get user information
         self._session.headers["Accept"] = "application/json"
         response = self._session.request("GET", self._SESSION_INFO_URL)

--- a/astroquery/mast/core.py
+++ b/astroquery/mast/core.py
@@ -11,35 +11,38 @@ from __future__ import print_function, division
 import warnings
 import json
 import time
-import string
+#import string
 import os
-import re
+#import re
 import keyring
 import threading
-import requests
+#import requests
 
 import numpy as np
 
 from requests import HTTPError
 from getpass import getpass
-from base64 import b64encode
+#from base64 import b64encode
 
 import astropy.units as u
 import astropy.coordinates as coord
-from astropy.utils import deprecated
 
 from astropy.table import Table, Row, vstack, MaskedColumn
-from six.moves.urllib.parse import quote as urlencode
-from six.moves.http_cookiejar import Cookie
-from astropy.utils.console import ProgressBarOrSpinner
-from astropy.utils.exceptions import AstropyWarning, AstropyDeprecationWarning
 from astropy.logger import log
+
+from astropy.utils import deprecated
+from astropy.utils.decorators import deprecated_renamed_argument
+from astropy.utils.console import ProgressBarOrSpinner
+from astropy.utils.exceptions import AstropyDeprecationWarning
+
+from six.moves.urllib.parse import quote as urlencode
+#from six.moves.http_cookiejar import Cookie
 
 from ..query import QueryWithLogin
 from ..utils import commons, async_to_sync
 from ..utils.class_or_instance import class_or_instance
 from ..exceptions import (TimeoutError, InvalidQueryError, RemoteServiceError,
-                          LoginError, ResolverError, MaxResultsWarning,
+                          ResolverError, MaxResultsWarning,
                           NoResultsWarning, InputWarning, AuthenticationWarning)
 
 from . import conf
@@ -203,7 +206,7 @@ class MastClass(QueryWithLogin):
 
         self._session.headers["Accept"] = "application/json"
         self._session.cookies["mast_token"] = token
-        info = self.session_info(silent=True)
+        info = self.session_info(verbose=False)
 
         if not info["anon"]:
             log.info("MAST API token accepted, welcome %s" % info["attrib"].get("display_name"))
@@ -215,20 +218,22 @@ class MastClass(QueryWithLogin):
 
         return not info["anon"]
 
-    @deprecated(since="v0.3.10", message=("The get_token function is deprecated, "
-                                          "session token is now the token used for login."))
+    @deprecated(since="v0.3.9.dev", message=("The get_token function is deprecated, "
+                                             "session token is now the token used for login."))
     def get_token(self):
         return None
 
-    def session_info(self, silent=False):
+    @deprecated_renamed_argument('silent', new_name=None, since="v0.3.9.dev", alternative='verbose')
+    def session_info(self, silent=None, verbose=True):
         """
         Displays information about current MAST user, and returns user info dictionary.
 
         Parameters
         ----------
-        silent : bool, optional
-            Default False.
-            Suppresses output to stdout.
+        silent :
+            Deprecated. Use verbose instead.
+        verbose : bool, optional
+            Default True. Set to False to suppress output to stdout.
 
         Returns
         -------
@@ -241,7 +246,7 @@ class MastClass(QueryWithLogin):
 
         info_dict = response.json()
 
-        if not silent:
+        if verbose:
             for key, value in info_dict.items():
                 if isinstance(value, dict):
                     for subkey, subval in value.items():
@@ -255,7 +260,7 @@ class MastClass(QueryWithLogin):
                  files=None, stream=False, auth=None, retrieve_all=True):
         """
         Override of the parent method:
-        A generic HTTP request method, similar to ``requests.Session.request``
+        A generic HTTP request method, similar to `~requests.Session.request`
 
         This is a low-level method not generally intended for use by astroquery
         end-users.
@@ -278,13 +283,13 @@ class MastClass(QueryWithLogin):
         auth : None or dict
         files : None or dict
         stream : bool
-            See ``requests.request``
+            See `~requests.request`
         retrieve_all : bool
             Default True. Retrieve all pages of data or just the one indicated in the params value.
 
         Returns
         -------
-        response : ``requests.Response``
+        response : `~requests.Response`
             The response from the server.
         """
 
@@ -377,12 +382,12 @@ class MastClass(QueryWithLogin):
 
     def _parse_result(self, responses, verbose=False):
         """
-        Parse the results of a list of ``requests.Response`` objects and returns an `astropy.table.Table` of results.
+        Parse the results of a list of `~requests.Response` objects and returns an `astropy.table.Table` of results.
 
         Parameters
         ----------
-        responses : list of ``requests.Response``
-            List of ``requests.Response`` objects.
+        responses : list of `~requests.Response`
+            List of `~requests.Response` objects.
         verbose : bool
             (presently does nothing - there is no output with verbose set to
             True or False)
@@ -390,7 +395,7 @@ class MastClass(QueryWithLogin):
 
         Returns
         -------
-        response : `astropy.table.Table`
+        response : `~astropy.table.Table`
         """
 
         # loading the columns config
@@ -453,7 +458,7 @@ class MastClass(QueryWithLogin):
 
         Returns
         -------
-        response : list of ``requests.Response``
+        response : list of `~requests.Response`
         """
 
         # setting self._current_service
@@ -685,7 +690,7 @@ class ObservationsClass(MastClass):
 
         Returns
         -------
-        response : list of ``requests.Response``
+        response : list of `~requests.Response`
         """
 
         # Put coordinates and radius into consistant format
@@ -729,7 +734,7 @@ class ObservationsClass(MastClass):
 
         Returns
         -------
-        response : list of ``requests.Response``
+        response : list of `~requests.Response`
         """
 
         coordinates = self._resolve_object(objectname)
@@ -764,7 +769,7 @@ class ObservationsClass(MastClass):
 
         Returns
         -------
-        response : list(`requests.Response`)
+        response : list of `~requests.Response`
         """
 
         # Seperating any position info from the rest of the filters
@@ -1001,7 +1006,7 @@ class ObservationsClass(MastClass):
 
         Returns
         -------
-            response : list(`requests.Response`)
+            response : list of `~requests.Response`
         """
 
         # getting the obsid list
@@ -1427,7 +1432,7 @@ class CatalogsClass(MastClass):
 
         Returns
         -------
-        response: list of ``requests.Response``
+        response : list of `~requests.Response`
         """
 
         # Put coordinates and radius into consistant format
@@ -1517,7 +1522,7 @@ class CatalogsClass(MastClass):
 
         Returns
         -------
-        response: list of ``requests.Response``
+        response : list of `~requests.Response`
         """
 
         coordinates = self._resolve_object(objectname)
@@ -1549,10 +1554,9 @@ class CatalogsClass(MastClass):
             RA and Dec must be given in decimal degrees, and datetimes in MJD.
             For example: filters=["FUV","NUV"],proposal_pi="Ost*",t_max=[52264.4586,54452.8914]
 
-
         Returns
         -------
-        response : list(`requests.Response`)
+        response : list of `~requests.Response`
         """
 
         # Seperating any position info from the rest of the filters
@@ -1627,9 +1631,9 @@ class CatalogsClass(MastClass):
             Can be used to override the default behavior of all results being returned to obtain
             one sepcific page of results.
 
-        Response
+        Returns
         --------
-        response : list(`requests.Response`)
+        response : list of `~requests.Response`
         """
 
         if isinstance(match, Row):
@@ -1661,9 +1665,9 @@ class CatalogsClass(MastClass):
             Can be used to override the default behavior of all results being returned to obtain
             one sepcific page of results.
 
-        Response
+        Returns
         --------
-        response : list(`requests.Response`)
+        response : list of `~requests.Response`
         """
 
         service = "Mast.HscSpectra.Db.All"
@@ -1690,9 +1694,9 @@ class CatalogsClass(MastClass):
             Default is False.  If true instead of downloading files directly, a curl script
             will be downloaded that can be used to download the data files at a later time.
 
-        Response
+        Returns
         --------
-        response : list(`requests.Response`)
+        response : list of `~requests.Response`
         """
 
         # if spectra is not a Table, put it in a list

--- a/astroquery/mast/core.py
+++ b/astroquery/mast/core.py
@@ -212,8 +212,8 @@ class MastClass(QueryWithLogin):
 
         return not info["anon"]
 
-    @deprecated(since="v0.3.9.dev", message=("The get_token function is deprecated, "
-                                             "session token is now the token used for login."))
+    @deprecated(since="v0.3.9", message=("The get_token function is deprecated, "
+                                         "session token is now the token used for login."))
     def get_token(self):
         return None
 

--- a/astroquery/mast/core.py
+++ b/astroquery/mast/core.py
@@ -11,18 +11,14 @@ from __future__ import print_function, division
 import warnings
 import json
 import time
-#import string
 import os
-#import re
 import keyring
 import threading
-#import requests
 
 import numpy as np
 
 from requests import HTTPError
 from getpass import getpass
-#from base64 import b64encode
 
 import astropy.units as u
 import astropy.coordinates as coord
@@ -36,7 +32,6 @@ from astropy.utils.console import ProgressBarOrSpinner
 from astropy.utils.exceptions import AstropyDeprecationWarning
 
 from six.moves.urllib.parse import quote as urlencode
-#from six.moves.http_cookiejar import Cookie
 
 from ..query import QueryWithLogin
 from ..utils import commons, async_to_sync

--- a/astroquery/mast/core.py
+++ b/astroquery/mast/core.py
@@ -218,7 +218,7 @@ class MastClass(QueryWithLogin):
     def get_token(self):
         return None
 
-    @deprecated_renamed_argument('silent', new_name=None, since="v0.3.9.dev", alternative='verbose')
+    @deprecated_renamed_argument('silent', new_name=None, since="v0.3.9.dev (use 'verbose' instead)")
     def session_info(self, silent=None, verbose=True):
         """
         Displays information about current MAST user, and returns user info dictionary.

--- a/astroquery/mast/core.py
+++ b/astroquery/mast/core.py
@@ -217,10 +217,10 @@ class MastClass(QueryWithLogin):
 
     @deprecated(since="v0.3.10", message=("The get_token function is deprecated, "
                                           "session token is now the token used for login."))
-    def get_token(self):  
+    def get_token(self):
         return None
 
-    def session_info(self, silent=False): 
+    def session_info(self, silent=False):
         """
         Displays information about current MAST user, and returns user info dictionary.
 
@@ -1111,7 +1111,7 @@ class ObservationsClass(MastClass):
         """
         import boto3
         import botocore
-        
+
         if profile is not None:
             self._boto3 = boto3.Session(profile_name=profile)
         else:

--- a/astroquery/mast/core.py
+++ b/astroquery/mast/core.py
@@ -65,9 +65,9 @@ def _prepare_service_request_string(json_obj):
     response : str
         URL encoded Mashup Request string.
     """
-    requestString = json.dumps(json_obj)
-    requestString = urlencode(requestString)
-    return "request="+requestString
+    request_string = json.dumps(json_obj)
+    request_string = urlencode(request_string)
+    return "request="+request_string
 
 
 def _mashup_json_to_table(json_obj, col_config=None):
@@ -86,8 +86,7 @@ def _mashup_json_to_table(json_obj, col_config=None):
     response : `~astropy.table.Table`
     """
 
-    dataTable = Table(masked=True)
-    absCorr = None
+    data_table = Table(masked=True)
 
     if not all(x in json_obj.keys() for x in ['fields', 'data']):
         raise KeyError("Missing required key(s) 'data' and/or 'fields.'")
@@ -99,40 +98,40 @@ def _mashup_json_to_table(json_obj, col_config=None):
             continue
 
         # reading the colum config if given
-        ignoreValue = None
+        ignore_value = None
         if col_config:
-            colProps = col_config.get(col, {})
-            ignoreValue = colProps.get("ignoreValue", None)
+            col_props = col_config.get(col, {})
+            ignore_value = col_props.get("ignoreValue", None)
 
         # making type adjustments
         if atype == "string":
             atype = "str"
-            ignoreValue = "" if (ignoreValue is None) else ignoreValue
+            ignore_value = "" if (ignore_value is None) else ignore_value
         if atype == "boolean":
             atype = "bool"
         if atype == "int":  # int arrays do not admit Non/nan vals
             atype = np.int64
-            ignoreValue = -999 if (ignoreValue is None) else ignoreValue
+            ignore_value = -999 if (ignore_value is None) else ignore_value
         if atype == "date":
             atype = "str"
-            ignoreValue = "" if (ignoreValue is None) else ignoreValue
+            ignore_value = "" if (ignore_value is None) else ignore_value
 
         # Make the column list (don't assign final type yet or there will be errors)
-        colData = np.array([x.get(col, ignoreValue) for x in json_obj['data']], dtype=object)
-        if ignoreValue is not None:
-            colData[np.where(np.equal(colData, None))] = ignoreValue
+        col_data = np.array([x.get(col, ignore_value) for x in json_obj['data']], dtype=object)
+        if ignore_value is not None:
+            col_data[np.where(np.equal(col_data, None))] = ignore_value
 
         # no consistant way to make the mask because np.equal fails on ''
         # and array == value fails with None
         if atype == 'str':
-            colMask = (colData == ignoreValue)
+            col_mask = (col_data == ignore_value)
         else:
-            colMask = np.equal(colData, ignoreValue)
+            col_mask = np.equal(col_data, ignore_value)
 
         # add the column
-        dataTable.add_column(MaskedColumn(colData.astype(atype), name=col, mask=colMask))
+        data_table.add_column(MaskedColumn(col_data.astype(atype), name=col, mask=col_mask))
 
-    return dataTable
+    return data_table
 
 
 @async_to_sync
@@ -144,7 +143,7 @@ class MastClass(QueryWithLogin):
     more flexible but less user friendly than `ObservationsClass`.
     """
 
-    def __init__(self, username=None, password=None, session_token=None):
+    def __init__(self, mast_token=None):
 
         super(MastClass, self).__init__()
 
@@ -157,64 +156,72 @@ class MastClass(QueryWithLogin):
         self._column_configs = dict()
         self._current_service = None
 
-        try:
-            self._auth_mode = self._get_auth_mode()
-        except (requests.exceptions.ConnectionError, IOError):
-            # this is fine, we're in test mode
-            self._auth_mode = 'SHIB-ECP'
+        self._SESSION_INFO_URL = conf.server + "/whoami"
+        self._MAST_DOWNLOAD_URL = conf.server + "/api/v0.1/Download/file"
+        self._MAST_BUNDLE_URL = conf.server + "/api/v0.1/Download/bundle"
 
-        if "SHIB-ECP" == self._auth_mode:
-            log.debug("Using Legacy Shibboleth login")
-            self._SESSION_INFO_URL = conf.server + "/Shibboleth.sso/Session"
-            self._SP_TARGET = conf.server + "/api/v0/Mashup/Login/login.html"
-            self._IDP_ENDPOINT = conf.ssoserver + "/idp/profile/SAML2/SOAP/ECP"
-            self._MAST_DOWNLOAD_URL = conf.server + "/api/v0/Download/file"
-        elif "MAST-AUTH" == self._auth_mode:
-            log.debug("Using Auth.MAST login")
-            self._SESSION_INFO_URL = conf.server + "/whoami"
-            self._MAST_DOWNLOAD_URL = conf.server + "/api/v0.1/Download/file"
-            self._MAST_BUNDLE_URL = conf.server + "/api/v0.1/Download/bundle"
-        else:
-            raise Exception("Unknown MAST Auth mode %s" % self._auth_mode)
+        if mast_token:
+            self.login(token=mast_token)
 
-        if username or session_token:
-            self.login(username, password, session_token)
-
-    def _get_auth_mode(self):
-        _auth_mode = "SHIB-ECP"
-
-        # Detect auth mode from auth_type endpoint
-        resp = self._session.get(conf.server + '/auth_type')
-        if resp.status_code == 200:
-            _auth_mode = resp.text.strip()
-        else:
-            log.warning("Unknown MAST auth mode, defaulting to Legacy Shibboleth login")
-        return _auth_mode
-
-    def _login(self, *args, **kwargs):
-        if "SHIB-ECP" == self._auth_mode:
-            return self._shib_legacy_login(*args, **kwargs)
-        elif "MAST-AUTH" == self._auth_mode:
-            return self._authorize(*args, **kwargs)
-        else:
-            raise Exception("Unknown MAST Auth mode %s" % self._auth_mode)
-
-    def get_token(self, *args, **kwargs):
+    def _login(self, token=None, store_token=False, reenter_token=False):  # pragma: no cover
         """
-        Returns MAST token cookie.
+        Log into the MAST portal.
 
-        Returns
-        -------
-        response : `~http.cookiejar.Cookie`
+        Parameters
+        ----------
+        token : string, optional
+            Default is None.
+            The token to authenticate the user.
+            This can be generated at
+                https://auth.mast.stsci.edu/token?suggested_name=Astroquery&suggested_scope=mast:exclusive_access.
+            If not supplied, it will be prompted for if not in the keyring or set via $MAST_API_TOKEN
+        store_token : bool, optional
+            Default False.
+            If true, MAST token will be stored securely in your keyring.
+        reenter_token :  bool, optional
+            Default False.
+            Asks for the token even if it is already stored in the keyring or $MAST_API_TOKEN environment variable.
+            This is the way to overwrite an already stored password on the keyring.
         """
-        if "SHIB-ECP" == self._auth_mode:
-            return self._shib_get_token(*args, **kwargs)
-        elif "MAST-AUTH" == self._auth_mode:
-            return self._get_token(*args, **kwargs)
-        else:
-            raise Exception("Unknown MAST Auth mode %s" % self._auth_mode)
 
-    def session_info(self, *args, **kwargs):  # pragma: no cover
+        auth_link = (conf.server.replace("mast", "auth.mast") +
+                     "/token?suggested_name=Astroquery&suggested_scope=mast:exclusive_access")
+
+        if token is None and "MAST_API_TOKEN" in os.environ:
+            token = os.environ["MAST_API_TOKEN"]
+
+        if token is None:
+            token = keyring.get_password("astroquery:mast.stsci.edu.token", "masttoken")
+
+        if token is None or reenter_token:
+            info_msg = "If you do not have an API token already, visit the following link to create one: "
+            log.info(info_msg + auth_link)
+            token = getpass("Enter MAST API Token: ")
+
+        # store token if desired
+        if store_token:
+            keyring.set_password("astroquery:mast.stsci.edu.token", "masttoken", token)
+
+        self._session.headers["Accept"] = "application/json"
+        self._session.cookies["mast_token"] = token
+        info = self.session_info(silent=True)
+
+        if not info["anon"]:
+            log.info("MAST API token accepted, welcome %s" % info["attrib"].get("display_name"))
+        else:
+            warn_msg = ("MAST API token invalid!\n"
+                        "To make create a new API token visit to following link: " +
+                        auth_link)
+            warnings.warn(warn_msg, AuthenticationWarning)
+
+        return not info["anon"]
+
+    @deprecated(since="v0.3.10", message=("The get_token function is deprecated, "
+                                          "session token is now the token used for login."))
+    def get_token(self):  
+        return None
+
+    def session_info(self, silent=False): 
         """
         Displays information about current MAST user, and returns user info dictionary.
 
@@ -228,170 +235,22 @@ class MastClass(QueryWithLogin):
         -------
         response : dict
         """
-        if "SHIB-ECP" == self._auth_mode:
-            return self._shib_session_info(*args, **kwargs)
-        elif "MAST-AUTH" == self._auth_mode:
-            return self._session_info(*args, **kwargs)
-        else:
-            raise Exception("Unknown MAST Auth mode %s" % self._auth_mode)
-
-    def _shib_attach_cookie(self, session_token):  # pragma: no cover
-        """
-        Attaches a valid shibboleth session cookie to the current session.
-
-        Parameters
-        ----------
-        session_token : dict or  `http.cookiejar.Cookie`
-            A valid MAST shibboleth session cookie.
-        """
-
-        # clear any previous shib cookies
-        self._session.cookies.clear_session_cookies()
-
-        if isinstance(session_token, Cookie):
-            # check it's a shibsession cookie
-            if "shibsession" not in session_token.name:
-                raise LoginError("Invalid session token")
-
-            # add cookie to session
-            self._session.cookies.set_cookie(session_token)
-
-        elif isinstance(session_token, dict):
-            if len(session_token) > 1:
-                warnings.warn("Too many entries in token dictionary, only shibsession cookie will be used",
-                              InputWarning)
-
-            # get the shibsession cookie
-            value = None
-            for name in session_token.keys():
-                if "shibsession" in name:
-                    value = session_token[name]
-                    break
-
-            if not value:
-                raise LoginError("Invalid session token")
-
-            # add cookie to session
-            self._session.cookies.set(name, value)
-
-        else:
-            # raise datatype error
-            raise LoginError("Session token must be given as a dictionary or http.cookiejar.Cookie object")
-
-        # Print session info
-        # get user information
-        response = self._session.request("GET", self._SESSION_INFO_URL)
-
-        if response.status_code != 200:
-            warnings.warn("Status code: {}\nAuthentication failed!".format(response.status_code),
-                          AuthenticationWarning)
-            return False
-
-        exp = re.findall(r'<strong>Session Expiration \(barring inactivity\):</strong> (.*?)\n', response.text)
-        if len(exp) == 0:
-            warnings.warn("{}\nAuthentication failed!".format(response.text),
-                          AuthenticationWarning)
-            return False
-        else:
-            exp = exp[0]
-
-        log.info("Authentication successful!\nSession Expiration: {}".format(exp))
-        return True
-
-    def _shib_login(self, username, password):  # pragma: no cover
-        """
-        Given username and password, logs into the MAST shibboleth client.
-
-        Parameters
-        ----------
-        username : string
-            The user's username, will usually be the users email address.
-        password : string
-            Password associated with the given username.
-        """
-
-        # clear any previous shib cookies
-        self._session.cookies.clear_session_cookies()
-
-        authenticationString = b64encode((('{}:{}'.format(username, password)).replace('\n', '')).encode('utf-8'))
-        del password  # do not let password hang around
-
-        # The initial get request (will direct the user to the sso login)
-        self._session.headers['Accept-Encoding'] = 'identity'
-        self._session.headers['Connection'] = 'close'
-        self._session.headers['Accept'] = 'text/html; application/vnd.paos+xml'
-        self._session.headers['PAOS'] = 'ver="urn:liberty:paos:2003-08";"urn:oasis:names:tc:SAML:2.0:profiles:SSO:ecp"'
-        resp = self._session.request("GET", self._SP_TARGET)
-
-        # The idp request is the sp response sanse header
-        sp_response = resp.text
-        idp_request = re.sub(r'<S:Header>.*?</S:Header>', '', sp_response)
-
-        # Removing unneeded headers
-        del self._session.headers['PAOS']
-        del self._session.headers['Accept']
-
-        # Getting the idp response
-        self._session.headers['Content-Type'] = 'text/xml; charset=utf-8'
-        self._session.headers['Authorization'] = 'Basic {}'.format(authenticationString.decode('utf-8'))
-        responseIdp = self._session.request("POST", self._IDP_ENDPOINT, data=idp_request)
-        idp_response = responseIdp.text
-
-        # Do not let the password hang around in the session headers (or anywhere else)
-        del self._session.headers['Authorization']
-        del authenticationString
-
-        # collecting the information we need
-        relay_state = re.findall(r'<ecp:RelayState.*ecp:RelayState>', sp_response)[0]
-        response_consumer_url = re.findall(r'<paos:Request.*?responseConsumerURL="(.*?)".*?/>', sp_response)[0]
-        assertion_consumer_service = re.findall(r'<ecp:Response.*?AssertionConsumerServiceURL="(.*?)".*?/>',
-                                                idp_response)[0]
-
-        # the response_consumer_url and assertion_consumer_service should be the same
-        assert response_consumer_url == assertion_consumer_service
-
-        # adding the relay_state to the sp_packacge and removing the xml header
-        relay_state = re.sub(r'S:', 'soap11:', relay_state)  # is this exactly how I want to do this?
-        sp_package = re.sub(r'<\?xml version="1.0" encoding="UTF-8"\?>\n(.*?)<ecp:Response.*?/>', r'\g<1>'+relay_state,
-                            idp_response)
-
-        # Sending the last post (that should result in the shibbolith session cookie being set)
-        self._session.headers['Content-Type'] = 'application/vnd.paos+xml'
-        response = self._session.request("POST", assertion_consumer_service, data=sp_package)
-
-        # setting the headers back to where they should be
-        del self._session.headers['Content-Type']
-        self._session.headers['Accept-Encoding'] = 'gzip, deflate'
-        self._session.headers['Accept'] = '*/*'
-        self._session.headers['Connection'] = 'keep-alive'
-
-        # check that the cookie was set
-        # (the name of the shib session cookie is not fixed so we have to search for it)
-        cookieFound = False
-        for cookie in self._session.cookies:
-            if "shibsession" in cookie.name:
-                cookieFound = True
-                break
-        if not cookieFound:
-            warnings.warn("Authentication failed!", AuthenticationWarning)
-            return
 
         # get user information
+        self._session.headers["Accept"] = "application/json"
         response = self._session.request("GET", self._SESSION_INFO_URL)
 
-        if response.status_code != 200:
-            warnings.warn("Authentication failed!", AuthenticationWarning)
-            return
+        info_dict = response.json()
 
-        exp = re.findall(r'<strong>Session Expiration \(barring inactivity\):</strong> (.*?)\n', response.text)
-        if len(exp) == 0:
-            warnings.warn("Authentication failed!", AuthenticationWarning)
-            return False
-        else:
-            exp = exp[0]
+        if not silent:
+            for key, value in info_dict.items():
+                if isinstance(value, dict):
+                    for subkey, subval in value.items():
+                        print("%s.%s: %s" % (key, subkey, subval))
+                else:
+                    print("%s: %s" % (key, value))
 
-        log.info("Authentication successful!\nSession Expiration: {}".format(exp))
-        return True
+        return info_dict
 
     def _request(self, method, url, params=None, data=None, headers=None,
                  files=None, stream=False, auth=None, retrieve_all=True):
@@ -430,12 +289,12 @@ class MastClass(QueryWithLogin):
             The response from the server.
         """
 
-        startTime = time.time()
-        allResponses = []
-        totalPages = 1
-        curPage = 0
+        start_time = time.time()
+        all_responses = []
+        total_pages = 1
+        cur_page = 0
 
-        while curPage < totalPages:
+        while cur_page < total_pages:
             status = "EXECUTING"
 
             while status == "EXECUTING":
@@ -443,7 +302,7 @@ class MastClass(QueryWithLogin):
                                                            headers=headers, files=files, cache=False,
                                                            stream=stream, auth=auth)
 
-                if (time.time() - startTime) >= self.TIMEOUT:
+                if (time.time() - start_time) >= self.TIMEOUT:
                     raise TimeoutError("Timeout limit of {} exceeded.".format(self.TIMEOUT))
 
                 result = response.json()
@@ -453,7 +312,7 @@ class MastClass(QueryWithLogin):
                 else:
                     status = result.get("status")
 
-            allResponses.append(response)
+            all_responses.append(response)
 
             if (status != "COMPLETE") or (not retrieve_all):
                 break
@@ -461,12 +320,12 @@ class MastClass(QueryWithLogin):
             paging = result.get("paging")
             if paging is None:
                 break
-            totalPages = paging['pagesFiltered']
-            curPage = paging['page']
+            total_pages = paging['pagesFiltered']
+            cur_page = paging['page']
 
-            data = data.replace("page%22%3A%20"+str(curPage)+"%2C", "page%22%3A%20"+str(curPage+1)+"%2C")
+            data = data.replace("page%22%3A%20"+str(cur_page)+"%2C", "page%22%3A%20"+str(cur_page+1)+"%2C")
 
-        return allResponses
+        return all_responses
 
     def _get_col_config(self, service, fetch_name=None):
         """
@@ -502,14 +361,14 @@ class MastClass(QueryWithLogin):
             more = True
 
         if more:
-            mashupRequest = {'service': all_name, 'params': {}, 'format': 'extjs'}
-            reqString = _prepare_service_request_string(mashupRequest)
-            response = self._request("POST", self._MAST_REQUEST_URL, data=reqString, headers=headers)
-            jsonResponse = response[0].json()
+            mashup_request = {'service': all_name, 'params': {}, 'format': 'extjs'}
+            req_string = _prepare_service_request_string(mashup_request)
+            response = self._request("POST", self._MAST_REQUEST_URL, data=req_string, headers=headers)
+            json_response = response[0].json()
 
-            self._column_configs[service].update(jsonResponse['data']['Tables'][0]
+            self._column_configs[service].update(json_response['data']['Tables'][0]
                                                  ['ExtendedProperties']['discreteHistogram'])
-            self._column_configs[service].update(jsonResponse['data']['Tables'][0]
+            self._column_configs[service].update(json_response['data']['Tables'][0]
                                                  ['ExtendedProperties']['continuousHistogram'])
             for col, val in self._column_configs[service].items():
                 val.pop('hist', None)  # don't want to save all this unecessary data
@@ -533,12 +392,12 @@ class MastClass(QueryWithLogin):
         """
 
         # loading the columns config
-        colConfig = None
+        col_config = None
         if self._current_service:
-            colConfig = self._column_configs.get(self._current_service)
+            col_config = self._column_configs.get(self._current_service)
             self._current_service = None  # clearing current service
 
-        resultList = []
+        result_list = []
 
         for resp in responses:
             result = resp.json()
@@ -547,121 +406,15 @@ class MastClass(QueryWithLogin):
             if result['status'] == "ERROR":
                 raise RemoteServiceError(result.get('msg', "There was an error with your request."))
 
-            resTable = _mashup_json_to_table(result, colConfig)
-            resultList.append(resTable)
+            result_table = _mashup_json_to_table(result, col_config)
+            result_list.append(result_table)
 
-        allResults = vstack(resultList)
+        all_results = vstack(result_list)
 
         # Check for no results
-        if not allResults:
+        if not all_results:
             warnings.warn("Query returned no results.", NoResultsWarning)
-        return allResults
-
-    def _authorize(self, token=None, store_token=False, reenter_token=False):  # pragma: no cover
-        """
-        Log into the MAST portal.
-
-        Parameters
-        ----------
-        token : string, optional
-            Default is None.
-            The token to authenticate the user.
-            This can be generated at
-                https://auth.mast.stsci.edu/token?suggested_name=Astroquery&suggested_scope=mast:exclusive_access.
-            If not supplied, it will be prompted for if not in the keyring or set via $MAST_API_TOKEN
-        store_token : bool, optional
-            Default False.
-            If true, username and password will be stored securely in your keyring.
-        """
-
-        if token is None and "MAST_API_TOKEN" in os.environ:
-            token = os.environ["MAST_API_TOKEN"]
-
-        if token is None:
-            token = keyring.get_password("astroquery:mast.stsci.edu.token", "masttoken")
-
-        if token is None or reenter_token:
-            auth_server = conf.server.replace("mast", "auth.mast")
-            auth_link = auth_server + "/token?suggested_name=Astroquery&suggested_scope=mast:exclusive_access"
-            info_msg = "If you do not have an API token already, visit the following link to create one: "
-            log.info(info_msg + auth_link)
-            token = getpass("Enter MAST API Token: ")
-
-        # store password if desired
-        if store_token:
-            keyring.set_password("astroquery:mast.stsci.edu.token", "masttoken", token)
-
-        self._session.headers["Accept"] = "application/json"
-        self._session.cookies["mast_token"] = token
-        info = self.session_info(silent=True)
-
-        if not info["anon"]:
-            log.info("MAST API token accepted, welcome %s" % info["attrib"].get("display_name"))
-        else:
-            log.warn("MAST API token invalid!")
-
-        return not info["anon"]
-
-    def _shib_legacy_login(self, username=None, password=None, session_token=None,
-                           store_password=False, reenter_password=False):  # pragma: no cover
-        """
-        Log into the MAST portal.
-
-        Parameters
-        ----------
-        username : string, optional
-            Default is None.
-            The username for the user logging in.
-            Usually this will be the user's email address.
-            If a username is necessary but not supplied it will be prompted for.
-        password : string, optional
-            Default is None.
-            The password associated with the given username.
-            For security passwords should not be typed into the terminal or jupyter
-            notebook, but input using a more secure method such as `~getpass.getpass`.
-            If a password is necessary but not supplied it will be prompted for.
-        session_token : dict or `~http.cookiejar.Cookie`, optional
-            A valid MAST session cookie that will be attached to the current session
-            in lieu of logging in with a username/password.
-            If username and/or password is supplied, this argument will be ignored.
-        store_password : bool, optional
-            Default False.
-            If true, username and password will be stored securely in your keyring.
-        reenter_password : bool, optional
-            Default False.
-            Asks for the password even if it is already stored in the keyring.
-            This is the way to overwrite an already stored password on the keyring.
-        """
-
-        # checking the inputs
-        if (username or password) and session_token:
-            warnings.warn("Both username and session token supplied, session token will be ignored.",
-                          InputWarning)
-            session_token = None
-        elif session_token and store_password:
-            warnings.warn("Password is not used for token based login, therefor password cannot be stored.",
-                          InputWarning)
-
-        if session_token:
-            return self._shib_attach_cookie(session_token)
-        else:
-            # get username if not supplied
-            if not username:
-                username = input("Enter your username: ")
-
-            # check keyring get password if not supplied
-            if not password and not reenter_password:
-                password = keyring.get_password("astroquery:mast.stsci.edu", username)
-
-            # get password if no password is found (or reenter_password is set)
-            if not password:
-                password = getpass("Enter password for {}: ".format(username))
-
-            # store password if desired
-            if store_password:
-                keyring.set_password("astroquery:mast.stsci.edu", username, password)
-
-            return self._shib_login(username, password)
+        return all_results
 
     def logout(self):  # pragma: no cover
         """
@@ -669,116 +422,6 @@ class MastClass(QueryWithLogin):
         """
         self._session.cookies.clear_session_cookies()
         self._authenticated = False
-
-    def _get_token(self):  # pragma: no cover
-        """
-        Returns MAST token cookie.
-
-        Returns
-        -------
-        response : `~http.cookiejar.Cookie`
-        """
-
-        tokenCookie = None
-        for cookie in self._session.cookies:
-            if "mast_token" in cookie.name:
-                tokenCookie = cookie
-                break
-
-        if not tokenCookie:
-            warnings.warn("No auth token found.", AuthenticationWarning)
-
-        return tokenCookie
-
-    def _session_info(self, silent=False):  # pragma: no cover
-        """
-        Displays information about current MAST user, and returns user info dictionary.
-
-        Parameters
-        ----------
-        silent : bool, optional
-            Default False.
-            Suppresses output to stdout.
-
-        Returns
-        -------
-        response : dict
-        """
-
-        # get user information
-        self._session.headers["Accept"] = "application/json"
-        response = self._session.request("GET", self._SESSION_INFO_URL)
-
-        infoDict = json.loads(response.text)
-
-        if not silent:
-            for key, value in infoDict.items():
-                if isinstance(value, dict):
-                    for subkey, subval in value.items():
-                        print("%s.%s: %s" % (key, subkey, subval))
-                else:
-                    print("%s: %s" % (key, value))
-
-        return infoDict
-
-    def _shib_get_token(self):  # pragma: no cover
-        """
-        Returns MAST session cookie.
-
-        Returns
-        -------
-        response : `~http.cookiejar.Cookie`
-        """
-
-        shibCookie = None
-        for cookie in self._session.cookies:
-            if "shibsession" in cookie.name:
-                shibCookie = cookie
-                break
-
-        if not shibCookie:
-            warnings.warn("No session token found.", AuthenticationWarning)
-
-        return shibCookie
-
-    def _shib_session_info(self, silent=False):  # pragma: no cover
-        """
-        Displays information about current MAST session, and returns session info dictionary.
-
-        Parameters
-        ----------
-        silent : bool, optional
-            Default False.
-            Suppresses output to stdout.
-
-        Returns
-        -------
-        response : dict
-        """
-
-        # get user information
-        response = self._session.request("GET", self._SESSION_INFO_URL)
-
-        sessionInfo = response.text
-
-        patternString = r'Session Expiration \(barring inactivity\):</strong> (.*?)\n.*?STScI_Email</strong>: ' + \
-                        r'(.*?)\n<strong>STScI_FirstName</strong>: (.*?)\n<strong>STScI_LastName</strong>: (.*?)\n'
-
-        userCats = ("Session Expiration", "Username", "First Name", "Last Name")
-        userInfo = re.findall(patternString, sessionInfo, re.DOTALL)
-
-        if len(userInfo) == 0:
-            infoDict = dict(zip(userCats, (None, "anonymous", "", "")))
-        else:
-            infoDict = dict(zip(userCats, userInfo[0]))
-            infoDict['Session Expiration'] = int(re.findall(r"(\d+) minute\(s\)",
-                                                            infoDict['Session Expiration'])[0])*u.min
-
-        if not silent:
-            for key in infoDict:
-                print(key+":", infoDict[key])
-
-        return infoDict
 
     @class_or_instance
     def service_request_async(self, service, params, pagesize=None, page=None, **kwargs):
@@ -822,26 +465,26 @@ class MastClass(QueryWithLogin):
             pagesize = self.PAGESIZE
         if not page:
             page = 1
-            retrieveAll = True
+            retrieve_all = True
         else:
-            retrieveAll = False
+            retrieve_all = False
 
         headers = {"User-Agent": self._session.headers["User-Agent"],
                    "Content-type": "application/x-www-form-urlencoded",
                    "Accept": "text/plain"}
 
-        mashupRequest = {'service': service,
+        mashup_request = {'service': service,
                          'params': params,
                          'format': 'json',
                          'pagesize': pagesize,
                          'page': page}
 
         for prop, value in kwargs.items():
-            mashupRequest[prop] = value
+            mashup_request[prop] = value
 
-        reqString = _prepare_service_request_string(mashupRequest)
-        response = self._request("POST", self._MAST_REQUEST_URL, data=reqString, headers=headers,
-                                 retrieve_all=retrieveAll)
+        req_string = _prepare_service_request_string(mashup_request)
+        response = self._request("POST", self._MAST_REQUEST_URL, data=req_string, headers=headers,
+                                 retrieve_all=retrieve_all)
 
         return response
 
@@ -902,9 +545,9 @@ class MastClass(QueryWithLogin):
         if not self._column_configs.get(service_name):
             self._get_col_config(service_name, fetch_name=column_config_name)
 
-        caomColConfig = self._column_configs[service_name]
+        caom_col_config = self._column_configs[service_name]
 
-        mashupFilters = []
+        mashup_filters = []
         for colname, value in filters.items():
 
             # make sure value is a list-like thing
@@ -912,33 +555,33 @@ class MastClass(QueryWithLogin):
                 value = [value]
 
             # Get the column type and separator
-            colInfo = caomColConfig.get(colname)
-            if not colInfo:
+            col_info = caom_col_config.get(colname)
+            if not col_info:
                 warnings.warn("Filter {} does not exist. This filter will be skipped.".format(colname), InputWarning)
                 continue
 
             colType = "discrete"
-            if (colInfo.get("vot.datatype", colInfo.get("type")) in ("double", "float", "numeric")) \
-               or colInfo.get("treatNumeric"):
+            if (col_info.get("vot.datatype", col_info.get("type")) in ("double", "float", "numeric")) \
+               or col_info.get("treatNumeric"):
                 colType = "continuous"
 
-            separator = colInfo.get("separator")
-            freeText = None
+            separator = col_info.get("separator")
+            free_text = None
 
             # validate user input
             if colType == "continuous":
                 if len(value) < 2:
-                    warningString = "{} is continuous, ".format(colname) + \
+                    warning_string = "{} is continuous, ".format(colname) + \
                                     "and filters based on min and max values.\n" + \
                                     "Not enough values provided, skipping..."
-                    warnings.warn(warningString, InputWarning)
+                    warnings.warn(warning_string, InputWarning)
                     continue
                 elif len(value) > 2:
-                    warningString = "{} is continuous, ".format(colname) + \
+                    warning_string = "{} is continuous, ".format(colname) + \
                                     "and filters based on min and max values.\n" + \
                                     "Too many values provided, the first two will be " + \
                                     "assumed to be the min and max values."
-                    warnings.warn(warningString, InputWarning)
+                    warnings.warn(warning_string, InputWarning)
             else:  # coltype is discrete, all values should be represented as strings, even if numerical
                 value = [str(x) for x in value]
 
@@ -946,13 +589,13 @@ class MastClass(QueryWithLogin):
 
                 for i, val in enumerate(value):
                     if ('*' in val) or ('%' in val):
-                        if freeText:  # freeText is already set cannot set again
-                            warningString = "Only one wildcarded value may be used per filter, " + \
-                                            "all others must be exact.\n" + \
-                                            "Skipping {}...".format(val)
-                            warnings.warn(warningString, InputWarning)
+                        if free_text:  # free_text is already set cannot set again
+                            warning_string = ("Only one wildcarded value may be used per filter, "
+                                             "all others must be exact.\n"
+                                             "Skipping {}...".format(val))
+                            warnings.warn(warning_string, InputWarning)
                         else:
-                            freeText = val.replace('*', '%')
+                            free_text = val.replace('*', '%')
                         value.pop(i)
 
             # craft mashup filter entry
@@ -964,12 +607,12 @@ class MastClass(QueryWithLogin):
                 entry["values"] = [{"min": value[0], "max":value[1]}]
             else:
                 entry["values"] = value
-            if freeText:
-                entry["freeText"] = freeText
+            if free_text:
+                entry["freeText"] = free_text
 
-            mashupFilters.append(entry)
+            mashup_filters.append(entry)
 
-        return mashupFilters
+        return mashup_filters
 
 
 @async_to_sync
@@ -1002,14 +645,14 @@ class ObservationsClass(MastClass):
         service = "Mast.Caom.All"
         params = {}
         response = self.service_request_async(service, params, format='extjs')
-        jsonResponse = response[0].json()
+        json_response = response[0].json()
 
         # getting the list of missions
-        histData = jsonResponse['data']['Tables'][0]['Columns']
-        for facet in histData:
+        hist_data = json_response['data']['Tables'][0]['Columns']
+        for facet in hist_data:
             if facet['text'] == "obs_collection":
-                missionInfo = facet['ExtendedProperties']['histObj']
-                missions = list(missionInfo.keys())
+                mission_info = facet['ExtendedProperties']['histObj']
+                missions = list(mission_info.keys())
                 missions.remove('hist')
                 return missions
 
@@ -1150,11 +793,11 @@ class ObservationsClass(MastClass):
 
         # Build the mashup filter object and store it in the correct service_name entry
         if coordinates or objectname:
-            mashupFilters = self._build_filter_set("Mast.Caom.Cone", "Mast.Caom.Filtered.Position", **criteria)
+            mashup_filters = self._build_filter_set("Mast.Caom.Cone", "Mast.Caom.Filtered.Position", **criteria)
         else:
-            mashupFilters = self._build_filter_set("Mast.Caom.Cone", "Mast.Caom.Filtered", **criteria)
+            mashup_filters = self._build_filter_set("Mast.Caom.Cone", "Mast.Caom.Filtered", **criteria)
 
-        if not mashupFilters:
+        if not mashup_filters:
             raise InvalidQueryError("At least one non-positional criterion must be supplied.")
 
         # handle position info (if any)
@@ -1182,12 +825,12 @@ class ObservationsClass(MastClass):
         if position:
             service = "Mast.Caom.Filtered.Position"
             params = {"columns": "*",
-                      "filters": mashupFilters,
+                      "filters": mashup_filters,
                       "position": position}
         else:
             service = "Mast.Caom.Filtered"
             params = {"columns": "*",
-                      "filters": mashupFilters}
+                      "filters": mashup_filters}
 
         return self.service_request_async(service, params)
 
@@ -1301,9 +944,9 @@ class ObservationsClass(MastClass):
 
         # Build the mashup filter object and store it in the correct service_name entry
         if coordinates or objectname:
-            mashupFilters = self._build_filter_set("Mast.Caom.Cone", "Mast.Caom.Filtered.Position", **criteria)
+            mashup_filters = self._build_filter_set("Mast.Caom.Cone", "Mast.Caom.Filtered.Position", **criteria)
         else:
-            mashupFilters = self._build_filter_set("Mast.Caom.Cone", "Mast.Caom.Filtered", **criteria)
+            mashup_filters = self._build_filter_set("Mast.Caom.Cone", "Mast.Caom.Filtered", **criteria)
 
         # handle position info (if any)
         position = None
@@ -1330,13 +973,13 @@ class ObservationsClass(MastClass):
         if position:
             service = "Mast.Caom.Filtered.Position"
             params = {"columns": "COUNT_BIG(*)",
-                      "filters": mashupFilters,
+                      "filters": mashup_filters,
                       "obstype": obstype,
                       "position": position}
         else:
             service = "Mast.Caom.Filtered"
             params = {"columns": "COUNT_BIG(*)",
-                      "filters": mashupFilters,
+                      "filters": mashup_filters,
                       "obstype": obstype}
 
         return self.service_request(service, params)[0][0].astype(int)
@@ -1397,18 +1040,18 @@ class ObservationsClass(MastClass):
         response : `~astropy.table.Table`
         """
 
-        filterMask = np.full(len(products), True, dtype=bool)
+        filter_mask = np.full(len(products), True, dtype=bool)
 
         # Applying the special filters (mrp_only and extension)
         if mrp_only:
-            filterMask &= (products['productGroupDescription'] == "Minimum Recommended Products")
+            filter_mask &= (products['productGroupDescription'] == "Minimum Recommended Products")
 
         if extension:
             mask = np.full(len(products), False, dtype=bool)
             for elt in extension:
                 mask |= [False if isinstance(x, np.ma.core.MaskedConstant) else x.endswith(elt)
                          for x in products["productFilename"]]
-            filterMask &= mask
+            filter_mask &= mask
 
         # Applying the rest of the filters
         for colname, vals in filters.items():
@@ -1420,9 +1063,9 @@ class ObservationsClass(MastClass):
             for elt in vals:
                 mask |= (products[colname] == elt)
 
-            filterMask &= mask
+            filter_mask &= mask
 
-        return products[np.where(filterMask)]
+        return products[np.where(filter_mask)]
 
     def _download_curl_script(self, products, out_dir):
         """
@@ -1440,81 +1083,22 @@ class ObservationsClass(MastClass):
         response : `astropy.table.Table`
         """
 
-        urlList = [("uri", url) for url in products['dataURI']]
-        downloadFile = "mastDownload_" + time.strftime("%Y%m%d%H%M%S")
-        localPath = os.path.join(out_dir.rstrip('/'), downloadFile + ".sh")
+        url_list = [("uri", url) for url in products['dataURI']]
+        download_file = "mastDownload_" + time.strftime("%Y%m%d%H%M%S")
+        local_path = os.path.join(out_dir.rstrip('/'), download_file + ".sh")
 
-        response = self._download_file(self._MAST_BUNDLE_URL + ".sh", localPath, data=urlList, method="POST")
+        response = self._download_file(self._MAST_BUNDLE_URL + ".sh", local_path, data=url_list, method="POST")
 
         status = "COMPLETE"
         msg = None
 
-        if not os.path.isfile(localPath):
+        if not os.path.isfile(local_path):
             status = "ERROR"
             msg = "Curl could not be downloaded"
 
-        manifest = Table({'Local Path': [localPath],
+        manifest = Table({'Local Path': [local_path],
                           'Status': [status],
                           'Message': [msg]})
-        return manifest
-
-    def _shib_download_curl_script(self, products, out_dir):
-        """
-        Takes an `astropy.table.Table` of data products and downloads a curl script to pull the datafiles.
-
-        Parameters
-        ----------
-        products : `astropy.table.Table`
-            Table containing products to be included in the curl script.
-        out_dir : str
-            Directory in which the curl script will be saved.
-
-        Returns
-        -------
-        response : `astropy.table.Table`
-        """
-
-        urlList = products['dataURI']
-        downloadFile = "mastDownload_" + time.strftime("%Y%m%d%H%M%S")
-        descriptionList = products['description']
-        productTypeList = products['dataproduct_type']
-
-        pathList = [downloadFile+"/"+x['obs_collection']+'/'+x['obs_id']+'/'+x['productFilename'] for x in products]
-
-        service = "Mast.Bundle.Request"
-        params = {"urlList": ",".join(urlList),
-                  "filename": downloadFile,
-                  "pathList": ",".join(pathList),
-                  "descriptionList": list(descriptionList),
-                  "productTypeList": list(productTypeList),
-                  "extension": 'curl'}
-
-        response = self.service_request_async(service, params)
-
-        bundlerResponse = response[0].json()
-
-        localPath = out_dir.rstrip('/') + "/" + downloadFile + ".sh"
-        self._download_file(bundlerResponse['url'], localPath)
-
-        status = "COMPLETE"
-        msg = None
-        url = None
-
-        if not os.path.isfile(localPath):
-            status = "ERROR"
-            msg = "Curl could not be downloaded"
-            url = bundlerResponse['url']
-        else:
-            missingFiles = [x for x in bundlerResponse['statusList'].keys()
-                            if bundlerResponse['statusList'][x] != 'COMPLETE']
-            if len(missingFiles):
-                msg = "{} files could not be added to the curl script".format(len(missingFiles))
-                url = ",".join(missingFiles)
-
-        manifest = Table({'Local Path': [localPath],
-                          'Status': [status],
-                          'Message': [msg],
-                          "URL": [url]})
         return manifest
 
     @deprecated(since="v0.3.9", alternative="enable_cloud_dataset")
@@ -1528,6 +1112,7 @@ class ObservationsClass(MastClass):
         """
         import boto3
         import botocore
+        
         if profile is not None:
             self._boto3 = boto3.Session(profile_name=profile)
         else:
@@ -1552,20 +1137,20 @@ class ObservationsClass(MastClass):
         self._botocore = None
 
     @deprecated(since="v0.3.9", alternative="get_cloud_uris")
-    def get_hst_s3_uris(self, dataProducts, includeBucket=True, fullUrl=False):
-        return self.get_cloud_uris(dataProducts, includeBucket, fullUrl)
+    def get_hst_s3_uris(self, data_products, include_bucket=True, full_url=False):
+        return self.get_cloud_uris(data_products, include_bucket, full_url)
 
-    def get_cloud_uris(self, dataProducts, includeBucket=True, fullUrl=False):
+    def get_cloud_uris(self, data_products, include_bucket=True, full_url=False):
         """ Takes an `astropy.table.Table` of data products and turns them into s3 uris. """
 
-        return [self.get_cloud_uri(dataProduct, includeBucket, fullUrl) for dataProduct in dataProducts]
+        return [self.get_cloud_uri(data_product, include_bucket, full_url) for data_product in data_products]
 
     @deprecated(since="v0.3.9", alternative="get_cloud_uri")
-    def get_hst_s3_uri(self, dataProduct, includeBucket=True, fullUrl=False):
-        return self.get_cloud_uri(dataProduct, includeBucket, fullUrl)
+    def get_hst_s3_uri(self, data_product, include_bucket=True, full_url=False):
+        return self.get_cloud_uri(data_product, include_bucket, full_url)
 
-    def get_cloud_uri(self, dataProduct, includeBucket=True, fullUrl=False):
-        """ Turns a dataProduct into a S3 URI """
+    def get_cloud_uri(self, data_product, include_bucket=True, full_url=False):
+        """ Turns a data_product into a S3 URI """
 
         if self._boto3 is None:
             raise AtrributeError("Must enable s3 dataset before attempting to query the s3 information")
@@ -1573,16 +1158,16 @@ class ObservationsClass(MastClass):
         # This is a cheap operation and does not perform any actual work yet
         s3_client = self._boto3.client('s3')
 
-        paths = fpl.paths(dataProduct)
+        paths = fpl.paths(data_product)
         if paths is None:
             raise Exception("Unsupported mission")
 
         for path in paths:
             try:
                 s3_client.head_object(Bucket=self._pubdata_bucket, Key=path, RequestPayer='requester')
-                if includeBucket:
+                if include_bucket:
                     path = "s3://%s/%s" % (self._pubdata_bucket, path)
-                elif fullUrl:
+                elif full_url:
                     path = "http://s3.amazonaws.com/%s/%s" % (self._pubdata_bucket, path)
                 return path
             except self._botocore.exceptions.ClientError as e:
@@ -1591,7 +1176,7 @@ class ObservationsClass(MastClass):
 
         raise Exception("Unable to locate file!")
 
-    def _download_from_cloud(self, dataProduct, localPath, cache=True):
+    def _download_from_cloud(self, data_product, local_path, cache=True):
         # The following is a mishmash of BaseQuery._download_file and s3 access through boto
 
         self._pubdata_bucket = 'stpubdata'
@@ -1601,31 +1186,31 @@ class ObservationsClass(MastClass):
         s3_client = self._boto3.client('s3')
         bkt = s3.Bucket(self._pubdata_bucket)
 
-        bucketPath = self.get_cloud_uri(dataProduct, False)
-        info_lookup = s3_client.head_object(Bucket=self._pubdata_bucket, Key=bucketPath, RequestPayer='requester')
+        bucket_path = self.get_cloud_uri(data_product, False)
+        info_lookup = s3_client.head_object(Bucket=self._pubdata_bucket, Key=bucket_path, RequestPayer='requester')
 
         # Unfortunately, we can't use the reported file size in the reported product.  STScI's backing
         # archive database (CAOM) is frequently out of date and in many cases omits the required information.
-        # length = dataProduct["size"]
+        # length = data_product["size"]
         # Instead we ask the webserver (in this case S3) what the expected content length is and use that.
         length = info_lookup["ContentLength"]
 
-        if cache and os.path.exists(localPath):
+        if cache and os.path.exists(local_path):
             if length is not None:
-                statinfo = os.stat(localPath)
+                statinfo = os.stat(local_path)
                 if statinfo.st_size != length:
                     log.warning("Found cached file {0} with size {1} that is "
                                 "different from expected size {2}"
-                                .format(localPath,
+                                .format(local_path,
                                         statinfo.st_size,
                                         length))
                 else:
                     log.info("Found cached file {0} with expected size {1}."
-                             .format(localPath, statinfo.st_size))
+                             .format(local_path, statinfo.st_size))
                     return
 
         with ProgressBarOrSpinner(length, ('Downloading URL s3://{0}/{1} to {2} ...'.format(
-                self._pubdata_bucket, bucketPath, localPath))) as pb:
+                self._pubdata_bucket, bucket_path, local_path))) as pb:
 
             # Bytes read tracks how much data has been received so far
             # This variable will be updated in multiple threads below
@@ -1644,7 +1229,7 @@ class ObservationsClass(MastClass):
                     bytes_read += numbytes
                     pb.update(bytes_read)
 
-            bkt.download_file(bucketPath, localPath, ExtraArgs={"RequestPayer": "requester"},
+            bkt.download_file(bucket_path, local_path, ExtraArgs={"RequestPayer": "requester"},
                               Callback=progress_callback)
 
     def _download_files(self, products, base_dir, cache=True):
@@ -1665,47 +1250,47 @@ class ObservationsClass(MastClass):
         response : `~astropy.table.Table`
         """
 
-        manifestArray = []
-        for dataProduct in products:
+        manifest_array = []
+        for data_product in products:
 
-            localPath = base_dir + "/" + dataProduct['obs_collection'] + "/" + dataProduct['obs_id']
-            dataUrl = self._MAST_DOWNLOAD_URL + "?uri=" + dataProduct["dataURI"]
+            local_path = base_dir + "/" + data_product['obs_collection'] + "/" + data_product['obs_id']
+            data_url = self._MAST_DOWNLOAD_URL + "?uri=" + data_product["dataURI"]
 
-            if not os.path.exists(localPath):
-                os.makedirs(localPath)
+            if not os.path.exists(local_path):
+                os.makedirs(local_path)
 
-            localPath += '/' + dataProduct['productFilename']
+            local_path += '/' + data_product['productFilename']
 
             status = "COMPLETE"
             msg = None
             url = None
 
             try:
-                if self._boto3 is not None and fpl.has_path(dataProduct):
+                if self._boto3 is not None and fpl.has_path(data_product):
                     try:
-                        self._download_from_cloud(dataProduct, localPath, cache)
+                        self._download_from_cloud(data_product, local_path, cache)
                     except Exception as ex:
                         log.exception("Error pulling from S3 bucket: %s" % ex)
                         log.warn("Falling back to mast download...")
-                        self._download_file(dataUrl, localPath, cache=cache, head_safe=True)
+                        self._download_file(data_url, local_path, cache=cache, head_safe=True, continuation=False)
                 else:
-                    self._download_file(dataUrl, localPath, cache=cache, head_safe=True)
+                    self._download_file(data_url, local_path, cache=cache, head_safe=True, continuation=False)
 
                 # check if file exists also this is where would perform md5,
                 # and also check the filesize if the database reliably reported file sizes
-                if not os.path.isfile(localPath):
+                if not os.path.isfile(local_path):
                     status = "ERROR"
                     msg = "File was not downloaded"
-                    url = dataUrl
+                    url = data_url
 
             except HTTPError as err:
                 status = "ERROR"
                 msg = "HTTPError: {0}".format(err)
-                url = dataUrl
+                url = data_url
 
-            manifestArray.append([localPath, status, msg, url])
+            manifest_array.append([local_path, status, msg, url])
 
-        manifest = Table(rows=manifestArray, names=('Local Path', 'Status', 'Message', "URL"))
+        manifest = Table(rows=manifest_array, names=('Local Path', 'Status', 'Message', "URL"))
 
         return manifest
 
@@ -1752,11 +1337,11 @@ class ObservationsClass(MastClass):
                 products = [products]
 
             # collect list of products
-            productLists = []
+            product_lists = []
             for oid in products:
-                productLists.append(self.get_product_list(oid))
+                product_lists.append(self.get_product_list(oid))
 
-            products = vstack(productLists)
+            products = vstack(product_lists)
 
         # apply filters
         products = self.filter_products(products, mrp_only, **filters)
@@ -1770,10 +1355,7 @@ class ObservationsClass(MastClass):
             download_dir = '.'
 
         if curl_flag:  # don't want to download the files now, just the curl script
-            if "SHIB-ECP" == self._auth_mode:
-                manifest = self._shib_download_curl_script(products, download_dir)
-            else:
-                manifest = self._download_curl_script(products, download_dir)
+            manifest = self._download_curl_script(products, download_dir)
 
         else:
             base_dir = download_dir.rstrip('/') + "/mastDownload"
@@ -1794,17 +1376,17 @@ class CatalogsClass(MastClass):
 
         super(CatalogsClass, self).__init__()
 
-        self.catalogLimit = None
+        self.catalog_limit = None
 
     def _parse_result(self, response, verbose=False):
 
-        resultsTable = super(CatalogsClass, self)._parse_result(response, verbose)
+        results_table = super(CatalogsClass, self)._parse_result(response, verbose)
 
-        if len(resultsTable) == self.catalogLimit:
+        if len(results_table) == self.catalog_limit:
             warnings.warn("Maximum catalog results returned, may not include all sources within radius.",
                           MaxResultsWarning)
 
-        return resultsTable
+        return results_table
 
     @class_or_instance
     def query_region_async(self, coordinates, radius=0.2*u.deg, catalog="Hsc",
@@ -1862,11 +1444,11 @@ class CatalogsClass(MastClass):
                 if version not in (3, None):
                     warnings.warn("Invalid HSC version number, defaulting to v3.", InputWarning)
                 service = "Mast.Hsc.Db.v3"
-            self.catalogLimit = kwargs.get('nr', 50000)
+            self.catalog_limit = kwargs.get('nr', 50000)
 
         elif catalog.lower() == "galex":
             service = "Mast.Galex.Catalog"
-            self.catalogLimit = kwargs.get('maxrecords', 50000)
+            self.catalog_limit = kwargs.get('maxrecords', 50000)
 
         elif catalog.lower() == "gaia":
             if version == 1:
@@ -1878,7 +1460,7 @@ class CatalogsClass(MastClass):
 
         else:
             service = "Mast.Catalogs." + catalog + ".Cone"
-            self.catalogLimit = None
+            self.catalog_limit = None
 
         # basic params
         params = {'ra': coordinates.ra.deg,
@@ -1981,18 +1563,18 @@ class CatalogsClass(MastClass):
             service = "Mast.Catalogs.Filtered.Tic"
             if coordinates or objectname:
                 service += ".Position"
-            mashupFilters = self._build_filter_set("Mast.Catalogs.Tess.Cone", service, **criteria)
+            mashup_filters = self._build_filter_set("Mast.Catalogs.Tess.Cone", service, **criteria)
 
         elif catalog.lower() == "diskdetective":
             service = "Mast.Catalogs.Filtered.DiskDetective"
             if coordinates or objectname:
                 service += ".Position"
-            mashupFilters = self._build_filter_set("Mast.Catalogs.Dd.Cone", service, **criteria)
+            mashup_filters = self._build_filter_set("Mast.Catalogs.Dd.Cone", service, **criteria)
 
         else:
             raise InvalidQueryError("Criteria query not availible for {}".format(catalog))
 
-        if not mashupFilters:
+        if not mashup_filters:
             raise InvalidQueryError("At least one non-positional criterion must be supplied.")
 
         if objectname and coordinates:
@@ -2012,12 +1594,12 @@ class CatalogsClass(MastClass):
 
         # build query
         if coordinates:
-            params = {"filters": mashupFilters,
+            params = {"filters": mashup_filters,
                       "ra": coordinates.ra.deg,
                       "dec": coordinates.dec.deg,
                       "radius": radius.deg}
         else:
-            params = {"filters": mashupFilters}
+            params = {"filters": mashup_filters}
 
         # TIC needs columns specified
         if catalog == "Tic":
@@ -2121,54 +1703,54 @@ class CatalogsClass(MastClass):
 
         if curl_flag:  # don't want to download the files now, just the curl script
 
-            downloadFile = "mastDownload_" + time.strftime("%Y%m%d%H%M%S")
+            download_file = "mastDownload_" + time.strftime("%Y%m%d%H%M%S")
 
-            urlList = []
-            pathList = []
+            url_list = []
+            path_list = []
             for spec in spectra:
                 if spec['SpectrumType'] < 2:
-                    urlList.append('https://hla.stsci.edu/cgi-bin/getdata.cgi?config=ops&dataset={0}'
+                    url_list.append('https://hla.stsci.edu/cgi-bin/getdata.cgi?config=ops&dataset={0}'
                                    .format(spec['DatasetName']))
 
                 else:
-                    urlList.append('https://hla.stsci.edu/cgi-bin/ecfproxy?file_id={0}'
+                    url_list.append('https://hla.stsci.edu/cgi-bin/ecfproxy?file_id={0}'
                                    .format(spec['DatasetName']) + '.fits')
 
-                pathList.append(downloadFile + "/HSC/" + spec['DatasetName'] + '.fits')
+                path_list.append(download_file + "/HSC/" + spec['DatasetName'] + '.fits')
 
-            descriptionList = [""]*len(spectra)
-            productTypeList = ['spectrum']*len(spectra)
+            description_list = [""]*len(spectra)
+            producttype_list = ['spectrum']*len(spectra)
 
             service = "Mast.Bundle.Request"
-            params = {"urlList": ",".join(urlList),
-                      "filename": downloadFile,
-                      "pathList": ",".join(pathList),
-                      "descriptionList": list(descriptionList),
-                      "productTypeList": list(productTypeList),
+            params = {"urlList": ",".join(url_list),
+                      "filename": download_file,
+                      "pathList": ",".join(path_list),
+                      "descriptionList": list(description_list),
+                      "productTypeList": list(producttype_list),
                       "extension": 'curl'}
 
             response = self.service_request_async(service, params)
-            bundlerResponse = response[0].json()
+            bundler_response = response[0].json()
 
-            localPath = download_dir.rstrip('/') + "/" + downloadFile + ".sh"
-            self._download_file(bundlerResponse['url'], localPath, head_safe=True)
+            local_path = download_dir.rstrip('/') + "/" + download_file + ".sh"
+            self._download_file(bundler_response['url'], local_path, head_safe=True, continuation=False)
 
             status = "COMPLETE"
             msg = None
             url = None
 
-            if not os.path.isfile(localPath):
+            if not os.path.isfile(local_path):
                 status = "ERROR"
                 msg = "Curl could not be downloaded"
-                url = bundlerResponse['url']
+                url = bundler_response['url']
             else:
-                missingFiles = [x for x in bundlerResponse['statusList'].keys()
-                                if bundlerResponse['statusList'][x] != 'COMPLETE']
-                if len(missingFiles):
-                    msg = "{} files could not be added to the curl script".format(len(missingFiles))
-                    url = ",".join(missingFiles)
+                missing_files = [x for x in bundler_response['statusList'].keys()
+                                if bundler_response['statusList'][x] != 'COMPLETE']
+                if len(missing_files):
+                    msg = "{} files could not be added to the curl script".format(len(missing_files))
+                    url = ",".join(missing_files)
 
-            manifest = Table({'Local Path': [localPath],
+            manifest = Table({'Local Path': [local_path],
                               'Status': [status],
                               'Message': [msg],
                               "URL": [url]})
@@ -2179,41 +1761,41 @@ class CatalogsClass(MastClass):
             if not os.path.exists(base_dir):
                 os.makedirs(base_dir)
 
-            manifestArray = []
+            manifest_array = []
             for spec in spectra:
 
-                # localPath = base_dir + "/HSC"# + spec['DatasetName'] + ".fits"
+                # local_path = base_dir + "/HSC"# + spec['DatasetName'] + ".fits"
 
                 if spec['SpectrumType'] < 2:
-                    dataUrl = 'https://hla.stsci.edu/cgi-bin/getdata.cgi?config=ops&dataset=' \
+                    data_url = 'https://hla.stsci.edu/cgi-bin/getdata.cgi?config=ops&dataset=' \
                               + spec['DatasetName']
                 else:
-                    dataUrl = 'https://hla.stsci.edu/cgi-bin/ecfproxy?file_id=' \
+                    data_url = 'https://hla.stsci.edu/cgi-bin/ecfproxy?file_id=' \
                               + spec['DatasetName'] + '.fits'
 
-                localPath = base_dir + '/' + spec['DatasetName'] + ".fits"
+                local_path = base_dir + '/' + spec['DatasetName'] + ".fits"
 
                 status = "COMPLETE"
                 msg = None
                 url = None
 
                 try:
-                    self._download_file(dataUrl, localPath, cache=cache, head_safe=True)
+                    self._download_file(data_url, local_path, cache=cache, head_safe=True)
 
                     # check file size also this is where would perform md5
-                    if not os.path.isfile(localPath):
+                    if not os.path.isfile(local_path):
                         status = "ERROR"
                         msg = "File was not downloaded"
-                        url = dataUrl
+                        url = data_url
 
                 except HTTPError as err:
                     status = "ERROR"
                     msg = "HTTPError: {0}".format(err)
-                    url = dataUrl
+                    url = data_url
 
-                manifestArray.append([localPath, status, msg, url])
+                manifest_array.append([local_path, status, msg, url])
 
-                manifest = Table(rows=manifestArray, names=('Local Path', 'Status', 'Message', "URL"))
+                manifest = Table(rows=manifest_array, names=('Local Path', 'Status', 'Message', "URL"))
 
         return manifest
 

--- a/astroquery/mast/tesscut.py
+++ b/astroquery/mast/tesscut.py
@@ -48,17 +48,6 @@ class TesscutClass(BaseQuery):
 
         self._TESSCUT_URL = conf.server + "/tesscut/api/v0.1/"
 
-    def _tesscut_livecheck(self):  # pragma: no cover
-        """
-        Temporary function to check if the tesscut service is live.
-        We'll remove this function once tesscut is released.
-        """
-
-        response = self._request("GET", conf.server + "/tesscut/")
-        if not response.status_code == 200:
-            raise RemoteServiceError("The TESSCut service hasn't been released yet.\n"
-                                     "Try again Soon!\n( More info at https://archive.stsci.edu/tess/ )")
-
     def get_sectors(self, coordinates, radius=0.2*u.deg):  # pragma: no cover
         """
         Get a list of the TESS data sectors whose footprints intersect
@@ -81,9 +70,6 @@ class TesscutClass(BaseQuery):
         response : `~astropy.table.Table`
             Sector/camera/chip information for given coordinates/raduis.
         """
-
-        # Check if tesscut is live before proceeding.
-        self._tesscut_livecheck()
 
         # Put coordinates and radius into consistant format
         coordinates = commons.parse_coordinates(coordinates)
@@ -153,9 +139,6 @@ class TesscutClass(BaseQuery):
         -------
         response : `~astropy.table.Table`
         """
-
-        # Check if tesscut is live before proceeding.
-        self._tesscut_livecheck()
 
         # Put coordinates and radius into consistant format
         coordinates = commons.parse_coordinates(coordinates)
@@ -252,9 +235,6 @@ class TesscutClass(BaseQuery):
         -------
         response : A list of `~astropy.io.fits.HDUList` objects.
         """
-
-        # Check if tesscut is live before proceeding.
-        self._tesscut_livecheck()
 
         # Put coordinates and radius into consistant format
         coordinates = commons.parse_coordinates(coordinates)

--- a/astroquery/mast/tests/test_mast.py
+++ b/astroquery/mast/tests/test_mast.py
@@ -112,6 +112,7 @@ def session_info_mockreturn(silent=False):
                    'token': None}
     return anon_session
 
+
 def tesscut_get_mockreturn(method="GET", url=None, data=None, timeout=10, **kwargs):
     if "sector" in url:
         filename = data_path(DATA_FILES['tess_sector'])

--- a/astroquery/mast/tests/test_mast.py
+++ b/astroquery/mast/tests/test_mast.py
@@ -65,8 +65,6 @@ def patch_post(request):
     mp.setattr(mast.Observations, 'session_info', session_info_mockreturn)
     mp.setattr(mast.Tesscut, "_request", tesscut_get_mockreturn)
     mp.setattr(mast.Tesscut, '_download_file', tess_download_mockreturn)
-    mp.setattr(mast.Tesscut, "_tesscut_livecheck", tesscut_livecheck)
-    mp.setattr(mast.Observations, '_get_auth_mode', _get_auth_mode_mockreturn)
     return mp
 
 
@@ -105,17 +103,14 @@ def download_mockreturn(*args, **kwargs):
 
 
 def session_info_mockreturn(silent=False):
-    anonSession = {'First Name': '',
-                   'Last Name': '',
-                   'Session Expiration': None,
-                   'Username': 'anonymous'}
-
-    return anonSession
-
-
-def _get_auth_mode_mockreturn(self):
-    return "SHIB-ECP"
-
+    anon_session = {'eppn': '',
+                   'ezid': 'anonymous',
+                   'attrib': {},
+                   'anon': True,
+                   'scopes': [],
+                   'session': None,
+                   'token': None}
+    return anon_session
 
 def tesscut_get_mockreturn(method="GET", url=None, data=None, timeout=10, **kwargs):
     if "sector" in url:
@@ -131,10 +126,6 @@ def tess_download_mockreturn(url, file_path):
     filename = data_path(DATA_FILES['tess_cutout'])
     copyfile(filename, file_path)
     return
-
-
-def tesscut_livecheck():  # making sure the livecheck passes so we can test the functionality
-    return True
 
 ###################
 # MastClass tests #

--- a/astroquery/mast/tests/test_mast_remote.py
+++ b/astroquery/mast/tests/test_mast_remote.py
@@ -56,11 +56,10 @@ class TestMast(object):
         # Are the two GALEX observations with obs_id 6374399093149532160 in the results table
         assert len(result[np.where(result["obs_id"] == "6374399093149532160")]) == 2
 
-    @pytest.mark.skip(reason="currently broken")
     def test_mast_sesion_info(self):
         sessionInfo = mast.Mast.session_info(True)
-        assert sessionInfo['Username'] == 'anonymous'
-        assert sessionInfo['Session Expiration'] is None
+        assert sessionInfo['ezid'] == 'anonymous'
+        assert sessionInfo['token'] is None
 
     ###########################
     # ObservationsClass tests #
@@ -234,7 +233,7 @@ class TestMast(object):
 
     def test_observations_download_products(self, tmpdir):
         observations = mast.Observations.query_object("M8", radius=".02 deg")
-        test_obs_id = str(observations[0]['obsid'])
+        test_obs_id = str(observations[210]['obsid'])
 
         # actually download the products
         result = mast.Observations.download_products(test_obs_id,
@@ -430,105 +429,70 @@ class TestMast(object):
     ######################
     # TesscutClass tests #
     ######################
-    @pytest.mark.skip(reason="no way of testing this till tesscut goes live")
     def test_tesscut_get_sectors(self):
 
         # Note: try except will be removed when the service goes live
         coord = SkyCoord(324.24368, -27.01029, unit="deg")
-        try:
-            sector_table = mast.Tesscut.get_sectors(coord)
-            assert isinstance(sector_table, Table)
-            assert len(sector_table) == 1
-            assert sector_table['sectorName'][0] == "tess-s0001-1-3"
-            assert sector_table['sector'][0] == 1
-            assert sector_table['camera'][0] == 1
-            assert sector_table['ccd'][0] == 3
-        except RemoteServiceError:
-            pass  # service is not live yet so can't test
+        sector_table = mast.Tesscut.get_sectors(coord)
+        assert isinstance(sector_table, Table)
+        assert len(sector_table) >= 1
+        assert sector_table['sectorName'][0] == "tess-s0001-1-3"
+        assert sector_table['sector'][0] == 1
+        assert sector_table['camera'][0] == 1
+        assert sector_table['ccd'][0] == 3
 
-        try:
-            # This should always return no results
-            coord = SkyCoord(0, 90, unit="deg")
-            sector_table = mast.Tesscut.get_sectors(coord)
-            assert isinstance(sector_table, Table)
-            assert len(sector_table) == 0
-        except RemoteServiceError:
-            pass  # service is not live yet so can't test
+        # This should always return no results
+        coord = SkyCoord(0, 90, unit="deg")
+        sector_table = mast.Tesscut.get_sectors(coord)
+        assert isinstance(sector_table, Table)
+        assert len(sector_table) == 0
 
-    @pytest.mark.skip(reason="no way of testing this till tesscut goes live")
     def test_tesscut_download_cutouts(self, tmpdir):
 
-        # Note: try excepts will be removed when the service goes live
-
         coord = SkyCoord(107.18696, -70.50919, unit="deg")
 
-        # Testing with inflate
-        try:
-            manifest = mast.Tesscut.download_cutouts(coord, 5, path=str(tmpdir))
-            assert isinstance(manifest, Table)
-            assert len(manifest) >= 1
-            assert manifest["Local Path"][0][-4:] == "fits"
-            for row in manifest:
-                assert os.path.isfile(row['Local Path'])
-        except RemoteServiceError:
-            pass  # service is not live yet so can't test
+        manifest = mast.Tesscut.download_cutouts(coord, 5, path=str(tmpdir))
+        assert isinstance(manifest, Table)
+        assert len(manifest) >= 1
+        assert manifest["Local Path"][0][-4:] == "fits"
+        for row in manifest:
+            assert os.path.isfile(row['Local Path'])
 
-        try:
-            manifest = mast.Tesscut.download_cutouts(coord, 5,
-                                                     sector=1, path=str(tmpdir))
-            assert isinstance(manifest, Table)
-            assert len(manifest) == 1
-            assert manifest["Local Path"][0][-4:] == "fits"
-            for row in manifest:
-                assert os.path.isfile(row['Local Path'])
-        except RemoteServiceError:
-            pass  # service is not live yet so can't test
+        manifest = mast.Tesscut.download_cutouts(coord, 5, sector=1, path=str(tmpdir))
+        assert isinstance(manifest, Table)
+        assert len(manifest) == 1
+        assert manifest["Local Path"][0][-4:] == "fits"
+        for row in manifest:
+            assert os.path.isfile(row['Local Path'])
 
-        try:
-            manifest = mast.Tesscut.download_cutouts(coord, [5, 7]*u.pix, path=str(tmpdir))
-            assert isinstance(manifest, Table)
-            assert len(manifest) >= 1
-            assert manifest["Local Path"][0][-4:] == "fits"
-            for row in manifest:
-                assert os.path.isfile(row['Local Path'])
-        except RemoteServiceError:
-            pass  # service is not live yet so can't test
+        manifest = mast.Tesscut.download_cutouts(coord, [5, 7]*u.pix, path=str(tmpdir))
+        assert isinstance(manifest, Table)
+        assert len(manifest) >= 1
+        assert manifest["Local Path"][0][-4:] == "fits"
+        for row in manifest:
+            assert os.path.isfile(row['Local Path'])
 
-        # Testing without inflate
-        try:
-            manifest = mast.Tesscut.download_cutouts(coord, 5, path=str(tmpdir), inflate=False)
-            assert isinstance(manifest, Table)
-            assert len(manifest) == 1
-            assert manifest["Local Path"][0][-3:] == "zip"
-            assert os.path.isfile(manifest[0]['Local Path'])
-        except RemoteServiceError:
-            pass  # service is not live yet so can't test
+        manifest = mast.Tesscut.download_cutouts(coord, 5, path=str(tmpdir), inflate=False)
+        assert isinstance(manifest, Table)
+        assert len(manifest) == 1
+        assert manifest["Local Path"][0][-3:] == "zip"
+        assert os.path.isfile(manifest[0]['Local Path'])
 
-    @pytest.mark.skip(reason="no way of testing this till tesscut goes live")
     def test_tesscut_get_cutouts(self, tmpdir):
 
-        # Note: try excepts will be removed when the service goes live
         coord = SkyCoord(107.18696, -70.50919, unit="deg")
-        try:
-            cutout_hdus_list = mast.Tesscut.get_cutouts(coord, 5)
-            assert isinstance(cutout_hdus_list, list)
-            assert len(cutout_hdus_list) >= 1
-            assert isinstance(cutout_hdus_list[0], fits.HDUList)
-        except RemoteServiceError:
-            pass  # service is not live yet so can't test
 
-        try:
-            cutout_hdus_list = mast.Tesscut.get_cutouts(coord, 5, sector=1)
-            assert isinstance(cutout_hdus_list, list)
-            assert len(cutout_hdus_list) == 1
-            assert isinstance(cutout_hdus_list[0], fits.HDUList)
-        except RemoteServiceError:
-            pass  # service is not live yet so can't test
+        cutout_hdus_list = mast.Tesscut.get_cutouts(coord, 5)
+        assert isinstance(cutout_hdus_list, list)
+        assert len(cutout_hdus_list) >= 1
+        assert isinstance(cutout_hdus_list[0], fits.HDUList)
 
-        try:
-            cutout_hdus_list = mast.Tesscut.get_cutouts(coord, [2, 4]*u.arcmin)
-            assert isinstance(cutout_hdus_list, list)
-            assert len(cutout_hdus_list) >= 1
-            assert isinstance(cutout_hdus_list[0], fits.HDUList)
-        except RemoteServiceError:
-            pass  # service is not live yet so can't test
+        cutout_hdus_list = mast.Tesscut.get_cutouts(coord, 5, sector=1)
+        assert isinstance(cutout_hdus_list, list)
+        assert len(cutout_hdus_list) == 1
+        assert isinstance(cutout_hdus_list[0], fits.HDUList)
+
+        cutout_hdus_list = mast.Tesscut.get_cutouts(coord, [2, 4]*u.arcmin)
+        assert isinstance(cutout_hdus_list, list)
+        assert len(cutout_hdus_list) >= 1
+        assert isinstance(cutout_hdus_list[0], fits.HDUList)

--- a/astroquery/mast/tests/test_mast_remote.py
+++ b/astroquery/mast/tests/test_mast_remote.py
@@ -232,10 +232,7 @@ class TestMast(object):
         assert len(result) == sum(products['productType'] == "SCIENCE")
 
     def test_observations_download_products(self, tmpdir):
-        observations = mast.Observations.query_object("M8", radius=".02 deg")
-        test_obs_id = str(observations[210]['obsid'])
-
-        # actually download the products
+        test_obs_id = '2003600312'
         result = mast.Observations.download_products(test_obs_id,
                                                      download_dir=str(tmpdir),
                                                      productType=["SCIENCE"],

--- a/astroquery/utils/commons.py
+++ b/astroquery/utils/commons.py
@@ -21,7 +21,7 @@ from astropy.io import fits, votable
 
 from astropy.coordinates import BaseCoordinateFrame
 
-from ..exceptions import TimeoutError
+from ..exceptions import TimeoutError, InputWarning
 from .. import version
 
 
@@ -83,7 +83,7 @@ def send_request(url, data, timeout, request_type='POST', headers={},
 
     if hasattr(timeout, "unit"):
         warnings.warn("Converting timeout to seconds and truncating "
-                      "to integer.")
+                      "to integer.", InputWarning)
         timeout = int(timeout.to(u.s).value)
 
     try:
@@ -157,19 +157,19 @@ def parse_coordinates(coordinates):
         try:
             c = ICRSCoordGenerator(coordinates)
             warnings.warn("Coordinate string is being interpreted as an "
-                          "ICRS coordinate.")
+                          "ICRS coordinate.", InputWarning)
 
         except u.UnitsError:
             warnings.warn("Only ICRS coordinates can be entered as "
                           "strings.\n For other systems please use the "
-                          "appropriate astropy.coordinates object.")
+                          "appropriate astropy.coordinates object.", InputWarning)
             raise u.UnitsError
         except ValueError as err:
             if isinstance(err.args[1], u.UnitsError):
                 try:
                     c = ICRSCoordGenerator(coordinates, unit='deg')
                     warnings.warn("Coordinate string is being interpreted as an "
-                                  "ICRS coordinate provided in degrees.")
+                                  "ICRS coordinate provided in degrees.", InputWarning)
 
                 except ValueError:
                     c = ICRSCoord.from_name(coordinates)
@@ -288,7 +288,7 @@ class TableList(list):
     def pprint(self, **kwargs):
         """ Helper function to make API more similar to astropy.Tables """
         if kwargs != {}:
-            warnings.warn("TableList is a container of astropy.Tables.")
+            warnings.warn("TableList is a container of astropy.Tables.", InputWarning)
         self.print_table_list()
 
 
@@ -354,7 +354,7 @@ class FileContainer(object):
         if (os.path.splitext(target)[1] == '.fits' and not
                 ('encoding' in kwargs and kwargs['encoding'] == 'binary')):
             warnings.warn("FITS files must be read as binaries; error is "
-                          "likely.")
+                          "likely.", InputWarning)
         self._readable_object = get_readable_fileobj(target, **kwargs)
 
     def get_fits(self):

--- a/docs/mast/mast.rst
+++ b/docs/mast/mast.rst
@@ -687,6 +687,15 @@ In this case, the async method should be used to get the raw http response, whic
                  'status': ''}
 
 
+
+Additional Resources
+====================
+
+`Accessing MAST Holdings with Astroquery, <https://stsci.app.box.com/s/4no7430kswla4gsg8bt2avs72k9agpne>`_ slides from an introductory MAST Astroquery talk.
+
+The Space Telescope Science Institute `Notebooks Repository <https://github.com/spacetelescope/notebooks>`_ includes many examples that use Astroquery.
+
+                 
 Reference/API
 =============
 

--- a/docs/mast/mast.rst
+++ b/docs/mast/mast.rst
@@ -584,16 +584,6 @@ To access data that is not publicly available users may log into their
 This can be done by using the `~astroquery.mast.MastClass.login` function,
 or by initializing a class instance with credentials.
 
-MAST is in the process of upgrading our Auth infrastructure to a token based system.
-This will be deployed early November 2018, at which point the credentials will
-switch from accepting a username/password and instead accept an auth token.
-
-
-Accessing Proprietary Data (Token Method)
------------------------------------------
-
-This will be enabled in early November 2018.
-
 If a token is not supplied, the user will be prompted to enter one.
 
 To view tokens accessible through your account, visit https://auth.mast.stsci.edu
@@ -633,73 +623,6 @@ the key is used within that time, the token's expiration pushed back to 10 days.
 age is 60 days, afterward the user must generate a token.
 The ``store_token`` argument can be used to store the token securely in the user's keyring.
 This token can be overwritten using the ``reenter_token`` argument.
-To logout before a session expires, the `~astroquery.mast.MastClass.logout` method may be used.
-
-
-Accessing Proprietary Data (Password Method)
---------------------------------------------
-
-This will be disabled in early November 2018.
-
-If a password is not supplied, the user will be prompted to enter one.
-
-.. code-block:: python
-
-                >>> from astroquery.mast import Observations
-                >>> Observations.login(username="testUser@stsci.edu",password="testPwd")
-
-                Authentication successful!
-                Session Expiration: 600 minute(s)
-
-                >>> sessionInfo = Observations.session_info()
-
-                Session Expiration: 559.0 min
-                Username: testUser@stsci.edu
-                First Name: Test
-                Last Name: User
-
-              
-.. code-block:: python
-
-                >>> from astroquery.mast import Observations
-                >>> mySession = Observations(username="testUser@stsci.edu",password="testPwd")
-
-                Authentication successful!
-                Session Expiration: 600 minute(s)
-
-                >>> sessionInfo = mySession.session_info()
-
-                Session Expiration: 559.0 min
-                Username: testUser@stsci.edu
-                First Name: Test
-                Last Name: User
-
-\* For security passwords should not be typed into a terminal or Jupyter notebook
-but instead input using a more secure method such as `~getpass.getpass`.
-
-
-MAST login can also be achieved with a "session token," from an existing valid MAST session.
-
-.. code-block:: python
-
-                >>> from astroquery.mast import Observations
-                >>> from astroquery.mast import Mast
-                >>> myObsSession = Observations(username="testUser@stsci.edu",password="testPwd")
-
-                Authentication successful!
-                Session Expiration: 600 minute(s)
-
-                >>> myToken = myObsSession.get_token()
-                >>> Mast.login(session_token=myToken)
-
-                Authentication successful!
-                Session Expiration: 599 minute(s)
-
-
-MAST sessions expire after 600 minutes, at which point the user must login again.
-The ``store_password`` argument can be used to store the username and password securely in the user's keyring.
-If the username/password are thus stored, only the username need be entered to login.
-This password can be overwritten using the ``reenter_password`` argument.
 To logout before a session expires, the `~astroquery.mast.MastClass.logout` method may be used.
 
 


### PR DESCRIPTION
This PR includes a number of cleanup tasks, primarily in the MAST codebase. With the exception of the documentation updates, most of the changes should be transparent to the user.

Changes included in this PR:

- Removal of deprecated MAST authentication code: Since MAST's transition to the new authentication system is complete I have removed all the code that was for the old system.
   - Remove all shibboleth login functionality
   - Remove password method instructions 
   - Deprecated `get_token` method since tokens are now the "secret" for authentication
   - Updated doc strings as needed
- Removed Tesscut livecheck: unnecessary now it's live
- Unskipped and fixed broken unit tests
   - Fixed session_info test for new result
   - Unskipped Tesscut tests now the service is live
- Converted all camelCase variables to under_score
   I probably missed some, but I tried to get them all.
- Added warning type to warnings in query.py: Not having an explicitly set warning type was making the warnings print oddly and cut off
- Added links to slides and STScI notebooks repository
