### PR TITLE
Fix example listing columns and column names

### DIFF
--- a/docs/utils/tap.rst
+++ b/docs/utils/tap.rst
@@ -134,8 +134,8 @@ Once a table is loaded, columns can be inspected
   >>>
   >>> gaia = TapPlus(url="http://gea.esac.esa.int/tap-server/tap")
   >>> table = gaia.load_table('gaiadr1.gaia_source')
-  >>> for column in (gaiadr1_table.get_columns()):
-  >>>   print(column.get_name())
+  >>> for column in (table.columns):
+  >>>   print(column.name)
 
   solution_id
   source_id


### PR DESCRIPTION
This is a simple doc fix.  As written the example listing columns and column names for the gaiadr2 source table did not work with the current version of `astroquery.utils.TapPlus`.  I have tested this change with version 0.3.9 of `astroquery`.