### PR TITLE
Adding little note for when files retrieved are empty

### DIFF
--- a/astroquery/utils/commons.py
+++ b/astroquery/utils/commons.py
@@ -364,6 +364,9 @@ class FileContainer(object):
         """
         filedata = self.get_string()
 
+        if len(filedata) == 0:
+            raise ValueError("The file retrieved was empty.")
+
         self._fits = fits.HDUList.fromstring(filedata)
 
         return self._fits

--- a/astroquery/utils/commons.py
+++ b/astroquery/utils/commons.py
@@ -365,7 +365,7 @@ class FileContainer(object):
         filedata = self.get_string()
 
         if len(filedata) == 0:
-            raise ValueError("The file retrieved was empty.")
+            raise TypeError("The file retrieved was empty.")
 
         self._fits = fits.HDUList.fromstring(filedata)
 


### PR DESCRIPTION
Fixes #1586 (makes a more informative error than the current failure when files retrieved are empty).