### PR TITLE
MNT: Ensure vo_conesearch tests still run

### DIFF
--- a/astroquery/vo_conesearch/__init__.py
+++ b/astroquery/vo_conesearch/__init__.py
@@ -11,7 +11,7 @@ class Conf(_config.ConfigNamespace):
     """
     # Config related to remote database of "reliable" services.
     vos_baseurl = _config.ConfigItem(
-        'https://astropy.stsci.edu/aux/vo_databases/',
+        'http://astropy.stsci.edu/aux/vo_databases/',
         'URL where the VO Service database file is stored.')
     conesearch_dbname = _config.ConfigItem(
         'conesearch_good',

--- a/astroquery/vo_conesearch/tests/test_conesearch.py
+++ b/astroquery/vo_conesearch/tests/test_conesearch.py
@@ -104,8 +104,8 @@ class TestConeSearch(object):
         with pytest.raises(VOSError) as e:
             conesearch.conesearch(
                 SCS_CENTER, SCS_RADIUS, pedantic=self.pedantic, cache=False,
-                verbose=self.verbose, catalog_db=self.url, timeout=0.0001)
-        assert 'timed out' in str(e), 'test_timeout failed'
+                verbose=self.verbose, catalog_db=self.url, timeout=1e-6)
+        assert 'timed out' in str(e.value), 'test_timeout failed'
 
     def test_searches(self):
         tab_2 = conesearch.conesearch(


### PR DESCRIPTION
This was a subset of #1508 that makes more sense as its own PR, because then it can be merged faster and no affect other PRs if `vo_conesearch` tests start failing irrespective of the `utils.timer` move.