### PR TITLE
Stick with pure python reader for stability

### DIFF
--- a/astroquery/atomic/core.py
+++ b/astroquery/atomic/core.py
@@ -283,7 +283,7 @@ class AtomicLineListClass(BaseQuery):
                 input.append('\t'.join(row))
         if input:
             return ascii.read(input, data_start=0, delimiter='\t',
-                              names=colnames)
+                              names=colnames, fast_reader=False)
         else:
             # return an empty table if the query yielded no results
             return Table()

--- a/astroquery/besancon/core.py
+++ b/astroquery/besancon/core.py
@@ -423,13 +423,10 @@ def parse_besancon_model_string(bms,):
         raise ValueError("Table parsing error: mismatch between # of "
                          "columns & header")
 
-    besancon_table = ascii.read(bms, Reader=ascii.FixedWidthNoHeader,
-                                header_start=None,
-                                data_start=data_start,
-                                names=names,
-                                col_starts=col_starts,
-                                col_ends=col_ends,
-                                data_end=data_end)
+    besancon_table = ascii.read(bms, format='fixed_width_no_header',
+                                data_start=data_start, data_end=data_end,
+                                col_starts=col_starts, col_ends=col_ends,
+                                names=names, fast_reader=False)
 
     if len(besancon_table) != nstars:
         raise ValueError("Besancon table did not match reported size")

--- a/astroquery/exoplanet_orbit_database/exoplanet_orbit_database.py
+++ b/astroquery/exoplanet_orbit_database/exoplanet_orbit_database.py
@@ -63,7 +63,7 @@ class ExoplanetOrbitDatabaseClass(object):
             if table_path is None:
                 table_path = download_file(EXOPLANETS_CSV_URL, cache=cache,
                                            show_progress=show_progress)
-            exoplanets_table = ascii.read(table_path)
+            exoplanets_table = ascii.read(table_path, fast_reader=False)
 
             # Store column of lowercase names for indexing:
             lowercase_names = [i.lower().replace(" ", "")

--- a/astroquery/imcce/core.py
+++ b/astroquery/imcce/core.py
@@ -627,9 +627,9 @@ class SkybotClass(BaseQuery):
         if len(response_txt) < 3 and len(response_txt[-1].split('|')) < 21:
             raise RuntimeError(response_txt[-1])
 
+        names = response_txt[0].replace('# ', '').strip().split(' | ')
         results = ascii.read(response_txt[1:], delimiter='|',
-                             names=response_txt[0].replace('# ',
-                                                           '').strip().split(' | '))
+                             names=names, fast_reader=False)
         results = QTable(results)
 
         # convert coordinates to degrees

--- a/astroquery/jplhorizons/core.py
+++ b/astroquery/jplhorizons/core.py
@@ -1188,7 +1188,8 @@ class HorizonsClass(BaseQuery):
         data = ascii.read(raw_data,
                           names=headerline,
                           fill_values=[('.n.a.', '0'),
-                                       ('n.a.', '0')])
+                                       ('n.a.', '0')],
+                          fast_reader=False)
         # force to a masked table
         data = Table(data, masked=True)
 

--- a/astroquery/jplspec/core.py
+++ b/astroquery/jplspec/core.py
@@ -156,16 +156,15 @@ class JPLSpecClass(BaseQuery):
         QN":   Quantum numbers for the lower state.
         """
 
-        result = ascii.read(response.text,
-                            header_start=None,
-                            data_start=0,  # start at 0 since regex was applied
-                            # Warning for a result with more than 1000 lines:
-                            # THIS form is currently limited to 1000 lines.
+        # data starts at 0 since regex was applied
+        # Warning for a result with more than 1000 lines:
+        # THIS form is currently limited to 1000 lines.
+        result = ascii.read(response.text, header_start=None, data_start=0,
                             comment=r'THIS|^\s{12,14}\d{4,6}.*',
                             names=('FREQ', 'ERR', 'LGINT', 'DR', 'ELO', 'GUP',
                                    'TAG', 'QNFMT', 'QN\'', 'QN"'),
                             col_starts=(0, 13, 21, 29, 31, 41, 44, 51, 55, 67),
-                            format='fixed_width')
+                            format='fixed_width', fast_reader=False)
 
         if len(result) > self.maxlines:
             warnings.warn("This form is currently limited to {0} lines."
@@ -207,17 +206,13 @@ class JPLSpecClass(BaseQuery):
 
         """
 
-        result = ascii.read(data_path(catfile),
-                            header_start=None,
-                            data_start=0,
-                            names=('TAG', 'NAME', 'NLINE',
-                                   'QLOG1', 'QLOG2',
-                                   'QLOG3', 'QLOG4',
-                                   'QLOG5', 'QLOG6',
+        result = ascii.read(data_path(catfile), header_start=None, data_start=0,
+                            names=('TAG', 'NAME', 'NLINE', 'QLOG1', 'QLOG2',
+                                   'QLOG3', 'QLOG4', 'QLOG5', 'QLOG6',
                                    'QLOG7', 'VER'),
                             col_starts=(0, 6, 20, 26, 33, 40, 47, 54, 61,
                                         68, 75),
-                            format='fixed_width')
+                            format='fixed_width', fast_reader=False)
 
         # store the corresponding temperatures as metadata
         result['QLOG1'].meta = {'Temperature (K)': 300}

--- a/astroquery/mpc/core.py
+++ b/astroquery/mpc/core.py
@@ -1123,7 +1123,7 @@ class MPCClass(BaseQuery):
             tab = ascii.read(text_table, format='fixed_width_no_header',
                              names=names, col_starts=col_starts,
                              col_ends=col_ends, data_start=data_start,
-                             fill_values=(('N/A', np.nan),))
+                             fill_values=(('N/A', np.nan),), fast_reader=False)
 
             for col, unit in zip(names, units):
                 tab[col].unit = unit
