### PR TITLE
Fix SyntaxWarning in python 3.8

### DIFF
--- a/astroquery/jplhorizons/core.py
+++ b/astroquery/jplhorizons/core.py
@@ -2,7 +2,7 @@
 from __future__ import print_function
 
 # 1. standard library imports
-from numpy import nan as nan
+from numpy import nan
 from numpy import isnan
 from numpy import ndarray
 from collections import OrderedDict
@@ -1084,19 +1084,19 @@ class HorizonsClass(BaseQuery):
         headerline = []
         for idx, line in enumerate(src):
             # read in ephemerides header line; replace some field names
-            if (self.query_type is 'ephemerides' and
+            if (self.query_type == 'ephemerides' and
                     "Date__(UT)__HR:MN" in line):
                 headerline = str(line).split(',')
                 headerline[2] = 'solar_presence'
                 headerline[3] = 'flags'
                 headerline[-1] = '_dump'
             # read in elements header line
-            elif (self.query_type is 'elements' and
+            elif (self.query_type == 'elements' and
                   "JDTDB," in line):
                 headerline = str(line).split(',')
                 headerline[-1] = '_dump'
             # read in vectors header line
-            elif (self.query_type is 'vectors' and
+            elif (self.query_type == 'vectors' and
                   "JDTDB," in line):
                 headerline = str(line).split(',')
                 headerline[-1] = '_dump'
@@ -1228,15 +1228,15 @@ class HorizonsClass(BaseQuery):
                                    name='phasecoeff'), index=7)
 
         # replace missing airmass values with 999 (not observable)
-        if self.query_type is 'ephemerides' and 'a-mass' in data.colnames:
+        if self.query_type == 'ephemerides' and 'a-mass' in data.colnames:
             data['a-mass'] = data['a-mass'].filled(999)
 
         # set column definition dictionary
-        if self.query_type is 'ephemerides':
+        if self.query_type == 'ephemerides':
             column_defs = conf.eph_columns
-        elif self.query_type is 'elements':
+        elif self.query_type == 'elements':
             column_defs = conf.elem_columns
-        elif self.query_type is 'vectors':
+        elif self.query_type == 'vectors':
             column_defs = conf.vec_columns
         else:
             raise TypeError('Query type unknown.')

--- a/astroquery/jplhorizons/tests/test_jplhorizons.py
+++ b/astroquery/jplhorizons/tests/test_jplhorizons.py
@@ -146,60 +146,61 @@ def test_elements_vectors(patch_request):
          res['vx'], res['vy'], res['vz'],
          res['lighttime'], res['range'], res['range_rate']], rtol=1e-3)
 
-    def test_ephemerides_query_payload(self):
-        obj = jplhorizons.Horizons(id='Halley', id_type='comet_name',
-                                   location='290',
-                                   epochs={'start': '2080-01-01',
-                                           'stop': '2080-02-01',
-                                           'step': '3h'})
-        res = obj.ephemerides(airmass_lessthan=1.2, skip_daylight=True,
-                              closest_apparition=True,
-                              hour_angle=10,
-                              solar_elongation=(150, 180),
-                              get_query_payload=True)
 
-        assert res == OrderedDict([
-            ('batch', 1),
-            ('TABLE_TYPE', 'OBSERVER'),
-            ('QUANTITIES', ('"1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,'
-                            '18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,'
-                            '33,34,35,36,37,38,39,40,41,42,43"')),
-            ('COMMAND', '"COMNAM=Halley; CAP;"'),
-            ('SOLAR_ELONG', '"150,180"'),
-            ('LHA_CUTOFF', '10'),
-            ('CSV_FORMAT', 'YES'),
-            ('CAL_FORMAT', 'BOTH'),
-            ('ANG_FORMAT', 'DEG'),
-            ('APPARENT', 'AIRLESS'),
-            ('REF_SYSTEM', 'J2000'),
-            ('CENTER', "'290'"),
-            ('START_TIME', '"2080-01-01"'),
-            ('STOP_TIME', '"2080-02-01"'),
-            ('STEP_SIZE', '"3h"'),
-            ('AIRMASS', '1.2'),
-            ('SKIP_DAYLT', 'YES'),
-            ('EXTRA_PREC', 'NO')])
+def test_ephemerides_query_payload():
+    obj = jplhorizons.Horizons(id='Halley', id_type='comet_name',
+                               location='290',
+                               epochs={'start': '2080-01-01',
+                                       'stop': '2080-02-01',
+                                       'step': '3h'})
+    res = obj.ephemerides(airmass_lessthan=1.2, skip_daylight=True,
+                          closest_apparition=True,
+                          max_hour_angle=10,
+                          solar_elongation=(150, 180),
+                          get_query_payload=True)
 
