### PR TITLE
Change Simbad query_objectids_async to yield meaningful response content

### DIFF
--- a/astroquery/simbad/core.py
+++ b/astroquery/simbad/core.py
@@ -907,9 +907,14 @@ class SimbadClass(BaseQuery):
         """
         request_payload = dict(script="\n".join(('format object "%IDLIST"',
                                                  'query id %s' % object_name)))
+
+        if get_query_payload:
+            return request_payload
+
         response = self._request("POST", self.SIMBAD_URL, data=request_payload,
                                  timeout=self.TIMEOUT, cache=cache)
-        return response.text
+
+        return response
 
     def _get_query_header(self, get_raw=False):
         votable_fields = ','.join(self.get_votable_fields())

--- a/astroquery/simbad/core.py
+++ b/astroquery/simbad/core.py
@@ -909,7 +909,7 @@ class SimbadClass(BaseQuery):
                                                  'query id %s' % object_name)))
         response = self._request("POST", self.SIMBAD_URL, data=request_payload,
                                  timeout=self.TIMEOUT, cache=cache)
-        return response
+        return response.text
 
     def _get_query_header(self, get_raw=False):
         votable_fields = ','.join(self.get_votable_fields())


### PR DESCRIPTION
Fixes #1413. 

Now when I do the following:
```
>>> from astroquery.simbad import Simbad
>>> response = Simbad.query_objectids_async("m1")
```
Instead of getting the rather bland `<Response [200]>` when I do `print(response)`, now I get instead:
```
::script::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::

format object "%IDLIST"
query id m1

::console:::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::

C.D.S.  -  SIMBAD4 rel 1.7  -  2019.04.12CEST09:39:15
total execution time: 0.115 secs
simbatch done

::data::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::

3FHL J0534.5+2201
SNR G184.6-05.8
1H 0531+219
1M 0531+219
2C  481
2E  1309
2U 0531+22
3A 0531+219
3C 144
3C 144.0
3CR 144
3U 0531+21
4C 21.19
4U 0531+21
AJG   1
CTA  36
CTB 18
Cul 0531+21
Cul 0531+219
DA 179
DB  38
H 0534+21
H 0531+219
IRAS 05314+2200
LBN   833
LBN 184.62-05.65
M   1
Mills 05+2A
NAME CRAB NEB
NAME Crab
NAME Crab Nebula
NAME Tau A
NAME Taurus A
NGC  1952
NRAO 214
NRL  2
PKS 0531+219
SH  2-244
SIM 0531+21.0
VRO 21.05.01
X Tau X-1
X Tau XR-1
[BM83] X0531+219
[DGW65]  25
[PT56]  5
1ES 0532+21.5
2E 0531.5+2159
PBC J0534.5+2201
SWIFT J0534.6+2204
SWIFT J0534.5+2200
GRS G184.60 -05.80
W 9
NVSS J053428+220202
ARGO J0535+2203
3FGL J0534.5+2201i
TeV J0534+220
```