### PR TITLE
Fix bug in the list_missions method of IbeClass

### DIFF
--- a/astroquery/ibe/core.py
+++ b/astroquery/ibe/core.py
@@ -276,7 +276,7 @@ class IbeClass(BaseQuery):
 
             root = BeautifulSoup(response.text)
             links = root.findAll('a')
-            missions = [os.path.basename(a.attrs['href']) for a in links]
+            missions = [os.path.basename(a.attrs['href'].rstrip('/')) for a in links]
             self._missions = missions
 
         return missions


### PR DESCRIPTION
Add `.rstrip('/')` to prevent `os.path.basename` from returning empty strings.