### PR TITLE
ENH: Cache refactoring

### DIFF
--- a/astroquery/__init__.py
+++ b/astroquery/__init__.py
@@ -40,11 +40,12 @@ logging.addLevelName(5, "TRACE")
 log = logging.getLogger()
 log = _init_log()
 
+
 # Set up cache configuration
 class Conf(_config.ConfigNamespace):
 
     default_cache_timeout = _config.ConfigItem(
-          604800 ,  # 1 week
+          604800,  # 1 week
           'Astroquery-wide default cache timeout (seconds).'
           )
     cache_location = _config.ConfigItem(

--- a/astroquery/__init__.py
+++ b/astroquery/__init__.py
@@ -16,6 +16,7 @@ import os
 import logging
 
 from .logger import _init_log
+from astropy import config as _config
 
 __all__ = ["__version__", "__githash__", "__citation__", "__bibtex__", "test", "log"]
 
@@ -38,3 +39,13 @@ __citation__ = __bibtex__ = _get_bibtex()
 logging.addLevelName(5, "TRACE")
 log = logging.getLogger()
 log = _init_log()
+
+# Set up cache configuration
+class Conf(_config.ConfigNamespace):
+    
+    default_cache_timeout = _config.ConfigItem(
+          60.0*60.0*24.0,
+          'Astroquery-wide default cache timeout (seconds).'
+          )
+
+conf = Conf()

--- a/astroquery/__init__.py
+++ b/astroquery/__init__.py
@@ -48,11 +48,11 @@ class Conf(_config.ConfigNamespace):
           604800,  # 1 week
           'Astroquery-wide default cache timeout (seconds).'
           )
