### PR TITLE
Add optional kwargs of BaseQuery to modules and modify tests where necessary

### DIFF
--- a/astroquery/alma/core.py
+++ b/astroquery/alma/core.py
@@ -146,9 +146,10 @@ class AlmaClass(QueryWithLogin):
         if get_query_payload:
             return payload
 
-        response = self._request('GET', url, params=payload,
-                                 timeout=self.TIMEOUT,
-                                 cache=cache and not get_html_version)
+        response = self._request('GET', url, params=payload, data=None, headers=None,
+                                 files=None, save=False, savedir='', timeout=self.TIMEOUT,
+                                 cache=cache and not get_html_version,
+                                 stream=False, auth=None, continuation=True, verify=True)
         self._last_response = response
         response.raise_for_status()
 
@@ -170,9 +171,10 @@ class AlmaClass(QueryWithLogin):
                                           response.text),
                                       params={'query_url':
                                               response.url.split("?")[-1]},
+                                      data=None, headers=None, files=None, save=False, savedir='',
                                       timeout=self.TIMEOUT,
-                                      cache=False,
-                                      )
+                                      cache=False, stream=False, auth=None, continuation=True,
+                                      verify=True)
             self._last_response = response2
             response2.raise_for_status()
             if len(response2.text) == 0:
@@ -207,8 +209,10 @@ class AlmaClass(QueryWithLogin):
         for kw in payload:
             vpayload = {'field': kw,
                         kw: payload[kw]}
-            response = self._request('GET', vurl, params=vpayload, cache=cache,
-                                     timeout=self.TIMEOUT)
+            response = self._request('GET', vurl, params=vpayload, data=None, headers=None,
+                                     files=None, save=False, savedir='', timeout=self.TIMEOUT,
+                                     cache=cache, stream=False, auth=None, continuation=True,
+                                     verify=True)
 
             if response.content:
                 bad_kws[kw] = response.content
@@ -224,8 +228,10 @@ class AlmaClass(QueryWithLogin):
         """
         if not hasattr(self, 'dataarchive_url'):
             if self.archive_url in ('http://almascience.org', 'https://almascience.org'):
-                response = self._request('GET', self.archive_url + "/aq",
-                                         cache=False)
+                response = self._request('GET', self.archive_url + "/aq", params=None,
+                                         data=None, headers=None, files=None, save=False,
+                                         savedir='', timeout=None, cache=False, stream=False,
+                                         auth=None, continuation=True, verify=True)
                 response.raise_for_status()
                 # Jan 2017: we have to force https because the archive doesn't
                 # tell us it needs https.
@@ -282,8 +288,10 @@ class AlmaClass(QueryWithLogin):
         # Request staging for the UIDs
         # This component cannot be cached, since the returned data can change
         # if new data are uploaded
-        response = self._request('POST', url, data=payload,
-                                 timeout=self.TIMEOUT, cache=False)
+        response = self._request('POST', url, params=None, data=payload, headers=None,
+                                 files=None, save=False, savedir='',
+                                 timeout=self.TIMEOUT, cache=False, stream=False, auth=None,
+                                 continuation=True, verify=True)
         self._staging_log['initial_response'] = response
         log.debug("First response URL: {0}".format(response.url))
         if 'login' in response.url:
@@ -306,8 +314,10 @@ class AlmaClass(QueryWithLogin):
             time.sleep(1)
             # CANNOT cache this stage: it not a real data page!  results in
             # infinite loops
-            response = self._request('POST', url, data=payload,
-                                     timeout=self.TIMEOUT, cache=False)
+            response = self._request('POST', url, params=None, data=payload, headers=None,
+                                     files=None, save=False, savedir='',
+                                     timeout=self.TIMEOUT, cache=False, stream=False,
+                                     auth=None, continuation=True, verify=True)
             self._staging_log['initial_response'] = response
             if 'j_spring_cas_security_check' in response.url:
                 log.warning("Staging request was not successful.  Try again?")
@@ -328,7 +338,10 @@ class AlmaClass(QueryWithLogin):
                                  url_helpers.join('rh/submission', request_id))
         log.debug("Submission URL: {0}".format(submission_url))
         self._staging_log['submission_url'] = submission_url
-        staging_submission = self._request('GET', submission_url, cache=True)
+        staging_submission = self._request('GET', submission_url, params=None, data=None,
+                                           headers=None, files=None, save=False, savedir='',
+                                           timeout=None, cache=True, stream=False, auth=None,
+                                           continuation=True, verify=True)
         self._staging_log['staging_submission'] = staging_submission
         staging_submission.raise_for_status()
 
@@ -338,16 +351,20 @@ class AlmaClass(QueryWithLogin):
         self._staging_log['staging_page_id'] = dpid
 
         # CANNOT cache this step: please_wait will happen infinitely
-        data_page = self._request('GET', data_page_url, cache=False)
+        data_page = self._request('GET', data_page_url, params=None, data=None, headers=None,
+                                  files=None, save=False, savedir='', timeout=None,
+                                  cache=False, stream=False, auth=None, continuation=True,
+                                  verify=True)
         self._staging_log['data_page'] = data_page
         data_page.raise_for_status()
 
         has_completed = False
         while not has_completed:
             time.sleep(1)
-            summary = self._request('GET', url_helpers.join(data_page_url,
-                                                            'summary'),
-                                    cache=False)
+            summary = self._request('GET', url_helpers.join(data_page_url, 'summary'),
+                                    params=None, data=None, headers=None, files=None,
+                                    save=False, savedir='', timeout=None, cache=False,
+                                    stream=False, auth=None, continuation=True, verify=True)
             summary.raise_for_status()
             print(".", end='')
             sys.stdout.flush()
@@ -389,8 +406,10 @@ class AlmaClass(QueryWithLogin):
         data_sizes = {}
         pb = ProgressBar(len(files))
         for ii, fileLink in enumerate(files):
-            response = self._request('HEAD', fileLink, stream=False,
-                                     cache=False, timeout=self.TIMEOUT)
+            response = self._request('HEAD', fileLink, params=None, data=None, headers=None,
+                                     files=None, save=False, savedir='', timeout=self.TIMEOUT,
+                                     cache=False, stream=False, auth=None, continuation=True,
+                                     verify=True)
             filesize = (int(response.headers['content-length']) * u.B).to(u.GB)
             totalsize += filesize
             data_sizes[fileLink] = filesize
@@ -412,10 +431,10 @@ class AlmaClass(QueryWithLogin):
             savedir = self.cache_location
         for fileLink in unique(files):
             try:
-                filename = self._request("GET", fileLink, save=True,
-                                         savedir=savedir,
-                                         timeout=self.TIMEOUT, cache=cache,
-                                         continuation=continuation)
+                filename = self._request("GET", fileLink, params=None, data=None, headers=None,
+                                         files=None, save=True, savedir=savedir,
+                                         timeout=self.TIMEOUT, cache=cache, stream=False,
+                                         auth=None, continuation=continuation, verify=True)
                 downloaded_files.append(filename)
             except requests.HTTPError as ex:
                 if ex.response.status_code == 401:
@@ -541,16 +560,19 @@ class AlmaClass(QueryWithLogin):
 
         # set session cookies (they do not get set otherwise)
         cookiesetpage = self._request("GET",
-                                      urljoin(self._get_dataarchive_url(),
-                                              'rh/forceAuthentication'),
-                                      cache=False)
+                                      urljoin(self._get_dataarchive_url(), 'rh/forceAuthentication'),
+                                      params=None, data=None, headers=None, files=None,
+                                      save=False, savedir='', timeout=None, cache=False,
+                                      stream=False, auth=None, continuation=True, verify=True)
         self._login_cookiepage = cookiesetpage
         cookiesetpage.raise_for_status()
         assert 'rh-cas.alma.cl/cas/login' in cookiesetpage.request.url
 
         # Check if already logged in
-        loginpage = self._request("GET", "https://rh-cas.alma.cl/cas/login",
-                                  cache=False)
+        loginpage = self._request("GET", "https://rh-cas.alma.cl/cas/login", params=None,
+                                  data=None, headers=None, files=None, save=False, savedir='',
+                                  timeout=None, cache=False, stream=False, auth=None,
+                                  continuation=True, verify=True)
         root = BeautifulSoup(loginpage.content, 'html5lib')
         if root.find('div', class_='success'):
             log.info("Already logged in.")
@@ -571,8 +593,9 @@ class AlmaClass(QueryWithLogin):
 
         login_response = self._request("POST", "https://rh-cas.alma.cl/cas/login",
                                        params={'service': self._get_dataarchive_url()},
-                                       data=data,
-                                       cache=False)
+                                       data=data, headers=None, files=None, save=False,
+                                       savedir='', timeout=None, cache=False, stream=False,
+                                       auth=None, continuation=True, verify=True)
 
         # save the login response for debugging purposes
         self._login_response = login_response
@@ -626,8 +649,10 @@ class AlmaClass(QueryWithLogin):
         if not hasattr(self, '_cycle0_tarfile_content_table'):
             url = urljoin(self._get_dataarchive_url(),
                           'alma-data/archive/cycle-0-tarfile-content')
-            response = self._request('GET', url, cache=True)
-
+            response = self._request('GET', url, params=None, data=None, headers=None,
+                                     files=None, save=False, savedir='', timeout=None,
+                                     cache=True, stream=False, auth=None, continuation=True,
+                                     verify=True)
             # html.parser is needed because some <tr>'s have form:
             # <tr width="blah"> which the default parser does not pick up
             root = BeautifulSoup(response.content, 'html.parser')
@@ -757,8 +782,10 @@ class AlmaClass(QueryWithLogin):
                     continue
 
             try:
-                tarball_name = self._request('GET', url, save=True,
-                                             timeout=self.TIMEOUT)
+                tarball_name = self._request('GET', url, params=None, data=None, headers=None,
+                                             files=None, save=True, savedir='',
+                                             timeout=self.TIMEOUT, cache=True, stream=False,
+                                             auth=None, continuation=True, verify=True)
             except requests.ConnectionError as ex:
                 self.partial_file_list = all_files
                 log.error("There was an error downloading the file. "
@@ -823,9 +850,10 @@ class AlmaClass(QueryWithLogin):
 
     def _get_help_page(self, cache=True):
         if not hasattr(self, '_help_list') or not self._help_list:
-            querypage = self._request(
-                'GET', self._get_dataarchive_url() + "/aq/",
-                cache=cache, timeout=self.TIMEOUT)
+            querypage = self._request('GET', self._get_dataarchive_url() + "/aq/",
+                                      params=None, data=None, headers=None, files=None,
+                                      save=False, savedir='', timeout=self.TIMEOUT, cache=cache,
+                                      stream=False, auth=None, continuation=True, verify=True)
             root = BeautifulSoup(querypage.content, "html5lib")
             sections = root.findAll('td', class_='category')
 

--- a/astroquery/atomic/core.py
+++ b/astroquery/atomic/core.py
@@ -186,8 +186,10 @@ class AtomicLineListClass(BaseQuery):
             The HTTP response returned from the service.
         """
         if self._default_form_values is None:
