### PR TITLE
Fix two bugs found in CADC

### DIFF
--- a/astroquery/cadc/core.py
+++ b/astroquery/cadc/core.py
@@ -296,8 +296,7 @@ class CadcClass(BaseQuery):
         -------
         A table object
         """
-        return self._cadctap.load_table(table,
-                                         verbose)
+        return self._cadctap.load_table(table, verbose)
 
     def query_async(self, query):
         """

--- a/astroquery/cadc/core.py
+++ b/astroquery/cadc/core.py
@@ -443,7 +443,9 @@ class CadcClass(BaseQuery):
 
     def _args_to_payload(self, *args, **kwargs):
         # convert arguments to a valid requests payload
-        coordinates = commons.parse_coordinates(kwargs['coordinates'])
+        # and force the coordinates to FK5 (assuming FK5/ICRS are
+        # interchangeable) since RA/Dec are used below
+        coordinates = commons.parse_coordinates(kwargs['coordinates']).fk5
         radius = kwargs['radius']
         payload = {format: 'VOTable'}
         payload['query'] = \
@@ -544,4 +546,4 @@ def get_access_url(service, capability=None):
                        "anonymous or cookie access".format(capability))
 
 
-Cadc = CadcClass
+Cadc = CadcClass()

--- a/astroquery/cadc/core.py
+++ b/astroquery/cadc/core.py
@@ -99,7 +99,6 @@ class CadcClass(BaseQuery):
 
         self._verbose = verbose
 
-
     @property
     def _cadctap(self):
         if self._tap_plus_handler is None:

--- a/astroquery/cadc/core.py
+++ b/astroquery/cadc/core.py
@@ -89,22 +89,41 @@ class CadcClass(BaseQuery):
         if url is not None and tap_plus_handler is not None:
             raise AttributeError('Can not input both url and tap handler')
 
-        if tap_plus_handler is None:
-            if url is None:
+        self._cadc_url = None
+        self._tap_plus_handler = None
+
+        if url is not None:
+            self._cadc_url = url
+        elif tap_plus_handler is not None:
+            self._tap_plus_handler = tap_plus_handler
+
+        self._verbose = verbose
+
+
+    @property
+    def _cadctap(self):
+        if self._tap_plus_handler is None:
+            if self._cadc_url is None:
                 u = get_access_url(self.CADCTAP_SERVICE_URI)
                 # remove capabilities endpoint to get to the service url
                 u = u.rstrip('capabilities')
-                self.__cadctap = TapPlusCadc(
+                self._tap_plus_handler = TapPlusCadc(
                     url=u,
-                    verbose=verbose)
+                    verbose=self._verbose)
             else:
-                self.__cadctap = TapPlusCadc(url=url, verbose=verbose)
-        else:
-            self.__cadctap = tap_plus_handler
+                self._tap_plus_handler = TapPlusCadc(url=self._cadc_url,
+                                                     verbose=self._verbose)
 
-        self.data_link_url = get_access_url(
-            self.CADCDATALINK_SERVICE_URI,
-            "ivo://ivoa.net/std/DataLink#links-1.0")
+        return self._tap_plus_handler
+
+    @property
+    def data_link_url(self):
+        if not hasattr(self, '__data_link_url'):
+            self.__data_link_url = get_access_url(
+                self.CADCDATALINK_SERVICE_URI,
+                "ivo://ivoa.net/std/DataLink#links-1.0")
+
+        return self.__data_link_url
 
     def login(self, user=None, password=None, certificate_file=None):
         """
@@ -121,7 +140,7 @@ class CadcClass(BaseQuery):
         """
         login_url = get_access_url(self.CADCLOGIN_SERVICE_URI,
                                    'ivo://ivoa.net/std/UMS#login-0.1')