-    cache_location = _config.ConfigItem(
+    default_cache_location = _config.ConfigItem(
           os.path.join(_config.paths.get_cache_dir(), 'astroquery'),
           'Astroquery default cache location (within astropy cache).'
           )
-    use_cache = _config.ConfigItem(
+    default_cache_active = _config.ConfigItem(
         True,
         "Astroquery global cache usage, False turns off all caching."
         )

--- a/astroquery/__init__.py
+++ b/astroquery/__init__.py
@@ -44,7 +44,7 @@ log = _init_log()
 class Conf(_config.ConfigNamespace):
 
     default_cache_timeout = _config.ConfigItem(
-          86400,  # 24 hours
+          604800 ,  # 1 week
           'Astroquery-wide default cache timeout (seconds).'
           )
     cache_location = _config.ConfigItem(

--- a/astroquery/__init__.py
+++ b/astroquery/__init__.py
@@ -12,7 +12,6 @@ to access online Astronomical data. Each web service has its own sub-package.
 from ._astropy_init import __version__, __githash__, test
 # ----------------------------------------------------------------------------
 
-
 import os
 import logging
 
@@ -45,9 +44,16 @@ log = _init_log()
 class Conf(_config.ConfigNamespace):
     
     default_cache_timeout = _config.ConfigItem(
-          60.0*60.0*24.0,
+          86400, # 24 hours
           'Astroquery-wide default cache timeout (seconds).'
           )
-
+    cache_location = _config.ConfigItem(
+          os.path.join(_config.paths.get_cache_dir(), 'astroquery'),
+          'Astroquery default cache location (within astropy cache).'
+          )
+    use_cache = _config.ConfigItem(
+        True,
+        "Astroquery global cache usage, False turns off all caching."
+        )
 
 conf = Conf()

--- a/astroquery/__init__.py
+++ b/astroquery/__init__.py
@@ -45,8 +45,8 @@ log = _init_log()
 class Cache_Conf(_config.ConfigNamespace):
 
     cache_timeout = _config.ConfigItem(
-        604800,  # 1 week
-        'Astroquery-wide cache timeout (seconds).',
+        604800,
+        'Astroquery-wide cache timeout (seconds). Default is 1 week (604800).',
         cfgtype='integer'
     )
 

--- a/astroquery/__init__.py
+++ b/astroquery/__init__.py
@@ -42,7 +42,7 @@ log = _init_log()
 
 
 # Set up cache configuration
-class Conf(_config.ConfigNamespace):
+class Cache_Conf(_config.ConfigNamespace):
 
     cache_timeout = _config.ConfigItem(
         604800,  # 1 week
@@ -57,4 +57,4 @@ class Conf(_config.ConfigNamespace):
     )
 
 
-conf = Conf()
+cache_conf = Cache_Conf()

--- a/astroquery/__init__.py
+++ b/astroquery/__init__.py
@@ -42,9 +42,9 @@ log = _init_log()
 
 # Set up cache configuration
 class Conf(_config.ConfigNamespace):
-    
+
     default_cache_timeout = _config.ConfigItem(
-          86400, # 24 hours
+          86400,  # 24 hours
           'Astroquery-wide default cache timeout (seconds).'
           )
     cache_location = _config.ConfigItem(
@@ -55,5 +55,6 @@ class Conf(_config.ConfigNamespace):
         True,
         "Astroquery global cache usage, False turns off all caching."
         )
+
 
 conf = Conf()

--- a/astroquery/__init__.py
+++ b/astroquery/__init__.py
@@ -46,7 +46,8 @@ class Cache_Conf(_config.ConfigNamespace):
 
     cache_timeout = _config.ConfigItem(
         604800,
-        'Astroquery-wide cache timeout (seconds). Default is 1 week (604800).',
+        ('Astroquery-wide cache timeout (seconds). Default is 1 week (604800). '
+         'Setting to None prevents the cache from expiring (not recommended).'),
         cfgtype='integer'
     )
 

--- a/astroquery/__init__.py
+++ b/astroquery/__init__.py
@@ -44,18 +44,17 @@ log = _init_log()
 # Set up cache configuration
 class Conf(_config.ConfigNamespace):
 
-    default_cache_timeout = _config.ConfigItem(
-          604800,  # 1 week
-          'Astroquery-wide default cache timeout (seconds).'
-          )
-    default_cache_location = _config.ConfigItem(
-          os.path.join(_config.paths.get_cache_dir(), 'astroquery'),
-          'Astroquery default cache location (within astropy cache).'
-          )
-    default_cache_active = _config.ConfigItem(
+    cache_timeout = _config.ConfigItem(
+        604800,  # 1 week
+        'Astroquery-wide cache timeout (seconds).',
+        cfgtype='integer'
+    )
+
+    cache_active = _config.ConfigItem(
         True,
-        "Astroquery global cache usage, False turns off all caching."
-        )
+        "Astroquery global cache usage, False turns off all caching.",
+        cfgtype='boolean'
+    )
 
 
 conf = Conf()

--- a/astroquery/__init__.py
+++ b/astroquery/__init__.py
@@ -12,6 +12,7 @@ to access online Astronomical data. Each web service has its own sub-package.
 from ._astropy_init import __version__, __githash__, test
 # ----------------------------------------------------------------------------
 
+
 import os
 import logging
 
@@ -47,5 +48,6 @@ class Conf(_config.ConfigNamespace):
           60.0*60.0*24.0,
           'Astroquery-wide default cache timeout (seconds).'
           )
+
 
 conf = Conf()

--- a/astroquery/query.py
+++ b/astroquery/query.py
@@ -199,7 +199,6 @@ class BaseQuery(metaclass=LoginABCMeta):
         self._cache_active = conf.use_cache
         self.cache_timeout = conf.default_cache_timeout
 
-
     def __call__(self, *args, **kwargs):
         """ init a fresh copy of self """
         return self.__class__(*args, **kwargs)
@@ -237,7 +236,7 @@ class BaseQuery(metaclass=LoginABCMeta):
                     f"{response.text}\n"
                     f"-----------------------------------------", '\t')
             log.log(5, f"HTTP response\n{response_log}")
-     
+
     def clear_cache(self):
         """Removes all cache files."""
 

--- a/astroquery/query.py
+++ b/astroquery/query.py
@@ -35,7 +35,7 @@ def to_cache(response, cache_file):
         for key in tuple(response.request.hooks.keys()):
             del response.request.hooks[key]
     with open(cache_file, "wb") as f:
-        pickle.dump(response, f)
+        pickle.dump(response, f, protocol=4)
 
 
 def _replace_none_iterable(iterable):
@@ -284,7 +284,7 @@ class BaseQuery(metaclass=LoginABCMeta):
             somewhere other than `BaseQuery.cache_location`
         timeout : int
         cache : bool
-            Override global cache settings.
+            Optional, if specified, overrides global cache settings.
         verify : bool
             Verify the server's TLS certificate?
             (see http://docs.python-requests.org/en/master/_modules/requests/sessions/?highlight=verify)

--- a/astroquery/query.py
+++ b/astroquery/query.py
@@ -19,7 +19,6 @@ import astropy.units as u
 from astropy.utils.console import ProgressBarOrSpinner
 import astropy.utils.data
 from astropy.utils import deprecated
-from astropy.utils.exceptions import AstropyDeprecationWarning
 
 from astroquery import version, log, cache_conf
 from astroquery.utils import system_tools

--- a/astroquery/query.py
+++ b/astroquery/query.py
@@ -241,14 +241,14 @@ class BaseQuery(metaclass=LoginABCMeta):
                     f"-----------------------------------------", '\t')
             log.log(5, f"HTTP response\n{response_log}")
      
-     def clear_cache():
+    def clear_cache(self):
         """Removes all cache files."""
 
-        cache_files = [x for x in os.listdir(self.cache_location) if x.endswidth("pickle")]
+        cache_files = [x for x in os.listdir(self.cache_location) if x.endswith("pickle")]
         for fle in cache_files:
-            os.remove(fle)
+            os.remove(os.path.join(self.cache_location,fle))
 
-    def reset_cache_preferences():
+    def reset_cache_preferences(self):
         """Resets cache preferences to default values"""
 
         self.cache_location = os.path.join(

--- a/astroquery/query.py
+++ b/astroquery/query.py
@@ -191,8 +191,6 @@ class BaseQuery(metaclass=LoginABCMeta):
                     olduseragent=S.headers['User-Agent']))
 
         self.name = self.__class__.__name__.split("Class")[0]
-
-
         self.reset_cache_preferences()
 
     def __call__(self, *args, **kwargs):

--- a/astroquery/query.py
+++ b/astroquery/query.py
@@ -13,6 +13,7 @@ import requests
 import textwrap
 
 from datetime import datetime, timedelta
+from pathlib import Path
 
 from astropy.config import paths
 from astroquery import log
@@ -29,10 +30,14 @@ __all__ = ['BaseQuery', 'QueryWithLogin']
 
 def to_cache(response, cache_file):
     log.debug("Caching data to {0}".format(cache_file))
+
     response = copy.deepcopy(response)
     if hasattr(response, 'request'):
         for key in tuple(response.request.hooks.keys()):
             del response.request.hooks[key]
