### PR TITLE
ALMA login URLs are a moving target

### DIFF
--- a/astroquery/alma/core.py
+++ b/astroquery/alma/core.py
@@ -540,6 +540,7 @@ class AlmaClass(QueryWithLogin):
             else:
                 username = self.USERNAME
 
+        success = False
         for auth_url in auth_urls:
             # set session cookies (they do not get set otherwise)
             cookiesetpage = self._request("GET",


### PR DESCRIPTION
See #1395, #1381.  This is an attempt to make ALMA's login tool more robust
against these changes and give a better error message.