### PR TITLE
Fixing field_help mocking for SDSS and other small fixes to xmatch and ogle

### DIFF
--- a/astroquery/ogle/core.py
+++ b/astroquery/ogle/core.py
@@ -5,6 +5,7 @@ import warnings
 import functools
 import numpy as np
 from astropy.table import Table
+from astropy.utils.exceptions import AstropyDeprecationWarning
 
 from ..query import BaseQuery
 from ..utils import commons, async_to_sync, prepend_docstr_nosections
@@ -190,8 +191,8 @@ class OgleClass(BaseQuery):
                     raise CoordParseError()
             # list-like of values
             elif (len(shape) == 2) & (shape[0] == 2):
-                warnings.warn('Non-Astropy coordinates may not be supported \
-                              in a future version.', FutureWarning)
+                warnings.warn('Non-Astropy coordinates may not be supported '
+                              'in a future version.', AstropyDeprecationWarning)
                 return coord
             else:
                 raise CoordParseError()

--- a/astroquery/sdss/core.py
+++ b/astroquery/sdss/core.py
@@ -950,14 +950,16 @@ class SDSSClass(BaseQuery):
                                      self.TIMEOUT)['name']
 
         if field_help:
-            ret = 0
-            if field_help in photoobj_all:
-                print("{0} is a valid 'photoobj_field'".format(field_help))
-                ret += 1
-            elif field_help in specobj_all:
-                print("{0} is a valid 'specobj_field'".format(field_help))
-                ret += 1
-
+            if field_help is True:
+                ret = 0
+            elif field_help:
+                ret = 0
+                if field_help in photoobj_all:
+                    print("{0} is a valid 'photoobj_field'".format(field_help))
+                    ret += 1
+                elif field_help in specobj_all:
+                    print("{0} is a valid 'specobj_field'".format(field_help))
+                    ret += 1
             if ret > 0:
                 return
             else:

--- a/astroquery/sdss/core.py
+++ b/astroquery/sdss/core.py
@@ -957,7 +957,7 @@ class SDSSClass(BaseQuery):
                 if field_help in photoobj_all:
                     print("{0} is a valid 'photoobj_field'".format(field_help))
                     ret += 1
-                elif field_help in specobj_all:
+                if field_help in specobj_all:
                     print("{0} is a valid 'specobj_field'".format(field_help))
                     ret += 1
             if ret > 0:

--- a/astroquery/sdss/field_names.py
+++ b/astroquery/sdss/field_names.py
@@ -46,7 +46,7 @@ def get_field_info(cls, tablename, sqlurl, timeout=conf.timeout):
         try:
             _cached_table_fields[key] = _columns_json_to_table(qryres.json())
         except ValueError:
-            if isinstance(qryres, MockResponse):# and data_release == 12:
+            if isinstance(qryres, MockResponse):
                 return _load_builtin_table_fields()[tablename]
 
             else:

--- a/astroquery/sdss/tests/test_sdss.py
+++ b/astroquery/sdss/tests/test_sdss.py
@@ -366,10 +366,16 @@ def test_field_help_region(patch_get):
     assert 'photoobj_all' in valid_field
 
     existing_p_field = sdss.SDSS.query_region(coords,
-                                              field_help='psfmag_r')
+                                              field_help='psfMag_r')
 
-    existing_p_s_field = sdss.SDSS.query_region(coords,
-                                                field_help='psfmag_r')
+    existing_s_field = sdss.SDSS.query_region(coords,
+                                              field_help='spectroSynFlux_r')
 
     non_existing_field = sdss.SDSS.query_region(coords,
                                                 field_help='nonexist')
+
+    assert existing_p_field is None
+    assert existing_s_field is None
+
+    assert len(non_existing_field) == 2
+    assert set(non_existing_field.keys()) == set(('photoobj_all', 'specobj_all'))

--- a/astroquery/xmatch/core.py
+++ b/astroquery/xmatch/core.py
@@ -127,6 +127,7 @@ class XMatchClass(BaseQuery):
         else:
             # assume it's a file-like object, support duck-typing
             kwargs['files'] = {catstr: ('cat1.csv', cat.read())}
+
         if not self.is_table_available(cat):
             if ((colRA is None) or (colDec is None)):
                 raise ValueError('Specify the name of the RA/Dec columns in' +
@@ -154,8 +155,15 @@ class XMatchClass(BaseQuery):
         available VizieR tables, otherwise False.
 
         """
-        if isinstance(table_id, six.string_types) and (table_id[:7] == 'vizier:'):
+
+        # table_id can actually be a Table instance, there is no point in
+        # comparing those to stings
+        if not isinstance(table_id, six.string_types):
+            return False
+
+        if (table_id[:7] == 'vizier:'):
             table_id = table_id[7:]
+
         return table_id in self.get_available_tables()
 
     def get_available_tables(self, cache=True):
@@ -171,7 +179,6 @@ class XMatchClass(BaseQuery):
         )
 
         content = response.text
-
         return content.splitlines()
 
     def _parse_text(self, text):


### PR DESCRIPTION
The main motivation for this PR is to fix the FutureWarnings.

It seems that we never really mocked the field names from `photoobjall` and `specobjall` and compared filed names to empty tables while we had a totally valid local dump of the files.

This PR also 
* fixes xmatch to avoid comparing a Table to a catalogue ids. 
* changes the FutureWarning in the ogle module to be a Deprecation warning. It's time to be stricter with accepting only astropy compatible formats (a proper holistic cleanup however is beyond the scope of this PR)