-            response = self._request("GET", url=self.FORM_URL, data={},
-                                     timeout=self.TIMEOUT)
+            response = self._request("GET", url=self.FORM_URL, params=None, data={},
+                                     headers=None, files=None, save=False, savedir='',
+                                     timeout=self.TIMEOUT, cache=True, stream=False,
+                                     auth=None, continuation=True, verify=True)
             bs = BeautifulSoup(response.text)
             form = bs.find('form')
             self._default_form_values = self._get_default_form_values(form)
@@ -296,8 +298,10 @@ class AtomicLineListClass(BaseQuery):
         """
         if input is None:
             input = {}
-        response = self._request("GET", url=self.FORM_URL, data={},
-                                 timeout=self.TIMEOUT)
+        response = self._request("GET", url=self.FORM_URL, params=None, data={},
+                                 headers=None, files=None, save=False, savedir='',
+                                 timeout=self.TIMEOUT, cache=True, stream=False,
+                                 auth=None, continuation=True, verify=True)
         bs = BeautifulSoup(response.text)
         form = bs.find('form')
         # cache the default values to save HTTP traffic
@@ -310,8 +314,10 @@ class AtomicLineListClass(BaseQuery):
             if v is not None:
                 payload[k] = v
         url = urlparse.urljoin(self.FORM_URL, form.get('action'))
-        response = self._request("POST", url=url, data=payload,
-                                 timeout=self.TIMEOUT)
+        response = self._request("POST", url=url, params=None, data=payload,
+                                 headers=None, files=None, save=False, savedir='',
+                                 timeout=self.TIMEOUT, cache=True, stream=False,
+                                 auth=None, continuation=True, verify=True)
         return response
 
     def _get_default_form_values(self, form):

--- a/astroquery/besancon/core.py
+++ b/astroquery/besancon/core.py
@@ -299,8 +299,10 @@ class BesanconClass(BaseQuery):
         if kwargs.get('get_query_payload'):
             return data_payload
 
-        response = self._request("POST", url=self.QUERY_URL, data=data_payload,
-                                 timeout=self.TIMEOUT, stream=True)
+        response = self._request("POST", url=self.QUERY_URL, params=None, data=data_payload,
+                                 headers=None, file=None, save=False, savedir='',
+                                 timeout=self.TIMEOUT, cache=True, stream=True,
+                                 auth=None, continuation=True, verify=True)
         return response
 
 

--- a/astroquery/cosmosim/core.py
+++ b/astroquery/cosmosim/core.py
@@ -231,7 +231,6 @@ class CosmoSimClass(QueryWithLogin):
             result = self._request('POST',
                                    CosmoSim.QUERY_URL,
                                    params=None,
-                                   params=None,
                                    data={'query': query_string, 'phase': 'run',
                                          'queue': queue},
                                    headers=None,

--- a/astroquery/cosmosim/core.py
+++ b/astroquery/cosmosim/core.py
@@ -658,7 +658,6 @@ class CosmoSimClass(QueryWithLogin):
                                   continuation=True,
                                   verify=True)
                                  ]
-                                  
                 self.response_dict_current = {}
                 self.response_dict_current[jobid] = (
                     self._generate_response_dict(response_list[0]))

--- a/astroquery/cosmosim/core.py
+++ b/astroquery/cosmosim/core.py
@@ -86,9 +86,20 @@ class CosmoSimClass(QueryWithLogin):
         # Authenticate
         warnings.warn("Authenticating {0} on www.cosmosim.org..."
                       .format(self.username))
-        authenticated = self._request('POST', CosmoSim.QUERY_URL,
+        authenticated = self._request('POST',
+                                      CosmoSim.QUERY_URL,
+                                      params=None,
+                                      data=None,
+                                      headers=None,
+                                      files=None,
+                                      save=False,
+                                      savedir='',
+                                      timeout=None,
+                                      cache=False,
+                                      stream=False,
                                       auth=(self.username, self.password),
-                                      cache=False)
+                                      continuation=True,
+                                      verify=True)
         if authenticated.status_code == 200:
             warnings.warn("Authentication successful!")
         elif (authenticated.status_code == 401 or
@@ -153,9 +164,20 @@ class CosmoSimClass(QueryWithLogin):
 
         if (hasattr(self, 'username') and hasattr(self, 'password') and
                 hasattr(self, 'session')):
-            authenticated = self._request('POST', CosmoSim.QUERY_URL,
+            authenticated = self._request('POST',
+                                          CosmoSim.QUERY_URL,
+                                          params=None,
+                                          data=None,
+                                          headers=None,
+                                          files=None,
+                                          save=False,
+                                          savedir='',
+                                          timeout=None,
+                                          cache=False,
+                                          stream=False,
                                           auth=(self.username, self.password),
-                                          cache=False)
+                                          continuation=True,
+                                          verify=True)
             if authenticated.status_code == 200:
                 warnings.warn("Status: You are logged in as {0}."
                               .format(self.username))
@@ -208,10 +230,20 @@ class CosmoSimClass(QueryWithLogin):
         if tablename in self.table_dict.values():
             result = self._request('POST',
                                    CosmoSim.QUERY_URL,
-                                   auth=(self.username, self.password),
+                                   params=None,
+                                   params=None,
                                    data={'query': query_string, 'phase': 'run',
                                          'queue': queue},
-                                   cache=cache)
+                                   headers=None,
+                                   files=None,
+                                   save=False,
+                                   savedir='',
+                                   timeout=None,
+                                   cache=cache,
+                                   stream=False,
+                                   auth=(self.username, self.password),
+                                   continuation=True,
+                                   verfity=True)
             soup = BeautifulSoup(result.content, "lxml")
             phase = soup.find("uws:phase").string
             if phase in ['ERROR']:
@@ -224,18 +256,38 @@ class CosmoSimClass(QueryWithLogin):
                             .format(tablename))
             warnings.warn("Generated table name: {0}".format(gen_tablename))
         elif tablename is None:
-            result = self._request('POST', CosmoSim.QUERY_URL,
-                                   auth=(self.username, self.password),
+            result = self._request('POST',
+                                   CosmoSim.QUERY_URL,
+                                   params=None,
                                    data={'query': query_string, 'phase': 'run',
                                          'queue': queue},
-                                   cache=cache)
-        else:
-            result = self._request('POST', CosmoSim.QUERY_URL,
+                                   headers=None,
+                                   files=None,
+                                   save=False,
+                                   savedir='',
+                                   timeout=None,
+                                   cache=cache,
+                                   stream=False,
                                    auth=(self.username, self.password),
+                                   continuation=True,
+                                   verify=True)
+        else:
+            result = self._request('POST',
+                                   CosmoSim.QUERY_URL,
+                                   params=None,
                                    data={'query': query_string,
                                          'table': str(tablename),
                                          'phase': 'run', 'queue': queue},
-                                   cache=cache)
+                                   headers=None,
+                                   files=None,
+                                   save=False,
+                                   savedir='',
+                                   timeout=None,
+                                   cache=cache,
+                                   stream=False,
+                                   auth=(self.username, self.password),
+                                   continuation=True,
+                                   verify=True)
             self._existing_tables()
 
         soup = BeautifulSoup(result.content, "lxml")
@@ -288,10 +340,20 @@ class CosmoSimClass(QueryWithLogin):
             else:
                 jobid = self.current_job
 
-        response = self._request(
-            'GET', CosmoSim.QUERY_URL + '/{}'.format(jobid) + '/phase',
-            auth=(self.username, self.password), data={'print': 'b'},
-            cache=False)
+        response = self._request('GET',
+                                 CosmoSim.QUERY_URL + '/{}'.format(jobid) + '/phase',
+                                 params=None,
+                                 data={'print': 'b'},
+                                 headers=None,
+                                 files=None,
+                                 save=False,
+                                 savedir='',
+                                 timeout=None,
+                                 cache=False,
+                                 stream=False,
+                                 auth=(self.username, self.password),
+                                 continuation=True,
+                                 verify=True)
 
         logging.info("Job {}: {}".format(jobid, response.content))
         return response.content
@@ -322,9 +384,20 @@ class CosmoSimClass(QueryWithLogin):
             The requests response for the GET request for finding all
             existing jobs.
         """
-        checkalljobs = self._request('GET', CosmoSim.QUERY_URL,
+        checkalljobs = self._request('GET',
+                                     CosmoSim.QUERY_URL,
+                                     params={'print': 'b'},
+                                     data=None,
+                                     headers=None,
+                                     files=None,
+                                     save=False,
+                                     savedir='',
+                                     timeout=None,
+                                     cache=False,
+                                     stream=False,
                                      auth=(self.username, self.password),
-                                     params={'print': 'b'}, cache=False)
+                                     continuation=True,
+                                     verify=True)
 
         self.job_dict = {}
         soup = BeautifulSoup(checkalljobs.content, "lxml")
@@ -549,10 +622,20 @@ class CosmoSimClass(QueryWithLogin):
             completed_jobids = [key for key in self.job_dict.keys()
                                 if self.job_dict[key] == 'COMPLETED']
             response_list = [
-                self._request(
-                    'GET',
-                    CosmoSim.QUERY_URL + "/{}".format(completed_jobids[i]),
-                    auth=(self.username, self.password), cache=False)
+                self._request('GET',
+                              CosmoSim.QUERY_URL + "/{}".format(completed_jobids[i]),
+                              params=None,
+                              data=None,
+                              headers=None,
+                              files=None,
+                              save=False,
+                              savedir='',
+                              timeout=None,
+                              cache=False,
+                              stream=False,
+                              auth=(self.username, self.password),
+                              continuation=True,
+                              verify=True)
                 for i in range(len(completed_jobids))]
             self.response_dict_current = {}
             for i, vals in enumerate(completed_jobids):
@@ -561,9 +644,22 @@ class CosmoSimClass(QueryWithLogin):
         else:
             if self.job_dict[jobid] == 'COMPLETED':
                 response_list = [
-                    self._request(
-                        'GET', CosmoSim.QUERY_URL + "/{}".format(jobid),
-                        auth=(self.username, self.password), cache=False)]
+                    self._request('GET',
+                                  CosmoSim.QUERY_URL + "/{}".format(jobid),
+                                  params=None,
+                                  data=None,
+                                  headers=None,
+                                  files=None,
+                                  save=False,
+                                  savedir='',
+                                  timeout=None,
+                                  cache=False,
+                                  stream=False,
+                                  auth=(self.username, self.password),
+                                  continuation=True,
+                                  verify=True)
+                                 ]
+                                  
                 self.response_dict_current = {}
                 self.response_dict_current[jobid] = (
                     self._generate_response_dict(response_list[0]))
@@ -630,8 +726,18 @@ class CosmoSimClass(QueryWithLogin):
                          if self.job_dict[key] == 'COMPLETED']
         response_list = [self._request('GET',
                                        CosmoSim.QUERY_URL + "/{}".format(i),
+                                       params=None,
+                                       data=None,
+                                       headers=None,
+                                       files=None,
+                                       save=False,
+                                       savedir='',
+                                       timeout=None,
+                                       cache=False,
+                                       stream=False,
                                        auth=(self.username, self.password),
-                                       cache=False)
+                                       continuation=True,
+                                       verify=True)
                          for i in completed_ids]
         soups = [BeautifulSoup(response_list[i].content, "lxml")
                  for i in range(len(response_list))]
