### PR TITLE
Removing python2 testing and it's mention in the install docs and readme

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -52,7 +52,6 @@ env:
         - secure: "al9u/QSQfrwNljdu8gYUaT9z4BxEL1FlE4ntsn6eqtN2Y0rurqll+gq46quYjtE6zgcpb0uYtGIubusJkp7ceE6IBGhQdsel4UY16VIqeEuQ3GpVDb4RiJgU51SAjbmXYV1dMAJnOm4Ra41WzxokStKRDdoRraAsae9zK3H6AnI="
 
     matrix:
-        - PYTHON_VERSION=2.7 SETUP_CMD='egg_info'
         - PYTHON_VERSION=3.7 SETUP_CMD='egg_info'
 
 matrix:
@@ -70,12 +69,6 @@ matrix:
           env: EVENT_TYPE='push cron' DEBUG=True ASTROPY_VERSION=dev
                SETUP_CMD='test -R -V -a "--durations=50"'
                CONDA_DEPENDENCIES=$CONDA_DEPENDENCIES_REMOTE
-        - os: linux
-          stage: Remote data tests
-          env: EVENT_TYPE='push cron' PYTHON_VERSION=2.7
-               SETUP_CMD='test --remote-data -V -a "--durations=50"'
-               CONDA_DEPENDENCIES=$CONDA_DEPENDENCIES_REMOTE
-               KEYRING_VERSION='<12.0' PYTEST_VERSION='<3.7'
 
         # No need to run it from cron
         # Try MacOS X
@@ -121,11 +114,6 @@ matrix:
         # Try with optional dependencies disabled
         - os: linux
           stage: Test docs, astropy dev, and without optional dependencies
-          env: PYTHON_VERSION=2.7  KEYRING_VERSION='<12.0' PYTEST_VERSION='<3.7'
-               CONDA_DEPENDENCIES='requests beautifulsoup4 html5lib keyring'
-               ASTROPY_VERSION=lts NUMPY_VERSION=1.13
-        - os: linux
-          stage: Test docs, astropy dev, and without optional dependencies
           env: CONDA_DEPENDENCIES='requests beautifulsoup4 html5lib keyring'
                NUMPY_VERSION=1.16
 
@@ -159,12 +147,7 @@ matrix:
           env: EVENT_TYPE='push cron' DEBUG=True ASTROPY_VERSION=dev
                SETUP_CMD='test -R -V -a "--durations=50"'
                CONDA_DEPENDENCIES=$CONDA_DEPENDENCIES_REMOTE
-        - os: linux
-          stage: Remote data tests
-          env: EVENT_TYPE='push cron' PYTHON_VERSION=2.7
-               SETUP_CMD='test --remote-data -V -a "--durations=50"'
-               CONDA_DEPENDENCIES=$CONDA_DEPENDENCIES_REMOTE
-               KEYRING_VERSION='<12.0' PYTEST_VERSION='<3.7'
+
 
 install:
     - git clone git://github.com/astropy/ci-helpers.git

--- a/.travis.yml
+++ b/.travis.yml
@@ -94,13 +94,7 @@ matrix:
         # Test the oldest astropy version without optional dependencies.
         - os: linux
           stage: Tests with other Python/Numpy versions
-          env: PYTHON_VERSION=3.5 NUMPY_VERSION=1.12  KEYRING_VERSION='<12.0'
-               CONDA_DEPENDENCIES="keyring requests beautifulsoup4 html5lib secretstorage pyvo"
-               SECRETSTORAGE_VERSION='<3.0.1'
-               ASTROPY_VERSION=2 PYTEST_VERSION='<3.7'
-        - os: linux
-          stage: Tests with other Python/Numpy versions
-          env: PYTHON_VERSION=3.5.5 NUMPY_VERSION=1.14 KEYRING_VERSION='<12.0'
+          env: PYTHON_VERSION=3.6 NUMPY_VERSION=1.14 KEYRING_VERSION='<12.0'
                ASTROPY_VERSION=3.0 APLPY_VERSION='<2.0'
 
         - os: linux

--- a/README.rst
+++ b/README.rst
@@ -38,7 +38,7 @@ website <http://simbad.u-strasbg.fr/simbad/>`_, use the ``simbad`` sub-package:
 Installation and Requirements
 -----------------------------
 
-Astroquery works with Python 2.7 and 3.5 or later.
+Astroquery works with Python 3.5 or later.
 As an `astropy`_ affiliate, astroquery requires `astropy`_ version 2.0 or later.
 
 astroquery uses the `requests <http://docs.python-requests.org/en/latest/>`_

--- a/README.rst
+++ b/README.rst
@@ -38,7 +38,7 @@ website <http://simbad.u-strasbg.fr/simbad/>`_, use the ``simbad`` sub-package:
 Installation and Requirements
 -----------------------------
 
-Astroquery works with Python 3.5 or later.
+Astroquery works with Python 3.6 or later.
 As an `astropy`_ affiliate, astroquery requires `astropy`_ version 2.0 or later.
 
 astroquery uses the `requests <http://docs.python-requests.org/en/latest/>`_

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -64,7 +64,7 @@ The development version can be obtained and installed from github:
 Requirements
 ------------
 
-Astroquery works with Python 2.7 and 3.5 or later.
+Astroquery works with Python 3.5 or later.
 
 The following packages are required for astroquery installation & use:
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -64,11 +64,11 @@ The development version can be obtained and installed from github:
 Requirements
 ------------
 
-Astroquery works with Python 3.5 or later.
+Astroquery works with Python 3.6 or later.
 
 The following packages are required for astroquery installation & use:
 
-* `numpy <http://www.numpy.org>`_ >= 1.12
+* `numpy <http://www.numpy.org>`_ >= 1.14
 * `astropy <http://www.astropy.org>`__ (>=2.0)
 * `requests <http://docs.python-requests.org/en/latest/>`_
 * `keyring <https://pypi.python.org/pypi/keyring>`_


### PR DESCRIPTION
This PR doesn't yet directly remove python2 support, but removes the promise of it. 

I'm happy to further and do the whole cleanup once @keflavich gives the all green for it. Also I'm happy to go for 3.6+, but that also needs the consensus.

@pllim - once this is merged you can go ahead with #1508.