### PR TITLE
Removing imp usage

### DIFF
--- a/astroquery/irsa/tests/test_irsa_remote.py
+++ b/astroquery/irsa/tests/test_irsa_remote.py
@@ -6,12 +6,8 @@ from astropy.table import Table
 from astropy.coordinates import SkyCoord
 import astropy.units as u
 
-import requests
-import imp
-
 from ... import irsa
 
-imp.reload(requests)
 
 OBJ_LIST = ["m31", "00h42m44.330s +41d16m07.50s",
             SkyCoord(l=121.1743, b=-21.5733, unit=(u.deg, u.deg),

--- a/astroquery/irsa_dust/tests/test_irsa_dust_remote.py
+++ b/astroquery/irsa_dust/tests/test_irsa_dust_remote.py
@@ -1,15 +1,12 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
-import imp
 import os
 import astropy.units as u
 import pytest
-import requests
 
 from astropy.tests.helper import remote_data
 from astropy.table import Table
 from ... import irsa_dust
 
-imp.reload(requests)
 
 M31_XML = "dustm31.xml"
 M81_XML = "dustm81.xml"

--- a/astroquery/lamda/tests/test_lamda_remote.py
+++ b/astroquery/lamda/tests/test_lamda_remote.py
@@ -1,9 +1,6 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 from astropy.tests.helper import remote_data
 from ... import lamda
-import requests
-import imp
-imp.reload(requests)
 
 
 @remote_data

--- a/astroquery/lcogt/tests/test_lcogt_remote.py
+++ b/astroquery/lcogt/tests/test_lcogt_remote.py
@@ -1,9 +1,7 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 from __future__ import print_function
 
-import imp
 import pytest
-import requests
 
 from astropy.tests.helper import remote_data
 from astropy.table import Table
@@ -11,8 +9,6 @@ from astropy.coordinates import SkyCoord
 import astropy.units as u
 
 from ... import lcogt
-
-imp.reload(requests)
 
 OBJ_LIST = ["m31", "00h42m44.330s +41d16m07.50s",
             SkyCoord(l=121.1743, b=-21.5733, unit=(u.deg, u.deg),

--- a/astroquery/magpis/tests/test_magpis_remote.py
+++ b/astroquery/magpis/tests/test_magpis_remote.py
@@ -4,12 +4,8 @@ from __future__ import print_function
 from astropy.coordinates import SkyCoord
 import astropy.units as u
 from astropy.tests.helper import remote_data
-import requests
-import imp
 
 from ... import magpis
-
-imp.reload(requests)
 
 
 @remote_data

--- a/astroquery/ned/tests/test_ned_remote.py
+++ b/astroquery/ned/tests/test_ned_remote.py
@@ -3,12 +3,8 @@ from __future__ import print_function
 
 from astropy.tests.helper import remote_data
 from astropy.table import Table
-import requests
-import imp
 
 from ... import ned
-
-imp.reload(requests)
 
 
 @remote_data

--- a/astroquery/nrao/tests/test_nrao_remote.py
+++ b/astroquery/nrao/tests/test_nrao_remote.py
@@ -5,12 +5,8 @@ from astropy.tests.helper import remote_data
 from astropy.table import Table
 import astropy.coordinates as coord
 from astropy import units as u
-import requests
-import imp
 
 from ... import nrao
-
-imp.reload(requests)
 
 
 @remote_data

--- a/astroquery/nvas/tests/test_nvas_remote.py
+++ b/astroquery/nvas/tests/test_nvas_remote.py
@@ -4,12 +4,8 @@ from __future__ import print_function
 from astropy.coordinates import SkyCoord
 import astropy.units as u
 from astropy.tests.helper import remote_data
-import requests
-import imp
 
 from ...import nvas
-
-imp.reload(requests)
 
 
 @remote_data

--- a/astroquery/simbad/tests/test_simbad_remote.py
+++ b/astroquery/simbad/tests/test_simbad_remote.py
@@ -8,10 +8,6 @@ from astropy.table import Table
 from ...utils.testing_tools import MockResponse
 from ... import simbad
 
-# double-check super-undo monkeypatching...
-import requests
-import imp
-imp.reload(requests)
 
 # M42 coordinates
 ICRS_COORDS_M42 = coord.SkyCoord("05h35m17.3s -05h23m28s", frame='icrs')

--- a/astroquery/ukidss/tests/test_ukidss_remote.py
+++ b/astroquery/ukidss/tests/test_ukidss_remote.py
@@ -6,11 +6,8 @@ from astropy.table import Table
 from astropy.coordinates import SkyCoord
 import astropy.units as u
 import requests
-import imp
 
 from ... import ukidss
-
-imp.reload(requests)
 
 
 @remote_data

--- a/astroquery/vizier/tests/test_vizier_remote.py
+++ b/astroquery/vizier/tests/test_vizier_remote.py
@@ -6,9 +6,6 @@ import astropy.units as u
 from astropy import coordinates
 from ... import vizier
 from ...utils import commons
-import requests
-import imp
-imp.reload(requests)
 
 
 @remote_data

--- a/astroquery/vsa/tests/test_vista_remote.py
+++ b/astroquery/vsa/tests/test_vista_remote.py
@@ -7,12 +7,8 @@ from astropy.tests.helper import remote_data
 from astropy.table import Table
 from astropy.coordinates import SkyCoord
 import astropy.units as u
-import requests
-import imp
 
 from ... import vsa
-
-imp.reload(requests)
 
 
 vista = vsa.core.VsaClass()


### PR DESCRIPTION
This should take care of the recent travis failures.

I think this reload of requests is not needed any more, at least this PR doesn't seem to cause much troubles with the remote tests.

