### PR TITLE
Unescape raw HTML character codes in query result text back to Unicode

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -14,6 +14,9 @@
 - CADC: Initial version [#1354]
 - MAST: Remove deprecated authorization code, fix unit tests, general code
   cleanup, documentation additions [#1409]
+- NIST: Unescape raw HTML codes in returned data back into Unicode equivalents
+  to stop them silently breaking Table parsing [#1431]
+
 
 0.3.9 (2018-12-06)
 ------------------

--- a/astroquery/nist/core.py
+++ b/astroquery/nist/core.py
@@ -5,12 +5,15 @@ import re
 
 import astropy.units as u
 import astropy.io.ascii as asciitable
-from six import PY3
+from six import PY2
 
 from ..query import BaseQuery
 from ..utils import async_to_sync, prepend_docstr_nosections
 from . import conf
 from ..exceptions import TableParseError
+
+if not PY2:
+    import html  # html is available in Py3 stdlib, but not in Py2
 
 __all__ = ['Nist', 'NistClass']
 
@@ -170,8 +173,7 @@ class NistClass(BaseQuery):
         try:
             table = _strip_blanks(pre)
             table = links_re.sub(r'\1', table)
-            if PY3:
-                import html
+            if not PY2:
                 table = html.unescape(table)
             table = asciitable.read(table, Reader=asciitable.FixedWidth,
                                     data_start=3, delimiter='|')

--- a/astroquery/nist/core.py
+++ b/astroquery/nist/core.py
@@ -146,7 +146,7 @@ class NistClass(BaseQuery):
 
     def _parse_result(self, response, verbose=False):
         """
-        Parses the results form the HTTP response to `astropy.table.Table`.
+        Parses the results from the HTTP response to `astropy.table.Table`.
 
         Parameters
         ----------

--- a/astroquery/nist/core.py
+++ b/astroquery/nist/core.py
@@ -1,11 +1,11 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 from __future__ import print_function
 
-import html
 import re
 
 import astropy.units as u
 import astropy.io.ascii as asciitable
+from six import PY3
 
 from ..query import BaseQuery
 from ..utils import async_to_sync, prepend_docstr_nosections
@@ -170,7 +170,9 @@ class NistClass(BaseQuery):
         try:
             table = _strip_blanks(pre)
             table = links_re.sub(r'\1', table)
-            table = html.unescape(table)
+            if PY3:
+                import html
+                table = html.unescape(table)
             table = asciitable.read(table, Reader=asciitable.FixedWidth,
                                     data_start=3, delimiter='|')
             return table

--- a/astroquery/nist/core.py
+++ b/astroquery/nist/core.py
@@ -1,6 +1,7 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 from __future__ import print_function
 
+import html
 import re
 
 import astropy.units as u
@@ -169,6 +170,7 @@ class NistClass(BaseQuery):
         try:
             table = _strip_blanks(pre)
             table = links_re.sub(r'\1', table)
+            table = html.unescape(table)
             table = asciitable.read(table, Reader=asciitable.FixedWidth,
                                     data_start=3, delimiter='|')
             return table

--- a/astroquery/nist/tests/test_nist_remote.py
+++ b/astroquery/nist/tests/test_nist_remote.py
@@ -24,3 +24,11 @@ class TestNist:
         # check that no javascript was left in the table
         # (regression test for 1355)
         assert np.all(result['TP'] == 'T8637')
+
+    def test_unescape_html(self):
+        response = nist.core.Nist.query_async(4333 * u.AA, 4334 * u.AA, "V I")
+        assert '&dagger;' in response.text
+        # check that Unicode characters have been properly unescaped from their
+        # raw HTML code equivalents during parsing
+        response = nist.core.Nist._parse_result(response)
+        assert any('†' in s for s in response['Ei           Ek'])

--- a/astroquery/nist/tests/test_nist_remote.py
+++ b/astroquery/nist/tests/test_nist_remote.py
@@ -6,6 +6,8 @@ import numpy as np
 from astropy.tests.helper import remote_data
 from astropy.table import Table
 import astropy.units as u
+from six import PY2
+import pytest
 
 from ... import nist
 
@@ -25,6 +27,7 @@ class TestNist:
         # (regression test for 1355)
         assert np.all(result['TP'] == 'T8637')
 
+    @pytest.mark.skipif('PY2')
     def test_unescape_html(self):
         response = nist.core.Nist.query_async(4333 * u.AA, 4334 * u.AA, "V I")
         assert '&dagger;' in response.text


### PR DESCRIPTION
This change simply uses the standard Python `html` module to unescape possible raw HTML character codes back to their Unicode equivalents in the raw text returned by a query, to prevent breaking the parsing of query results using the FixedWidth `astropy.table.Table` formatting.

Also fixed a typo in the docstring for `_parse_result` function.

(Edit from the future: this is to rectify issue [#1418](https://github.com/astropy/astroquery/issues/1418).)