@@ -675,9 +781,20 @@ class CosmoSimClass(QueryWithLogin):
                           self.job_dict.values().count('QUEUED')))
             return
         else:
-            response_list = [self._request(
-                'GET', CosmoSim.QUERY_URL + "/{}".format(jobid),
-                auth=(self.username, self.password), cache=False)]
+            response_list = [self._request('GET',
+                                           CosmoSim.QUERY_URL + "/{}".format(jobid),
+                                           params=None,
+                                           data=None,
+                                           headers=None,
+                                           files=None,
+                                           save=False,
+                                           savedir='',
+                                           timeout=None,
+                                           cache=False,
+                                           stream=False,
+                                           auth=(self.username, self.password),
+                                           continuation=True,
+                                           verify=True)]
 
             if response_list[0].ok is False:
                 logging.error('Must provide a valid jobid.')
@@ -836,10 +953,20 @@ class CosmoSimClass(QueryWithLogin):
         the database (in the form of a dictionary).
         """
 
-        response = self._request('GET', CosmoSim.SCHEMA_URL,
-                                 auth=(self.username, self.password),
+        response = self._request('GET',
+                                 CosmoSim.SCHEMA_URL,
+                                 params=None,
+                                 data=None,
                                  headers={'Accept': 'application/json'},
-                                 cache=False)
+                                 files=None,
+                                 save=False,
+                                 savedir='',
+                                 timeout=None,
+                                 cache=False,
+                                 stream=False,
+                                 auth=(self.username, self.password),
+                                 continuation=True,
+                                 verify=True)
         data = response.json()
         self.db_dict = {}
         for i in range(len(data['databases'])):
@@ -1116,9 +1243,20 @@ class CosmoSimClass(QueryWithLogin):
                                     'Put In Description']
                 t.pprint()
             if format:
-                results = self._request(
-                    'GET', self.QUERY_URL + "/{}/results".format(jobid),
-                    auth=(self.username, self.password))
+                results = self._request('GET',
+                                        self.QUERY_URL + "/{}/results".format(jobid),
+                                        params=None,
+                                        data=None,
+                                        headers=None,
+                                        files=None,
+                                        save=False,
+                                        savedir='',
+                                        timeout=None,
+                                        cache=True,
+                                        stream=False,
+                                        auth=(self.username, self.password),
+                                        continuation=True,
+                                        verify=True)
                 soup = BeautifulSoup(results.content, "lxml")
                 urls = [i.get('xlink:href')
                         for i in soup.findAll({'uws:result'})]
@@ -1134,10 +1272,20 @@ class CosmoSimClass(QueryWithLogin):
                                         auth=(self.username, self.password))
                 elif not filename:
                     if format.upper() == 'CSV':
-                        raw_table_data = self._request(
-                            'GET', downloadurl,
-                            auth=(self.username, self.password),
-                            cache=cache).content
+                        raw_table_data = self._request('GET',
+                                                       downloadurl,
+                                                       params=None,
+                                                       data=None,
+                                                       headers=None,
+                                                       files=None,
+                                                       save=False,
+                                                       savedir='',
+                                                       timeout=None,
+                                                       cache=cache,
+                                                       stream=False,
+                                                       auth=(self.username, self.password),
+                                                       continuation=True,
+                                                       verify=True).content
                         raw_headers = raw_table_data.split('\n')[0]
                         num_cols = len(raw_headers.split(','))
                         num_rows = len(raw_table_data.split('\n')) - 2
@@ -1157,10 +1305,20 @@ class CosmoSimClass(QueryWithLogin):
                     elif format.upper() == 'VOTABLE':
                         # for terminal output, get data in csv format
                         tmp_downloadurl = urls[formatlist.index('CSV')]
-                        raw_table_data = self._request(
-                            'GET', tmp_downloadurl,
-                            auth=(self.username, self.password),
-                            cache=cache).content
+                        raw_table_data = self._request('GET',
+                                                       tmp_downloadurl,
+                                                       params=None,
+                                                       data=None,
+                                                       headers=None,
+                                                       files=None,
+                                                       save=False,
+                                                       savedir='',
+                                                       timeout=None,
+                                                       cache=cache,
+                                                       stream=False,
+                                                       auth=(self.username, self.password),
+                                                       continuation=True,
+                                                       verify=True).content
                         raw_headers = raw_table_data.split('\n')[0]
                         num_cols = len(raw_headers.split(','))
                         num_rows = len(raw_table_data.split('\n')) - 2

--- a/astroquery/esasky/core.py
+++ b/astroquery/esasky/core.py
@@ -553,8 +553,19 @@ class ESASkyClass(BaseQuery):
                     response = self._request(
                         'GET',
                         product_url,
+                        params=None,
+                        data=None,
+                        headers=self._get_header(),
+                        files=None,
+                        save=False,
+                        savedir='',
+                        timeout=None,
                         cache=cache,
-                        headers=self._get_header())
+                        stream=False,
+                        auth=None,
+                        continuation=True,
+                        verify=True
+                        )
 
                     try:
                         response.raise_for_status()
@@ -590,8 +601,10 @@ class ESASkyClass(BaseQuery):
     def _get_herschel_map(self, product_url, directory_path, cache):
         observation = dict()
         tar_file = tempfile.NamedTemporaryFile(delete=False)
-        response = self._request('GET', product_url, cache=cache,
-                                 headers=self._get_header())
+        response = self._request('GET', product_url, params=None, data=None,
+                                 headers=self._get_header(), files=None, save=False,
+                                 savedir='', timeout=None, cache=cache, stream=False,
+                                 auth=None, continuation=True, verify=True)
 
         response.raise_for_status()
 
@@ -813,8 +826,18 @@ class ESASkyClass(BaseQuery):
         response = self._request(
             'GET',
             url,
+            params=None,
+            data=None,
+            headers=self._get_header(),
+            files=None,
+            save=False,
+            savedir='',
+            timeout=None,
             cache=False,
-            headers=self._get_header())
+            stream=False,
+            auth=None,
+            continuation=True,
+            verify=True)
 
         response.raise_for_status()
 
@@ -849,9 +872,17 @@ class ESASkyClass(BaseQuery):
         return self._request('GET',
                              url,
                              params=request_payload,
+                             data=None,
+                             headers=self._get_header(),
+                             files=None,
+                             save=False,
+                             savedir='',
                              timeout=self.TIMEOUT,
                              cache=cache,
-                             headers=self._get_header())
+                             stream=False,
+                             auth=None,
+                             continuation=True,
+                             verify=True)
 
     def _parse_xml_table(self, response):
         # try to parse the result into an astropy.Table, else

--- a/astroquery/eso/core.py
+++ b/astroquery/eso/core.py
@@ -184,11 +184,23 @@ class EsoClass(QueryWithLogin):
 
         # Send payload
         if fmt == 'get':
-            response = self._request("GET", url, params=payload, cache=cache)
+            response = self._request("GET", url, params=payload, data=None,
+                                     headers=None, files=None, save=False,
+                                     savedir='', timeout=None, cache=cache,
+                                     stream=False, auth=None, continuation=True,
+                                     verify=True)
         elif fmt == 'multipart/form-data':
-            response = self._request("POST", url, files=payload, cache=cache)
+            response = self._request("POST", url, params=None, data=None,
+                                     headers=None, files=payload, save=False,
+                                     savedir='', timeout=None, cache=cache,
+                                     stream=False, auth=None, continuation=True,
+                                     verify=True)
         elif fmt == 'application/x-www-form-urlencoded':
-            response = self._request("POST", url, data=payload, cache=cache)
+            response = self._request("POST", url, params=None, data=payload,
+                                     headers=None, files=None, save=False,
+                                     savedir='', timeout=None, cache=cache,
+                                     stream=False, auth=None, continuation=True,
+                                     verify=True)
 
         return response
 
@@ -230,20 +242,36 @@ class EsoClass(QueryWithLogin):
 
         # Do not cache pieces of the login process
         login_response = self._request("GET", "https://www.eso.org/sso/login",
-                                       cache=False)
+                                       params=None, data=None, headers=None,
+                                       files=None, save=False, savedir='',
+                                       timeout=None, cache=False, stream=False,
+                                       auth=None, continuation=True,
+                                       verify=True)
         root = BeautifulSoup(login_response.content, 'html5lib')
         login_input = root.find(name='input', attrs={'name': 'execution'})
         if login_input is None:
             raise ValueError("ESO login page did not have the correct attributes.")
         execution = login_input.get('value')
 
-        login_result_response = self._request("POST", "https://www.eso.org/sso/login",
+        login_result_response = self._request("POST",
+                                              "https://www.eso.org/sso/login",
+                                              params=None,
                                               data={'username': username,
                                                     'password': password,
                                                     'execution': execution,
                                                     '_eventId': 'submit',
                                                     'geolocation': '',
-                                                    })
+                                                    }
+                                              headers=None,
+                                              files=None,
+                                              save=False,
+                                              savedir='',
+                                              timeout=None,
+                                              cache=True,
+                                              stream=False,
+                                              auth=None,
+                                              continuation=True,
+                                              verify=True)
         login_result_response.raise_for_status()
         root = BeautifulSoup(login_result_response.content, 'html5lib')
         authenticated = root.find('h4').text == 'Login successful'
@@ -270,7 +298,20 @@ class EsoClass(QueryWithLogin):
         """
         if self._instrument_list is None:
             url = "http://archive.eso.org/cms/eso-data/instrument-specific-query-forms.html"
-            instrument_list_response = self._request("GET", url, cache=cache)
+            instrument_list_response = self._request("GET",
+                                                     url,
+                                                     params=None,
+                                                     data=None,
+                                                     headers=None,
+                                                     files=None,
+                                                     save=False,
+                                                     savedir='',
+                                                     timeout=None,
+                                                     cache=cache,
+                                                     stream=False,
+                                                     auth=None,
+                                                     continuation=True,
+                                                     verify=True)
             root = BeautifulSoup(instrument_list_response.content, 'html5lib')
             self._instrument_list = []
             for element in root.select("div[id=col3] a[href]"):
@@ -293,7 +334,9 @@ class EsoClass(QueryWithLogin):
         if self._survey_list is None:
             survey_list_response = self._request(
                 "GET", "http://archive.eso.org/wdb/wdb/adp/phase3_main/form",
-                cache=cache)
+                params=None, data=None, headers=None, files=None,
+                save=False, savedir='', timeout=None, cache=cache,
+                stream=False, auth=None, continuation=True, verify=True)
             root = BeautifulSoup(survey_list_response.content, 'html5lib')
             self._survey_list = []
             collections_table = root.find('table', id='collections_table')
@@ -344,7 +387,20 @@ class EsoClass(QueryWithLogin):
         elif help:
             self._print_surveys_help(url, cache=cache)
         else:
