### PR TITLE
Add Datalink metadata into vizier queries

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1063,7 +1063,9 @@ Infrastructure, Utility and Other Changes and Additions
 
 - Added a new ``astroquery.__citation__`` and ``astroquery.__bibtex__``
   attributes which give a citation for astroquery in bibtex format. [#1391]
-
+- VIZIER: Support using the output values of ``find_catalog`` in
+  ``get_catalog``. [#603]
+- Vizier: Add 'datalink' column (link to FITS) when present. [#1455]
 
 
 0.3.9 (2018-12-06)

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -415,8 +415,10 @@ splatalogue
 vizier
 ^^^^^^
 
-- It is now possible to specify 'galatic' centers in region queries to
+- It is now possible to specify 'galactic' centers in region queries to
   have box queries oriented along the galactic axes. [#2152]
+
+- Add 'datalink' column (link to FITS) when present. [#1455]
 
 
 Infrastructure, Utility and Other Changes and Additions
@@ -1063,9 +1065,7 @@ Infrastructure, Utility and Other Changes and Additions
 
 - Added a new ``astroquery.__citation__`` and ``astroquery.__bibtex__``
   attributes which give a citation for astroquery in bibtex format. [#1391]
-- VIZIER: Support using the output values of ``find_catalog`` in
-  ``get_catalog``. [#603]
-- Vizier: Add 'datalink' column (link to FITS) when present. [#1455]
+
 
 
 0.3.9 (2018-12-06)

--- a/astroquery/vizier/core.py
+++ b/astroquery/vizier/core.py
@@ -610,7 +610,9 @@ class VizierClass(BaseQuery):
             for (key, value) in center.items():
                 body[key] = value
         # add column metadata: name, unit, UCD1+, and description
-        body["-out.meta"] = "huUD"
+        # big L: data link that we need to parse
+        # big l: data link that is parsed on the server side
+        body["-out.meta"] = "huUDL"
         # merge tables when a list is queried against a single catalog
         body["-out.form"] = "mini"
         # computed position should always be in decimal degrees

--- a/astroquery/vizier/core.py
+++ b/astroquery/vizier/core.py
@@ -830,6 +830,7 @@ def _parse_angle(angle):
     else:
         return u.deg, "d", angle.to_value(u.deg)
 
+
 def vo_link_parser_onerow(volink, tablerow):
     """
     VO tables can have 'LINK' associated metadata in Vizier; the votable 1.1
@@ -842,23 +843,18 @@ def vo_link_parser_onerow(volink, tablerow):
     >>> vo_link_parser(linkstr, row)
     'http://vizier.u-strasbg.fr/viz-bin/getassocdata?obs_publisher_did=ivo://CDS.VizieR/V/127A?res=1001_ha.fits'
     """
+    # TODO: add check that only [a-zA-Z_] (no special characters) are in the {name of column} region.
 
     rowdict = dict(zip(tablerow.colnames, tablerow))
-    pstring = volink.replace("$","").format(**rowdict)
+    pstring = volink.replace("$", "").format(**rowdict)
 
     return pstring
 
+
 def vo_link_parser_table(votable):
     """
-    VO tables can have 'LINK' associated metadata in Vizier; the votable 1.1
-    and 1.2 format may be different from 1.3 but we don't have to worry about
-    that yet.
-
-    Example
-    -------
-    >>> linkstr = 'http://vizier.u-strasbg.fr/viz-bin/getassocdata?obs_publisher_did=ivo://CDS.VizieR/V/127A?res=${img}_ha.fits'
-    >>> vo_link_parser(linkstr, row)
-    'http://vizier.u-strasbg.fr/viz-bin/getassocdata?obs_publisher_did=ivo://CDS.VizieR/V/127A?res=1001_ha.fits'
+    Add a new column that includes the whole URL parsed from the meta.link.href
+    metadata.  See `vo_link_parser_onerow`.
     """
 
     for colname in votable.colnames:
@@ -871,6 +867,7 @@ def vo_link_parser_table(votable):
             new_column = tbl.Column(data=[vo_link_parser_onerow(href, row) for row in votable],
                                     name=column.name+"_link")
             votable.add_column(new_column)
+
 
 class VizierKeyword(list):
 


### PR DESCRIPTION
Vizier tables with linked data can output URLs in a column that link to the data files.  You can get those metadata with `-out.meta='l'` or `-out.meta='L'`; the latter is more efficient (smaller), but requires additional parsing (not yet implemented) on our end.