### PR TITLE
Minor fixes in conftest

### DIFF
--- a/astroquery/conftest.py
+++ b/astroquery/conftest.py
@@ -47,6 +47,7 @@ import astropy
 if int(astropy.__version__[0]) > 1:
     # The warnings_to_ignore_by_pyver parameter was added in astropy 2.0
     enable_deprecations_as_exceptions(modules_to_ignore_on_import=['requests'])
+    enable_deprecations_as_exceptions(modules_to_ignore_on_import=['regions'])
 
 # add '_testrun' to the version name so that the user-agent indicates that
 # it's being run in a test

--- a/astroquery/utils/tests/test_utils.py
+++ b/astroquery/utils/tests/test_utils.py
@@ -102,6 +102,7 @@ def test_send_request_post(monkeypatch):
     assert response.url == 'https://github.com/astropy/astroquery'
     assert response.data == dict(msg='ok')
     assert 'astroquery' in response.headers['User-Agent']
+    assert response.headers['User-Agent'].endswith("_testrun")
 
 
 def test_send_request_get(monkeypatch):


### PR DESCRIPTION
- regions needs to be excepted for deprecations as the latest release still uses `six` from astropy

- add test for User-Agent, as I run into trobles trying to move the definition around in the conftest file