-            survey_form = self._request("GET", url, cache=cache)
+            survey_form = self._request("GET",
+                                        url,
+                                        params=None,
+                                        data=None,
+                                        headers=None,
+                                        files=None,
+                                        save=False,
+                                        savedir='',
+                                        timeout=None,
+                                        cache=cache,
+                                        stream=False,
+                                        auth=None,
+                                        continuation=True,
+                                        verify=True)
             query_dict = kwargs
             query_dict["wdbo"] = "csv/download"
             if isinstance(surveys, six.string_types):
@@ -451,7 +507,20 @@ class EsoClass(QueryWithLogin):
         elif help:
             self._print_query_help(url)
         else:
-            instrument_form = self._request("GET", url, cache=cache)
+            instrument_form = self._request("GET",
+                                            url,
+                                            params=None,
+                                            data=None,
+                                            headers=None,
+                                            files=None,
+                                            save=False,
+                                            savedir='',
+                                            timeout=None,
+                                            cache=cache,
+                                            stream=False,
+                                            auth=None,
+                                            continuation=True,
+                                            verify=True)
             query_dict = {}
             query_dict.update(column_filters)
             # TODO: replace this with individually parsed kwargs
@@ -517,7 +586,9 @@ class EsoClass(QueryWithLogin):
         for dp_id in product_ids:
             response = self._request(
                 "GET", "http://archive.eso.org/hdr?DpId={0}".format(dp_id),
-                cache=cache)
+                params=None, data=None, headers=None, files=None,
+                save=False, savedir='', timeout=None, cache=cache,
+                stream=False, auth=None, continuation=True, verify=True)
             root = BeautifulSoup(response.content, 'html5lib')
             hdr = root.select('pre')[0].text
             header = {'DP.ID': dp_id}
@@ -612,6 +683,12 @@ class EsoClass(QueryWithLogin):
         trials = 1
         while trials <= 2:
             resp = super(EsoClass, self)._download_file(url, local_filepath,
+                                                        timeout=None,
+                                                        auth=None,
+                                                        continuation=True,
+                                                        cache=False,
+                                                        method="GET",
+                                                        head_safe=False,
                                                         **kwargs)
 
             # trying to detect the failing authentication:
@@ -709,7 +786,20 @@ class EsoClass(QueryWithLogin):
             url = "http://archive.eso.org/cms/eso-data/eso-data-direct-retrieval.html"
             with suspend_cache(self):  # Never cache staging operations
                 log.info("Contacting retrieval server...")
-                retrieve_data_form = self._request("GET", url, cache=False)
+                retrieve_data_form = self._request("GET",
+                                                   url,
+                                                   params=None,
+                                                   data=None,
+                                                   headeres=None,
+                                                   files=None,
+                                                   save=False,
+                                                   savedir='',
+                                                   timeout=None,
+                                                   cache=False,
+                                                   stream=False,
+                                                   auth=None,
+                                                   continuation=True,
+                                                   verify=True)
                 retrieve_data_form.raise_for_status()
                 log.info("Staging request...")
                 inputs = {"list_of_datasets": "\n".join(datasets_to_download)}
@@ -744,7 +834,18 @@ class EsoClass(QueryWithLogin):
                     time.sleep(2.0)
                     data_download_form = self._request("GET",
                                                        data_download_form.url,
-                                                       cache=False)
+                                                       params=None,
+                                                       data=None,
+                                                       headers=None,
+                                                       files=None,
+                                                       save=False,
+                                                       savedir='',
+                                                       timeout=None,
+                                                       cache=False,
+                                                       stream=False,
+                                                       auth=None,
+                                                       continuation=True,
+                                                       verify=True)
                     root = BeautifulSoup(data_download_form.content,
                                          'html5lib')
                     state = root.select('span[id=requestState]')[0].text
@@ -773,7 +874,11 @@ class EsoClass(QueryWithLogin):
                         "and therefore appears invalid.")
 
                 href = link.attrs['href']
-                script = self._request("GET", href, cache=False)
+                script = self._request("GET", href, params=None, data=None,
+                                       headers=None, files=None, save=False,
+                                       savedir='', timeout=None, cache=False,
+                                       stream=False, auth=None,
+                                       continuation=True, verify=True)
                 fileLinks = re.findall(
                     r'"(https://dataportal.eso.org/dataPortal/api/requests/.*)"',
                     script.text)
@@ -809,9 +914,20 @@ class EsoClass(QueryWithLogin):
                 fileId = fileLink.rsplit('/', maxsplit=1)[1]
                 log.info("Downloading file {}/{}: {}..."
                          .format(i, nfiles, fileId))
-                filename = self._request("GET", fileLink, save=True,
-                                         continuation=True)
-
+                filename = self._request("GET",
+                                         fileLink,
+                                         params=None,
+                                         data=None,
+                                         headers=None,
+                                         files=None,
+                                         save=True,
+                                         savedir='',
+                                         timeout=None,
+                                         cache=True,
+                                         stream=False,
+                                         auth=None,
+                                         continuation=True,
+                                         verify=True)
                 if filename.endswith(('.gz', '.7z', '.bz2', '.xz', '.Z')):
                     log.info("Unzipping file {0}...".format(fileId))
                     filename = system_tools.gunzip(filename)
@@ -845,7 +961,11 @@ class EsoClass(QueryWithLogin):
                    'ascii_out_mode': 'true',
                    }
         # Never cache this as it is verifying the existence of remote content
-        response = self._request("POST", url, params=payload, cache=False)
+        response = self._request("POST", url, params=payload, data=None,
+                                 headers=None, files=None, save=False,
+                                 savedir='', timeout=None, cache=False,
+                                 stream=False, auth=None, continuation=True,
+                                 verify=True)
 
         content = response.text
 
@@ -878,7 +998,11 @@ class EsoClass(QueryWithLogin):
                 payload['prog_id'] = project_id
             payload.update(kwargs)
 
-            apex_form = self._request("GET", apex_query_url, cache=cache)
+            apex_form = self._request("GET", apex_query_url, params=None,
+                                      data=None, headers=None, files=None,
+                                      save=False, savedir='', timeout=None,
+                                      cache=cache, stream=False, auth=None,
+                                      continuation=True, verify=True)
             apex_response = self._activate_form(
                 apex_form, form_id='queryform', form_index=0, inputs=payload,
                 cache=cache, method='application/x-www-form-urlencoded')
@@ -916,7 +1040,10 @@ class EsoClass(QueryWithLogin):
 
         result_string = []
 
-        resp = self._request("GET", url, cache=cache)
+        resp = self._request("GET", url, params=None, data=None, headers=None,
+                             files=None, save=False, savedir='', timeout=None,
+                             cache=cache, stream=False, auth=None,
+                             continuation=True, verify=True)
         doc = BeautifulSoup(resp.content, 'html5lib')
         form = doc.select("html body form pre")[0]
         # Unwrap all paragraphs
@@ -979,7 +1106,10 @@ class EsoClass(QueryWithLogin):
 
         result_string = []
 
-        resp = self._request("GET", url, cache=cache)
+        resp = self._request("GET", url, params=None, data=None, headers=None,
+                             files=None, save=False, savedir='', timeout=None,
+                             cache=cache, stream=False, auth=None,
+                             continuation=True, verify=True)
         doc = BeautifulSoup(resp.content, 'html5lib')
         form = doc.select("html body form")[0]
 

--- a/astroquery/eso/core.py
+++ b/astroquery/eso/core.py
@@ -261,7 +261,7 @@ class EsoClass(QueryWithLogin):
                                                     'execution': execution,
                                                     '_eventId': 'submit',
                                                     'geolocation': '',
-                                                    }
+                                                    },
                                               headers=None,
                                               files=None,
                                               save=False,

--- a/astroquery/fermi/core.py
+++ b/astroquery/fermi/core.py
@@ -43,18 +43,9 @@ class FermiLATClass(BaseQuery):
 
         result = self._request("POST",
                                url=self.request_url,
-                               params=None,
                                data=payload,
-                               headers=None,
-                               files=None,
-                               save=False,
-                               savedir='',
-                               timeout=self.TIMEOUT
-                               cache=True,
-                               stream=False,
-                               auth=None,
-                               continuation=True,
-                               verify=True)
+                               timeout=self.TIMEOUT,
+                               cache=True)
         re_result = self.result_url_re.findall(result.text)
 
         if len(re_result) == 0:

--- a/astroquery/fermi/core.py
+++ b/astroquery/fermi/core.py
@@ -41,8 +41,20 @@ class FermiLATClass(BaseQuery):
         if kwargs.get('get_query_payload'):
             return payload
 
-        result = self._request("POST", url=self.request_url,
-                               data=payload, timeout=self.TIMEOUT)
+        result = self._request("POST",
+                               url=self.request_url,
+                               params=None,
+                               data=payload,
+                               headers=None,
+                               files=None,
+                               save=False,
+                               savedir='',
+                               timeout=self.TIMEOUT
+                               cache=True,
+                               stream=False,
+                               auth=None,
+                               continuation=True,
+                               verify=True)
         re_result = self.result_url_re.findall(result.text)
 
         if len(re_result) == 0:

--- a/astroquery/fermi/tests/test_fermi.py
+++ b/astroquery/fermi/tests/test_fermi.py
@@ -30,7 +30,7 @@ def patch_post(request):
     return mp
 
 
-def post_mockreturn(method="POST", url=None, data=None, timeout=50, **kwargs):
+def post_mockreturn(method="POST", url=None, data=None, timeout=50, cache=False, **kwargs):
     if data is not None:
         with open(data_path(DATA_FILES['async']), 'rb') as r:
             response = MockResponse(r.read(), **kwargs)
@@ -62,7 +62,5 @@ def test_getfermilatdatafile(patch_post):
 
 def test_FermiLAT_query(patch_post):
     # Make a query that results in small SC and PH file sizes
-    result = fermi.core.FermiLAT.query_object(
-        FK5_COORDINATES, energyrange_MeV='1000, 100000',
-        obsdates='2013-01-01 00:00:00, 2013-01-02 00:00:00')
+    result = fermi.core.FermiLAT.query_object(FK5_COORDINATES, energyrange_MeV='1000, 100000', obsdates='2013-01-01 00:00:00, 2013-01-02 00:00:00')
     assert result == DATA_FILES['fits']

--- a/astroquery/gama/core.py
+++ b/astroquery/gama/core.py
@@ -32,8 +32,20 @@ class GAMAClass(BaseQuery):
         if kwargs.get('get_query_payload'):
             return payload
 
-        result = self._request("POST", url=self.request_url,
-                               data=payload, timeout=self.timeout)
+        result = self._request("POST",
+                               url=self.request_url,
+                               params=None,
+                               data=payload,
+                               headers=None,
+                               files=None,
+                               save=False,
+                               savedir='',
+                               timeout=self.timeout,
+                               cache=True,
+                               stream=False,
+                               auth=None,
+                               continuation=True,
+                               verify=True)
 
         result_url_relative = find_data_url(result.text)
         result_url = os.path.join(self.request_url, result_url_relative)

