### PR TITLE
CADC Bug fix for radius parsing

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -22,6 +22,8 @@ cadc
 
 - Module added to access data at the Canadian Astronomy Data Centre. [#1354]
 
+- Bugfix for radius parsing. [#1507]
+
 esa
 ^^^
 

--- a/astroquery/cadc/tests/test_cadctap_remote.py
+++ b/astroquery/cadc/tests/test_cadctap_remote.py
@@ -12,7 +12,7 @@ from datetime import datetime
 from astropy.coordinates import SkyCoord
 from astropy.io import fits
 from astropy.tests.helper import remote_data
-
+from astropy import units as u
 
 from astroquery.cadc import Cadc
 from astropy.utils.exceptions import AstropyDeprecationWarning
@@ -84,7 +84,7 @@ class TestCadcClass:
         assert len(result) == len(result2[result2['collection'] == 'CFHT'])
 
         # search for a target
-        results = cadc.query_region(SkyCoord.from_name('M31'))
+        results = cadc.query_region(SkyCoord.from_name('M31'), radius=0.016)
         assert len(results) > 20
 
     @pytest.mark.skipif(one_test, reason='One test mode')
@@ -164,7 +164,7 @@ class TestCadcClass:
     def test_get_images(self):
         cadc = Cadc()
         coords = '08h45m07.5s +54d18m00s'
-        radius = 0.05
+        radius = 0.005*u.deg
         images = cadc.get_images(coords, radius, collection='CFHT')
         assert images is not None
 
@@ -177,7 +177,7 @@ class TestCadcClass:
     def test_get_images_against_AS(self):
         cadc = Cadc()
         coords = '08h45m07.5s +54d18m00s'
-        radius = 0.05
+        radius = 0.05*u.deg
 
         # Compare results from cadc advanced search to get_images
         query = cadc._args_to_payload(**{'coordinates': coords,
@@ -189,7 +189,8 @@ class TestCadcClass:
         icrs_coords = parse_coordinates(coords).icrs
         data = {'uris': ' '.join(uri_list),
                 'params': 'cutout=Circle ICRS {} {} {}'.
-                format(icrs_coords.ra.degree, icrs_coords.dec.degree, radius),
+                format(icrs_coords.ra.degree, icrs_coords.dec.degree,
+                       radius.value),
                 'method': 'URL List'
                 }
 
@@ -209,7 +210,7 @@ class TestCadcClass:
     def test_get_images_async(self):
         cadc = Cadc()
         coords = '01h45m07.5s +23d18m00s'
-        radius = 0.05
+        radius = '0.05 deg'
         readable_objs = cadc.get_images_async(coords, radius, collection="CFHT")
         assert readable_objs is not None
         for obj in readable_objs:

--- a/astroquery/utils/tests/test_utils.py
+++ b/astroquery/utils/tests/test_utils.py
@@ -469,3 +469,11 @@ def test_filecontainer_get(patch_getreadablefileobj):
 def test_is_coordinate(coordinates, expected):
     out = commons._is_coordinate(coordinates)
     assert out == expected
+
+
+@pytest.mark.parametrize(('radius'),
+                         [0.01*u.deg, '0.01 deg', 0.01*u.arcmin]
+                         )
+def test_radius_to_unit(radius):
+    c = commons.radius_to_unit(radius)
+    assert c is not None

--- a/docs/cadc/cadc.rst
+++ b/docs/cadc/cadc.rst
@@ -150,15 +150,13 @@ resolve the cutout of a result.
   >>>
   >>> cadc = Cadc()
   >>> coords = '01h45m07.5s +23d18m00s'
-  >>> radius = 0.1
+  >>> radius = '0.01 deg'
   >>> images = cadc.get_images(coords, radius, collection='CFHT')
   >>> for image in images:
   ...    print(image)
 
-    [<astropy.io.fits.hdu.image.PrimaryHDU object at 0x7fbf210e5080>, ..., <astropy.io.fits.hdu.image.ImageHDU object at 0x7fbf13f72cf8>]
-    [<astropy.io.fits.hdu.image.PrimaryHDU object at 0x7fbf2041a160>, ..., <astropy.io.fits.hdu.image.ImageHDU object at 0x7fbf0bb33c50>]
-    [<astropy.io.fits.hdu.image.PrimaryHDU object at 0x7fbf20079ef0>, ..., <astropy.io.fits.hdu.image.ImageHDU object at 0x7fbf09170668>]
-    [<astropy.io.fits.hdu.image.PrimaryHDU object at 0x7fbf13f91e48>, ..., <astropy.io.fits.hdu.image.ImageHDU object at 0x7fbf08b3cda0>]
+    [<astropy.io.fits.hdu.image.PrimaryHDU object at 0x7f3805a06ef0>]
+    [<astropy.io.fits.hdu.image.PrimaryHDU object at 0x7f3805b23b38>]
 
 
 Alternatively, if the query result is large and data does not need to be
@@ -166,19 +164,21 @@ in memory, lazy access to the downloaded FITS file can be used.
 
 .. code-block:: python
 
+  >>> from astropy import units as u
+  >>> from astropy.coordinates import SkyCoord
   >>> from astroquery.cadc import Cadc
   >>>
   >>> cadc = Cadc()
-  >>> coords = '01h45m07.5s +23d18m00s'
-  >>> radius = 0.1
+  >>> coords = SkyCoord(10, 20, unit='deg')
+  >>> radius = 0.01*u.deg
   >>> readable_objs = cadc.get_images_async(coords, radius, collection='CFHT')
   >>> for obj in readable_objs:
   ...    print(obj)
 
-    Downloaded object from URL https://www.cadc-ccda.hia-iha.nrc-cnrc.gc.ca/caom2ops/sync?ID=ad%3ACFHT%2F2228689p.fits.fz&RUNID=pxzsggm04kdvps1l&POS=CIRCLE+26.2812589776878+23.299999818906816+0.1 with ID 140458871653208
-    Downloaded object from URL https://www.cadc-ccda.hia-iha.nrc-cnrc.gc.ca/caom2ops/sync?ID=ad%3ACFHT%2F2228383o.fits.fz&RUNID=pxzsggm04kdvps1l&POS=CIRCLE+26.2812589776878+23.299999818906816+0.1 with ID 140458270069200
-    Downloaded object from URL https://www.cadc-ccda.hia-iha.nrc-cnrc.gc.ca/caom2ops/sync?ID=ad%3ACFHT%2F2228383p.fits.fz&RUNID=pxzsggm04kdvps1l&POS=CIRCLE+26.2812589776878+23.299999818906816+0.1 with ID 140458270070600
-    Downloaded object from URL https://www.cadc-ccda.hia-iha.nrc-cnrc.gc.ca/caom2ops/sync?ID=ad%3ACFHT%2F2368279o.fits.fz&RUNID=pxzsggm04kdvps1l&POS=CIRCLE+26.2812589776878+23.299999818906816+0.1 with ID 140458270064368
+    Downloaded object from URL https://www.cadc-ccda.hia-iha.nrc-cnrc.gc.ca/caom2ops/sync?ID=ad%3ACFHT%2F449264c.fits.gz&RUNID=qs0jrrwbsd45qcxk&POS=CIRCLE+10.00000850225453+20.000001529485854+0.1 with ID 139878698093816
+    Downloaded object from URL https://www.cadc-ccda.hia-iha.nrc-cnrc.gc.ca/caom2ops/sync?ID=ad%3ACFHT%2F289915a.fits.gz&RUNID=qom9bhlqi8g9bx2j&POS=CIRCLE+10.00000850225453+20.000001529485854+0.1 with ID 139878697229280
+    Downloaded object from URL https://www.cadc-ccda.hia-iha.nrc-cnrc.gc.ca/caom2ops/sync?ID=ad%3ACFHT%2F1821295x.fits.fz&RUNID=qom9bhlqi8g9bx2j&POS=CIRCLE+10.00000850225453+20.000001529485854+0.1 with ID 139878696451264
+    Downloaded object from URL https://www.cadc-ccda.hia-iha.nrc-cnrc.gc.ca/caom2ops/sync?ID=ad%3ACFHT%2F248912o.fits.gz&RUNID=qom9bhlqi8g9bx2j&POS=CIRCLE+10.00000850225453+20.000001529485854+0.1 with ID 139878590752136
 
 
 If the cutout urls from a complicated query are needed, the result table


### PR DESCRIPTION
Allow `astropy.units.Quantity` as input for radius. Fix for issue #1440.