### PR TITLE
TAP: add MAXREC support (#1581)

### DIFF
--- a/astroquery/utils/tap/core.py
+++ b/astroquery/utils/tap/core.py
@@ -234,7 +234,7 @@ class Tap:
         log.info("Done.")
         return tsp.get_tables()
 
-    def launch_job(self, query, name=None, output_file=None,
+    def launch_job(self, query, maxrec=None, name=None, output_file=None,
                    output_format="votable", verbose=False,
                    dump_to_file=False, upload_resource=None,
                    upload_table_name=None):
@@ -246,6 +246,8 @@ class Tap:
             query to be executed
         name : str, optional, default None
             custom name defined by the user for the job that is going to be created
+        maxrec : int, optional, default None
+            maximum number of rows to return (TAP `MAXREC` parameter)
         output_file : str, optional, default None
             file name where the results are saved if dumpToFile is True.
             If this parameter is not provided, the jobid is used instead
@@ -274,7 +276,7 @@ class Tap:
             if upload_table_name is None:
                 raise ValueError("Table name is required when a resource " +
                                  "is uploaded")
-            response = self.__launchJobMultipart(query,
+            response = self.__launchJobMultipart(query, maxrec,
                                                  upload_resource,
                                                  upload_table_name,
                                                  output_format,
@@ -282,7 +284,7 @@ class Tap:
                                                  verbose,
                                                  name)
         else:
-            response = self.__launchJob(query,
+            response = self.__launchJob(query, maxrec,
                                         output_format,
                                         "sync",
                                         verbose,
@@ -349,7 +351,7 @@ class Tap:
             job._phase = 'COMPLETED'
         return job
 
-    def launch_job_async(self, query, name=None, output_file=None,
+    def launch_job_async(self, query, maxrec=None, name=None, output_file=None,
                          output_format="votable", verbose=False,
                          dump_to_file=False, background=False,
                          upload_resource=None, upload_table_name=None,
@@ -362,6 +364,8 @@ class Tap:
             query to be executed
         name : str, optional, default None
             custom name defined by the user for the job that is going to be created
+        maxrec : int, optional, default None
+            maximum number of rows to return (TAP `MAXREC` parameter)
         output_file : str, optional, default None
             file name where the results are saved if dumpToFile is True.
             If this parameter is not provided, the jobid is used instead
@@ -398,6 +402,7 @@ class Tap:
                 raise ValueError(
                     "Table name is required when a resource is uploaded")
             response = self.__launchJobMultipart(query,
+                                                 maxrec,
                                                  upload_resource,
                                                  upload_table_name,
                                                  output_format,
@@ -407,6 +412,7 @@ class Tap:
                                                  autorun)
         else:
             response = self.__launchJob(query,
+                                        maxrec,
                                         output_format,
                                         "async",
                                         verbose,
@@ -569,7 +575,7 @@ class Tap:
         """
         job.save_results(verbose=verbose)
 
-    def __launchJobMultipart(self, query, uploadResource, uploadTableName,
+    def __launchJobMultipart(self, query, maxrec, uploadResource, uploadTableName,
                              outputFormat, context, verbose, name=None,
                              autorun=True):
         uploadValue = f"{uploadTableName},param:{uploadTableName}"
@@ -580,6 +586,8 @@ class Tap:
             "tapclient": str(TAP_CLIENT_ID),
             "QUERY": str(query),
             "UPLOAD": "" + str(uploadValue)}
+        if maxrec is not None:
+            args['MAXREC'] = maxrec
         if autorun is True:
             args['PHASE'] = 'RUN'
         if name is not None:
@@ -609,7 +617,7 @@ class Tap:
             print(response.getheaders())
         return response
 
-    def __launchJob(self, query, outputFormat, context, verbose, name=None,
+    def __launchJob(self, query, maxrec, outputFormat, context, verbose, name=None,
                     autorun=True):
         args = {
             "REQUEST": "doQuery",
@@ -617,6 +625,8 @@ class Tap:
             "FORMAT": str(outputFormat),
             "tapclient": str(TAP_CLIENT_ID),
             "QUERY": str(query)}
+        if maxrec is not None:
+            args['MAXREC'] = maxrec
         if autorun is True:
             args['PHASE'] = 'RUN'
         if name is not None:

--- a/astroquery/utils/tap/core.py
+++ b/astroquery/utils/tap/core.py
@@ -261,7 +261,7 @@ class Tap:
             resource temporary table name associated to the uploaded resource.
             This argument is required if upload_resource is provided.
         maxrec : int, optional, default None
-            maximum number of rows to return (TAP `MAXREC` parameter)
+            maximum number of rows to return (TAP ``MAXREC`` parameter)
 
         Returns
         -------
@@ -387,7 +387,7 @@ class Tap:
             if 'True', sets 'phase' parameter to 'RUN',
             so the framework can start the job.
         maxrec : int, optional, default None
-            maximum number of rows to return (TAP `MAXREC` parameter)
+            maximum number of rows to return (TAP ``MAXREC`` parameter)
 
         Returns
         -------

--- a/astroquery/utils/tap/tests/test_tap.py
+++ b/astroquery/utils/tap/tests/test_tap.py
@@ -172,7 +172,7 @@ def test_launch_sync_job():
     connHandler.set_response(jobRequest, responseLaunchJob)
 
     with pytest.raises(Exception):
-        tap.launch_job(query)
+        tap.launch_job(query, maxrec=10)
 
     responseLaunchJob.set_status_code(200)
     job = tap.launch_job(query)
@@ -449,6 +449,7 @@ def test_abort_job():
         "REQUEST": "doQuery",
         "LANG": "ADQL",
         "FORMAT": "votable",
+        "MAXREC": 10,
         "tapclient": str(TAP_CLIENT_ID),
         "QUERY": str(query)}
     sortedKey = taputils.taputil_create_sorted_dict_key(dictTmp)
@@ -482,6 +483,7 @@ def test_job_parameters():
         "REQUEST": "doQuery",
         "LANG": "ADQL",
         "FORMAT": "votable",
+        "MAXREC": 10,
         "tapclient": str(TAP_CLIENT_ID),
         "QUERY": str(query)}
     sortedKey = taputils.taputil_create_sorted_dict_key(dictTmp)
@@ -501,7 +503,7 @@ def test_job_parameters():
     connHandler.set_response(req, responseResultsJob)
 
     responseResultsJob.set_status_code(200)
-    job = tap.launch_job_async(query, autorun=False)
+    job = tap.launch_job_async(query, maxrec=10, autorun=False)
     assert job is not None
     assert job.get_phase() == 'PENDING'
 

--- a/astroquery/utils/tap/tests/test_tap.py
+++ b/astroquery/utils/tap/tests/test_tap.py
@@ -175,6 +175,7 @@ def test_launch_sync_job():
         tap.launch_job(query, maxrec=10)
 
     responseLaunchJob.set_status_code(200)
+
     job = tap.launch_job(query)
 
     assert job is not None
@@ -456,7 +457,7 @@ def test_abort_job():
     req = f"async?{sortedKey}"
     connHandler.set_response(req, responseLaunchJob)
 
-    job = tap.launch_job_async(query, autorun=False)
+    job = tap.launch_job_async(query, autorun=False, maxrec=10)
     assert job is not None
     assert job.get_phase() == 'PENDING'
     # abort job


### PR DESCRIPTION
Although the TAP module would be deprecated in favour of PyVO, a key parameter like [MAXREC](http://www.ivoa.net/documents/TAP/20190927/REC-TAP-1.1.html#tth_sEc2.7.4) needs support for the time being.

(Short) Discussion on this at #1581 and #836 .


closes #1581

