### PR TITLE
minor updates to jplhorizons

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -24,6 +24,8 @@
   attributes which give a citation for astroquery in bibtex format. [#1391]
 - VIZIER: Support using the output values of ``find_catalog`` in
   ``get_catalog``. [#603]
+- JPLHorizons: Vector queries provide different aberrations, ephemerides queries
+  provide extra precision option. [#1478]
 
 
 0.3.9 (2018-12-06)

--- a/astroquery/jplhorizons/__init__.py
+++ b/astroquery/jplhorizons/__init__.py
@@ -175,6 +175,7 @@ class Conf(_config.ConfigNamespace):
                    'JDTDB': ('datetime_jd', 'd'),
                    'Calendar Date (TDB)': ('datetime_str',
                                            '---'),
+                   'delta-T': ('delta_T', 's'),
                    'H': ('H', 'mag'),
                    'G': ('G', '---'),
                    'M1': ('M1', 'mag'),

--- a/astroquery/jplhorizons/core.py
+++ b/astroquery/jplhorizons/core.py
@@ -146,9 +146,9 @@ class HorizonsClass(BaseQuery):
                           refsystem='J2000',
                           closest_apparition=False, no_fragments=False,
                           quantities=conf.eph_quantities,
-                          extra_precision=False,
                           get_query_payload=False,
-                          get_raw_response=False, cache=True):
+                          get_raw_response=False, cache=True,
+                          extra_precision=False):
         """
         Query JPL Horizons for ephemerides. The ``location`` parameter
         in ``HorizonsClass`` refers in this case to the location of
@@ -442,14 +442,14 @@ class HorizonsClass(BaseQuery):
             Observer Table Quantities
             <https://ssd.jpl.nasa.gov/?horizons_doc#table_quantities>`_;
             default: all quantities
-        extra_precision : boolean, optional
-            Enables extra precision in RA and DEC values; default: False
         get_query_payload : boolean, optional
             When set to `True` the method returns the HTTP request
             parameters as a dict, default: False
         get_raw_response : boolean, optional
             Return raw data as obtained by JPL Horizons without parsing the
             data into a table, default: False
+        extra_precision : boolean, optional
+            Enables extra precision in RA and DEC values; default: False
 
 
         Returns
@@ -812,9 +812,9 @@ class HorizonsClass(BaseQuery):
 
     def vectors_async(self, get_query_payload=False,
                       closest_apparition=False, no_fragments=False,
+                      get_raw_response=False, cache=True,
                       refplane='ecliptic', aberrations='geometric',
-                      delta_T=False,
-                      get_raw_response=False, cache=True):
+                      delta_T=False,):
         """
         Query JPL Horizons for state vectors. The ``location``
         parameter in ``HorizonsClass`` refers in this case to the center
@@ -890,6 +890,12 @@ class HorizonsClass(BaseQuery):
             Only applies to comets. Reject all comet fragments from
             selection; default: False. Do not use this option for
             non-cometary objects.
+        get_query_payload : boolean, optional
+            When set to `True` the method returns the HTTP request
+            parameters as a dict, default: False
+        get_raw_response: boolean, optional
+            Return raw data as obtained by JPL Horizons without parsing the
+            data into a table, default: False
         refplane : string
             Reference plane for all output quantities: ``'ecliptic'``
             (ecliptic and mean equinox of reference epoch), ``'earth'``
@@ -902,12 +908,6 @@ class HorizonsClass(BaseQuery):
         delta_T : boolean, optional
             Triggers output of time-varying difference between TDB and UT
             time-scales. Default: False
-        get_query_payload : boolean, optional
-            When set to `True` the method returns the HTTP request
-            parameters as a dict, default: False
-        get_raw_response: boolean, optional
-            Return raw data as obtained by JPL Horizons without parsing the
-            data into a table, default: False
 
 
         Returns

--- a/astroquery/jplhorizons/core.py
+++ b/astroquery/jplhorizons/core.py
@@ -809,7 +809,9 @@ class HorizonsClass(BaseQuery):
 
     def vectors_async(self, get_query_payload=False,
                       closest_apparition=False, no_fragments=False,
-                      get_raw_response=False, cache=True, refplane='ecliptic'):
+                      refplane='ecliptic', aberrations='geometric',
+                      delta_T=False,
+                      get_raw_response=False, cache=True):
         """
         Query JPL Horizons for state vectors. The ``location``
         parameter in ``HorizonsClass`` refers in this case to the center
@@ -843,6 +845,9 @@ class HorizonsClass(BaseQuery):
         | datetime_str     | epoch Date (str, ``Calendar Date (TDB)``)     |
         +------------------+-----------------------------------------------+
         | datetime_jd      | epoch Julian Date (float, ``JDTDB``)          |
+        +------------------+-----------------------------------------------+
+        | delta_T          | time-varying difference between TDB and UT    |
+        |                  | (float, ``delta-T``, optional)                |
         +------------------+-----------------------------------------------+
         | x                | x-component of position vector                |
         |                  | (float, au, ``X``)                            |
@@ -882,18 +887,24 @@ class HorizonsClass(BaseQuery):
             Only applies to comets. Reject all comet fragments from
             selection; default: False. Do not use this option for
             non-cometary objects.
-        get_query_payload : boolean, optional
-            When set to `True` the method returns the HTTP request
-            parameters as a dict, default: False
-        get_raw_response: boolean, optional
-            Return raw data as obtained by JPL Horizons without parsing the
-            data into a table, default: False
         refplane : string
             Reference plane for all output quantities: ``'ecliptic'``
             (ecliptic and mean equinox of reference epoch), ``'earth'``
             (Earth mean equator and equinox of reference epoch), or
             ``'body'`` (body mean equator and node of date); default:
             ``'ecliptic'``
+        aberrations : string, optional
+            Aberrations to be accounted for: [``'geometric'``,
+            ``'astrometric'``, ``'apparent'``]. Default: ``'geometric'``
+        delta_T : boolean, optional
+            Triggers output of time-varying difference between TDB and UT
+            time-scales. Default: False
+        get_query_payload : boolean, optional
+            When set to `True` the method returns the HTTP request
+            parameters as a dict, default: False
+        get_raw_response: boolean, optional
+            Return raw data as obtained by JPL Horizons without parsing the
+            data into a table, default: False
 
 
         Returns
@@ -979,6 +990,9 @@ class HorizonsClass(BaseQuery):
             ('REF_SYSTEM', 'J2000'),
             ('TP_TYPE', 'ABSOLUTE'),
             ('LABELS', 'YES'),
+            ('VECT_CORR', {'geometric': '"NONE"', 'astrometric': '"LT"',
+                           'apparent': '"LT+S"'}[aberrations]),
+            ('VEC_DELTA_T', {True: 'YES', False: 'NO'}[delta_T]),
             ('OBJ_DATA', 'YES')]
         )
 

--- a/astroquery/jplhorizons/core.py
+++ b/astroquery/jplhorizons/core.py
@@ -146,6 +146,7 @@ class HorizonsClass(BaseQuery):
                           refsystem='J2000',
                           closest_apparition=False, no_fragments=False,
                           quantities=conf.eph_quantities,
+                          extra_precision=False,
                           get_query_payload=False,
                           get_raw_response=False, cache=True):
         """
