### PR TITLE
Removing pandas dependency, using Table.read() directly

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -38,8 +38,7 @@ env:
         - NUMPY_VERSION=stable
         - ASTROPY_VERSION=stable
         - CONDA_DEPENDENCIES='requests beautifulsoup4 html5lib keyring aplpy matplotlib pyregion jinja2 flask regions'
-        # pandas is used as a workaround of an astropy issue, sometimes it's required for the remote tests
-        - CONDA_DEPENDENCIES_REMOTE='requests beautifulsoup4 html5lib keyring aplpy matplotlib pyregion jinja2 flask pandas regions'
+        - CONDA_DEPENDENCIES_REMOTE='requests beautifulsoup4 html5lib keyring aplpy matplotlib pyregion jinja2 flask regions'
         - PIP_DEPENDENCIES='https://github.com/keflavich/httpbin/archive/master.zip astropy_healpix mocpy>=0.5.2 pytest-dependency pytest-astropy pyvo'
         - HTTP_BIN_CMD="import httpbin; httpbin.app.run()"
         - RUN_HTTPBIN='python -c "$HTTP_BIN_CMD" & ACTIVE_HTTPBIN=True'

--- a/astroquery/alma/core.py
+++ b/astroquery/alma/core.py
@@ -470,8 +470,7 @@ class AlmaClass(QueryWithLogin):
             if response.text == "":
                 raise RemoteServiceError("Empty return.")
             # this is a CSV-like table returned via a direct browser request
-            import pandas
-            table = Table.from_pandas(pandas.read_csv(StringIO(response.text)))
+            table = Table.read(response.text, format='ascii.csv', fast_reader=False)
 
         else:
             fixed_content = self._hack_bad_arraysize_vofix(response.content)

--- a/astroquery/conftest.py
+++ b/astroquery/conftest.py
@@ -36,6 +36,7 @@ try:
     PYTEST_HEADER_MODULES['pyregion'] = 'pyregion'
     del PYTEST_HEADER_MODULES['h5py']
     del PYTEST_HEADER_MODULES['Scipy']
+    del PYTEST_HEADER_MODULES['Pandas']
 except (NameError, KeyError):
     pass
 
@@ -46,8 +47,7 @@ except (NameError, KeyError):
 import astropy
 if int(astropy.__version__[0]) > 1:
     # The warnings_to_ignore_by_pyver parameter was added in astropy 2.0
-    enable_deprecations_as_exceptions(modules_to_ignore_on_import=['requests'])
-    enable_deprecations_as_exceptions(modules_to_ignore_on_import=['regions'])
+    enable_deprecations_as_exceptions(warnings_to_ignore_entire_module=['pyregion'])
 
 # add '_testrun' to the version name so that the user-agent indicates that
 # it's being run in a test


### PR DESCRIPTION
The issue was that the fast reader, that is used by default for `Table.read()` is cannot handle unicode. We don't need pandas if we use the python ascii reader.

closes #938 