--- a/astroquery/heasarc/core.py
+++ b/astroquery/heasarc/core.py
@@ -33,8 +33,20 @@ class HeasarcClass(BaseQuery):
         Submit a query based on a given request_payload. This allows detailed
         control of the query to be submitted.
         """
-        response = self._request('GET', url, params=request_payload,
-                                 timeout=self.TIMEOUT, cache=cache)
+        response = self._request('GET',
+                                 url,
+                                 params=request_payload,
+                                 data=None,
+                                 headeres=None,
+                                 files=None,
+                                 save=False,
+                                 savedir='',
+                                 timeout=self.TIMEOUT,
+                                 cache=cache,
+                                 stream=False,
+                                 auth=None,
+                                 continuation=True,
+                                 verify=True)
         return response
 
     def query_mission_list(self, cache=True, get_query_payload=False):

--- a/astroquery/hitran/core.py
+++ b/astroquery/hitran/core.py
@@ -218,8 +218,17 @@ class HitranClass(BaseQuery):
         response = self._request(method='GET',
                                  url=self.QUERY_URL,
                                  params=params,
+                                 data=None,
+                                 headers=None,
+                                 files=None,
+                                 save=False,
+                                 savedir='',
                                  timeout=self.TIMEOUT,
-                                 cache=cache)
+                                 cache=cache,
+                                 stream=False,
+                                 auth=None,
+                                 continuation=True,
+                                 verify=True)
 
         return response
 

--- a/astroquery/ibe/core.py
+++ b/astroquery/ibe/core.py
@@ -419,8 +419,11 @@ class IbeClass(BaseQuery):
                 dataset=dataset or self.DATASET,
                 table=table or self.TABLE)
 
-        response = self._request(
-            'GET', url, {'FORMAT': 'METADATA'}, timeout=self.TIMEOUT)
+        response = self._request('GET',
+                                 url,
+                                 params = {'FORMAT': 'METADATA'},
+                                 timeout=self.TIMEOUT,
+                                 cache=True)
 
         # Raise exception, if request failed
         response.raise_for_status()

--- a/astroquery/ibe/core.py
+++ b/astroquery/ibe/core.py
@@ -421,7 +421,7 @@ class IbeClass(BaseQuery):
 
         response = self._request('GET',
                                  url,
-                                 params = {'FORMAT': 'METADATA'},
+                                 params={'FORMAT': 'METADATA'},
                                  timeout=self.TIMEOUT,
                                  cache=True)
 

--- a/astroquery/irsa/core.py
+++ b/astroquery/irsa/core.py
@@ -244,8 +244,11 @@ class IrsaClass(BaseQuery):
 
         if get_query_payload:
             return request_payload
-        response = self._request("GET", url=Irsa.IRSA_URL,
-                                 params=request_payload, timeout=Irsa.TIMEOUT)
+        response = self._request("GET",
+                                 url=Irsa.IRSA_URL,
+                                 params=request_payload,
+                                 timeout=Irsa.TIMEOUT,
+                                 cache=True)
         return response
 
     def _parse_spatial(self, spatial, coordinates, radius=None, width=None,
@@ -419,8 +422,11 @@ class IrsaClass(BaseQuery):
             name to be used in query functions, and the value is the verbose
             description of the catalog.
         """
-        response = self._request("GET", url=Irsa.GATOR_LIST_URL,
-                                 params=dict(mode='xml'), timeout=Irsa.TIMEOUT)
+        response = self._request("GET",
+                                 url=Irsa.GATOR_LIST_URL,
+                                 params=dict(mode='xml'),
+                                 timeout=Irsa.TIMEOUT,
+                                 cache=True)
 
         root = tree.fromstring(response.content)
         catalogs = {}

--- a/astroquery/irsa/tests/test_irsa.py
+++ b/astroquery/irsa/tests/test_irsa.py
@@ -39,7 +39,7 @@ def patch_get(request):
     return mp
 
 
-def get_mockreturn(method, url, params=None, timeout=10, **kwargs):
+def get_mockreturn(method, url, params=None, timeout=10, cache=False, **kwargs):
     filename = data_path(DATA_FILES[params['spatial']])
     content = open(filename, 'rb').read()
     return MockResponse(content, **kwargs)

--- a/astroquery/irsa_dust/core.py
+++ b/astroquery/irsa_dust/core.py
@@ -176,8 +176,11 @@ class IrsaDustClass(BaseQuery):
         """
         url = self.DUST_SERVICE_URL
         request_payload = self._args_to_payload(coordinate, radius=radius)
-        response = self._request("POST", url, data=request_payload,
-                                 timeout=timeout)
+        response = self._request("POST",
+                                 url,
+                                 data=request_payload,
+                                 timeout=timeout,
+                                 cache=True)
         return self.extract_image_urls(response.text, image_type=image_type)
 
     def get_extinction_table(self, coordinate, radius=None, timeout=TIMEOUT,
@@ -248,8 +251,11 @@ class IrsaDustClass(BaseQuery):
         """
         url = self.DUST_SERVICE_URL
         request_payload = self._args_to_payload(coordinate, radius=radius)
-        response = self._request("POST", url, data=request_payload,
-                                 timeout=timeout)
+        response = self._request("POST",
+                                 url,
+                                 data=request_payload,
+                                 timeout=timeout,
+                                 cache=True)
         xml_tree = utils.xml(response.text)
         result = SingleDustResult(xml_tree, coordinate)
         return commons.FileContainer(result.ext_detail_table(),
@@ -294,8 +300,11 @@ class IrsaDustClass(BaseQuery):
             Table representing the query results, (all or as per  specified).
         """
         request_payload = self._args_to_payload(coordinate, radius=radius)
-        response = self._request("POST", url, data=request_payload,
-                                 timeout=timeout)
+        response = self._request("POST",
+                                 url,
+                                 data=request_payload,
+                                 timeout=timeout,
+                                 cache=True)
         xml_tree = utils.xml(response.text)
         result = SingleDustResult(xml_tree, coordinate)
         if section is None or section in ["location", "loc", "l"]:

--- a/astroquery/irsa_dust/tests/test_irsa_dust.py
+++ b/astroquery/irsa_dust/tests/test_irsa_dust.py
@@ -332,7 +332,7 @@ class TestDust(DustTestCase):
         types = IrsaDust().list_image_types()
         assert types is not None
 
-    def send_request_mockreturn(self, method, url, data, timeout):
+    def send_request_mockreturn(self, method, url, data, timeout, cache):
         class MockResponse:
             text = self.read_data(M31_XML)
         return MockResponse

--- a/astroquery/jplhorizons/core.py
+++ b/astroquery/jplhorizons/core.py
@@ -585,8 +585,20 @@ class HorizonsClass(BaseQuery):
             self.return_raw = True
 
         # query and parse
-        response = self._request('GET', URL, params=request_payload,
-                                 timeout=self.TIMEOUT, cache=cache)
+        response = self._request('GET',
+                                 URL,
+                                 params=request_payload,
+                                 data=None,
+                                 headers=None,
+                                 files=None,
+                                 save=False,
+                                 savedir='',
+                                 timeout=self.TIMEOUT,
+                                 cache=cache,
+                                 stream=False,
+                                 auth=None,
+                                 continuation=True,
+                                 verify=True)
         self.uri = response.url
 
         # check length of uri
@@ -794,8 +806,20 @@ class HorizonsClass(BaseQuery):
             self.return_raw = True
 
         # query and parse
-        response = self._request('GET', URL, params=request_payload,
-                                 timeout=self.TIMEOUT, cache=cache)
+        response = self._request('GET',
+                                 URL,
+                                 params=request_payload,
+                                 data=None,
+                                 headers=None,
+                                 files=None,
+                                 save=False,
+                                 savedir='',
+                                 timeout=self.TIMEOUT,
+                                 cache=cache,
+                                 stream=False,
+                                 auth=None,
+                                 continuation=True,
+                                 verify=True)
         self.uri = response.url
 
         # check length of uri
@@ -1010,8 +1034,20 @@ class HorizonsClass(BaseQuery):
             self.return_raw = True
 
         # query and parse
-        response = self._request('GET', URL, params=request_payload,
-                                 timeout=self.TIMEOUT, cache=cache)
+        response = self._request('GET',
+                                 URL,
+                                 params=request_payload,
+                                 data=None,
+                                 headers=None,
+                                 files=None,
+                                 save=False,
+                                 savedir='',
+                                 timeout=self.TIMEOUT,
+                                 cache=cache,
+                                 stream=False,
+                                 auth=None,
+                                 continuation=True,
+                                 verify=True)
         self.uri = response.url
 
         # check length of uri

--- a/astroquery/jplsbdb/core.py
+++ b/astroquery/jplsbdb/core.py
@@ -170,9 +170,20 @@ class SBDBClass(BaseQuery):
         if get_query_payload:
             return request_payload
 
-        response = self._request(method='GET', url=URL,
+        response = self._request(method='GET',
+                                 url=URL,
                                  params=request_payload,
-                                 timeout=TIMEOUT, cache=cache)
+                                 data=None,
+                                 headers=None,
+                                 files=None,
+                                 save=False,
+                                 savedir='',
+                                 timeout=TIMEOUT,
+                                 cache=cache,
+                                 stream=False,
+                                 auth=None,
+                                 continuation=True,
+                                 verify=True)
 
         if get_raw_response:
             self._return_raw = True

--- a/astroquery/jplspec/core.py
+++ b/astroquery/jplspec/core.py
@@ -120,8 +120,20 @@ class JPLSpecClass(BaseQuery):
             return payload
         # BaseQuery classes come with a _request method that includes a
         # built-in caching system
-        response = self._request(method='POST', url=self.URL, data=payload,
-                                 timeout=self.TIMEOUT, cache=cache)
+        response = self._request(method='POST',
+                                 url=self.URL,
+                                 params=None,
+                                 data=payload,
+                                 headers=None,
+                                 files=None,
+                                 save=False,
+                                 savedir='',
+                                 timeout=self.TIMEOUT,
+                                 cache=cache,
+                                 stream=False,
+                                 auth=None,
+                                 continuation=True,
+                                 verify=True)
 
         return response
 

--- a/astroquery/lamda/core.py
+++ b/astroquery/lamda/core.py
@@ -49,8 +49,20 @@ class LamdaClass(BaseQuery):
         if mol not in self.molecule_dict:
             raise InvalidQueryError("Molecule {0} is not in the valid "
                                     "molecule list.  See Lamda.molecule_dict")
-        response = self._request('GET', self.molecule_dict[mol],
-                                 timeout=timeout, cache=cache)
+        response = self._request('GET',
+                                 self.molecule_dict[mol],
+                                 params=None,
+                                 data=None,
+                                 headers=None,
+                                 files=None,
+                                 save=False,
+                                 savedir='',
+                                 timeout=timeout,
+                                 cache=cache,
+                                 stream=False,
+                                 auth=None,
+                                 continuation=True,
+                                 verify=True)
         response.raise_for_status()
         return response
 
@@ -117,7 +129,20 @@ class LamdaClass(BaseQuery):
             return md
 
         main_url = 'http://home.strw.leidenuniv.nl/~moldata/'
-        response = self._request('GET', main_url, cache=cache)
+        response = self._request('GET',
+                                 main_url,
+                                 params=None,
+                                 data=None,
+                                 headers=None,
+                                 files=None,
+                                 save=False,
+                                 savedir='',
+                                 timeout=None,
+                                 cache=cache,
+                                 stream=False,
+                                 auth=None,
+                                 continuation=True,
+                                 verify=True)
         response.raise_for_status()
 
         soup = BeautifulSoup(response.content)
@@ -157,7 +182,20 @@ class LamdaClass(BaseQuery):
             # assume this is a bad URL, like a mailto:blah href
             return []
 
-        response = self._request('GET', myurl)
+        response = self._request('GET',
+                                 myurl,
+                                 params=None,
+                                 data=None,
+                                 headers=None,
+                                 files=None,
+                                 save=False,
+                                 savedir='',
+                                 timeout=None,
+                                 cache=True,
+                                 stream=False,
+                                 auth=None,
+                                 continuation=True,
+                                 verify=True)
         if raise_for_status:
             response.raise_for_status()
         elif not response.ok:

--- a/astroquery/magpis/core.py
+++ b/astroquery/magpis/core.py
@@ -113,8 +113,12 @@ class MagpisClass(BaseQuery):
             coordinates, image_size=image_size, survey=survey)
         if get_query_payload:
             return request_payload
-        response = self._request("POST", url=self.URL, data=request_payload,
-                                 timeout=self.TIMEOUT, verify=False)
+        response = self._request("POST",
+                                 url=self.URL,
+                                 data=request_payload,
+                                 timeout=self.TIMEOUT,
+                                 cache=True,
+                                 verify=False)
         return response
 
     def list_surveys(self):

--- a/astroquery/magpis/tests/test_magpis.py
+++ b/astroquery/magpis/tests/test_magpis.py
@@ -41,7 +41,7 @@ def patch_post(request):
     return mp
 
 
-def post_mockreturn(method, url, data, timeout, **kwargs):
+def post_mockreturn(method, url, data, timeout, cache, **kwargs):
     filename = data_path(DATA_FILES['image'])
     content = open(filename, 'rb').read()
     return MockResponse(content, **kwargs)

--- a/astroquery/mast/core.py
+++ b/astroquery/mast/core.py
@@ -394,7 +394,8 @@ class MastClass(QueryWithLogin):
         return True
 
     def _request(self, method, url, params=None, data=None, headers=None,
-                 files=None, stream=False, auth=None, retrieve_all=True):
+                 files=None, timeout=None, cache=False, stream=False,
+                 auth=None, retrieve_all=True):
         """
         Override of the parent method:
         A generic HTTP request method, similar to ``requests.Session.request``
@@ -439,9 +440,16 @@ class MastClass(QueryWithLogin):
             status = "EXECUTING"
 
             while status == "EXECUTING":
-                response = super(MastClass, self)._request(method, url, params=params, data=data,
-                                                           headers=headers, files=files, cache=False,
-                                                           stream=stream, auth=auth)
+                response = super(MastClass, self)._request(method,
+                                                           url,
+                                                           params=params,
+                                                           data=data,
+                                                           headers=headers,
+                                                           files=files,
+                                                           timeout=timeout,
+                                                           cache=cache,
+                                                           stream=stream,
+                                                           auth=auth)
 
                 if (time.time() - startTime) >= self.TIMEOUT:
                     raise TimeoutError("Timeout limit of {} exceeded.".format(self.TIMEOUT))
@@ -488,8 +496,17 @@ class MastClass(QueryWithLogin):
                    "Content-type": "application/x-www-form-urlencoded",
                    "Accept": "text/plain"}
 