@@ -434,13 +435,15 @@ class HorizonsClass(BaseQuery):
             selection; default: False. Do not use this option for
             non-cometary objects.
         quantities : integer or string, optional
-            single integer or comma-separated list in the form of a string
+            Single integer or comma-separated list in the form of a string
             corresponding to all the
             quantities to be queried from JPL Horizons using the coding
             according to the `JPL Horizons User Manual Definition of
             Observer Table Quantities
             <https://ssd.jpl.nasa.gov/?horizons_doc#table_quantities>`_;
             default: all quantities
+        extra_precision : boolean, optional
+            Enables extra precision in RA and DEC values; default: False
         get_query_payload : boolean, optional
             When set to `True` the method returns the HTTP request
             parameters as a dict, default: False
@@ -528,7 +531,8 @@ class HorizonsClass(BaseQuery):
             ('ANG_FORMAT', ('DEG')),
             ('APPARENT', ({False: 'AIRLESS',
                            True: 'REFRACTED'}[refraction])),
-            ('REF_SYSTEM', (refsystem))])
+            ('REF_SYSTEM', (refsystem)),
+            ('EXTRA_PREC', {True: 'YES', False: 'NO'}[extra_precision])])
 
         if isinstance(self.location, dict):
             if ('lon' not in self.location or 'lat' not in self.location or
@@ -763,8 +767,7 @@ class HorizonsClass(BaseQuery):
             ('REF_PLANE', {'ecliptic': 'ECLIPTIC', 'earth': 'FRAME',
                            'body': "'BODY EQUATOR'"}[refplane]),
             ('TP_TYPE', {'absolute': 'ABSOLUTE',
-                         'relative': 'RELATIVE'}[tp_type])]
-        )
+                         'relative': 'RELATIVE'}[tp_type])])
 
         # parse self.epochs
         if isinstance(self.epochs, (list, tuple, ndarray)):

