### PR TITLE
vo_conesearch: Update USNO-A2 and USNO-B1 URLs

### DIFF
--- a/astroquery/vo_conesearch/validator/data/conesearch_urls.txt
+++ b/astroquery/vo_conesearch/validator/data/conesearch_urls.txt
@@ -15,5 +15,5 @@ http://wfaudata.roe.ac.uk/sdssdr8-dsa/DirectCone?DSACAT=SDSS_DR8&amp;DSATAB=Phot
 http://wfaudata.roe.ac.uk/sdssdr8-dsa/DirectCone?DSACAT=SDSS_DR8&amp;DSATAB=SpecObjAll&amp;
 http://wfaudata.roe.ac.uk/twomass-dsa/DirectCone?DSACAT=TWOMASS&amp;DSATAB=twomass_psc&amp;
 http://wfaudata.roe.ac.uk/twomass-dsa/DirectCone?DSACAT=TWOMASS&amp;DSATAB=twomass_xsc&amp;
-http://www.nofs.navy.mil/cgi-bin/vo_cone.cgi?CAT=USNO-A2&amp;
-http://www.nofs.navy.mil/cgi-bin/vo_cone.cgi?CAT=USNO-B1&amp;
+http://astrometry.mit.edu/cgi-bin/vo_cone6.cgi?CAT=USNO-A2&amp;
+http://astrometry.mit.edu/cgi-bin/vo_cone6.cgi?CAT=USNO-B1&amp;


### PR DESCRIPTION
Fix the chronic validation failure for USNO-A2 and USNO-B1 catalogs. This is a subset of #871. Finally heard that the services moved from a defunct USNO site to http://astrometry.mit.edu/pica/vo_pica.html 