-        return self.__cadctap.login(user=user, password=password,
+        return self._cadctap.login(user=user, password=password,
                                     certificate_file=certificate_file,
                                     cookie_prefix=CADC_COOKIE_PREFIX,
                                     login_url=login_url,
@@ -131,7 +150,7 @@ class CadcClass(BaseQuery):
         """
         Logout
         """
-        return self.__cadctap.logout(verbose)
+        return self._cadctap.logout(verbose)
 
     @class_or_instance
     def query_region_async(self, coordinates, radius=0.016666666666667,
@@ -260,7 +279,7 @@ class CadcClass(BaseQuery):
         -------
         A list of table objects
         """
-        return self.__cadctap.load_tables(only_names, verbose)
+        return self._cadctap.load_tables(only_names, verbose)
 
     def get_table(self, table, verbose=False):
         """
@@ -277,7 +296,7 @@ class CadcClass(BaseQuery):
         -------
         A table object
         """
-        return self.__cadctap.load_table(table,
+        return self._cadctap.load_table(table,
                                          verbose)
 
     def query_async(self, query):
@@ -337,7 +356,7 @@ class CadcClass(BaseQuery):
         else:
             save_to_file = False
         if operation == 'sync':
-            job = self.__cadctap.launch_job(
+            job = self._cadctap.launch_job(
                 query,
                 None,
                 output_file=output_file,
@@ -348,7 +367,7 @@ class CadcClass(BaseQuery):
                 upload_table_name=upload_table_name)
             op = False
         elif operation == 'async':
-            job = self.__cadctap.launch_job_async(
+            job = self._cadctap.launch_job_async(
                 query,
                 None,
                 output_file=output_file,
@@ -360,7 +379,7 @@ class CadcClass(BaseQuery):
                 upload_table_name=upload_table_name)
             op = True
         cjob = JobCadc(async_job=op, query=job.parameters['query'],
-                       connhandler=self.__cadctap._TapPlus__getconnhandler())
+                       connhandler=self._cadctap._TapPlus__getconnhandler())
         cjob.jobid = job.jobid
         cjob.outputFile = job.outputFile
         cjob.set_response_status(job._Job__responseStatus,
@@ -393,7 +412,7 @@ class CadcClass(BaseQuery):
         -------
         A Job object
         """
-        return self.__cadctap.load_async_job(jobid, verbose=verbose)
+        return self._cadctap.load_async_job(jobid, verbose=verbose)
 
     def list_async_jobs(self, verbose=False):
         """
@@ -409,7 +428,7 @@ class CadcClass(BaseQuery):
         A list of Job objects
         """
         try:
-            joblist = self.__cadctap.list_async_jobs(verbose)
+            joblist = self._cadctap.list_async_jobs(verbose)
             cadclist = []
             if joblist is not None:
                 for job in joblist:
@@ -432,7 +451,7 @@ class CadcClass(BaseQuery):
         verbose : bool, optional, default 'False'
             flag to display information about the process
         """
-        return self.__cadctap.save_results(job, filename, verbose)
+        return self._cadctap.save_results(job, filename, verbose)
 
     def _parse_result(self, result, verbose=False):
         # result is a job

--- a/astroquery/cadc/tests/test_cadctap.py
+++ b/astroquery/cadc/tests/test_cadctap.py
@@ -1,13 +1,13 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 """
 =============
-Cadc TAP plus
+CadcClass TAP plus
 =============
 
 """
 import os
 
-from astroquery.cadc import Cadc, conf
+from astroquery.cadc import CadcClass, conf
 import astroquery.cadc.core as cadc_core
 from astroquery.utils.commons import parse_coordinates
 from astroquery.cadc.tests.DummyTapHandler import DummyTapHandler
@@ -27,7 +27,7 @@ def data_path(filename):
 def test_get_tables(monkeypatch):
     dummyTapHandler = DummyTapHandler()
     monkeypatch.setattr(cadc_core, 'get_access_url', get_access_url_mock)
-    tap = Cadc(tap_plus_handler=dummyTapHandler)
+    tap = CadcClass(tap_plus_handler=dummyTapHandler)
     # default parameters
     parameters = {}
     parameters['only_names'] = False
@@ -46,7 +46,7 @@ def test_get_tables(monkeypatch):
 def test_get_table(monkeypatch):
     dummyTapHandler = DummyTapHandler()
     monkeypatch.setattr(cadc_core, 'get_access_url', get_access_url_mock)
-    tap = Cadc(tap_plus_handler=dummyTapHandler)
+    tap = CadcClass(tap_plus_handler=dummyTapHandler)
     # default parameters
     parameters = {}
     parameters['table'] = 'table'
@@ -65,7 +65,7 @@ def test_get_table(monkeypatch):
 def test_run_query(monkeypatch):
     dummyTapHandler = DummyTapHandler()
     monkeypatch.setattr(cadc_core, 'get_access_url', get_access_url_mock)
-    tap = Cadc(tap_plus_handler=dummyTapHandler)
+    tap = CadcClass(tap_plus_handler=dummyTapHandler)
     query = "query"
     operation = 'sync'
     # default parameters
@@ -108,7 +108,7 @@ def test_run_query(monkeypatch):
 def test_load_async_job(monkeypatch):
     dummyTapHandler = DummyTapHandler()
     monkeypatch.setattr(cadc_core, 'get_access_url', get_access_url_mock)
-    tap = Cadc(tap_plus_handler=dummyTapHandler)
+    tap = CadcClass(tap_plus_handler=dummyTapHandler)
     jobid = '123'
     # default parameters
     parameters = {}
@@ -127,7 +127,7 @@ def test_load_async_job(monkeypatch):
 def test_list_async_jobs(monkeypatch):
     dummyTapHandler = DummyTapHandler()
     monkeypatch.setattr(cadc_core, 'get_access_url', get_access_url_mock)
-    tap = Cadc(tap_plus_handler=dummyTapHandler)
+    tap = CadcClass(tap_plus_handler=dummyTapHandler)
     # default parameters
     parameters = {}
     parameters['verbose'] = False
@@ -143,7 +143,7 @@ def test_list_async_jobs(monkeypatch):
 def test_save_results(monkeypatch):
     dummyTapHandler = DummyTapHandler()
     monkeypatch.setattr(cadc_core, 'get_access_url', get_access_url_mock)
-    tap = Cadc(tap_plus_handler=dummyTapHandler)
+    tap = CadcClass(tap_plus_handler=dummyTapHandler)
     job = '123'
     # default parameters
     parameters = {}
@@ -167,7 +167,7 @@ def test_login(monkeypatch):
 
     monkeypatch.setattr(cadc_core, 'get_access_url', get_access_url_mock)
     dummyTapHandler = DummyTapHandler()
-    tap = Cadc(tap_plus_handler=dummyTapHandler)
+    tap = CadcClass(tap_plus_handler=dummyTapHandler)
     user = 'user'
     password = 'password'
     cert = 'cert'
@@ -193,7 +193,7 @@ def test_login(monkeypatch):
 def test_logout(monkeypatch):
     dummyTapHandler = DummyTapHandler()
     monkeypatch.setattr(cadc_core, 'get_access_url', get_access_url_mock)
-    tap = Cadc(tap_plus_handler=dummyTapHandler)
+    tap = CadcClass(tap_plus_handler=dummyTapHandler)
     # default parameters
     parameters = {}
     parameters['verbose'] = False
@@ -263,7 +263,7 @@ def test_get_data_urls(monkeypatch):
 
     monkeypatch.setattr(cadc_core, 'parse_single_table', lambda x: vot_result)
     dummyTapHandler = DummyTapHandler()
-    cadc = Cadc(tap_plus_handler=dummyTapHandler)
+    cadc = CadcClass(tap_plus_handler=dummyTapHandler)
     cadc._request = get  # mock the request
     assert [vot_result.array[0]['access_url'].decode('ascii')] == \
         cadc.get_data_urls({'caomPublisherID': ['ivo://cadc.nrc.ca/foo']})
@@ -280,7 +280,7 @@ def test_get_data_urls(monkeypatch):
 def test_misc(monkeypatch):
     dummyTapHandler = DummyTapHandler()
     monkeypatch.setattr(cadc_core, 'get_access_url', get_access_url_mock)
-    cadc = Cadc(tap_plus_handler=dummyTapHandler)
+    cadc = CadcClass(tap_plus_handler=dummyTapHandler)
 
     class Result(object):
         pass

--- a/astroquery/cadc/tests/test_cadctap.py
+++ b/astroquery/cadc/tests/test_cadctap.py
@@ -15,8 +15,8 @@ import pytest
 
 
 # monkeypatch get_access_url to prevent internet calls
-def get_access_url_mock(arg1, arg2):
-    return "some.url"
+def get_access_url_mock(arg1, arg2=None):
+    return "https://some.url"
 
 
 def data_path(filename):
@@ -28,6 +28,10 @@ def test_get_tables(monkeypatch):
     dummyTapHandler = DummyTapHandler()
     monkeypatch.setattr(cadc_core, 'get_access_url', get_access_url_mock)
     tap = CadcClass(tap_plus_handler=dummyTapHandler)
+
+    # sanity check: make sure our Cadc instance is using the handler
+    assert tap._cadctap == dummyTapHandler
+
     # default parameters
     parameters = {}
     parameters['only_names'] = False
@@ -293,8 +297,8 @@ def test_misc(monkeypatch):
     result.results = 'WELL DONE'
     assert result.results == cadc._parse_result(result)
     coords = '08h45m07.5s +54d18m00s'
-    coords_ra = parse_coordinates(coords).ra.degree
-    coords_dec = parse_coordinates(coords).dec.degree
+    coords_ra = parse_coordinates(coords).fk5.ra.degree
+    coords_dec = parse_coordinates(coords).fk5.dec.degree
 
     assert "SELECT * from caom2.Observation o join caom2.Plane p ON " \
            "o.obsID=p.obsID WHERE INTERSECTS( CIRCLE('ICRS', " \


### PR DESCRIPTION
The idiom `from astroquery.cadc import Cadc` was broken.  It also did not allow Galactic coordinate objects.

There is another outstanding bug that I do not have a fix for:
```
>>> Cadc.query_region(coordinates=coordinates.SkyCoord(12*u.deg, 0*u.deg, frame='galactic'), radius=1*u.arcmin)
Traceback (most recent call last):
  File "<ipython-input-10-26cc62f40dde>", line 1, in <module>
    Cadc.query_region(coordinates=coordinates.SkyCoord(12*u.deg, 0*u.deg, frame='galactic'), radius=1*u.arcmin)
  File "/Users/adam/repos/astroquery/astroquery/utils/class_or_instance.py", line 25, in f
    return self.fn(obj, *args, **kwds)
  File "/Users/adam/repos/astroquery/astroquery/utils/process_asyncs.py", line 26, in newmethod
    response = getattr(self, async_method_name)(*args, **kwargs)
  File "/Users/adam/repos/astroquery/astroquery/utils/class_or_instance.py", line 25, in f
    return self.fn(obj, *args, **kwds)
  File "/Users/adam/repos/astroquery/astroquery/cadc/core.py", line 167, in query_region_async
    response = self.run_query(request_payload['query'], operation='sync')
  File "/Users/adam/repos/astroquery/astroquery/cadc/core.py", line 348, in run_query
    upload_table_name=upload_table_name)
  File "/Users/adam/repos/astroquery/astroquery/utils/tap/core.py", line 241, in launch_job
    raise requests.exceptions.HTTPError(response.reason)
HTTPError: Bad Request
```

I cannot perform any requests with `radius` specified.