+
+    chache_dir, _ = os.path.split(cache_file)
+    Path(chache_dir).mkdir(parents=True, exist_ok=True)
     with open(cache_file, "wb") as f:
         pickle.dump(response, f)
 

--- a/astroquery/query.py
+++ b/astroquery/query.py
@@ -21,7 +21,7 @@ import astropy.utils.data
 from astropy.utils import deprecated
 from astropy.utils.exceptions import AstropyDeprecationWarning
 
-from astroquery import version, log, conf
+from astroquery import version, log, cache_conf
 from astroquery.utils import system_tools
 
 
@@ -311,7 +311,7 @@ class BaseQuery(metaclass=LoginABCMeta):
             is True.
         """
 
-        cache &= conf.cache_active
+        cache &= cache_conf.cache_active
 
         if save:
             local_filename = url.split('/')[-1]
@@ -335,13 +335,13 @@ class BaseQuery(metaclass=LoginABCMeta):
             query = AstroQuery(method, url, params=params, data=data, headers=headers,
                                files=files, timeout=timeout, json=json)
             if (self.cache_location is None) or (not cache):
-                with conf.set_temp("cache_active", False):
+                with cache_conf.set_temp("cache_active", False):
                     response = query.request(self._session, stream=stream,
                                              auth=auth, verify=verify,
                                              allow_redirects=allow_redirects,
                                              json=json)
             else:
-                response = query.from_cache(self.cache_location, conf.cache_timeout)
+                response = query.from_cache(self.cache_location, cache_conf.cache_timeout)
                 if not response:
                     response = query.request(self._session,
                                              self.cache_location,
@@ -485,7 +485,7 @@ class suspend_cache:
     """
 
     def __init__(self, obj=None):
-        self.original_cache_setting = conf.cache_active
+        self.original_cache_setting = cache_conf.cache_active
 
     def __enter__(self):
         conf.cache_active = False

--- a/astroquery/query.py
+++ b/astroquery/query.py
@@ -191,7 +191,7 @@ class BaseQuery(metaclass=LoginABCMeta):
                     olduseragent=S.headers['User-Agent']))
 
         self.cache_location = os.path.join(
-            paths.get_cache_dir(), 'astroquery',
+            conf.cache_location,
             self.__class__.__name__.split("Class")[0])
         os.makedirs(self.cache_location, exist_ok=True)
 
@@ -248,7 +248,7 @@ class BaseQuery(metaclass=LoginABCMeta):
         """Resets cache preferences to default values"""
 
         self.cache_location = os.path.join(
-            paths.get_cache_dir(), 'astroquery',
+            conf.cache_location,
             self.__class__.__name__.split("Class")[0])
         os.makedirs(self.cache_location, exist_ok=True)
 

--- a/astroquery/query.py
+++ b/astroquery/query.py
@@ -246,7 +246,7 @@ class BaseQuery(metaclass=LoginABCMeta):
 
         cache_files = [x for x in os.listdir(self.cache_location) if x.endswith("pickle")]
         for fle in cache_files:
-            os.remove(os.path.join(self.cache_location,fle))
+            os.remove(os.path.join(self.cache_location, fle))
 
     def reset_cache_preferences(self):
         """Resets cache preferences to default values"""
@@ -254,7 +254,7 @@ class BaseQuery(metaclass=LoginABCMeta):
         self.cache_location = os.path.join(
             conf.cache_location,
             self.__class__.__name__.split("Class")[0])
-        
+
         self.use_cache = conf.use_cache
         self.cache_timeout = conf.default_cache_timeout
 
@@ -319,12 +319,12 @@ class BaseQuery(metaclass=LoginABCMeta):
             and the server response object, if ``save`` is True and ``return_response_on_save``
             is True.
         """
-    
+
         if (cache is not False) and self.use_cache:
             cache = True
         else:
             cache = False
-            
+
         if save:
             local_filename = url.split('/')[-1]
             if os.name == 'nt':

--- a/astroquery/query.py
+++ b/astroquery/query.py
@@ -248,8 +248,9 @@ class BaseQuery(metaclass=LoginABCMeta):
         """Resets cache preferences to default values"""
 
         self.cache_location = os.path.join(
-            conf.cache_location,
+            paths.get_cache_dir(), 'astroquery',
             self.__class__.__name__.split("Class")[0])
+        os.makedirs(self.cache_location, exist_ok=True)
 
         self._cache_active = conf.use_cache
         self.cache_timeout = conf.default_cache_timeout

--- a/astroquery/query.py
+++ b/astroquery/query.py
@@ -8,7 +8,6 @@ import hashlib
 import keyring
 import io
 import os
-import warnings
 import requests
 import textwrap
 
@@ -16,14 +15,13 @@ from datetime import datetime, timedelta
 from pathlib import Path
 
 from astropy.config import paths
-from astroquery import log
 import astropy.units as u
 from astropy.utils.console import ProgressBarOrSpinner
 import astropy.utils.data
 
-from . import version
-from .utils import system_tools
-from astroquery import conf
+from astroquery import version, log, conf
+from astroquery.utils import system_tools
+
 
 __all__ = ['BaseQuery', 'QueryWithLogin']
 
@@ -199,7 +197,6 @@ class BaseQuery(metaclass=LoginABCMeta):
 
         self.name = self.__class__.__name__.split("Class")[0]
         self._cache_active = conf.use_cache
-        self.use_cache = conf.use_cache
         self.cache_timeout = conf.default_cache_timeout
 
 
@@ -255,7 +252,7 @@ class BaseQuery(metaclass=LoginABCMeta):
             conf.cache_location,
             self.__class__.__name__.split("Class")[0])
 
-        self.use_cache = conf.use_cache
+        self._cache_active = conf.use_cache
         self.cache_timeout = conf.default_cache_timeout
 
     def _request(self, method, url,
@@ -320,7 +317,7 @@ class BaseQuery(metaclass=LoginABCMeta):
             is True.
         """
 