--- a/astroquery/jplhorizons/tests/test_jplhorizons.py
+++ b/astroquery/jplhorizons/tests/test_jplhorizons.py
@@ -216,6 +216,8 @@ def test_vectors_query_payload():
         ('REF_SYSTEM', 'J2000'),
         ('TP_TYPE', 'ABSOLUTE'),
         ('LABELS', 'YES'),
+        ('VECT_CORR', '"NONE"'),
+        ('VEC_DELTA_T', 'NO'),
         ('OBJ_DATA', 'YES'),
         ('TLIST', '2451544.5')])
 

--- a/astroquery/jplhorizons/tests/test_jplhorizons.py
+++ b/astroquery/jplhorizons/tests/test_jplhorizons.py
@@ -177,7 +177,8 @@ def test_elements_vectors(patch_request):
             ('STOP_TIME', '"2080-02-01"'),
             ('STEP_SIZE', '"3h"'),
             ('AIRMASS', '1.2'),
-            ('SKIP_DAYLT', 'YES')])
+            ('SKIP_DAYLT', 'YES'),
+            ('EXTRA_PREC', 'NO')])
 
     def test_elements_query_payload():
         res = (jplhorizons.Horizons(id='Ceres', location='500@10',
@@ -197,6 +198,7 @@ def test_elements_vectors(patch_request):
             ('REF_SYSTEM', 'J2000'),
             ('REF_PLANE', 'ECLIPTIC'),
             ('TP_TYPE', 'ABSOLUTE'),
+            ('EXTRA_PREC', 'NO')
             ('TLIST', '2451544.5')])
 
 

--- a/astroquery/jplhorizons/tests/test_jplhorizons_remote.py
+++ b/astroquery/jplhorizons/tests/test_jplhorizons_remote.py
@@ -370,3 +370,11 @@ class TestHorizonsClass:
 
         vec = obj.vectors(delta_T=True)
         assert_quantity_allclose(vec['delta_T'][0], 69.184373)
+
+    def test_ephemerides_extraprecision(self):
+        obj = jplhorizons.Horizons(id='1', epochs=2458500, location='G37')
+
+        vec_simple = obj.ephemerides(extra_precision=False)
+        vec_highprec = obj.ephemerides(extra_precision=True)
+
+        assert (vec_simple['RA'][0]-vec_highprec['RA'][0]) > 1e-7

--- a/astroquery/jplhorizons/tests/test_jplhorizons_remote.py
+++ b/astroquery/jplhorizons/tests/test_jplhorizons_remote.py
@@ -1,7 +1,7 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 from __future__ import print_function
 
