### PR TITLE
Docsbuild fix sphinx and numpydoc

### DIFF
--- a/astroquery/nasa_exoplanet_archive/nasa_exoplanet_archive.py
+++ b/astroquery/nasa_exoplanet_archive/nasa_exoplanet_archive.py
@@ -112,8 +112,8 @@ class NasaExoplanetArchiveClass(object):
         kwargs : dict (optional)
             Extra keyword arguments passed to ``get_confirmed_planets_table``.
 
-        Return
-        ------
+        Returns
+        -------
         table : `~astropy.table.QTable`
             Table of one exoplanet's properties.
         """

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -75,7 +75,7 @@ del intersphinx_mapping['scipy']
 del intersphinx_mapping['h5py']
 intersphinx_mapping.update({
     'astropy': ('http://docs.astropy.org/en/stable/', None),
-    'requests': ('http://docs.python-requests.org/en/stable/', None),
+    'requests': ('https://requests.kennethreitz.org/en/stable/', None),
     'pyregion': ('http://pyregion.readthedocs.io/en/stable/', None),
     'regions': ('http://astropy-regions.readthedocs.io/en/stable/', None),
     'mocpy': ('https://mocpy.readthedocs.io/en/latest/', None),


### PR DESCRIPTION
There are two sphinx warnings left, but we need new helpers to get rid of it, and that would mean to finally break away from python2, or do a last 2.0.x helpers release. 

Fix: #1567 
```
/Users/bsipocz/munka/devel/astroquery/astropy_helpers/astropy_helpers/sphinx/themes/bootstrap-astropy/layout.html:15: RemovedInSphinx30Warning: To modify script_files in the theme is deprecated. Please insert a <script> tag directly in your theme instead.
  <div class="topbar">
/Users/bsipocz/munka/devel/astroquery/astropy_helpers/astropy_helpers/sphinx/themes/bootstrap-astropy/layout.html:15: RemovedInSphinx30Warning: To modify script_files in the theme is deprecated. Please insert a <script> tag directly in your theme instead.
  <div class="topbar">
```