-    def test_elements_query_payload():
-        res = (jplhorizons.Horizons(id='Ceres', location='500@10',
-                                    epochs=2451544.5).elements(
-                                        get_query_payload=True))
+    assert res == OrderedDict([
+        ('batch', 1),
+        ('TABLE_TYPE', 'OBSERVER'),
+        ('QUANTITIES', "'1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,"
+                       "18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,"
+                       "33,34,35,36,37,38,39,40,41,42,43'"),
+        ('COMMAND', '"COMNAM=Halley; CAP;"'),
+        ('SOLAR_ELONG', '"150,180"'),
+        ('LHA_CUTOFF', '10'),
+        ('CSV_FORMAT', 'YES'),
+        ('CAL_FORMAT', 'BOTH'),
+        ('ANG_FORMAT', 'DEG'),
+        ('APPARENT', 'AIRLESS'),
+        ('REF_SYSTEM', 'J2000'),
+        ('EXTRA_PREC', 'NO'),
+        ('CENTER', "'290'"),
+        ('START_TIME', '"2080-01-01"'),
+        ('STOP_TIME', '"2080-02-01"'),
+        ('STEP_SIZE', '"3h"'),
+        ('AIRMASS', '1.2'),
+        ('SKIP_DAYLT', 'YES')])
 
-        assert res == OrderedDict([
-            ('batch', 1),
-            ('TABLE_TYPE', 'ELEMENTS'),
-            ('MAKE_EPHEM', 'YES'),
-            ('OUT_UNITS', 'AU-D'),
-            ('COMMAND', '"Ceres;"'),
-            ('CENTER', "'500@10'"),
-            ('CSV_FORMAT', 'YES'),
-            ('ELEM_LABELS', 'YES'),
-            ('OBJ_DATA', 'YES'),
-            ('REF_SYSTEM', 'J2000'),
-            ('REF_PLANE', 'ECLIPTIC'),
-            ('TP_TYPE', 'ABSOLUTE'),
-            ('EXTRA_PREC', 'NO')
-            ('TLIST', '2451544.5')])
+
+def test_elements_query_payload():
+    res = (jplhorizons.Horizons(id='Ceres', location='500@10',
+                                epochs=2451544.5).elements(
+                                    get_query_payload=True))
+
+    assert res == OrderedDict([
+        ('batch', 1),
+        ('TABLE_TYPE', 'ELEMENTS'),
+        ('MAKE_EPHEM', 'YES'),
+        ('OUT_UNITS', 'AU-D'),
+        ('COMMAND', '"Ceres;"'),
+        ('CENTER', "'500@10'"),
+        ('CSV_FORMAT', 'YES'),
+        ('ELEM_LABELS', 'YES'),
+        ('OBJ_DATA', 'YES'),
+        ('REF_SYSTEM', 'J2000'),
+        ('REF_PLANE', 'ECLIPTIC'),
+        ('TP_TYPE', 'ABSOLUTE'),
+        ('TLIST', '2451544.5')])
 
 
 def test_vectors_query_payload():


### PR DESCRIPTION
A SyntaxWarning is issued when using `is` identity check with literals.
```
/usr/lib/python3.8/site-packages/astroquery/jplhorizons/core.py:1087: SyntaxWarning: "is" with a literal. Did you mean "=="?
/usr/lib/python3.8/site-packages/astroquery/jplhorizons/core.py:1094: SyntaxWarning: "is" with a literal. Did you mean "=="?
/usr/lib/python3.8/site-packages/astroquery/jplhorizons/core.py:1099: SyntaxWarning: "is" with a literal. Did you mean "=="?
/usr/lib/python3.8/site-packages/astroquery/jplhorizons/core.py:1231: SyntaxWarning: "is" with a literal. Did you mean "=="?
/usr/lib/python3.8/site-packages/astroquery/jplhorizons/core.py:1235: SyntaxWarning: "is" with a literal. Did you mean "=="?
/usr/lib/python3.8/site-packages/astroquery/jplhorizons/core.py:1237: SyntaxWarning: "is" with a literal. Did you mean "=="?
/usr/lib/python3.8/site-packages/astroquery/jplhorizons/core.py:1239: SyntaxWarning: "is" with a literal. Did you mean "=="?
```