### PR TITLE
Add missing column definition to jplhorizons.

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -105,6 +105,8 @@ jplhorizons
 - Vector queries provide different aberrations, ephemerides queries provide
   extra precision option. [#1478]
 
+- Fix crash when precision to the second on epoch is requested. [#1488]
+
 jplsbdb
 ^^^^^^^
 

--- a/astroquery/jplhorizons/__init__.py
+++ b/astroquery/jplhorizons/__init__.py
@@ -39,6 +39,7 @@ class Conf(_config.ConfigNamespace):
     # query modes
     eph_columns = {'targetname': ('targetname', '---'),
                    'Date__(UT)__HR:MN': ('datetime_str', '---'),
+                   'Date__(UT)__HR:MN:SS': ('datetime_str', '---'),
                    'Date__(UT)__HR:MN:SC.fff': ('datetime_str', '---'),
                    'Date_________JDUT': ('datetime_jd', 'd'),
                    'H': ('H', 'mag'),


### PR DESCRIPTION
Two ephemeris requests, the one with seconds in the epochs definition crashes with `KeyError`:

First, the successful one:
```
In [9]: q = Horizons('65803', epochs={'start': '2001-11-26 02:18', 'stop': '2002-02-03 13:45', 'step': '1d'}, location='I41')

In [10]: q.ephemerides()
Out[10]: 
<Table masked=True length=70>
       targetname          datetime_str      datetime_jd       H       G    solar_presence flags ... DoppDelay_3sigma true_anom   hour_angle  alpha_true  PABLon   PABLat
          ---                  ---                d           mag     ---        ---        ---  ...        s            deg         ---         deg       deg      deg  
         str23                str17            float64      float64 float64      str1       str1 ...     float64       float64     float64     float64   float64  float64
----------------------- ----------------- ----------------- ------- ------- -------------- ----- ... ---------------- --------- ------------- ---------- -------- -------
65803 Didymos (1996 GT) 2001-Nov-26 02:18 2452239.595833333    18.0    0.15                    m ...         0.000234    66.228 -11.543299093    54.3917 125.7517  2.2342
65803 Didymos (1996 GT) 2001-Nov-27 02:18 2452240.595833333    18.0    0.15                    m ...         0.000233   67.0166 -11.506709225    54.0262 126.3565  2.3038
65803 Didymos (1996 GT) 2001-Nov-28 02:18 2452241.595833333    18.0    0.15                    m ...         0.000232   67.7986 -11.469428451    53.6566 126.9527  2.3728
65803 Didymos (1996 GT) 2001-Nov-29 02:18 2452242.595833333    18.0    0.15                    m ...         0.000232    68.574 -11.431451434    53.2829 127.5403  2.4412
65803 Didymos (1996 GT) 2001-Nov-30 02:18 2452243.595833333    18.0    0.15                    m ...         0.000231    69.343 -11.392772324    52.9048 128.1191  2.5091
65803 Didymos (1996 GT) 2001-Dec-01 02:18 2452244.595833333    18.0    0.15                    m ...         0.000231   70.1055 -11.353384656    52.5221 128.6892  2.5765
65803 Didymos (1996 GT) 2001-Dec-02 02:18 2452245.595833333    18.0    0.15                    m ...          0.00023   70.8615 -11.313281267    52.1348 129.2505  2.6434
...
```

This one crashes:
```
In [11]: q = Horizons('65803', epochs={'start': '2001-11-26 02:18:09', 'stop': '2002-02-03 13:45:13', 'step': '1d'}, location='I41')

In [12]: q.ephemerides()
---------------------------------------------------------------------------
KeyError                                  Traceback (most recent call last)
<ipython-input-12-92699ddb43ac> in <module>()
----> 1 q.ephemerides()

/home/msk/local/lib/python3.6/site-packages/astroquery-0.3.10.dev5266-py3.6.egg/astroquery/utils/class_or_instance.py in f(*args, **kwds)
     23         def f(*args, **kwds):
     24             if obj is not None:
---> 25                 return self.fn(obj, *args, **kwds)
     26             else:
     27                 return self.fn(cls, *args, **kwds)

/home/msk/local/lib/python3.6/site-packages/astroquery-0.3.10.dev5266-py3.6.egg/astroquery/utils/process_asyncs.py in newmethod(self, *args, **kwargs)
     27             if kwargs.get('get_query_payload') or kwargs.get('field_help'):
     28                 return response
---> 29             result = self._parse_result(response, verbose=verbose)
     30             self.table = result
     31             return result

/home/msk/local/lib/python3.6/site-packages/astroquery-0.3.10.dev5266-py3.6.egg/astroquery/jplhorizons/core.py in _parse_result(self, response, verbose)
   1249             return None
   1250         else:
-> 1251             data = self._parse_horizons(response.text)
   1252 
   1253         return data

/home/msk/local/lib/python3.6/site-packages/astroquery-0.3.10.dev5266-py3.6.egg/astroquery/jplhorizons/core.py in _parse_horizons(self, src)
   1212         rename = []
   1213         for col in data.columns:
-> 1214             data[col].unit = column_defs[col][1]
   1215             if data[col].name != column_defs[col][0]:
   1216                 rename.append(data[col].name)

KeyError: 'Date__(UT)__HR:MN:SS'
```

'Date__(UT)__HR:MN' and 'Date__(UT)__HR:MN:SC.fff' were present, but
'Date__(UT)__HR:MN:SS' also needed.  Adding a column definition for this key addresses the issue.
