### PR TITLE
GAIA: Add optional 'columns' parameter to select specific columns.

### DIFF
--- a/astroquery/gaia/core.py
+++ b/astroquery/gaia/core.py
@@ -203,10 +203,10 @@ class GaiaClass(TapPlus):
                     ORDER BY
                       dist ASC
                     """.format(**{
-                        'ra_column': self.MAIN_GAIA_TABLE_RA, 
-                        'dec_column': self.MAIN_GAIA_TABLE_DEC, 
+                        'ra_column': self.MAIN_GAIA_TABLE_RA,
+                        'dec_column': self.MAIN_GAIA_TABLE_DEC,
                         'columns': columns, 'table_name': self.MAIN_GAIA_TABLE,
-                        'ra': ra, 'dec': dec, 'width': widthDeg.value, 'height': heightDeg.value, 
+                        'ra': ra, 'dec': dec, 'width': widthDeg.value, 'height': heightDeg.value,
                     })
 
             if async_job:
@@ -344,10 +344,10 @@ class GaiaClass(TapPlus):
                 ORDER BY
                   dist ASC
                 """.format(**{
-                    'ra_column': ra_column_name, 
-                    'dec_column': dec_column_name, 
-                    'columns': columns, 'ra': ra, 
-                    'dec': dec, 'radius': radiusDeg, 
+                    'ra_column': ra_column_name,
+                    'dec_column': dec_column_name,
+                    'columns': columns, 'ra': ra,
+                    'dec': dec, 'radius': radiusDeg,
                     'table_name': table_name
                 })
 

--- a/astroquery/gaia/tests/DummyTapHandler.py
+++ b/astroquery/gaia/tests/DummyTapHandler.py
@@ -165,7 +165,7 @@ class DummyTapHandler(object):
 
     def cone_search(self, coordinate, radius, output_file=None,
                     output_format="votable", verbose=False,
-                    dump_to_file=False):
+                    dump_to_file=False, columns=[]):
         self.__invokedMethod = 'cone_search'
         self.__parameters['coordinate'] = coordinate
         self.__parameters['radius'] = radius
@@ -173,10 +173,11 @@ class DummyTapHandler(object):
         self.__parameters['output_format'] = output_format
         self.__parameters['verbose'] = verbose
         self.__parameters['dump_to_file'] = dump_to_file
+        self.__parameters['columns'] = columns
 
     def cone_search_async(self, coordinate, radius, background=False,
                           output_file=None, output_format="votable",
-                          verbose=False, dump_to_file=False):
+                          verbose=False, dump_to_file=False, columns=[]):
         self.__invokedMethod = 'cone_search_async'
         self.__parameters['coordinate'] = coordinate
         self.__parameters['radius'] = radius
@@ -185,6 +186,7 @@ class DummyTapHandler(object):
         self.__parameters['output_format'] = output_format
         self.__parameters['verbose'] = verbose
         self.__parameters['dump_to_file'] = dump_to_file
+        self.__parameters['columns'] = columns
 
     def remove_jobs(self, jobs_list, verbose=False):
         self.__invokedMethod = 'remove_jobs'


### PR DESCRIPTION
Hey! Some of the functions from the Gaia submodule (cone_search and query_object) are lacking a 'columns' parameter to query only for specific columns. Querying only for the desired columns would reduce the bandwidth and memory used every time you query for an object or do a cone search. My version of the code is compatible with old ones, as it adds an optional parameter that behaves just like it used to (in previous versions) if it's not set.

