### PR TITLE
Add parameter to allow to restrict xmatch area considered

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -150,7 +150,7 @@ mast
 
 - Remove deprecated authorization code, fix unit tests, general code cleanup,
   documentation additions. [#1409]
-  
+
 - MAST: Addition of observation metadata query. Addition of catalogs.MAST PanSTARRS catalog queries. [#1473]
 
 - TIC catalog search update. [#1483]
@@ -244,6 +244,9 @@ wfau
 
 xmatch
 ^^^^^^
+
+- Add parameter ``area`` to restrict sky  region considered. [#1476]
+
 
 
 Infrastructure, Utility and Other Changes and Additions

--- a/astroquery/xmatch/core.py
+++ b/astroquery/xmatch/core.py
@@ -77,7 +77,7 @@ class XMatchClass(BaseQuery):
 
     @prepend_docstr_nosections("\n" + query.__doc__)
     def query_async(self, cat1, cat2, max_distance, colRA1=None, colDec1=None,
-                    colRA2=None, colDec2=None, area, cache=True,
+                    colRA2=None, colDec2=None, area='allsky', cache=True,
                     get_query_payload=False):
         """
         Returns
@@ -141,9 +141,9 @@ class XMatchClass(BaseQuery):
             payload['area'] = 'allsky'
         elif isinstance(area, CircleSkyRegion):
             payload['area'] = 'cone'
-            cone_center = cone.center
-            payload['coneRA'] = center.icrs.ra.deg
-            payload['coneDec'] = center.icrs.dec.deg
+            cone_center = area.center
+            payload['coneRA'] = cone_center.icrs.ra.deg
+            payload['coneDec'] = cone_center.icrs.dec.deg
             payload['coneRadiusDeg'] = area.radius.to_value(u.deg) 
         else:
             raise ValueError('Unsupported area {}'.format(str(area)))

--- a/astroquery/xmatch/core.py
+++ b/astroquery/xmatch/core.py
@@ -21,10 +21,10 @@ class XMatchClass(BaseQuery):
     URL = conf.url
     TIMEOUT = conf.timeout
 
-    def query(self, cat1, cat2, max_distance, 
+    def query(self, cat1, cat2, max_distance,
               colRA1=None, colDec1=None,
-              colRA2=None, colDec2=None, 
-              area='allsky', 
+              colRA2=None, colDec2=None,
+              area='allsky',
               cache=True, get_query_payload=False):
         """
         Query the `CDS cross-match service
@@ -60,7 +60,7 @@ class XMatchClass(BaseQuery):
             ``cat2`` is an uploaded table or a pointer to a URL.
         area : CirleSkyRegion or 'allsky' str
             Restrict the area taken into account when performing the xmatch
-            Default value is 'allsky' (no restriction). If a CirleSkyRegion 
+            Default value is 'allsky' (no restriction). If a CirleSkyRegion
             object is given, only sources in this region will be considered.
 
         Returns
@@ -137,17 +137,16 @@ class XMatchClass(BaseQuery):
 
     def _prepare_area(self, payload, area):
         '''Set the area parameter in the payload'''
-        if area is None or area=='allsky':
+        if area is None or area == 'allsky':
             payload['area'] = 'allsky'
         elif isinstance(area, CircleSkyRegion):
             payload['area'] = 'cone'
             cone_center = area.center
             payload['coneRA'] = cone_center.icrs.ra.deg
             payload['coneDec'] = cone_center.icrs.dec.deg
-            payload['coneRadiusDeg'] = area.radius.to_value(u.deg) 
+            payload['coneRadiusDeg'] = area.radius.to_value(u.deg)
         else:
             raise ValueError('Unsupported area {}'.format(str(area)))
-
 
     def is_table_available(self, table_id):
         """Return True if the passed CDS table identifier is one of the

--- a/astroquery/xmatch/core.py
+++ b/astroquery/xmatch/core.py
@@ -2,7 +2,6 @@
 
 import six
 from astropy.io import ascii
-from astropy.units import arcsec
 import astropy.units as u
 from astropy.table import Table
 
@@ -13,7 +12,8 @@ from ..utils import url_helpers, prepend_docstr_nosections, async_to_sync
 try:
     from regions import CircleSkyRegion
 except ImportError:
-    print('Could not import CircleSkyRegion')
+    print('Could not import regions, which is required for some of the '
+          'functionalities of this module.')
 
 
 @async_to_sync
@@ -58,10 +58,11 @@ class XMatchClass(BaseQuery):
         colDec2 : str
             Name of the column holding the declination. Only required if
             ``cat2`` is an uploaded table or a pointer to a URL.
-        area : CirleSkyRegion or 'allsky' str
+        area : ``regions.CircleSkyRegion`` or 'allsky' str
             Restrict the area taken into account when performing the xmatch
-            Default value is 'allsky' (no restriction). If a CirleSkyRegion
-            object is given, only sources in this region will be considered.
+            Default value is 'allsky' (no restriction). If a
+            ``regions.CircleSkyRegion`` object is given, only sources in
+            this region will be considered.
 
         Returns
         -------
@@ -85,12 +86,12 @@ class XMatchClass(BaseQuery):
         response : `~requests.Response`
             The HTTP response returned from the service.
         """
-        if max_distance > 180 * arcsec:
+        if max_distance > 180 * u.arcsec:
             raise ValueError(
                 'max_distance argument must not be greater than 180')
         payload = {
             'request': 'xmatch',
-            'distMaxArcsec': max_distance.to(arcsec).value,
+            'distMaxArcsec': max_distance.to(u.arcsec).value,
             'RESPONSEFORMAT': 'csv',
         }
         kwargs = {}

--- a/astroquery/xmatch/tests/test_xmatch_remote.py
+++ b/astroquery/xmatch/tests/test_xmatch_remote.py
@@ -95,12 +95,10 @@ class TestXMatch:
         try:
             table = xmatch.query(
                 cat1='vizier:II/311/wise', cat2='vizier:II/246/out', max_distance=5 * arcsec,
-                area=CircleSkyRegion(center = SkyCoord(10, 10, unit='deg', frame='icrs'), radius = 12 * arcmin))
+                area=CircleSkyRegion(center=SkyCoord(10, 10, unit='deg', frame='icrs'), radius=12 * arcmin))
         except ReadTimeout:
             pytest.xfail("xmatch query timed out.")
         assert len(table) == 185
-
-
 
     def http_test(self):
         # this can be used to check that the API is still functional & doing as expected

--- a/astroquery/xmatch/tests/test_xmatch_remote.py
+++ b/astroquery/xmatch/tests/test_xmatch_remote.py
@@ -1,6 +1,7 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 import os.path
 import os
+import sys
 import pytest
 import requests
 from requests import ReadTimeout

--- a/astroquery/xmatch/tests/test_xmatch_remote.py
+++ b/astroquery/xmatch/tests/test_xmatch_remote.py
@@ -13,7 +13,10 @@ from astropy.io import ascii
 
 from astropy.coordinates import SkyCoord
 
-from regions import CircleSkyRegion
+try:
+    from regions import CircleSkyRegion
+except ImportError:
+    pass
 
 from ...xmatch import XMatch
 

--- a/astroquery/xmatch/tests/test_xmatch_remote.py
+++ b/astroquery/xmatch/tests/test_xmatch_remote.py
@@ -7,8 +7,12 @@ from requests import ReadTimeout
 
 from astropy.tests.helper import remote_data
 from astropy.table import Table
-from astropy.units import arcsec
+from astropy.units import arcsec, arcmin
 from astropy.io import ascii
+
+from astropy.coordinates import SkyCoord
+
+from regions import CircleSkyRegion
 
 from ...xmatch import XMatch
 
@@ -84,6 +88,19 @@ class TestXMatch:
 
         http_test_table = self.http_test()
         assert all(table == http_test_table)
+
+    @pytest.mark.skipif('regions' not in sys.modules,
+                        reason="requires astropy-regions")
+    def test_xmatch_query_with_cone_area(self, xmatch):
+        try:
+            table = xmatch.query(
+                cat1='vizier:II/311/wise', cat2='vizier:II/246/out', max_distance=5 * arcsec,
+                area=CircleSkyRegion(center = SkyCoord(10, 10, unit='deg', frame='icrs'), radius = 12 * arcmin))
+        except ReadTimeout:
+            pytest.xfail("xmatch query timed out.")
+        assert len(table) == 185
+
+
 
     def http_test(self):
         # this can be used to check that the API is still functional & doing as expected


### PR DESCRIPTION
This PR adds an area parameter which defaults to 'allsky'.
It can be restricted to a cone search by passing a astropy-regions CircleSkyRegion object.

This can be useful when users want to cross-match two large catalogues but are interested in a given region on the sky, and not on performing the cross-match on the whole sky. This will speed up the computation and returns a smaller result file. 
In the future, we plan to support additional types of regions (especially MOC - Multi Order Coverage maps)