-        response = self._request("POST", self._COLUMNS_CONFIG_URL,
-                                 data=("colConfigId="+fetch_name), headers=headers)
+        response = self._request("POST",
+                                 self._COLUMNS_CONFIG_URL,
+                                 params=None,
+                                 data=("colConfigId="+fetch_name),
+                                 headers=headers,
+                                 files=None,
+                                 timeout=None,
+                                 cache=False,
+                                 stream=False,
+                                 auth=None,
+                                 retrieve_all=True)
 
         self._column_configs[service] = response[0].json()
 
@@ -504,7 +521,17 @@ class MastClass(QueryWithLogin):
         if more:
             mashupRequest = {'service': all_name, 'params': {}, 'format': 'extjs'}
             reqString = _prepare_service_request_string(mashupRequest)
-            response = self._request("POST", self._MAST_REQUEST_URL, data=reqString, headers=headers)
+            response = self._request("POST",
+                                     self._MAST_REQUEST_URL,
+                                     params=None,
+                                     data=reqString,
+                                     headers=headers,
+                                     files=None,
+                                     timeout=None,
+                                     cache=False,
+                                     stream=False,
+                                     auth=None,
+                                     retrieve_all=True)
             jsonResponse = response[0].json()
 
             self._column_configs[service].update(jsonResponse['data']['Tables'][0]
@@ -840,7 +867,16 @@ class MastClass(QueryWithLogin):
             mashupRequest[prop] = value
 
         reqString = _prepare_service_request_string(mashupRequest)
-        response = self._request("POST", self._MAST_REQUEST_URL, data=reqString, headers=headers,
+        response = self._request("POST",
+                                 self._MAST_REQUEST_URL,
+                                 params=None,
+                                 data=reqString,
+                                 headers=headers,
+                                 files=None,
+                                 timeout=None,
+                                 cache=False,
+                                 stream=False,
+                                 auth=None,
                                  retrieve_all=retrieveAll)
 
         return response

--- a/astroquery/mpc/core.py
+++ b/astroquery/mpc/core.py
@@ -321,7 +321,20 @@ class MPCClass(BaseQuery):
 
         self.query_type = 'object'
         auth = (self.MPC_USERNAME, self.MPC_PASSWORD)
-        return self._request('GET', mpc_endpoint, params=request_args, auth=auth)
+        return self._request('GET',
+                             mpc_endpoint,
+                             params=request_args,
+                             data=None,
+                             headers=None,
+                             files=None,
+                             save=False,
+                             savedir='',
+                             timeout=None,
+                             cache=True,
+                             stream=False,
+                             auth=auth,
+                             continuation=True,
+                             verify=True)
 
     def get_mpc_object_endpoint(self, target_type):
         mpc_endpoint = self.MPC_URL
@@ -594,7 +607,20 @@ class MPCClass(BaseQuery):
             return request_args
 
         self.query_type = 'ephemeris'
-        response = self._request('POST', self.MPES_URL, data=request_args)
+        response = self._request('POST',
+                                 self.MPES_URL,
+                                 params=None,
+                                 data=request_args,
+                                 headers=None,
+                                 files=None,
+                                 save=False,
+                                 savedir='',
+                                 timeout=None,
+                                 cache=True,
+                                 stream=False,
+                                 auth=None,
+                                 continuation=True,
+                                 verfiy=True)
 
         return response
 
@@ -639,8 +665,20 @@ class MPCClass(BaseQuery):
         """
 
         self.query_type = 'observatory_code'
-        response = self._request('GET', self.OBSERVATORY_CODES_URL,
-                                 timeout=self.TIMEOUT, cache=cache)
+        response = self._request('GET',
+                                 self.OBSERVATORY_CODES_URL,
+                                 params=None,
+                                 data=None,
+                                 headers=None,
+                                 files=None,
+                                 save=False,
+                                 savedir='',
+                                 timeout=self.TIMEOUT,
+                                 cache=cache,
+                                 stream=False,
+                                 auth=None,
+                                 continuation=True,
+                                 verify=True)
 
         return response
 

--- a/astroquery/nasa_ads/core.py
+++ b/astroquery/nasa_ads/core.py
@@ -58,9 +58,20 @@ class ADSClass(BaseQuery):
         if get_query_payload:
             return request_url
 
-        response = self._request(method='GET', url=request_url,
+        response = self._request(method='GET',
+                                 url=request_url,
+                                 params=None,
+                                 data=None,
                                  headers={'Authorization': 'Bearer ' + self._get_token()},
-                                 timeout=self.TIMEOUT, cache=cache)
+                                 files=None,
+                                 save=False,
+                                 savedir='',
+                                 timeout=self.TIMEOUT,
+                                 cache=cache,
+                                 stream=False,
+                                 auth=None,
+                                 continuation=True,
+                                 verify=True)
 
         response.raise_for_status()
 

--- a/astroquery/ned/core.py
+++ b/astroquery/ned/core.py
@@ -96,8 +96,11 @@ class NedClass(BaseQuery):
         request_payload['objname'] = object_name
         if get_query_payload:
             return request_payload
-        response = self._request("GET", url=Ned.OBJ_SEARCH_URL,
-                                 params=request_payload, timeout=Ned.TIMEOUT)
+        response = self._request("GET",
+                                 url=Ned.OBJ_SEARCH_URL,
+                                 params=request_payload,
+                                 timeout=Ned.TIMEOUT,
+                                 cache=True)
 
         return response
 
@@ -202,8 +205,11 @@ class NedClass(BaseQuery):
                 raise TypeError("Coordinates not specified correctly")
         if get_query_payload:
             return request_payload
-        response = self._request("GET", url=Ned.OBJ_SEARCH_URL,
-                                 params=request_payload, timeout=Ned.TIMEOUT)
+        response = self._request("GET",
+                                 url=Ned.OBJ_SEARCH_URL,
+                                 params=request_payload,
+                                 timeout=Ned.TIMEOUT,
+                                 cache=True)
         return response
 
     def query_region_iau(self, iau_name, frame='Equatorial', equinox='B1950.0',
@@ -281,8 +287,11 @@ class NedClass(BaseQuery):
         request_payload['in_equinox'] = equinox
         if get_query_payload:
             return request_payload
-        response = self._request("GET", url=Ned.OBJ_SEARCH_URL,
-                                 params=request_payload, timeout=Ned.TIMEOUT)
+        response = self._request("GET",
+                                 url=Ned.OBJ_SEARCH_URL,
+                                 params=request_payload,
+                                 timeout=Ned.TIMEOUT,
+                                 cache=True)
         return response
 
     def query_refcode(self, refcode, get_query_payload=False, verbose=False):
@@ -340,8 +349,11 @@ class NedClass(BaseQuery):
         request_payload['refcode'] = refcode
         if get_query_payload:
             return request_payload
-        response = self._request("GET", url=Ned.OBJ_SEARCH_URL,
-                                 params=request_payload, timeout=Ned.TIMEOUT)
+        response = self._request("GET",
+                                 url=Ned.OBJ_SEARCH_URL,
+                                 params=request_payload,
+                                 timeout=Ned.TIMEOUT,
+                                 cache=True)
         return response
 
     def get_images(self, object_name, get_query_payload=False,
@@ -481,8 +493,11 @@ class NedClass(BaseQuery):
         if get_query_payload:
             return request_payload
         url = Ned.SPECTRA_URL if item == 'spectra' else Ned.IMG_DATA_URL
-        response = self._request("GET", url=url, params=request_payload,
-                                 timeout=Ned.TIMEOUT)
+        response = self._request("GET",
+                                 url=url,
+                                 params=request_payload,
+                                 timeout=Ned.TIMEOUT,
+                                 cache=True)
         return self.extract_image_urls(response.text)
 
     def extract_image_urls(self, html_in):
@@ -608,8 +623,11 @@ class NedClass(BaseQuery):
                                                      datetime.now().year)
         if get_query_payload:
             return request_payload
-        response = self._request("GET", url=Ned.DATA_SEARCH_URL,
-                                 params=request_payload, timeout=Ned.TIMEOUT)
+        response = self._request("GET",
+                                 url=Ned.DATA_SEARCH_URL,
+                                 params=request_payload,
+                                 timeout=Ned.TIMEOUT,
+                                 cache=True)
         return response
 
     def _request_payload_init(self):

--- a/astroquery/ned/tests/test_ned.py
+++ b/astroquery/ned/tests/test_ned.py
@@ -65,7 +65,7 @@ def patch_get_readable_fileobj(request):
     return mp
 
 
-def get_mockreturn(method, url, params=None, timeout=10, **kwargs):
+def get_mockreturn(method, url, params=None, timeout=10, cache=False, **kwargs):
     search_type = params.get('search_type')
     if search_type is not None:
         filename = data_path(DATA_FILES[search_type])

--- a/astroquery/nist/core.py
+++ b/astroquery/nist/core.py
@@ -140,8 +140,11 @@ class NistClass(BaseQuery):
         if get_query_payload:
             return request_payload
 
-        response = self._request("GET", url=Nist.URL, params=request_payload,
-                                 timeout=Nist.TIMEOUT)
+        response = self._request("GET",
+                                 url=Nist.URL,
+                                 params=request_payload,
+                                 timeout=Nist.TIMEOUT,
+                                 cache=True)
         return response
 
     def _parse_result(self, response, verbose=False):

--- a/astroquery/nist/tests/test_nist.py
+++ b/astroquery/nist/tests/test_nist.py
@@ -27,7 +27,7 @@ def patch_get(request):
     return mp
 
 
-def get_mockreturn(method, url, params=None, timeout=10, **kwargs):
+def get_mockreturn(method, url, params=None, timeout=10, cache=False, **kwargs):
     filename = data_path(DATA_FILES['lines'])
     content = open(filename, 'rb').read()
     return MockResponse(content, **kwargs)

--- a/astroquery/nrao/core.py
+++ b/astroquery/nrao/core.py
@@ -291,8 +291,20 @@ class NraoClass(QueryWithLogin):
                 username = self.USERNAME
 
         # Check if already logged in
-        loginpage = self._request("GET", "https://my.nrao.edu/cas/login",
-                                  cache=False)
+        loginpage = self._request("GET",
+                                  "https://my.nrao.edu/cas/login",
+                                  params=None,
+                                  data=None,
+                                  headers=None,
+                                  files=None,
+                                  save=False,
+                                  savedir='',
+                                  timeout=None,
+                                  cache=False,
+                                  stream=False,
+                                  auth=None,
+                                  continuation=True,
+                                  verify=True)
         root = BeautifulSoup(loginpage.content, 'html5lib')
         if root.find('div', class_='success'):
             log.info("Already logged in.")
@@ -313,8 +325,20 @@ class NraoClass(QueryWithLogin):
         data['_eventId'] = 'submit'
         data['submit'] = 'LOGIN'
 
-        login_response = self._request("POST", "https://my.nrao.edu/cas/login",
-                                       data=data, cache=False)
+        login_response = self._request("POST",
+                                       "https://my.nrao.edu/cas/login",
+                                       params=None,
+                                       data=data,
+                                       headers=None,
+                                       files=None,
+                                       save=False,
+                                       savedir='',
+                                       timeout=None,
+                                       cache=False,
+                                       stream=False,
+                                       auth=None,
+                                       continuation=True,
+                                       verify=True)
 
         authenticated = ('You have successfully logged in' in
                          login_response.text)
@@ -347,8 +371,20 @@ class NraoClass(QueryWithLogin):
 
         if get_query_payload:
             return request_payload
-        response = self._request('POST', self.DATA_URL, params=request_payload,
-                                 timeout=self.TIMEOUT, cache=cache)
+        response = self._request('POST',
+                                 self.DATA_URL,
+                                 params=request_payload,
+                                 data=None,
+                                 headers=None,
+                                 files=None,
+                                 save=False,
+                                 savedir='',
+                                 timeout=self.TIMEOUT,
+                                 cache=cache,
+                                 stream=False,
+                                 auth=None,
+                                 continuation=True,
+                                 verify=True)
         self._last_response = response
 
         response.raise_for_status()

--- a/astroquery/nvas/core.py
+++ b/astroquery/nvas/core.py
@@ -185,8 +185,11 @@ class NvasClass(BaseQuery):
         request_payload["nvas_bnd"] = "" if band == "all" else band.upper()
         if get_query_payload:
             return request_payload
-        response = self._request("POST", url=Nvas.URL, data=request_payload,
-                                 timeout=Nvas.TIMEOUT)
+        response = self._request("POST",
+                                 url=Nvas.URL,
+                                 data=request_payload,
+                                 timeout=Nvas.TIMEOUT,
+                                 cache=True)
         image_urls = self.extract_image_urls(response.text,
                                              get_uvfits=get_uvfits)
         return image_urls

--- a/astroquery/nvas/tests/test_nvas.py
+++ b/astroquery/nvas/tests/test_nvas.py
@@ -49,7 +49,7 @@ def patch_parse_coordinates(request):
     return mp
 
 
-def post_mockreturn(method, url, data, timeout, **kwargs):
+def post_mockreturn(method, url, data, timeout, cache, **kwargs):
     filename = data_path(DATA_FILES['image_search'])
     content = open(filename, 'rb').read()
     response = MockResponse(content, **kwargs)

--- a/astroquery/ogle/core.py
+++ b/astroquery/ogle/core.py
@@ -136,8 +136,12 @@ class OgleClass(BaseQuery):
         files = self._args_to_payload(*args, **kwargs)
         # Make request
         params = {'dnfile': 'submit'}
-        response = self._request("POST", url=self.DATA_URL, data=params,
-                                 timeout=self.TIMEOUT, files=files)
+        response = self._request("POST",
+                                 url=self.DATA_URL,
+                                 data=params,
+                                 timeout=self.TIMEOUT,
+                                 cache=True,
+                                 files=files)
 
         response.raise_for_status()
         return response

--- a/astroquery/ogle/tests/test_ogle.py
+++ b/astroquery/ogle/tests/test_ogle.py
@@ -26,7 +26,7 @@ def patch_post(request):
     return mp
 
 
-def post_mockreturn(method, url, data, timeout, files=None, **kwargs):
+def post_mockreturn(method, url, data, timeout, cache, files=None, **kwargs):
     if files is not None:
         content = open(data_path(DATA_FILES['gal_0_3']), 'rb').read()
         response = MockResponse(content, **kwargs)

--- a/astroquery/simbad/core.py
+++ b/astroquery/simbad/core.py
@@ -473,8 +473,11 @@ class SimbadClass(BaseQuery):
 
         request_payload = self._args_to_payload(caller='query_criteria_async',
                                                 *args, **kwargs)
-        response = self._request("POST", self.SIMBAD_URL, data=request_payload,
-                                 timeout=self.TIMEOUT, cache=cache)
+        response = self._request("POST",
+                                 self.SIMBAD_URL,
+                                 data=request_payload,
+                                 timeout=self.TIMEOUT,
+                                 cache=cache)
         return response
 
     def query_object(self, object_name, wildcard=False, verbose=False,
@@ -537,8 +540,11 @@ class SimbadClass(BaseQuery):
         if get_query_payload:
             return request_payload
 
-        response = self._request("POST", self.SIMBAD_URL, data=request_payload,
-                                 timeout=self.TIMEOUT, cache=cache)
+        response = self._request("POST",
+                                 self.SIMBAD_URL,
+                                 data=request_payload,
+                                 timeout=self.TIMEOUT,
+                                 cache=cache)
         return response
 
     def query_objects(self, object_names, wildcard=False, verbose=False,
@@ -675,8 +681,11 @@ class SimbadClass(BaseQuery):
         if get_query_payload:
             return request_payload
 
-        response = self._request("POST", self.SIMBAD_URL, data=request_payload,
-                                 timeout=self.TIMEOUT, cache=cache)
+        response = self._request("POST",
+                                 self.SIMBAD_URL,
+                                 data=request_payload,
+                                 timeout=self.TIMEOUT,
+                                 cache=cache)
         return response
 
     def query_catalog(self, catalog, verbose=False, cache=True,
@@ -732,8 +741,11 @@ class SimbadClass(BaseQuery):
         if get_query_payload:
             return request_payload
 
-        response = self._request("POST", self.SIMBAD_URL, data=request_payload,
-                                 timeout=self.TIMEOUT, cache=cache)
+        response = self._request("POST",
+                                 self.SIMBAD_URL,
+                                 data=request_payload,
+                                 timeout=self.TIMEOUT,
+                                 cache=cache)
         return response
 
     def query_bibobj(self, bibcode, verbose=False, get_query_payload=False):
@@ -787,8 +799,11 @@ class SimbadClass(BaseQuery):
         if get_query_payload:
             return request_payload
 
-        response = self._request("POST", self.SIMBAD_URL, data=request_payload,
-                                 timeout=self.TIMEOUT, cache=cache)
+        response = self._request("POST",
+                                 self.SIMBAD_URL,
+                                 data=request_payload,
+                                 timeout=self.TIMEOUT,
+                                 cache=cache)
         return response
 
     def query_bibcode(self, bibcode, wildcard=False, verbose=False,
@@ -855,8 +870,11 @@ class SimbadClass(BaseQuery):
         if get_query_payload:
             return request_payload
 
-        response = self._request("POST", self.SIMBAD_URL, cache=cache,
-                                 data=request_payload, timeout=self.TIMEOUT)
+        response = self._request("POST",
+                                 self.SIMBAD_URL,
+                                 data=request_payload,
+                                 timeout=self.TIMEOUT,
+                                 cache=cache)
 
         return response
 
@@ -907,8 +925,11 @@ class SimbadClass(BaseQuery):
         """
         request_payload = dict(script="\n".join(('format object "%IDLIST"',
                                                  'query id %s' % object_name)))
-        response = self._request("POST", self.SIMBAD_URL, data=request_payload,
-                                 timeout=self.TIMEOUT, cache=cache)
+        response = self._request("POST",
+                                 self.SIMBAD_URL,
+                                 data=request_payload,
+                                 timeout=self.TIMEOUT,
+                                 cache=cache)
         return response
 
     def _get_query_header(self, get_raw=False):

--- a/astroquery/skyview/core.py
+++ b/astroquery/skyview/core.py
@@ -64,7 +64,10 @@ class SkyViewClass(BaseQuery):
         """
         if input is None:
             input = {}
-        form_response = self._request('GET', self.URL)
+        form_response = self._request('GET',
+                                      self.URL,
+                                      timeout=None,
+                                      cache=True)
         bs = BeautifulSoup(form_response.content, "html.parser")
         form = bs.find('form')
         # cache the default values to save HTTP traffic
@@ -81,7 +84,11 @@ class SkyViewClass(BaseQuery):
 
     def _submit_form(self, input=None, cache=True):
         url, payload = self._generate_payload(input=input)
-        response = self._request('GET', url, params=payload, cache=cache)
+        response = self._request('GET',
+                                 url,
+                                 params=payload,
+                                 timeout=None,
+                                 cache=cache)
         return response
 
     def get_images(self, position, survey, coordinates=None, projection=None,
@@ -292,7 +299,10 @@ class SkyViewClass(BaseQuery):
     def survey_dict(self):
         if not hasattr(self, '_survey_dict'):
 
-            response = self._request('GET', self.URL, cache=False)
+            response = self._request('GET',
+                                     self.URL,
+                                     timeout=None,
+                                     cache=False)
             page = BeautifulSoup(response.content, "html.parser")
             surveys = page.findAll('select', {'name': 'survey'})
 

--- a/astroquery/skyview/tests/test_skyview.py
+++ b/astroquery/skyview/tests/test_skyview.py
@@ -42,7 +42,7 @@ class MockResponseSkyView(MockResponse):
 
 
 class MockResponseSkyviewForm(MockResponse):
-    def __init__(self, method, url, cache=False, params=None, **kwargs):
+    def __init__(self, method, url, timeout=None, cache=False, params=None, **kwargs):
         super(MockResponseSkyviewForm, self).__init__(**kwargs)
         self.content = self.get_content(method, url)
 

--- a/astroquery/splatalogue/core.py
+++ b/astroquery/splatalogue/core.py
@@ -451,9 +451,18 @@ class SplatalogueClass(BaseQuery):
 
         response = self._request(method='POST',
                                  url=self.QUERY_URL,
+                                 params=None,
                                  data=data_payload,
+                                 headers=None,
+                                 files=None,
+                                 save=False,
+                                 savedir='',
                                  timeout=self.TIMEOUT,
-                                 cache=cache)
+                                 cache=cache,
+                                 stream=False,
+                                 auth=None,
+                                 continuation=True,
+                                 verify=True)
 
         self.response = response
 

--- a/astroquery/ukidss/tests/test_ukidss.py
+++ b/astroquery/ukidss/tests/test_ukidss.py
@@ -6,7 +6,7 @@ from contextlib import contextmanager
 import pytest
 from astropy.table import Table
 import astropy.units as u
-import numpy.testing as npt
+# import numpy.testing as npt
 
 from ... import ukidss
 from ...utils import commons
@@ -72,7 +72,11 @@ def patch_parse_coordinates(request):
 
 
 def get_mockreturn(method='GET', url='default_url',
-                   params=None, timeout=10, **kwargs):
+                   params=None, data=None, headers=None,
+                   files=None, save=False, savedir='',
+                   timeout=10, cache=False, stream=False,
+                   auth=None, continuation=False, verify=False,
+                   **kwargs):
     if "Image" in url:
         filename = DATA_FILES["image_results"]
         url = "Image_URL"

--- a/astroquery/vizier/core.py
+++ b/astroquery/vizier/core.py
@@ -214,9 +214,20 @@ class VizierClass(BaseQuery):
 
         if max_catalogs is not None:
             data_payload['-meta.max'] = max_catalogs
-        response = self._request(
-            method='POST', url=self._server_to_url(return_type=return_type),
-            data=data_payload, timeout=self.TIMEOUT)
+        response = self._request(method='POST',
+                                 url=self._server_to_url(return_type=return_type),
+                                 params=None,
+                                 data=data_payload,
+                                 headers=None,
+                                 files=None,
+                                 save=False,
+                                 savedir='',
+                                 timeout=self.TIMEOUT,
+                                 cache=True,
+                                 stream=False,
+                                 auth=None,
+                                 continuation=True,
+                                 verify=True)
 
         if 'STOP, Max. number of RESOURCE reached' in response.text:
             raise ValueError("Maximum number of catalogs exceeded.  Try "
@@ -256,9 +267,20 @@ class VizierClass(BaseQuery):
         if get_query_payload:
             return data_payload
 
-        response = self._request(
-            method='POST', url=self._server_to_url(return_type=return_type),
-            data=data_payload, timeout=self.TIMEOUT)
+        response = self._request(method='POST',
+                                 url=self._server_to_url(return_type=return_type),
+                                 params=None,
+                                 data=data_payload,
+                                 headers=None,
+                                 files=None,
+                                 save=False,
+                                 savedir='',
+                                 timeout=self.TIMEOUT,
+                                 cache=True,
+                                 stream=False,
+                                 auth=None,
+                                 continuation=True,
+                                 verify=True)
 
         return response
 
@@ -308,9 +330,20 @@ class VizierClass(BaseQuery):
             catalog=catalog)
         if get_query_payload:
             return data_payload
-        response = self._request(
-            method='POST', url=self._server_to_url(return_type=return_type),
-            data=data_payload, timeout=self.TIMEOUT, cache=cache)
+        response = self._request(method='POST',
+                                 url=self._server_to_url(return_type=return_type),
+                                 params=None,
+                                 data=data_payload,
+                                 headers=None,
+                                 files=None,
+                                 save=False,
+                                 savedir='',
+                                 timeout=self.TIMEOUT,
+                                 cache=cache,
+                                 stream=False,
+                                 auth=None,
+                                 continuation=True,
+                                 verify=True)
         return response
 
     def query_region_async(self, coordinates, radius=None, inner_radius=None,
@@ -437,9 +470,20 @@ class VizierClass(BaseQuery):
         if get_query_payload:
             return data_payload
 
-        response = self._request(
-            method='POST', url=self._server_to_url(return_type=return_type),
-            data=data_payload, timeout=self.TIMEOUT, cache=cache)
+        response = self._request(method='POST',
+                                 url=self._server_to_url(return_type=return_type),
+                                 params=None,
+                                 data=data_payload,
+                                 headers=None,
+                                 files=None,
+                                 save=False,
+                                 savedir='',
+                                 timeout=self.TIMEOUT,
+                                 cache=cache,
+                                 stream=False,
+                                 auth=None,
+                                 continuation=True,
+                                 verify=True)
         return response
 
     def query_constraints_async(self, catalog=None, return_type='votable',
@@ -504,9 +548,20 @@ class VizierClass(BaseQuery):
             center={'-c.rd': 180})
         if get_query_payload:
             return data_payload
-        response = self._request(
-            method='POST', url=self._server_to_url(return_type=return_type),
-            data=data_payload, timeout=self.TIMEOUT, cache=cache)
+        response = self._request(method='POST',
+                                 url=self._server_to_url(return_type=return_type),
+                                 params=None,
+                                 data=data_payload,
+                                 headers=None,
+                                 files=None,
+                                 save=False,
+                                 savedir='',
+                                 timeout=self.TIMEOUT,
+                                 cache=cache,
+                                 stream=False,
+                                 auth=None,
+                                 continuation=True,
+                                 verify=True)
         return response
 
     def _args_to_payload(self, *args, **kwargs):

--- a/astroquery/vo_conesearch/core.py
+++ b/astroquery/vo_conesearch/core.py
@@ -137,8 +137,20 @@ class ConeSearchClass(BaseQuery):
         else:
             url = self.URL
 
-        response = self._request('GET', url, params=request_payload,
-                                 timeout=self.TIMEOUT, cache=cache)
+        response = self._request('GET',
+                                 url,
+                                 params=request_payload,
+                                 data=None,
+                                 headers=None,
+                                 files=None,
+                                 save=False,
+                                 savedir='',
+                                 timeout=self.TIMEOUT,
+                                 cache=cache,
+                                 stream=False,
+                                 auth=None,
+                                 continuation=True,
+                                 verify=True)
         result = self._parse_result(response, pars=request_payload,
                                     verbose=verbose)
         return result

--- a/astroquery/wfau/core.py
+++ b/astroquery/wfau/core.py
@@ -697,8 +697,20 @@ class BaseWFAUClass(QueryWithLogin):
             response = self.session.get(url, params=request_payload,
                                         timeout=self.TIMEOUT)
         else:
-            response = self._request("GET", url=url, params=request_payload,
-                                     timeout=self.TIMEOUT)
+            response = self._request("GET",
+                                     url=url,
+                                     params=request_payload,
+                                     data=None,
+                                     headers=None,
+                                     files=None,
+                                     save=False,
+                                     savedir='',
+                                     timeout=self.TIMEOUT,
+                                     cache=True,
+                                     stream=False,
+                                     auth=None,
+                                     continuation=True,
+                                     verify=True)
         return response
 
     def _check_page(self, url, keyword, wait_time=1, max_attempts=30):
@@ -820,10 +832,20 @@ class BaseWFAUClass(QueryWithLogin):
                                          files={'file.txt': fh},
                                          timeout=self.TIMEOUT)
         else:
-            response = self._request("POST", url=self.CROSSID_URL,
+            response = self._request("POST",
+                                     url=self.CROSSID_URL,
                                      params=request_payload,
+                                     data=None,
+                                     headers=None,
                                      files={'file.txt': fh},
-                                     timeout=self.TIMEOUT)
+                                     save=False,
+                                     savedir='',
+                                     timeout=self.TIMEOUT,
+                                     cache=True,
+                                     stream=False,
+                                     auth=None,
+                                     continuation=True,
+                                     verify=True)
 
         raise NotImplementedError("It appears we haven't implemented the file "
                                   "upload correctly.  Help is needed.")

--- a/astroquery/xmatch/core.py
+++ b/astroquery/xmatch/core.py
@@ -88,8 +88,20 @@ class XMatchClass(BaseQuery):
         if get_query_payload:
             return payload, kwargs
 
-        response = self._request(method='POST', url=self.URL, data=payload,
-                                 timeout=self.TIMEOUT, cache=cache, **kwargs)
+        response = self._request(method='POST',
+                                 url=self.URL,
+                                 params=None,
+                                 data=payload,
+                                 headers=None,
+                                 files=None,
+                                 save=False,
+                                 savedir='',
+                                 timeout=self.TIMEOUT,
+                                 cache=cache,
+                                 stream=False,
+                                 auth=None,
+                                 continuation=True,
+                                 verify=True)
         response.raise_for_status()
 
         return response
@@ -135,12 +147,20 @@ class XMatchClass(BaseQuery):
         xMatch service and return them as a list of strings.
 
         """
-        response = self._request(
-            'GET',
-            url_helpers.urljoin_keep_path(self.URL, 'tables'),
-            {'action': 'getVizieRTableNames', 'RESPONSEFORMAT': 'txt'},
-            cache=cache,
-        )
+        response = self._request('GET',
+                                 url_helpers.urljoin_keep_path(self.URL, 'tables'),
+                                 params={'action': 'getVizieRTableNames', 'RESPONSEFORMAT': 'txt'},
+                                 data=None,
+                                 headers=None,
+                                 files=None,
+                                 save=False,
+                                 savedir='',
+                                 timeout=None,
+                                 cache=cache,
+                                 stream=False,
+                                 auth=None,
+                                 continuation=True,
+                                 verify=True)
 
         content = response.text
 


### PR DESCRIPTION
Fixes #1233. 

Add at least the kwargs `timeout` and `cache` to all modules to facilitate easy debugging. Changes to some tests needed to be introduced because of the new kwargs. 