### PR TITLE
TST: Temporarily ignore AstropyDeprecationWarning

### DIFF
--- a/astroquery/conftest.py
+++ b/astroquery/conftest.py
@@ -44,7 +44,8 @@ except (NameError, KeyError):
     pass
 
 # ignoring pyvo can be removed once we require >0.9.3
-enable_deprecations_as_exceptions(warnings_to_ignore_entire_module=['pyregion'],
+enable_deprecations_as_exceptions(include_astropy_deprecations=False,
+                                  warnings_to_ignore_entire_module=['pyregion'],
                                   modules_to_ignore_on_import=['pyvo'])
 
 # add '_testrun' to the version name so that the user-agent indicates that


### PR DESCRIPTION
This would allow `AstropyDeprecationWarning` to exist and not fail other PRs like #1163 until #1508 can be merged after PY2 removal. 😬 