### PR TITLE
MNT: Change vos_baseurl in vo_conesearch

### DIFF
--- a/astroquery/vo_conesearch/__init__.py
+++ b/astroquery/vo_conesearch/__init__.py
@@ -11,7 +11,7 @@ class Conf(_config.ConfigNamespace):
     """
     # Config related to remote database of "reliable" services.
     vos_baseurl = _config.ConfigItem(
-        'http://astropy.stsci.edu/aux/vo_databases/',
+        'https://astroconda.org/aux/vo_databases/',
         'URL where the VO Service database file is stored.')
     conesearch_dbname = _config.ConfigItem(
         'conesearch_good',

--- a/docs/vo_conesearch/client.rst
+++ b/docs/vo_conesearch/client.rst
@@ -246,7 +246,7 @@ also see :ref:`Cone Search Examples <vo-sec-scs-examples>`):
 
 >>> from astroquery.vo_conesearch import vos_catalog
 >>> my_db = vos_catalog.get_remote_catalog_db('conesearch_good')
-Downloading https://astropy.stsci.edu/aux/vo_databases/conesearch_good.json
+Downloading https://astroconda.org/aux/vo_databases/conesearch_good.json
 |==========================================|  37k/ 37k (100.00%)         0s
 >>> print(my_db)
 Guide Star Catalog v2 1
@@ -662,7 +662,7 @@ validation warnings. One should use these sites with caution:
 >>> from astroquery.vo_conesearch import conf
 >>> conf.conesearch_dbname = 'conesearch_warn'
 >>> conesearch.list_catalogs()
-Downloading https://astropy.stsci.edu/aux/vo_databases/conesearch_warn.json
+Downloading https://astroconda.org/aux/vo_databases/conesearch_warn.json
 |==========================================| 312k/312k (100.00%)         0s
 ['2MASS All-Sky Catalog of Point Sources (Cutri+ 2003) 1',
  'Data release 7 of Sloan Digital Sky Survey catalogs 1',

--- a/docs/vo_conesearch/vo_conesearch.rst
+++ b/docs/vo_conesearch/vo_conesearch.rst
@@ -108,7 +108,7 @@ List the available Cone Search catalogs that passed daily validation:
 
 >>> from astroquery.vo_conesearch import conesearch
 >>> conesearch.list_catalogs()
-Downloading https://astropy.stsci.edu/aux/vo_databases/conesearch_good.json
+Downloading https://astroconda.org/aux/vo_databases/conesearch_good.json
 |==========================================|  37k/ 37k (100.00%)         0s
 ['Guide Star Catalog v2 1',
  'SDSS DR8 - Sloan Digital Sky Survey Data Release 8 1',
@@ -202,7 +202,7 @@ See Also
 
 - `STScI VAO Registry <http://vao.stsci.edu/directory/NVORegInt.asmx?op=VOTCapabilityPredOpt>`_
 
-- `STScI VO Databases <https://astropy.stsci.edu/aux/vo_databases/>`_
+- `STScI VO Databases <https://astroconda.org/aux/vo_databases/>`_
 
 
 Reference/API


### PR DESCRIPTION
Due to, uh, unforeseen circumstances, this has to happen. The old `vos_baseurl` still works but is no longer updated daily and will eventually be outdated enough that it will not be accurate.

cc @jhunkeler