### PR TITLE
MAST: Tesscut query by objectname

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -132,6 +132,8 @@ mast
 
 - TIC catalog search update. [#1483]
 
+- Add search by object name to Tesscut, make resolver_object public, minor bugfixes. [#1499]
+
 mpc
 ^^^
 

--- a/astroquery/mast/core.py
+++ b/astroquery/mast/core.py
@@ -480,7 +480,7 @@ class MastClass(QueryWithLogin):
         total_pages = 1
         cur_page = 0
 
-        while cur_page < total_pages:
+        while cur_page < total_pages: 
             status = "EXECUTING"
 
             while status == "EXECUTING":
@@ -831,14 +831,24 @@ class MastClass(QueryWithLogin):
 
         return criteria_check
 
+    @deprecated(since="v0.3.10", alternative="resolve_object")
     def _resolve_object(self, objectname):
+        return self.resolve_object(objectname)
+
+    def resolve_object(self, objectname):
         """
+        
         Resolves an object name to a position on the sky.
 
         Parameters
         ----------
         objectname : str
             Name of astronomical object to resolve.
+
+        Returns
+        -------
+        response : `~astropy.coordinates.SkyCoord`
+            The sky position of the given object.
         """
 
         service = 'Mast.Name.Lookup'
@@ -1166,7 +1176,7 @@ class ObservationsClass(MastClass):
         response : list of `~requests.Response`
         """
 
-        coordinates = self._resolve_object(objectname)
+        coordinates = self.resolve_object(objectname)
 
         return self.query_region_async(coordinates, radius, pagesize, page)
 
@@ -1243,7 +1253,7 @@ class ObservationsClass(MastClass):
             raise InvalidQueryError("Only one of objectname and coordinates may be specified.")
 
         if objectname:
-            coordinates = self._resolve_object(objectname)
+            coordinates = self.resolve_object(objectname)
 
         if coordinates:
             # Put coordinates and radius into consitant format
@@ -1337,7 +1347,7 @@ class ObservationsClass(MastClass):
         response : int
         """
 
-        coordinates = self._resolve_object(objectname)
+        coordinates = self.resolve_object(objectname)
 
         return self.query_region_count(coordinates, radius, pagesize, page)
 
@@ -1391,7 +1401,7 @@ class ObservationsClass(MastClass):
             raise InvalidQueryError("Only one of objectname and coordinates may be specified.")
 
         if objectname:
-            coordinates = self._resolve_object(objectname)
+            coordinates = self.resolve_object(objectname)
 
         if coordinates:
             # Put coordinates and radius into consitant format
@@ -2015,7 +2025,7 @@ class CatalogsClass(MastClass):
         response : list of `~requests.Response`
         """
 
-        coordinates = self._resolve_object(objectname)
+        coordinates = self.resolve_object(objectname)
 
         return self.query_region_async(coordinates, radius, catalog, pagesize, page, **kwargs)
 
@@ -2092,7 +2102,7 @@ class CatalogsClass(MastClass):
             raise InvalidQueryError("Only one of objectname and coordinates may be specified.")
 
         if objectname:
-            coordinates = self._resolve_object(objectname)
+            coordinates = self.resolve_object(objectname)
 
         if coordinates:
             # Put coordinates and radius into consitant format
@@ -2106,8 +2116,8 @@ class CatalogsClass(MastClass):
         # build query
         params = {}
         if coordinates:
-            params["ra"] = coordinates.ra.deg,
-            params["dec"] = coordinates.dec.deg,
+            params["ra"] = coordinates.ra.deg
+            params["dec"] = coordinates.dec.deg
             params["radius"] = radius.deg
 
         if not catalogs_service:
@@ -2121,7 +2131,7 @@ class CatalogsClass(MastClass):
             # For catalogs service append criteria to main parameters
             for prop, value in criteria.items():
                 params[prop] = value
-
+        
         if catalogs_service:
             return self.catalogs_service_request_async(service, params, page_size=pagesize, page=page)
         return self.service_request_async(service, params, pagesize=pagesize, page=page)

--- a/astroquery/mast/core.py
+++ b/astroquery/mast/core.py
@@ -831,10 +831,6 @@ class MastClass(QueryWithLogin):
 
         return criteria_check
 
-    @deprecated(since="v0.3.10", alternative="resolve_object")
-    def _resolve_object(self, objectname):
-        return self.resolve_object(objectname)
-
     def resolve_object(self, objectname):
         """
         Resolves an object name to a position on the sky.

--- a/astroquery/mast/core.py
+++ b/astroquery/mast/core.py
@@ -480,7 +480,7 @@ class MastClass(QueryWithLogin):
         total_pages = 1
         cur_page = 0
 
-        while cur_page < total_pages: 
+        while cur_page < total_pages:
             status = "EXECUTING"
 
             while status == "EXECUTING":
@@ -837,7 +837,6 @@ class MastClass(QueryWithLogin):
 
     def resolve_object(self, objectname):
         """
-        
         Resolves an object name to a position on the sky.
 
         Parameters
@@ -1495,7 +1494,7 @@ class ObservationsClass(MastClass):
         if extension:
             if type(extension) == str:
                 extension = [extension]
-                
+
             mask = np.full(len(products), False, dtype=bool)
             for elt in extension:
                 mask |= [False if isinstance(x, np.ma.core.MaskedConstant) else x.endswith(elt)
@@ -2131,7 +2130,7 @@ class CatalogsClass(MastClass):
             # For catalogs service append criteria to main parameters
             for prop, value in criteria.items():
                 params[prop] = value
-        
+
         if catalogs_service:
             return self.catalogs_service_request_async(service, params, page_size=pagesize, page=page)
         return self.service_request_async(service, params, pagesize=pagesize, page=page)

--- a/astroquery/mast/core.py
+++ b/astroquery/mast/core.py
@@ -1461,7 +1461,7 @@ class ObservationsClass(MastClass):
             Table containing data products to be filtered.
         mrp_only : bool, optional
             Default False. When set to true only "Minimum Recommended Products" will be returned.
-        extension : string, optional
+        extension : string or array, optional
             Default None. Option to filter by file extension.
         **filters :
             Filters to be applied.  Valid filters are all products fields listed
@@ -1483,6 +1483,9 @@ class ObservationsClass(MastClass):
             filter_mask &= (products['productGroupDescription'] == "Minimum Recommended Products")
 
         if extension:
+            if type(extension) == str:
+                extension = [extension]
+                
             mask = np.full(len(products), False, dtype=bool)
             for elt in extension:
                 mask |= [False if isinstance(x, np.ma.core.MaskedConstant) else x.endswith(elt)

--- a/astroquery/mast/tesscut.py
+++ b/astroquery/mast/tesscut.py
@@ -97,16 +97,16 @@ class TesscutClass(BaseQuery):
             The target around which to search. It may be specified as a
             string or as the appropriate `astropy.coordinates` object.
             One and only one of coordinates and objectname must be supplied.
-        objectname : str, optional
-            The target around which to search, by name (objectname="M104")
-            or TIC ID (objectname="TIC 141914082").
-            One and only one of coordinates and objectname must be supplied.
         radius : str, float, or `~astropy.units.Quantity` object, optional
             Default 0.2 degrees.
             If supplied as a float degrees is the assumed unit.
             The string must be parsable by `~astropy.coordinates.Angle`. The
             appropriate `~astropy.units.Quantity` object from
             `astropy.units` may also be used.
+        objectname : str, optional
+            The target around which to search, by name (objectname="M104")
+            or TIC ID (objectname="TIC 141914082").
+            One and only one of coordinates and objectname must be supplied.
 
         Returns
         -------
@@ -156,10 +156,6 @@ class TesscutClass(BaseQuery):
             The target around which to search. It may be specified as a
             string or as the appropriate `astropy.coordinates` object.
             One and only one of coordinates and objectname must be supplied.
-        objectname : str, optional
-            The target around which to search, by name (objectname="M104")
-            or TIC ID (objectname="TIC 141914082").
-            One and only one of coordinates and objectname must be supplied.
         size : int, array-like, `~astropy.units.Quantity`
             Optional, default 5 pixels.
             The size of the cutout array. If ``size`` is a scalar number or
@@ -181,7 +177,10 @@ class TesscutClass(BaseQuery):
             Cutout target pixel files are returned from the server in a zip file,
             by default they will be inflated and the zip will be removed.
             Set inflate to false to stop before the inflate step.
-
+        objectname : str, optional
+            The target around which to search, by name (objectname="M104")
+            or TIC ID (objectname="TIC 141914082").
+            One and only one of coordinates and objectname must be supplied.
 
         Returns
         -------
@@ -267,10 +266,6 @@ class TesscutClass(BaseQuery):
             The target around which to search. It may be specified as a
             string or as the appropriate `astropy.coordinates` object.
             One and only one of coordinates and objectname must be supplied.
-        objectname : str, optional
-            The target around which to search, by name (objectname="M104")
-            or TIC ID (objectname="TIC 141914082").
-            One and only one of coordinates and objectname must be supplied.
         size : int, array-like, `~astropy.units.Quantity`
             Optional, default 5 pixels.
             The size of the cutout array. If ``size`` is a scalar number or
@@ -283,6 +278,10 @@ class TesscutClass(BaseQuery):
             Optional.
             The TESS sector to return the cutout from.  If not supplied, cutouts
             from all available sectors on which the coordinate appears will be returned.
+        objectname : str, optional
+            The target around which to search, by name (objectname="M104")
+            or TIC ID (objectname="TIC 141914082").
+            One and only one of coordinates and objectname must be supplied.
 
         Returns
         -------

--- a/astroquery/mast/tesscut.py
+++ b/astroquery/mast/tesscut.py
@@ -35,6 +35,7 @@ from .core import Mast
 
 __all__ = ["TesscutClass", "Tesscut"]
 
+
 def _parse_input_location(coordinates=None, objectname=None):
     """
     Convenience function to parse user input of coordinates and objectname.
@@ -46,7 +47,7 @@ def _parse_input_location(coordinates=None, objectname=None):
         string or as the appropriate `astropy.coordinates` object.
         One and only one of coordinates and objectname must be supplied.
     objectname : str, optional
-        The target around which to search, by name (objectname="M104") 
+        The target around which to search, by name (objectname="M104")
         or TIC ID (objectname="TIC 141914082").
         One and only one of coordinates and objectname must be supplied.
 
@@ -70,7 +71,7 @@ def _parse_input_location(coordinates=None, objectname=None):
         obj_coord = commons.parse_coordinates(coordinates)
 
     return obj_coord
-    
+
 class TesscutClass(BaseQuery):
     """
     MAST TESS FFI cutout query class.
@@ -96,7 +97,7 @@ class TesscutClass(BaseQuery):
             string or as the appropriate `astropy.coordinates` object.
             One and only one of coordinates and objectname must be supplied.
         objectname : str, optional
-            The target around which to search, by name (objectname="M104") 
+            The target around which to search, by name (objectname="M104")
             or TIC ID (objectname="TIC 141914082").
             One and only one of coordinates and objectname must be supplied.
         radius : str, float, or `~astropy.units.Quantity` object, optional
@@ -155,7 +156,7 @@ class TesscutClass(BaseQuery):
             string or as the appropriate `astropy.coordinates` object.
             One and only one of coordinates and objectname must be supplied.
         objectname : str, optional
-            The target around which to search, by name (objectname="M104") 
+            The target around which to search, by name (objectname="M104")
             or TIC ID (objectname="TIC 141914082").
             One and only one of coordinates and objectname must be supplied.
         size : int, array-like, `~astropy.units.Quantity`
@@ -266,7 +267,7 @@ class TesscutClass(BaseQuery):
             string or as the appropriate `astropy.coordinates` object.
             One and only one of coordinates and objectname must be supplied.
         objectname : str, optional
-            The target around which to search, by name (objectname="M104") 
+            The target around which to search, by name (objectname="M104")
             or TIC ID (objectname="TIC 141914082").
             One and only one of coordinates and objectname must be supplied.
         size : int, array-like, `~astropy.units.Quantity`

--- a/astroquery/mast/tesscut.py
+++ b/astroquery/mast/tesscut.py
@@ -72,6 +72,7 @@ def _parse_input_location(coordinates=None, objectname=None):
 
     return obj_coord
 
+
 class TesscutClass(BaseQuery):
     """
     MAST TESS FFI cutout query class.

--- a/astroquery/mast/tesscut.py
+++ b/astroquery/mast/tesscut.py
@@ -31,10 +31,46 @@ from ..utils import commons
 from ..exceptions import NoResultsWarning, InvalidQueryError, RemoteServiceError
 
 from . import conf
+from .core import Mast
 
 __all__ = ["TesscutClass", "Tesscut"]
 
+def _parse_input_location(coordinates=None, objectname=None):
+    """
+    Convenience function to parse user input of coordinates and objectname.
 
+    Parameters
+    ----------
+    coordinates : str or `astropy.coordinates` object, optional
+        The target around which to search. It may be specified as a
+        string or as the appropriate `astropy.coordinates` object.
+        One and only one of coordinates and objectname must be supplied.
+    objectname : str, optional
+        The target around which to search, by name (objectname="M104") 
+        or TIC ID (objectname="TIC 141914082").
+        One and only one of coordinates and objectname must be supplied.
+
+    Returns
+    -------
+    response : `~astropy.coordinates.SkyCoord`
+        The given coordinates, or object's location as an `~astropy.coordinates.SkyCoord` object.
+    """
+
+    # Checking for valid input
+    if objectname and coordinates:
+        raise InvalidQueryError("Only one of objectname and coordinates may be specified.")
+
+    if not (objectname or coordinates):
+        raise InvalidQueryError("One of objectname and coordinates must be specified.")
+
+    if objectname:
+        obj_coord = Mast.resolve_object(objectname)
+
+    if coordinates:
+        obj_coord = commons.parse_coordinates(coordinates)
+
+    return obj_coord
+    
 class TesscutClass(BaseQuery):
     """
     MAST TESS FFI cutout query class.
@@ -48,16 +84,21 @@ class TesscutClass(BaseQuery):
 
         self._TESSCUT_URL = conf.server + "/tesscut/api/v0.1/"
 
-    def get_sectors(self, coordinates, radius=0.2*u.deg):  # pragma: no cover
+    def get_sectors(self, coordinates=None, radius=0.2*u.deg, objectname=None):
         """
         Get a list of the TESS data sectors whose footprints intersect
         with the given search area.
 
         Parameters
         ----------
-        coordinates : str or `astropy.coordinates` object
+        coordinates : str or `astropy.coordinates` object, optional
             The target around which to search. It may be specified as a
             string or as the appropriate `astropy.coordinates` object.
+            One and only one of coordinates and objectname must be supplied.
+        objectname : str, optional
+            The target around which to search, by name (objectname="M104") 
+            or TIC ID (objectname="TIC 141914082").
+            One and only one of coordinates and objectname must be supplied.
         radius : str, float, or `~astropy.units.Quantity` object, optional
             Default 0.2 degrees.
             If supplied as a float degrees is the assumed unit.
@@ -71,10 +112,10 @@ class TesscutClass(BaseQuery):
             Sector/camera/chip information for given coordinates/raduis.
         """
 
-        # Put coordinates and radius into consistant format
-        coordinates = commons.parse_coordinates(coordinates)
+        # Get Skycoord object for coordinates/object
+        coordinates = _parse_input_location(coordinates, objectname)
 
-        # if radius is just a number we assume degrees
+        # If radius is just a number we assume degrees
         if isinstance(radius, (int, float)):
             radius = radius * u.deg
         radius = Angle(radius)
@@ -103,15 +144,20 @@ class TesscutClass(BaseQuery):
             warnings.warn("Coordinates are not in any TESS sector.", NoResultsWarning)
         return Table(sector_dict)
 
-    def download_cutouts(self, coordinates, size=5, sector=None, path=".", inflate=True):  # pragma: no cover
+    def download_cutouts(self, coordinates=None, size=5, sector=None, path=".", inflate=True, objectname=None):
         """
         Download cutout target pixel file(s) around the given coordinates with indicated size.
 
         Parameters
         ----------
-        coordinates : str or `astropy.coordinates` object
+        coordinates : str or `astropy.coordinates` object, optional
             The target around which to search. It may be specified as a
             string or as the appropriate `astropy.coordinates` object.
+            One and only one of coordinates and objectname must be supplied.
+        objectname : str, optional
+            The target around which to search, by name (objectname="M104") 
+            or TIC ID (objectname="TIC 141914082").
+            One and only one of coordinates and objectname must be supplied.
         size : int, array-like, `~astropy.units.Quantity`
             Optional, default 5 pixels.
             The size of the cutout array. If ``size`` is a scalar number or
@@ -140,8 +186,8 @@ class TesscutClass(BaseQuery):
         response : `~astropy.table.Table`
         """
 
-        # Put coordinates and radius into consistant format
-        coordinates = commons.parse_coordinates(coordinates)
+        # Get Skycoord object for coordinates/object
+        coordinates = _parse_input_location(coordinates, objectname)
 
         # Making size into an array [ny, nx]
         if np.isscalar(size):
@@ -208,16 +254,21 @@ class TesscutClass(BaseQuery):
         localpath_table['Local Path'] = [path+x for x in cutout_files]
         return localpath_table
 
-    def get_cutouts(self, coordinates, size=5, sector=None):  # pragma: no cover
+    def get_cutouts(self, coordinates=None, size=5, sector=None, objectname=None):
         """
         Get cutout target pixel file(s) around the given coordinates with indicated size,
         and return them as a list of  `~astropy.io.fits.HDUList` objects.
 
         Parameters
         ----------
-        coordinates : str or `astropy.coordinates` object
+        coordinates : str or `astropy.coordinates` object, optional
             The target around which to search. It may be specified as a
             string or as the appropriate `astropy.coordinates` object.
+            One and only one of coordinates and objectname must be supplied.
+        objectname : str, optional
+            The target around which to search, by name (objectname="M104") 
+            or TIC ID (objectname="TIC 141914082").
+            One and only one of coordinates and objectname must be supplied.
         size : int, array-like, `~astropy.units.Quantity`
             Optional, default 5 pixels.
             The size of the cutout array. If ``size`` is a scalar number or
@@ -236,8 +287,8 @@ class TesscutClass(BaseQuery):
         response : A list of `~astropy.io.fits.HDUList` objects.
         """
 
-        # Put coordinates and radius into consistant format
-        coordinates = commons.parse_coordinates(coordinates)
+        # Get Skycoord object for coordinates/object
+        coordinates = _parse_input_location(coordinates, objectname)
 
         # Making size into an array [ny, nx]
         if np.isscalar(size):

--- a/astroquery/mast/tests/test_mast.py
+++ b/astroquery/mast/tests/test_mast.py
@@ -168,7 +168,14 @@ def test_mast_service_request(patch_post):
 
     assert isinstance(result, Table)
 
+def test_resolve_object(patch_post):
 
+    m103_loc = mast.Mast.resolve_object("M103")
+    assert m103_loc.separation(SkyCoord("23.34086 60.658", unit='deg')).value == 0
+
+
+
+    
 ###########################
 # ObservationsClass tests #
 ###########################
@@ -493,7 +500,7 @@ def test_catalogs_download_hsc_spectra(patch_post, tmpdir):
 
 def test_tesscut_get_sector(patch_post):
     coord = SkyCoord(324.24368, -27.01029, unit="deg")
-    sector_table = mast.Tesscut.get_sectors(coord)
+    sector_table = mast.Tesscut.get_sectors(coordinates=coord)
     assert isinstance(sector_table, Table)
     assert len(sector_table) == 1
     assert sector_table['sectorName'][0] == "tess-s0001-1-3"
@@ -501,7 +508,16 @@ def test_tesscut_get_sector(patch_post):
     assert sector_table['camera'][0] == 1
     assert sector_table['ccd'][0] == 3
 
-    sector_table = mast.Tesscut.get_sectors(coord, radius=0.2)
+    sector_table = mast.Tesscut.get_sectors(coordinates=coord, radius=0.2)
+    assert isinstance(sector_table, Table)
+    assert len(sector_table) == 1
+    assert sector_table['sectorName'][0] == "tess-s0001-1-3"
+    assert sector_table['sector'][0] == 1
+    assert sector_table['camera'][0] == 1
+    assert sector_table['ccd'][0] == 3
+
+    # Exercising the search by object name
+    sector_table = mast.Tesscut.get_sectors(objectname="M103")
     assert isinstance(sector_table, Table)
     assert len(sector_table) == 1
     assert sector_table['sectorName'][0] == "tess-s0001-1-3"
@@ -515,24 +531,38 @@ def test_tesscut_download_cutouts(patch_post, tmpdir):
     coord = SkyCoord(107.27, -70.0, unit="deg")
 
     # Testing with inflate
-    manifest = mast.Tesscut.download_cutouts(coord, 5, path=str(tmpdir))
+    manifest = mast.Tesscut.download_cutouts(coordinates=coord, size=5, path=str(tmpdir))
     assert isinstance(manifest, Table)
     assert len(manifest) == 1
     assert manifest["Local Path"][0][-4:] == "fits"
     assert os.path.isfile(manifest[0]['Local Path'])
 
     # Testing without inflate
-    manifest = mast.Tesscut.download_cutouts(coord, 5, path=str(tmpdir), inflate=False)
+    manifest = mast.Tesscut.download_cutouts(coordinates=coord, size=5,
+                                             path=str(tmpdir), inflate=False)
     assert isinstance(manifest, Table)
     assert len(manifest) == 1
     assert manifest["Local Path"][0][-3:] == "zip"
+    assert os.path.isfile(manifest[0]['Local Path'])
+
+    # Exercising the search by object name
+    manifest = mast.Tesscut.download_cutouts(objectname="M103", size=5, path=str(tmpdir))
+    assert isinstance(manifest, Table)
+    assert len(manifest) == 1
+    assert manifest["Local Path"][0][-4:] == "fits"
     assert os.path.isfile(manifest[0]['Local Path'])
 
 
 def test_tesscut_get_cutouts(patch_post, tmpdir):
 
     coord = SkyCoord(107.27, -70.0, unit="deg")
-    cutout_hdus_list = mast.Tesscut.get_cutouts(coord, 5)
+    cutout_hdus_list = mast.Tesscut.get_cutouts(coordinates=coord, size=5)
+    assert isinstance(cutout_hdus_list, list)
+    assert len(cutout_hdus_list) == 1
+    assert isinstance(cutout_hdus_list[0], fits.HDUList)
+
+    # Exercising the search by object name
+    cutout_hdus_list = mast.Tesscut.get_cutouts(objectname="M103", size=5)
     assert isinstance(cutout_hdus_list, list)
     assert len(cutout_hdus_list) == 1
     assert isinstance(cutout_hdus_list[0], fits.HDUList)

--- a/astroquery/mast/tests/test_mast.py
+++ b/astroquery/mast/tests/test_mast.py
@@ -168,14 +168,13 @@ def test_mast_service_request(patch_post):
 
     assert isinstance(result, Table)
 
-def test_resolve_object(patch_post):
 
+def test_resolve_object(patch_post):
     m103_loc = mast.Mast.resolve_object("M103")
     assert m103_loc.separation(SkyCoord("23.34086 60.658", unit='deg')).value == 0
 
 
 
-    
 ###########################
 # ObservationsClass tests #
 ###########################

--- a/astroquery/mast/tests/test_mast.py
+++ b/astroquery/mast/tests/test_mast.py
@@ -174,7 +174,6 @@ def test_resolve_object(patch_post):
     assert m103_loc.separation(SkyCoord("23.34086 60.658", unit='deg')).value == 0
 
 
-
 ###########################
 # ObservationsClass tests #
 ###########################

--- a/astroquery/mast/tests/test_mast_remote.py
+++ b/astroquery/mast/tests/test_mast_remote.py
@@ -68,10 +68,10 @@ class TestMast(object):
         ticobj_loc = mast.Mast.resolve_object("TIC 141914082")
         assert round(ticobj_loc.separation(SkyCoord("94.6175354 -72.04484622", unit='deg')).value, 4) == 0
 
-
     ###########################
     # ObservationsClass tests #
     ###########################
+
 
     def test_observations_list_missions(self):
         missions = mast.Observations.list_missions()

--- a/astroquery/mast/tests/test_mast_remote.py
+++ b/astroquery/mast/tests/test_mast_remote.py
@@ -68,7 +68,7 @@ class TestMast(object):
         ticobj_loc = mast.Mast.resolve_object("TIC 141914082")
         assert round(ticobj_loc.separation(SkyCoord("94.6175354 -72.04484622", unit='deg')).value, 4) == 0
 
-        
+
     ###########################
     # ObservationsClass tests #
     ###########################
@@ -498,7 +498,7 @@ class TestMast(object):
 
         sector_table = mast.Tesscut.get_sectors(objectname="M104")
         assert isinstance(sector_table, Table)
-        assert len(sector_table) >=1
+        assert len(sector_table) >= 1
         assert sector_table['sectorName'][0] == "tess-s0010-1-4"
         assert sector_table['sector'][0] == 10
         assert sector_table['camera'][0] == 1

--- a/astroquery/mast/tests/test_mast_remote.py
+++ b/astroquery/mast/tests/test_mast_remote.py
@@ -72,7 +72,6 @@ class TestMast(object):
     # ObservationsClass tests #
     ###########################
 
-
     def test_observations_list_missions(self):
         missions = mast.Observations.list_missions()
         assert isinstance(missions, list)

--- a/astroquery/mast/tests/test_mast_remote.py
+++ b/astroquery/mast/tests/test_mast_remote.py
@@ -61,6 +61,14 @@ class TestMast(object):
         assert sessionInfo['ezid'] == 'anonymous'
         assert sessionInfo['token'] is None
 
+    def test_resolve_object(self):
+        m101_loc = mast.Mast.resolve_object("M101")
+        assert round(m101_loc.separation(SkyCoord("210.80227 54.34895", unit='deg')).value, 4) == 0
+
+        ticobj_loc = mast.Mast.resolve_object("TIC 141914082")
+        assert round(ticobj_loc.separation(SkyCoord("94.6175354 -72.04484622", unit='deg')).value, 4) == 0
+
+        
     ###########################
     # ObservationsClass tests #
     ###########################
@@ -321,7 +329,7 @@ class TestMast(object):
         result = mast.Catalogs.query_region("322.49324 12.16683", radius=0.01,
                                             catalog="panstarrs", table="mean", pagesize=3)
         assert isinstance(result, Table)
-        assert len(result) > 800
+        assert len(result) == 3
 
     def test_catalogs_query_object_async(self):
         responses = mast.Catalogs.query_object_async("M10", radius=.02, catalog="TIC")
@@ -343,7 +351,7 @@ class TestMast(object):
 
         result = mast.Catalogs.query_object("M10", radius=.001, catalog="panstarrs", table="mean")
         assert isinstance(result, Table)
-        assert len(result) >= 500
+        assert len(result) >= 5
 
     def test_catalogs_query_criteria_async(self):
         # without position
@@ -372,7 +380,7 @@ class TestMast(object):
 
         responses = mast.Catalogs.query_criteria_async(catalog="panstarrs", table="mean",
                                                        objectname="M10",
-                                                       radius=2,
+                                                       radius=.02,
                                                        qualityFlag=48)
         assert isinstance(responses, list)
 
@@ -407,9 +415,9 @@ class TestMast(object):
         assert result[np.where(result['designation'] == 'J165628.40-054630.8')]
 
         result = mast.Catalogs.query_criteria(catalog="panstarrs", objectname="M10", radius=.01,
-                                              qualityFlag=48, zoneID=17320)
+                                              qualityFlag=32, zoneID=10306)
         assert isinstance(result, Table)
-        assert len(result) >= 10
+        assert len(result) >= 5
 
     def test_catalogs_query_hsc_matchid_async(self):
         catalogData = mast.Catalogs.query_object("M10", radius=.001, catalog="HSC", magtype=1)
@@ -473,9 +481,8 @@ class TestMast(object):
     ######################
     def test_tesscut_get_sectors(self):
 
-        # Note: try except will be removed when the service goes live
         coord = SkyCoord(324.24368, -27.01029, unit="deg")
-        sector_table = mast.Tesscut.get_sectors(coord)
+        sector_table = mast.Tesscut.get_sectors(coordinates=coord)
         assert isinstance(sector_table, Table)
         assert len(sector_table) >= 1
         assert sector_table['sectorName'][0] == "tess-s0001-1-3"
@@ -485,56 +492,75 @@ class TestMast(object):
 
         # This should always return no results
         coord = SkyCoord(0, 90, unit="deg")
-        sector_table = mast.Tesscut.get_sectors(coord)
+        sector_table = mast.Tesscut.get_sectors(coordinates=coord)
         assert isinstance(sector_table, Table)
         assert len(sector_table) == 0
+
+        sector_table = mast.Tesscut.get_sectors(objectname="M104")
+        assert isinstance(sector_table, Table)
+        assert len(sector_table) >=1
+        assert sector_table['sectorName'][0] == "tess-s0010-1-4"
+        assert sector_table['sector'][0] == 10
+        assert sector_table['camera'][0] == 1
+        assert sector_table['ccd'][0] == 4
 
     def test_tesscut_download_cutouts(self, tmpdir):
 
         coord = SkyCoord(107.18696, -70.50919, unit="deg")
 
-        manifest = mast.Tesscut.download_cutouts(coord, 5, path=str(tmpdir))
+        manifest = mast.Tesscut.download_cutouts(coordinates=coord, size=5, path=str(tmpdir))
         assert isinstance(manifest, Table)
         assert len(manifest) >= 1
         assert manifest["Local Path"][0][-4:] == "fits"
         for row in manifest:
             assert os.path.isfile(row['Local Path'])
 
-        manifest = mast.Tesscut.download_cutouts(coord, 5, sector=1, path=str(tmpdir))
+        manifest = mast.Tesscut.download_cutouts(coordinates=coord, size=5, sector=1, path=str(tmpdir))
         assert isinstance(manifest, Table)
         assert len(manifest) == 1
         assert manifest["Local Path"][0][-4:] == "fits"
-        for row in manifest:
-            assert os.path.isfile(row['Local Path'])
+        assert os.path.isfile(manifest[0]['Local Path'])
 
-        manifest = mast.Tesscut.download_cutouts(coord, [5, 7]*u.pix, path=str(tmpdir))
+        manifest = mast.Tesscut.download_cutouts(coordinates=coord, size=[5, 7]*u.pix, path=str(tmpdir))
         assert isinstance(manifest, Table)
         assert len(manifest) >= 1
         assert manifest["Local Path"][0][-4:] == "fits"
         for row in manifest:
             assert os.path.isfile(row['Local Path'])
 
-        manifest = mast.Tesscut.download_cutouts(coord, 5, path=str(tmpdir), inflate=False)
+        manifest = mast.Tesscut.download_cutouts(coordinates=coord, size=5, path=str(tmpdir), inflate=False)
         assert isinstance(manifest, Table)
         assert len(manifest) == 1
         assert manifest["Local Path"][0][-3:] == "zip"
         assert os.path.isfile(manifest[0]['Local Path'])
 
+        manifest = mast.Tesscut.download_cutouts(objectname="TIC 32449963", size=5, path=str(tmpdir))
+        assert isinstance(manifest, Table)
+        assert len(manifest) >= 1
+        assert manifest["Local Path"][0][-4:] == "fits"
+        for row in manifest:
+            assert os.path.isfile(row['Local Path'])
+
     def test_tesscut_get_cutouts(self, tmpdir):
 
         coord = SkyCoord(107.18696, -70.50919, unit="deg")
 
-        cutout_hdus_list = mast.Tesscut.get_cutouts(coord, 5)
+        cutout_hdus_list = mast.Tesscut.get_cutouts(coordinates=coord, size=5)
         assert isinstance(cutout_hdus_list, list)
         assert len(cutout_hdus_list) >= 1
         assert isinstance(cutout_hdus_list[0], fits.HDUList)
 
-        cutout_hdus_list = mast.Tesscut.get_cutouts(coord, 5, sector=1)
+        cutout_hdus_list = mast.Tesscut.get_cutouts(coordinates=coord, size=5, sector=1)
         assert isinstance(cutout_hdus_list, list)
         assert len(cutout_hdus_list) == 1
         assert isinstance(cutout_hdus_list[0], fits.HDUList)
 
-        cutout_hdus_list = mast.Tesscut.get_cutouts(coord, [2, 4]*u.arcmin)
+        cutout_hdus_list = mast.Tesscut.get_cutouts(coordinates=coord, size=[2, 4]*u.arcmin)
+        assert isinstance(cutout_hdus_list, list)
+        assert len(cutout_hdus_list) >= 1
+        assert isinstance(cutout_hdus_list[0], fits.HDUList)
+
+        cutout_hdus_list = mast.Tesscut.get_cutouts(objectname="TIC 32449963", size=5)
         assert isinstance(cutout_hdus_list, list)
         assert len(cutout_hdus_list) >= 1
         assert isinstance(cutout_hdus_list[0], fits.HDUList)

--- a/docs/mast/mast.rst
+++ b/docs/mast/mast.rst
@@ -672,13 +672,13 @@ be accessed in Astroquery by using the Tesscut class.
 Cutouts
 -------
 
-The `~astroquery.mast.TesscutClass.get_cutouts` function takes a coordinate and
-cutout size (in pixels or an angular quantity) and returns the cutout target pixel
-file(s) as a list of `~astropy.io.fits.HDUList` objects.
+The `~astroquery.mast.TesscutClass.get_cutouts` function takes a coordinate or object name
+(such as "M104" or "TIC 32449963") and cutout size (in pixels or an angular quantity) and
+returns the cutout target pixel file(s) as a list of `~astropy.io.fits.HDUList` objects.
 
-If a given coordinate appears in more than one TESS sector a target pixel file will be
-produced for each sector.  If the cutout area overlaps more than one camera or ccd
-a target pixel file will be produced for each one.
+If the given coordinate/object location appears in more than one TESS sector a target pixel
+file will be produced for each sector.  If the cutout area overlaps more than one camera or
+ccd a target pixel file will be produced for each one.
 
 .. code-block:: python
 
@@ -686,18 +686,31 @@ a target pixel file will be produced for each one.
                 >>> from astropy.coordinates import SkyCoord
                 
                 >>> cutout_coord = SkyCoord(107.18696, -70.50919, unit="deg")
-                >>> hdulist = Tesscut.get_cutouts(cutout_coord, 5)
+                >>> hdulist = Tesscut.get_cutouts(coordinates=cutout_coord, size=5)
                 >>> hdulist[0].info()
-                Filename: tess-s0001-4-3_107.18696_-70.50919_5x5_astrocut.fits
+                Filename: <class '_io.BytesIO'>
                 No.    Name      Ver    Type      Cards   Dimensions   Format
-                0  PRIMARY       1 PrimaryHDU      45   ()      
-                1  PIXELS        1 BinTableHDU    225   1282R x 12C   [D, E, J, 25J, 25E, 25E, 25E, 25E, J, E, E, 38A]   
-                2  APERTURE      1 ImageHDU       134   (5, 5)   float64
+                  0  PRIMARY       1 PrimaryHDU      55   ()      
+                  1  PIXELS        1 BinTableHDU    279   1282R x 12C   [D, E, J, 25J, 25E, 25E, 25E, 25E, J, E, E, 38A]   
+                  2  APERTURE      1 ImageHDU        79   (5, 5)   int32
 
 
-The `~astroquery.mast.TesscutClass.download_cutouts` function takes a coordinate
-and cutout size (in pixels or an angular quantity) and downloads the cutout target
-pixel file(s).
+.. code-block:: python
+
+                >>> from astroquery.mast import Tesscut
+                
+                >>> hdulist = Tesscut.get_cutouts(objectname="TIC 32449963", size=5)
+                >>> hdulist[0].info()
+                Filename: <class '_io.BytesIO'>
+                No.    Name      Ver    Type      Cards   Dimensions   Format
+                  0  PRIMARY       1 PrimaryHDU      56   ()      
+                  1  PIXELS        1 BinTableHDU    280   1211R x 12C   [D, E, J, 25J, 25E, 25E, 25E, 25E, J, E, E, 38A]   
+                  2  APERTURE      1 ImageHDU        80   (5, 5)   int32 
+
+                
+The `~astroquery.mast.TesscutClass.download_cutouts` function takes a coordinate or object name
+(such as "M104" or "TIC 32449963") and cutout size (in pixels or an angular quantity) and
+downloads the cutout target pixel file(s).
 
 If a given coordinate appears in more than one TESS sector a target pixel file will be
 produced for each sector.  If the cutout area overlaps more than one camera or ccd
@@ -710,7 +723,7 @@ a target pixel file will be produced for each one.
                 >>> import astropy.units as u
                  
                 >>> cutout_coord = SkyCoord(107.18696, -70.50919, unit="deg")
-                >>> manifest = Tesscut.download_cutouts(cutout_coord, [5, 7]*u.arcmin)
+                >>> manifest = Tesscut.download_cutouts(coordinates=cutout_coord, size=[5, 7]*u.arcmin)
                 Downloading URL https://mast.stsci.edu/tesscut/api/v0.1/astrocut?ra=107.18696&dec=-70.50919&y=0.08333333333333333&x=0.11666666666666667&units=d&sector=1 to ./tesscut_20181102104719.zip ... [Done]
                 Inflating...
 
@@ -730,11 +743,22 @@ To access sector information at a particular location there is  `~astroquery.mas
                 >>> from astropy.coordinates import SkyCoord
                 
                 >>> coord = SkyCoord(324.24368, -27.01029,unit="deg")
-                >>> sector_table = Tesscut.get_sectors(coord)
+                >>> sector_table = Tesscut.get_sectors(coordinates=coord)
                 >>> print(sector_table)
-                sectorName   sector camera ccd
+                  sectorName   sector camera ccd
                 -------------- ------ ------ ---
                 tess-s0001-1-3      1      1   3
+
+
+.. code-block:: python
+
+                >>> from astroquery.mast import Tesscut
+                
+                >>> sector_table = Tesscut.get_sectors(objectname="TIC 32449963")
+                >>> print(sector_table)
+                  sectorName   sector camera ccd
+                -------------- ------ ------ ---
+                tess-s0010-1-4     10      1   4
            
 
 Accessing Proprietary Data


### PR DESCRIPTION
This PR encompasses one piece of new functionality and a number of small improvements and bugfixes:

- **Tesscut:** Added the ability to query by objectname, where objectname can be a TIC ID, or something like "M101." 
The objectname argument works just like it does in the Observastions/Catalogs classes, where the given objectname is passed through the MAST resolver to get the correct RA/Dec to query.
The argument was added at the end of the argument list to preserve backwards compatibility.
Added new unit tests and documentation to go along with this new functionality.
- **resolve_object:** Make public function. 
I deprecated _resolve_object, replacing it with the public function resolve_object, in response to user requests for this functionality.
- **filter_products:** Bugfix on extension filter
The "extension" filter was not working because the function assumed it was given as an array, while in fact an array or a string should both be valid inputs.
- **TIC query criteria with position:** bugfix.
Some stray commas were breaking this function.
- **Panstarrs tests:** Various small bugfixes on the panstarrs tests