-        if (cache is not False) and self.use_cache:
+        if (cache is not False) and self._cache_active:
             cache = True
         else:
             cache = False

--- a/astroquery/query.py
+++ b/astroquery/query.py
@@ -478,6 +478,22 @@ class BaseQuery(metaclass=LoginABCMeta):
         return response
 
 
+class suspend_cache:
+    """
+    A context manager that suspends caching.
+    """
+
+    def __init__(self, obj=None):
+        self.original_cache_setting = conf.cache_active
+
+    def __enter__(self):
+        conf.cache_active = False
+
+    def __exit__(self, exc_type, exc_value, traceback):
+        conf.cache_active = self.original_cache_setting
+        return False
+
+
 class QueryWithLogin(BaseQuery):
     """
     This is the base class for all the query classes which are required to

--- a/astroquery/setup_package.py
+++ b/astroquery/setup_package.py
@@ -3,4 +3,3 @@
 
 def get_package_data():
     return {'astroquery': ['CITATION']}
-

--- a/astroquery/setup_package.py
+++ b/astroquery/setup_package.py
@@ -3,3 +3,4 @@
 
 def get_package_data():
     return {'astroquery': ['CITATION']}
+

--- a/astroquery/tests/test_cache.py
+++ b/astroquery/tests/test_cache.py
@@ -12,38 +12,39 @@ URL2 = "http://fakeurl.ac.uk"
 TEXT1 = "Penguin"
 TEXT2 = "Walrus"
 
+
 def set_response(resp_text, resp_status=200):
     """Function that allows us to set a specific mock response for cache testing"""
 
     def get_mockreturn(url, *args, **kwargs):
         """Generate a mock return to a requests call"""
-    
+
         myresp = requests.Response()
         myresp._content = resp_text
         myresp.request = requests.PreparedRequest()
         myresp.status_code = resp_status
-    
+
         return myresp
-    
+
     requests.Session.request = get_mockreturn
 
     
 class TestClass(QueryWithLogin):
     """Bare bones class for testing caching"""
-    
+
     def test_func(self, requrl):
-        
+
         return self._request(method="GET", url=requrl)
-    
+
     def _login(self, username):
-        
+
         resp = self._request(method="GET", url=username)
-        
+
         if resp.content == "Penguin":
             return True
         else:
             return False
-        
+
 
 def test_cache_reset():
     mytest = TestClass()
@@ -60,7 +61,7 @@ def test_cache_reset():
     assert mytest.cache_timeout == default_timeout
     assert mytest.cache_location == default_loc
 
-    
+
 def test_basic_caching():
 
     mytest = TestClass()
@@ -68,7 +69,7 @@ def test_basic_caching():
 
     mytest.clear_cache()
     assert len(os.listdir(mytest.cache_location)) == 0
-    
+
     set_response(TEXT1)
 
     resp = mytest.test_func(URL1)
@@ -120,19 +121,18 @@ def test_timeout():
     mytest.clear_cache()
     assert len(os.listdir(mytest.cache_location)) == 0
 
-    mytest.cache_timeout = 2  # Set to 2 sec so we can reach timeout easily 
-    
+    mytest.cache_timeout = 2  # Set to 2 sec so we can reach timeout easily
+
     set_response(TEXT1)  # setting the response
-    
+
     resp = mytest.test_func(URL1)  # should be cached
     assert resp.content == TEXT1
 
     set_response(TEXT2)  # changing the respont
-    
+
     resp = mytest.test_func(URL1)  # should access cached value
     assert resp.content == TEXT1
 
     sleep(2)  # run out cache time
     resp = mytest.test_func(URL1)
     assert resp.content == TEXT2  # no see the new response
-    

--- a/astroquery/tests/test_cache.py
+++ b/astroquery/tests/test_cache.py
@@ -1,0 +1,138 @@
+import pytest
+import requests
+import os
+
+from time import sleep
+
+from astroquery.query import QueryWithLogin
+
+URL1 = "http://fakeurl.edu"
+URL2 = "http://fakeurl.ac.uk"
+
+TEXT1 = "Penguin"
+TEXT2 = "Walrus"
+
+def set_response(resp_text, resp_status=200):
+    """Function that allows us to set a specific mock response for cache testing"""
+
+    def get_mockreturn(url, *args, **kwargs):
+        """Generate a mock return to a requests call"""
+    
+        myresp = requests.Response()
+        myresp._content = resp_text
+        myresp.request = requests.PreparedRequest()
+        myresp.status_code = resp_status
+    
+        return myresp
+    
+    requests.Session.request = get_mockreturn
+
+    
+class TestClass(QueryWithLogin):
+    """Bare bones class for testing caching"""
+    
+    def test_func(self, requrl):
+        
+        return self._request(method="GET", url=requrl)
+    
+    def _login(self, username):
+        
+        resp = self._request(method="GET", url=username)
+        
+        if resp.content == "Penguin":
+            return True
+        else:
+            return False
+        
+
+def test_cache_reset():
+    mytest = TestClass()
+    assert mytest._cache_active
+
+    default_timeout = mytest.cache_timeout
+    default_loc = mytest.cache_location
+
+    mytest.cache_timeout = 5
+    mytest.cache_location = "new/location"
+
+    mytest.reset_cache_preferences()
+
+    assert mytest.cache_timeout == default_timeout
+    assert mytest.cache_location == default_loc
+
+    
+def test_basic_caching():
+
+    mytest = TestClass()
+    assert mytest._cache_active
+
+    mytest.clear_cache()
+    assert len(os.listdir(mytest.cache_location)) == 0
+    
+    set_response(TEXT1)
+
+    resp = mytest.test_func(URL1)
+    assert resp.content == TEXT1
+    assert len(os.listdir(mytest.cache_location)) == 1
+
+    set_response(TEXT2)
+
+    resp = mytest.test_func(URL2)  # query that has not been cached
+    assert resp.content == TEXT2
+    assert len(os.listdir(mytest.cache_location)) == 2
+ 
+    resp = mytest.test_func(URL1)
+    assert resp.content == TEXT1  # query that was cached
+    assert len(os.listdir(mytest.cache_location)) == 2  # no new cache file
+
+    mytest.clear_cache()
+    assert len(os.listdir(mytest.cache_location)) == 0
+
+    resp = mytest.test_func(URL1)
+    assert resp.content == TEXT2  # Now get new response
+
+
+def test_login():
+
+    mytest = TestClass()
+    assert mytest._cache_active
+
+    mytest.clear_cache()
+    assert len(os.listdir(mytest.cache_location)) == 0
+
+    set_response(TEXT1)  # Text 1 is set as the approved password
+
+    mytest.login("ceb")
+    assert mytest.authenticated()
+    assert len(os.listdir(mytest.cache_location)) == 0  # request should not be cached
+
+    set_response(TEXT2)  # Text 1 is not the approved password
+
+    mytest.login("ceb")
+    assert not mytest.authenticated()  # Should not be accessing cache
+
+
+def test_timeout():
+
+    mytest = TestClass()
+    assert mytest._cache_active
+
+    mytest.clear_cache()
+    assert len(os.listdir(mytest.cache_location)) == 0
+
+    mytest.cache_timeout = 2  # Set to 2 sec so we can reach timeout easily 
+    
+    set_response(TEXT1)  # setting the response
+    
+    resp = mytest.test_func(URL1)  # should be cached
+    assert resp.content == TEXT1
+
+    set_response(TEXT2)  # changing the respont
+    
+    resp = mytest.test_func(URL1)  # should access cached value
+    assert resp.content == TEXT1
+
+    sleep(2)  # run out cache time
+    resp = mytest.test_func(URL1)
+    assert resp.content == TEXT2  # no see the new response
+    

--- a/astroquery/tests/test_cache.py
+++ b/astroquery/tests/test_cache.py
@@ -1,7 +1,8 @@
 import requests
 import os
 
-from time import sleep
+from time import mktime
+from datetime import datetime
 
 from astropy.config import paths
 
@@ -146,7 +147,7 @@ def test_login():
     assert not mytest.authenticated()  # Should not be accessing cache
 
 
-def test_timeout():
+def test_timeout(monkeypatch):
     cache_conf.reset()
 
     mytest = CacheTestClass()
@@ -155,21 +156,23 @@ def test_timeout():
     mytest.clear_cache()
     assert len(os.listdir(mytest.cache_location)) == 0
 
-    cache_conf.cache_timeout = 2  # Set to 2 sec so we can reach timeout easily
-
     set_response(TEXT1)  # setting the response
 
     resp = mytest.test_func(URL1)  # should be cached
     assert resp.content == TEXT1
 
-    set_response(TEXT2)  # changing the respont
+    set_response(TEXT2)  # changing the response
 
     resp = mytest.test_func(URL1)  # should access cached value
     assert resp.content == TEXT1
 
-    sleep(2)  # run out cache time
+    # Changing the file date so the cache will consider it expired
+    cache_file = list(mytest.cache_location.iterdir())[0]
+    modTime = mktime(datetime(1970, 1, 1).timetuple())
+    os.utime(cache_file, (modTime, modTime))
+    
     resp = mytest.test_func(URL1)
-    assert resp.content == TEXT2  # no see the new response
+    assert resp.content == TEXT2  # now see the new response
 
 
 def test_deactivate():

--- a/astroquery/tests/test_cache.py
+++ b/astroquery/tests/test_cache.py
@@ -48,7 +48,7 @@ class TestClass(QueryWithLogin):
 
 def test_cache_reset():
     mytest = TestClass()
-    assert mytest._cache_active
+    assert mytest.cache_active
 
     default_timeout = mytest.cache_timeout
     default_loc = mytest.cache_location
@@ -65,7 +65,7 @@ def test_cache_reset():
 def test_basic_caching():
 
     mytest = TestClass()
-    assert mytest._cache_active
+    assert mytest.cache_active
 
     mytest.clear_cache()
     assert len(os.listdir(mytest.cache_location)) == 0
@@ -96,7 +96,7 @@ def test_basic_caching():
 def test_login():
 
     mytest = TestClass()
-    assert mytest._cache_active
+    assert mytest.cache_active
 
     mytest.clear_cache()
     assert len(os.listdir(mytest.cache_location)) == 0
@@ -116,7 +116,7 @@ def test_login():
 def test_timeout():
 
     mytest = TestClass()
-    assert mytest._cache_active
+    assert mytest.cache_active
 
     mytest.clear_cache()
     assert len(os.listdir(mytest.cache_location)) == 0
@@ -136,3 +136,24 @@ def test_timeout():
     sleep(2)  # run out cache time
     resp = mytest.test_func(URL1)
     assert resp.content == TEXT2  # no see the new response
+
+
+def test_deactivate():
+
+    mytest = TestClass()
+    mytest.cache_active = False
+
+    mytest.clear_cache()
+    assert len(os.listdir(mytest.cache_location)) == 0
+
+    set_response(TEXT1)
+
+    resp = mytest.test_func(URL1)
+    assert resp.content == TEXT1
+    assert len(os.listdir(mytest.cache_location)) == 0
+
+    set_response(TEXT2)
+
+    resp = mytest.test_func(URL1)
+    assert resp.content == TEXT2
+    assert len(os.listdir(mytest.cache_location)) == 0

--- a/astroquery/tests/test_cache.py
+++ b/astroquery/tests/test_cache.py
@@ -167,12 +167,19 @@ def test_timeout(monkeypatch):
     assert resp.content == TEXT1
 
     # Changing the file date so the cache will consider it expired
-    cache_file = list(mytest.cache_location.iterdir())[0]
+    cache_file = next(mytest.cache_location.iterdir())
     modTime = mktime(datetime(1970, 1, 1).timetuple())
     os.utime(cache_file, (modTime, modTime))
-    
+
     resp = mytest.test_func(URL1)
     assert resp.content == TEXT2  # now see the new response
+
+    # Testing a cache timeout of "none"
+    cache_conf.cache_timeout = None
+    set_response(TEXT1)
+
+    resp = mytest.test_func(URL1)
+    assert resp.content == TEXT2 # cache is accessed
 
 
 def test_deactivate():

--- a/astroquery/tests/test_cache.py
+++ b/astroquery/tests/test_cache.py
@@ -1,9 +1,7 @@
-import pytest
 import requests
 import os
 
 from time import sleep
-from pathlib import Path
 
 from astropy.config import paths
 

--- a/astroquery/tests/test_cache.py
+++ b/astroquery/tests/test_cache.py
@@ -3,8 +3,12 @@ import requests
 import os
 
 from time import sleep
+from pathlib import Path
+
+from astropy.config import paths
 
 from astroquery.query import QueryWithLogin
+from astroquery import conf
 
 URL1 = "http://fakeurl.edu"
 URL2 = "http://fakeurl.ac.uk"
@@ -46,68 +50,99 @@ class TestClass(QueryWithLogin):
             return False
 
 
-def test_cache_reset():
-    mytest = TestClass()
-    assert mytest.cache_active
+def test_conf():
+    default_timeout = conf.cache_timeout
+    default_active = conf.cache_active
 
-    default_timeout = mytest.cache_timeout
-    default_loc = mytest.cache_location
+    assert default_timeout == 604800
+    assert default_active is True
 
-    mytest.cache_timeout = 5
-    mytest.cache_location = "new/location"
+    with conf.set_temp("cache_timeout", 5):
+        assert conf.cache_timeout == 5
 
-    mytest.reset_cache_preferences()
+    with conf.set_temp("cache_active", False):
+        assert conf.cache_active is False
 
-    assert mytest.cache_timeout == default_timeout
-    assert mytest.cache_location == default_loc
+    assert conf.cache_timeout == default_timeout
+    assert conf.cache_active == default_active
+
+    conf.cache_timeout = 5
+    conf.cache_active = False
+    conf.reset()
+
+    assert conf.cache_timeout == default_timeout
+    assert conf.cache_active == default_active
 
 
 def test_basic_caching():
 
     mytest = TestClass()
-    assert mytest.cache_active
+    assert conf.cache_active
 
     mytest.clear_cache()
-    assert len(os.listdir(mytest.cache_location)) == 0
+    assert len(os.listdir(mytest.get_cache_location())) == 0
 
     set_response(TEXT1)
 
     resp = mytest.test_func(URL1)
     assert resp.content == TEXT1
-    assert len(os.listdir(mytest.cache_location)) == 1
+    assert len(os.listdir(mytest.get_cache_location())) == 1
 
     set_response(TEXT2)
 
     resp = mytest.test_func(URL2)  # query that has not been cached
     assert resp.content == TEXT2
-    assert len(os.listdir(mytest.cache_location)) == 2
+    assert len(os.listdir(mytest.get_cache_location())) == 2
 
     resp = mytest.test_func(URL1)
     assert resp.content == TEXT1  # query that was cached
-    assert len(os.listdir(mytest.cache_location)) == 2  # no new cache file
+    assert len(os.listdir(mytest.get_cache_location())) == 2  # no new cache file
 
     mytest.clear_cache()
-    assert len(os.listdir(mytest.cache_location)) == 0
+    assert len(os.listdir(mytest.get_cache_location())) == 0
 
     resp = mytest.test_func(URL1)
     assert resp.content == TEXT2  # Now get new response
 
 
+def test_change_location(tmpdir):
+
+    mytest = TestClass()
+    default_cache_location = mytest.get_cache_location()
+
+    assert paths.get_cache_dir() in default_cache_location
+    assert "astroquery" in mytest.get_cache_location()
+    assert mytest.name in mytest.get_cache_location()
+
+    new_loc = os.path.join(tmpdir, "new_dir")
+    mytest.cache_location = new_loc
+    assert mytest.get_cache_location() == new_loc
+
+    mytest.reset_cache_location()
+    assert mytest.get_cache_location() == default_cache_location
+
+    Path(new_loc).mkdir(parents=True, exist_ok=True)
+    with paths.set_temp_cache(new_loc):
+        assert new_loc in mytest.get_cache_location()
+        assert "astroquery" in mytest.get_cache_location()
+        assert mytest.name in mytest.get_cache_location()
+
+
 def test_login():
 
     mytest = TestClass()
-    assert mytest.cache_active
+    assert conf.cache_active
 
     mytest.clear_cache()
-    assert len(os.listdir(mytest.cache_location)) == 0
+    assert len(os.listdir(mytest.get_cache_location())) == 0
 
     set_response(TEXT1)  # Text 1 is set as the approved password
 
     mytest.login("ceb")
     assert mytest.authenticated()
-    assert len(os.listdir(mytest.cache_location)) == 0  # request should not be cached
+    assert len(os.listdir(mytest.get_cache_location())) == 0  # request should not be cached
 
-    set_response(TEXT2)  # Text 1 is not the approved password
+    set_response(TEXT2)  # Text 2 is not the approved password
 
     mytest.login("ceb")
     assert not mytest.authenticated()  # Should not be accessing cache
@@ -116,12 +151,12 @@ def test_login():
 def test_timeout():
 
     mytest = TestClass()
-    assert mytest.cache_active
+    assert conf.cache_active
 
     mytest.clear_cache()
-    assert len(os.listdir(mytest.cache_location)) == 0
+    assert len(os.listdir(mytest.get_cache_location())) == 0
 
-    mytest.cache_timeout = 2  # Set to 2 sec so we can reach timeout easily
+    conf.cache_timeout = 2  # Set to 2 sec so we can reach timeout easily
 
     set_response(TEXT1)  # setting the response
 
@@ -141,19 +176,19 @@ def test_timeout():
 def test_deactivate():
 
     mytest = TestClass()
-    mytest.cache_active = False
+    conf.cache_active = False
 
     mytest.clear_cache()
-    assert len(os.listdir(mytest.cache_location)) == 0
+    assert len(os.listdir(mytest.get_cache_location())) == 0
 
     set_response(TEXT1)
 
     resp = mytest.test_func(URL1)
     assert resp.content == TEXT1
-    assert len(os.listdir(mytest.cache_location)) == 0
+    assert len(os.listdir(mytest.get_cache_location())) == 0
 
     set_response(TEXT2)
 
     resp = mytest.test_func(URL1)
     assert resp.content == TEXT2
-    assert len(os.listdir(mytest.cache_location)) == 0
+    assert len(os.listdir(mytest.get_cache_location())) == 0

--- a/astroquery/tests/test_cache.py
+++ b/astroquery/tests/test_cache.py
@@ -28,7 +28,7 @@ def set_response(resp_text, resp_status=200):
 
     requests.Session.request = get_mockreturn
 
-    
+
 class TestClass(QueryWithLogin):
     """Bare bones class for testing caching"""
 
@@ -81,7 +81,7 @@ def test_basic_caching():
     resp = mytest.test_func(URL2)  # query that has not been cached
     assert resp.content == TEXT2
     assert len(os.listdir(mytest.cache_location)) == 2
- 
+
     resp = mytest.test_func(URL1)
     assert resp.content == TEXT1  # query that was cached
     assert len(os.listdir(mytest.cache_location)) == 2  # no new cache file

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -172,6 +172,36 @@ uncomment the relevant configuration item(s), and insert your desired value(s).
 
   configuration
 
+
+Caching
+-------
+
+By default Astroquery employs query caching with a timeout of 1 week, although individual services
+may have different settings. The user can clear their cache at any time, as well as suspend cache usage,
+and change the cache location. Caching persists between Astroquery sessions.
+If you know the service you are using has released new data recently, or if you believe you are
+not recieving the newest data, try clearing the cache.
+
+The Astroquery cache is divided by service, so each service's cache should be managed invidually.
+Shown here are the cache properties, using `~astroquery.simbad.Simbad` as an example.
+
+.. code-block:: python
+
+  >>> from astroquery.simbad import Simbad
+
+  >>> # Is the cache active?
+  >>> print(Simbad.cache_active)
+  True
+
+  >>> # Cache location
+  >>> print(Simbad.cache_location)
+  /Users/username/.astropy/cache/astroquery/Simbad
+
+  >>> # Cache timout in seconds
+  >>> print(Simbad.cache_timeout)
+  604800
+
+
 Available Services
 ==================
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -176,8 +176,8 @@ uncomment the relevant configuration item(s), and insert your desired value(s).
 Caching
 -------
 
-By default Astroquery employs query caching with a timeout of 1 week, although individual services
-may have different settings. The user can clear their cache at any time, as well as suspend cache usage,
+By default Astroquery employs query caching with a timeout of 1 week.
+The user can clear their cache at any time, as well as suspend cache usage,
 and change the cache location. Caching persists between Astroquery sessions.
 If you know the service you are using has released new data recently, or if you believe you are
 not recieving the newest data, try clearing the cache.
@@ -185,7 +185,7 @@ not recieving the newest data, try clearing the cache.
 
 The Astroquery cache location is divided by service, so each service's cache should be managed invidually,
 however whether the cache is active and the expiration time are controlled centrally through the
-astroquery ``conf`` module. Astroquery uses the Astropy configuration infrastructure, information about
+astroquery ``cache_conf`` module. Astroquery uses the Astropy configuration infrastructure, information about
 temporarily or permanently changing configuration values can be found
 `here <https://docs.astropy.org/en/latest/config/index.html>`_.
 
@@ -193,20 +193,28 @@ Shown here are the cache properties, using Simbad as an example:
 
 .. code-block:: python
 
-  >>> from astroquery import conf
+  >>> from astroquery import cache_conf
   >>> from astroquery.simbad import Simbad
 
   >>> # Is the cache active?
-  >>> print(conf.cache_active)
+  >>> print(cache_conf.cache_active)
   True
 
   >>> # Cache timout in seconds
-  >>> print(conf.cache_timeout)
+  >>> print(cache_conf.cache_timeout)
   604800
   
   >>> # Cache location
   >>> print(Simbad.cache_location)
   /Users/username/.astropy/cache/astroquery/Simbad
+
+
+To clear the cache:
+
+.. code-block:: python
+
+    >>> Simbad.clear_cache()
+
 
 
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -195,17 +195,15 @@ Shown here are the cache properties, using Simbad as an example:
 
   >>> from astroquery import cache_conf
   >>> from astroquery.simbad import Simbad
-
+  ...
   >>> # Is the cache active?
   >>> print(cache_conf.cache_active)
   True
-
   >>> # Cache timout in seconds
   >>> print(cache_conf.cache_timeout)
   604800
-  
   >>> # Cache location
-  >>> print(Simbad.cache_location)
+  >>> print(Simbad.cache_location)   # doctest: +IGNORE_OUTPUT
   /Users/username/.astropy/cache/astroquery/Simbad
 
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -183,7 +183,7 @@ If you know the service you are using has released new data recently, or if you 
 not recieving the newest data, try clearing the cache.
 
 The Astroquery cache is divided by service, so each service's cache should be managed invidually.
-Shown here are the cache properties, using `~astroquery.simbad.Simbad` as an example.
+Shown here are the cache properties, using Simbad as an example.
 
 .. code-block:: python
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -182,24 +182,32 @@ and change the cache location. Caching persists between Astroquery sessions.
 If you know the service you are using has released new data recently, or if you believe you are
 not recieving the newest data, try clearing the cache.
 
-The Astroquery cache is divided by service, so each service's cache should be managed invidually.
-Shown here are the cache properties, using Simbad as an example.
+
+The Astroquery cache location is divided by service, so each service's cache should be managed invidually,
+however whether the cache is active and the expiration time are controlled centrally through the
+astroquery ``conf`` module. Astroquery uses the Astropy configuration infrastructure, information about
+temporarily or permanently changing configuration values can be found
+`here <https://docs.astropy.org/en/latest/config/index.html>`_.
+
+Shown here are the cache properties, using Simbad as an example:
 
 .. code-block:: python
 
+  >>> from astroquery import conf
   >>> from astroquery.simbad import Simbad
 
   >>> # Is the cache active?
-  >>> print(Simbad.cache_active)
+  >>> print(conf.cache_active)
   True
 
+  >>> # Cache timout in seconds
+  >>> print(conf.cache_timeout)
+  604800
+  
   >>> # Cache location
   >>> print(Simbad.cache_location)
   /Users/username/.astropy/cache/astroquery/Simbad
 
-  >>> # Cache timout in seconds
-  >>> print(Simbad.cache_timeout)
-  604800
 
 
 Available Services


### PR DESCRIPTION
This PR is a continuation of https://github.com/astropy/astroquery/pull/442 so I am not sure it should be it's own separate thing (@bsipocz @keflavich @jwoillez).

Work included:
- Rebased https://github.com/astropy/astroquery/pull/442 onto current master
- Cache timeout functionality (see https://github.com/astropy/astroquery/pull/442)
- Added configurable cache location (defaults to current cache location)
- Added option to turn off caching all-together (addresses https://github.com/astropy/astroquery/issues/1511)
- Added support for `cache_timeout = None` which prevents the cache from ever timing out 
- Added `clear_cache` function that removes all cache pickle files from the current cache location (addresses https://github.com/astropy/astroquery/issues/1531)
- Added `reset_cache_preferences` that resets cache location, timout, and enabled/disabled status to astroquery defaults 
- Moved cache directory creation (if necessary) into `to_cache` function, guarding against users who manually blow away their cache while in the middle of a session (addresses https://github.com/astropy/astroquery/issues/1625)
- `_request` function cache argument defaults to "None," which means that the default cache preference will be used, setting to either True or False overrides the the global preference.
- Reordered the local_filepath `or` order in `_request`, so that savedir overrides the global cache location if set (I believe this is the intended behavior)

Questions:
- I kept the updates to astroquery.cfg added by https://github.com/astropy/astroquery/pull/442, but did not further update, because I don't understand how this file is used. @bsipocz @keflavich what is the purpose of this file?
- `suspend_chache` function: I don't understand how this function works or is being used. It sets the cache active status to False, however as far as I can tell we only cache when the `to_cache` function is explicitly called, so it isn't clear to me that it is actually doing anything. I assume its presence in the login function is to make sure that login credentials aren't accidentally cached which is very important, so I don't want to mess that up. I changed the private class member `_cache_active` into the public member `use_cache` to allow users to turn caching on/off, but it is unclear to me if I can just change `self.obj._cache_active` to `self.obj.use_cache` in the `suspend_cache` function or if something more complicated is needed. @bsipocz @keflavich if you can clarify this, I will update `suspend_cache` properly.

Outstanding work:
- Documentation on how to use the new cache functionality
- Test cases for the new cache functionality