@@ -1204,7 +1204,8 @@ class MPCClass(BaseQuery):
                                   col_starts=(0, 5, 12, 13, 14, 15,
                                               32, 44, 65, 70, 77),
                                   col_ends=(4, 11, 12, 13, 14, 31,
-                                            43, 55, 69, 70, 79))
+                                            43, 55, 69, 70, 79),
+                                  fast_reader=False)
 
                 # convert asteroid designations
                 # old designation style, e.g.: 1989AB
@@ -1248,7 +1249,8 @@ class MPCClass(BaseQuery):
                                   col_starts=(0, 4, 5, 13, 14, 15,
                                               32, 44, 65, 70, 77),
                                   col_ends=(3, 4, 12, 13, 14, 31,
-                                            43, 55, 69, 70, 79))
+                                            43, 55, 69, 70, 79),
+                                  fast_reader=False)
 
                 # convert comet designations
                 ident = data['desig'][0]

--- a/astroquery/nasa_exoplanet_archive/nasa_exoplanet_archive.py
+++ b/astroquery/nasa_exoplanet_archive/nasa_exoplanet_archive.py
@@ -89,7 +89,7 @@ class NasaExoplanetArchiveClass(object):
                 table_path = download_file(exoplanets_url, cache=cache,
                                            show_progress=show_progress,
                                            timeout=120)
-            exoplanets_table = ascii.read(table_path)
+            exoplanets_table = ascii.read(table_path, fast_reader=False)
 
             # Create sky coordinate mixin column
             exoplanets_table['sky_coord'] = SkyCoord(ra=exoplanets_table['ra'] * u.deg,
@@ -150,7 +150,7 @@ class NasaExoplanetArchiveClass(object):
                 table_path = download_file(exoplanets_url, cache=cache,
                                            show_progress=show_progress,
                                            timeout=120)
-            exoplanets_table = ascii.read(table_path)
+            exoplanets_table = ascii.read(table_path, fast_reader=False)
 
             # Create sky coordinate mixin column
             exoplanets_table['sky_coord'] = SkyCoord(ra=exoplanets_table['ra'] * u.deg,

--- a/astroquery/splatalogue/core.py
+++ b/astroquery/splatalogue/core.py
@@ -476,15 +476,8 @@ class SplatalogueClass(BaseQuery):
             splatalogue to make them more terminal-friendly
         """
 
-        try:
-            result = ascii.read(response.text.split('\n'),
-                                delimiter=':',
-                                format='basic')
-        except TypeError:
-            # deprecated
-            result = ascii.read(response.text.split('\n'),
-                                delimiter=':',
-                                Reader=ascii.Basic)
+        result = ascii.read(response.text.split('\n'), delimiter=':',
+                            format='basic', fast_reader=False)
 
         return result
 

--- a/astroquery/xmatch/core.py
+++ b/astroquery/xmatch/core.py
@@ -194,7 +194,7 @@ class XMatchClass(BaseQuery):
                     colnames[colnames.index(cn)] = cn + "_{ii}".format(ii=ii)
                     ii += 1
         new_text = ",".join(colnames) + "\n" + "\n".join(text.split("\n")[1:])
-        result = ascii.read(new_text, format='csv')
+        result = ascii.read(new_text, format='csv', fast_reader=False)
 
         return result
 

--- a/astroquery/xmatch/tests/test_xmatch.py
+++ b/astroquery/xmatch/tests/test_xmatch.py
@@ -90,7 +90,7 @@ def test_xmatch_query_local(monkeypatch):
         response = xm.query_async(
             cat1=pos_list, cat2='vizier:II/246/out', max_distance=5 * arcsec,
             colRA1='ra', colDec1='dec')
-    table = ascii.read(response.text, format='csv')
+    table = ascii.read(response.text, format='csv', fast_reader=False)
     assert isinstance(table, Table)
     assert table.colnames == [
         'angDist', 'ra', 'dec', 'my_id', '2MASS', 'RAJ2000', 'DEJ2000',
@@ -114,7 +114,7 @@ def test_xmatch_query_cat1_table_local(monkeypatch):
     response = xm.query_async(
         cat1=input_table, cat2='vizier:II/246/out', max_distance=5 * arcsec,
         colRA1='ra', colDec1='dec')
-    table = ascii.read(response.text, format='csv')
+    table = ascii.read(response.text, format='csv', fast_reader=False)
     assert isinstance(table, Table)
     assert table.colnames == [
         'angDist', 'ra', 'dec', 'my_id', '2MASS', 'RAJ2000', 'DEJ2000',

--- a/astroquery/xmatch/tests/test_xmatch_remote.py
+++ b/astroquery/xmatch/tests/test_xmatch_remote.py
@@ -112,5 +112,5 @@ class TestXMatch:
                   '-F cat1=@{1} -F colRA1=ra -F colDec1=dec -F cat2=vizier:II/246/out  '
                   'http://cdsxmatch.u-strasbg.fr/xmatch/api/v1/sync > {0}'.
                   format(outfile, infile))
-        table = ascii.read(outfile, format='csv')
+        table = ascii.read(outfile, format='csv', fast_reader=False)
         return table


### PR DESCRIPTION
This is to address #1626 (for motivation, and performance discussion, see: https://github.com/astropy/astropy/issues/9886)

Vizier is the only module where the fast reader is kept (for now), as it was intentionally added in #526. However there are some issues with functionality anyway, so opting out the fast reader can be part of fixing https://github.com/astropy/astroquery/issues/1630