-from astropy.tests.helper import remote_data
+from astropy.tests.helper import remote_data, assert_quantity_allclose
 from numpy.ma import is_masked
 import numpy.testing as npt
 
@@ -348,3 +348,25 @@ class TestHorizonsClass:
         # skip data['a-mass'].filled(99) if 'a-mass' not returned
         eph = target.ephemerides(quantities='1')
         assert len(eph) == 1
+
+    def test_vectors_aberrations(self):
+        """Check functionality of `aberrations` options"""
+        obj = jplhorizons.Horizons(id='1', epochs=2458500, location='500@0')
+
+        vec = obj.vectors(aberrations='geometric')
+        assert_quantity_allclose(vec['x'][0], -2.08648627706842)
+
+        vec = obj.vectors(aberrations='astrometric')
+        assert_quantity_allclose(vec['x'][0], -2.086575559005298)
+
+        vec = obj.vectors(aberrations='apparent')
+        assert_quantity_allclose(vec['x'][0], -2.086575559005298)
+
+    def test_vectors_delta_T(self):
+        obj = Horizons(id='1', epochs=2458500, location='500@0')
+
+        vec = obj.vectors(delta_T=False)
+        assert 'delta_T' not in vec.columns
+
+        vec = obj.vectors(delta_T=True)
+        assert_quantity_allclose(vec['delta_T'][0], 69.184373)

--- a/docs/jplhorizons/jplhorizons.rst
+++ b/docs/jplhorizons/jplhorizons.rst
@@ -268,15 +268,19 @@ The following fields are queried:
    <TableColumns names=('targetname','datetime_jd','datetime_str','H','G','x','y','z','vx','vy','vz','lighttime','range','range_rate')>
 
 
-Similar to the other :class:`~astroquery.jplhorizons.HorizonsClass` functions,
-optional parameters of :meth:`~astroquery.jplhorizons.HorizonsClass.vectors` are
+Similar to the other :class:`~astroquery.jplhorizons.HorizonsClass`
+functions, optional parameters of
+:meth:`~astroquery.jplhorizons.HorizonsClass.vectors` are
 ``get_query_payload=True``, which skips the query and only returns the
 query payload, and ``get_raw_response=True``, which returns the raw
 query response instead of the astropy table. For comets, the options
-``closest_apparation`` and ``no_fragments`` are available, which select
-the closest apparition in time and reject fragments,
+``closest_apparation`` and ``no_fragments`` are available, which
+select the closest apparition in time and reject fragments,
 respectively. Note that these options should only be used for comets
-and will crash the query for other object types.
+and will crash the query for other object types. Options
+``aberrations`` and ``delta_T`` provide different choices for
+aberration corrections as well as a measure for time-varying
+differences between TDB and UT time-scales, respectively.
 
 
 How to Use the Query Tables

--- a/docs/jplhorizons/jplhorizons.rst
+++ b/docs/jplhorizons/jplhorizons.rst
@@ -166,9 +166,11 @@ default).. For comets, the options ``closest_apparation`` and
 ``no_fragments`` are available, which select the closest apparition in
 time and reject fragments, respectively. Note that these options
 should only be used for comets and will crash the query for other
-object types.  Furthermore, ``get_query_payload=True`` skips the query
-and only returns the query payload, whereas ``get_raw_response=True``
-the raw query response instead of the astropy table returns.
+object types. Extra precision in the queried properties can be
+requested using the ``extra_precision`` option. Furthermore,
+``get_query_payload=True`` skips the query and only returns the query
+payload, whereas ``get_raw_response=True`` the raw query response
+instead of the astropy table returns.
 
 :meth:`~astroquery.jplhorizons.HorizonsClass.ephemerides` queries by
 default all available quantities from the JPL Horizons servers. This


### PR DESCRIPTION
This PR provides minor updates to the `astroquery.jplhorizons` functionality:
* as requested in #1450, different aberrations can be chosen when vectors are queried
* as requested per email, extra precision can be chosen when ephemerides are queried

Tests and docs have been updated accordingly.