### PR TITLE
Preparing for tagging 0.4

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -99,7 +99,7 @@ matrix:
 
         - os: linux
           stage: Tests with other Python/Numpy versions
-          env: PYTHON_VERSION=3.6 NUMPY_VERSION=1.15
+          env: PYTHON_VERSION=3.6 NUMPY_VERSION=1.15 ASTROPY_VERSION=3.2
 
         - os: linux
           stage: Test docs, astropy dev, and without optional dependencies

--- a/.travis.yml
+++ b/.travis.yml
@@ -108,7 +108,9 @@ matrix:
         # Try with optional dependencies disabled
         - os: linux
           stage: Test docs, astropy dev, and without optional dependencies
-          env: CONDA_DEPENDENCIES='requests beautifulsoup4 html5lib keyring'
+          env: PYTHON_VERSION=3.8
+               CONDA_DEPENDENCIES='requests beautifulsoup4 html5lib keyring'
+               PIP_DEPENDENCIES='https://github.com/keflavich/httpbin/archive/master.zip pytest-astropy'
                NUMPY_VERSION=1.16
 
         # Do a PEP8 test with pycodestyle

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -7,122 +7,42 @@ New Tools and Services
 casda
 ^^^^^
 
-- Module added to access data from the CSIRO ASKAP Science Data Archive (CASDA)  [#1505]
+- Module added to access data from the CSIRO ASKAP Science Data Archive.  [#1505]
 
 dace
 ^^^^
+
 - Added DACE Service. See https://dace.unige.ch/ for details. [#1370]
 
+gemini
+^^^^^^
+
+- Module added to access the Gemini archive. [#1596]
 
 
 Service fixes and enhancements
 ------------------------------
 
-alfalfa
-^^^^^^^
-
-alma
-^^^^
-
-astrometry_net
-^^^^^^^^^^^^^^
-
-atomic
-^^^^^^
-
-besancon
-^^^^^^^^
-
-cadc
-^^^^
-
-casda
-^^^^^
-
-cds
-^^^
-
-cosmosim
-^^^^^^^^
-
-esa
-^^^
-
-esasky
-^^^^^^
-
-eso
-^^^
-
-exoplanet_orbit_database
-^^^^^^^^^^^^^^^^^^^^^^^^
-
-fermi
-^^^^^
-
 gaia
 ^^^^
-
-gama
-^^^^
-
-gemini
-^^^^^^
-
-- initial support for the Gemini archive [#1596]
-
-heasarc
-^^^^^^^
-
-hitran
-^^^^^^
-
-ibe
-^^^
+- Add optional 'columns' parameter to select specific columns. [#1548]
 
 imcce
 ^^^^^
 
 - Fix Skybot return for unumbered asteroids. [#1598]
 
-irsa
-^^^^
-
-irsa_dust
-^^^^^^^^^
-
 jplhorizons
 ^^^^^^^^^^^
 
-- fix for changes in HORIZONS return results after 2020 Jan 21 update [#1620]
-
-jplsbdb
-^^^^^^^
-
-jplspec
-^^^^^^^
-
-lamda
-^^^^^
-
-lcogt
-^^^^^
-
-magpis
-^^^^^^
+- Fix for changes in HORIZONS return results after their 2020 Jan 21 update. [#1620]
 
 mast
 ^^^^
+
 - Add Kepler to missions with cloud support,
   Update ``get_cloud_uri`` so that if a file is not found it produces a warning
   and returns None rather than throwing an exception. [#1561]
-
-
-mpc
-^^^
-
-nasa_ads
-^^^^^^^^
 
 nasa_exoplanet_archive
 ^^^^^^^^^^^^^^^^^^^^^^
@@ -130,60 +50,10 @@ nasa_exoplanet_archive
   Added two functions ``query_planet`` (to query for a specific exoplanet), and
   ``query_star`` (to query for all exoplanets under a specific stellar system) [#1606]
 
-ned
-^^^
-
-nist
-^^^^
-
-nrao
-^^^^
-
-nvas
-^^^^
-
-oac
-^^^
-
-ogle
-^^^^
-
-open_exoplanet_catalogue
-^^^^^^^^^^^^^^^^^^^^^^^^
-
-sdss
-^^^^
-
-sha
-^^^
-
-simbad
-^^^^^^
-
-skyview
-^^^^^^^
-
-solarsystem
-^^^^^^^^^^^
-
 splatalogue
 ^^^^^^^^^^^
 
-- Added new 'only_astronomically_observed' option [#1600]
-
-ukidss
-^^^^^^
-
-utils
-^^^^^
-
-- Added timer functions. [#1508]
-
-vamdc
-^^^^^
-
-vizier
-^^^^^^
+- Added new 'only_astronomically_observed' option. [#1600]
 
 vo_conesearch
 ^^^^^^^^^^^^^
@@ -200,18 +70,14 @@ vo_conesearch
 
 - Result is now returned as ``astropy.table.Table`` by default. [#1528]
 
-vsa
-^^^
-
-wfau
-^^^^
-
-xmatch
-^^^^^^
-
 
 Infrastructure, Utility and Other Changes and Additions
 -------------------------------------------------------
+
+utils
+^^^^^
+
+- Added timer functions. [#1508]
 
 
 0.3.10 (2019-09-19)

--- a/astroquery/cadc/tests/test_cadctap_remote.py
+++ b/astroquery/cadc/tests/test_cadctap_remote.py
@@ -207,6 +207,7 @@ class TestCadcClass:
         assert len(filtered_resp_urls) == len(image_urls)
 
     @pytest.mark.skipif(one_test, reason='One test mode')
+    @pytest.mark.skipif(not pyvo_OK, reason='not pyvo_OK')
     def test_get_images_async(self):
         cadc = Cadc()
         coords = '01h45m07.5s +23d18m00s'

--- a/astroquery/conftest.py
+++ b/astroquery/conftest.py
@@ -32,7 +32,7 @@ except (NameError, KeyError):
 
 # ignoring pyvo can be removed once we require >0.9.3
 enable_deprecations_as_exceptions(include_astropy_deprecations=False,
-                                  warnings_to_ignore_entire_module=['pyregion'],)
+                                  warnings_to_ignore_entire_module=['pyregion', 'html5lib'],)
 
 # add '_testrun' to the version name so that the user-agent indicates that
 # it's being run in a test

--- a/astroquery/conftest.py
+++ b/astroquery/conftest.py
@@ -32,8 +32,7 @@ except (NameError, KeyError):
 
 # ignoring pyvo can be removed once we require >0.9.3
 enable_deprecations_as_exceptions(include_astropy_deprecations=False,
-                                  warnings_to_ignore_entire_module=['pyregion'],
-                                  modules_to_ignore_on_import=['pyvo'])
+                                  warnings_to_ignore_entire_module=['pyregion'],)
 
 # add '_testrun' to the version name so that the user-agent indicates that
 # it's being run in a test

--- a/astroquery/conftest.py
+++ b/astroquery/conftest.py
@@ -1,37 +1,18 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 import os
-from distutils.version import LooseVersion
 # this contains imports plugins that configure py.test for astropy tests.
 # by importing them here in conftest.py they are discoverable by py.test
 # no matter how it is invoked within the source tree.
 
-from astropy.version import version as astropy_version
-
-if LooseVersion(astropy_version) < LooseVersion('2.0.3'):
-    # Astropy is not compatible with the standalone plugins prior this while
-    # astroquery requires them, so we need this workaround. This will mess
-    # up the test header, but everything else will work.
-    from astropy.tests.pytest_plugins import (PYTEST_HEADER_MODULES,
-                                              TESTED_VERSIONS)
-elif astropy_version < '3.0':
-    # With older versions of Astropy, we actually need to import the pytest
-    # plugins themselves in order to make them discoverable by pytest.
-    from astropy.tests.pytest_plugins import *
-else:
-    # As of Astropy 3.0, the pytest plugins provided by Astropy are
-    # automatically made available when Astropy is installed. This means it's
-    # not necessary to import them here, but we still need to import global
-    # variables that are used for configuration.
-    from astropy.tests.plugins.display import (PYTEST_HEADER_MODULES,
-                                               TESTED_VERSIONS)
-    try:
-        # The astropy test runner sets up the header automatically,
-        # we should import it only when runnig pytest directly.
-        _ASTROPY_TEST_
-    except NameError:
-        from astropy.tests.plugins.display import pytest_report_header
+from pytest_astropy_header.display import (PYTEST_HEADER_MODULES,
+                                           TESTED_VERSIONS)
 
 from astropy.tests.helper import enable_deprecations_as_exceptions
+
+
+def pytest_configure(config):
+    config.option.astropy_header = True
+
 
 # Add astropy to test header information and remove unused packages.
 # Pytest header customisation was introduced in astropy 1.0.

--- a/astroquery/irsa_dust/tests/test_irsa_dust_remote.py
+++ b/astroquery/irsa_dust/tests/test_irsa_dust_remote.py
@@ -1,10 +1,11 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 import os
-import astropy.units as u
 import pytest
+import requests
 
 from astropy.tests.helper import remote_data
 from astropy.table import Table
+import astropy.units as u
 from ... import irsa_dust
 
 

--- a/astroquery/skyview/tests/data/survey_dict.json
+++ b/astroquery/skyview/tests/data/survey_dict.json
@@ -5,7 +5,7 @@
  "Optical:SDSS": ["SDSSg", "SDSSi", "SDSSr", "SDSSu", "SDSSz", "SDSSdr7g", "SDSSdr7i", "SDSSdr7r", "SDSSdr7u", "SDSSdr7z"],
  "OtherOptical": ["Mellinger Red", "Mellinger Green", "Mellinger Blue", "NEAT", "H-Alpha Comp", "SHASSA H", "SHASSA CC", "SHASSA C", "SHASSA Sm"],
  "IR:IRAS": ["IRIS  12", "IRIS  25", "IRIS  60", "IRIS 100", "SFD100m", "SFD Dust Map", "IRAS  12 micron", "IRAS  25 micron", "IRAS  60 micron", "IRAS 100 micron"],
- "IR:Planck": ["Planck 857", "Planck 545", "Planck 353", "Planck 217", "Planck 143", "Planck 100", "Planck 070", "Planck 044", "Planck 030"],
+ "IR:Planck": ["Planck 857 I", "Planck 545 I", "Planck 353 I", "Planck 353 Q", "Planck 353 U", "Planck 353 PI", "Planck 353 PA", "Planck 353 PI/I", "Planck 217 I", "Planck 217 Q", "Planck 217 U", "Planck 217 PI", "Planck 217 PA", "Planck 217 PI/I", "Planck 143 I", "Planck 143 Q", "Planck 143 U", "Planck 143 PI", "Planck 143 PA", "Planck 143 PI/I", "Planck 100 I", "Planck 100 Q", "Planck 100 U", "Planck 100 PI", "Planck 100 PA", "Planck 100 PI/I", "Planck 070 I", "Planck 070 Q", "Planck 070 U", "Planck 070 PI", "Planck 070 PA", "Planck 070 PI/I", "Planck 044 I", "Planck 044 Q", "Planck 044 U", "Planck 044 PI", "Planck 044 PA", "Planck 044 PI/I", "Planck 030 I", "Planck 030 Q", "Planck 030 U", "Planck 030 PI", "Planck 030 PA", "Planck 030 PI/I"],
  "IR:WMAP&COBE": ["WMAP ILC", "WMAP Ka", "WMAP K", "WMAP Q", "WMAP V", "WMAP W", "COBE DIRBE/AAM", "COBE DIRBE/ZSMA"],
  "Radio:GHz": ["CO", "GB6 (4850MHz)", "VLA FIRST (1.4 GHz)", "NVSS", "Stripe82VLA", "1420MHz (Bonn)", "HI4PI", "EBHIS", "nH"],
  "Allbands:GOODS/HDF/CDF": ["GOODS: Chandra ACIS HB", "GOODS: Chandra ACIS FB", "GOODS: Chandra ACIS SB", "GOODS: VLT VIMOS U", "GOODS: VLT VIMOS R", "GOODS: HST ACS B", "GOODS: HST ACS V", "GOODS: HST ACS I", "GOODS: HST ACS Z", "Hawaii HDF U", "Hawaii HDF B", "Hawaii HDF V0201", "Hawaii HDF V0401", "Hawaii HDF R", "Hawaii HDF I", "Hawaii HDF z", "Hawaii HDF HK", "GOODS: HST NICMOS", "GOODS: VLT ISAAC J", "GOODS: VLT ISAAC H", "GOODS: VLT ISAAC Ks", "HUDF: VLT ISAAC Ks", "GOODS: Spitzer IRAC 3.6", "GOODS: Spitzer IRAC 4.5", "GOODS: Spitzer IRAC 5.8", "GOODS: Spitzer IRAC 8.0", "GOODS: Spitzer MIPS 24", "GOODS: Herschel 100", "GOODS: Herschel 160", "GOODS: Herschel 250", "GOODS: Herschel 350", "GOODS: Herschel 500", "CDFS: LESS", "GOODS: VLA North"],
@@ -19,5 +19,5 @@
  "IR:UKIDSS class=": ["UKIDSS-Y", "UKIDSS-J", "UKIDSS-H", "UKIDSS-K"],
  "IR:WISE class=": ["WISE 3.4", "WISE 4.6", "WISE 12", "WISE 22"],
  "IR:AKARI class=": ["AKARI N60", "AKARI WIDE-S", "AKARI WIDE-L", "AKARI N160"],
- "Radio:MHz class=": ["SUMSS 843 MHz", "0408MHz", "WENSS", "TGSS ADR1", "VLSSr", "0035MHz"],
+ "Radio:MHz class=": ["SUMSS 843 MHz", "0408MHz", "WENSS", "TGSS ADR1", "VLSSr", "0035MHz", "0022MHz"],
  "Radio:GLEAM class=": ["GLEAM 72-103 MHz", "GLEAM 103-134 MHz", "GLEAM 139-170 MHz", "GLEAM 170-231 MHz"]}

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -87,6 +87,12 @@ full functionality of the `~astroquery.alma` module:
 * `APLpy <http://aplpy.readthedocs.io/>`_
 * `pyregion <http://pyregion.readthedocs.io/>`_
 
+
+The following packages are optional dependencies and are required for the
+functionality of the `~astroquery.cadc` module:
+
+* `pyVO`_ (>=1.0)
+
 The following packages are optional dependencies and are required for the
 full functionality of the `~astroquery.cds` module:
 


### PR DESCRIPTION
This PR is a collection of various cleanups in prep for tagging 0.4

Current content:
 * fixes for various remote test failures
 * fixing pytest headers
 * updating astropy-helpers
