### PR TITLE
ESO: option to prevent unzipping of downloaded files from the archive

### DIFF
--- a/astroquery/eso/core.py
+++ b/astroquery/eso/core.py
@@ -630,7 +630,7 @@ class EsoClass(QueryWithLogin):
         return resp
 
     def retrieve_data(self, datasets, continuation=False, destination=None,
-                      with_calib='none', request_all_objects=False):
+                      with_calib='none', request_all_objects=False, unzip=True):
         """
         Retrieve a list of datasets form the ESO archive.
 
@@ -654,6 +654,9 @@ class EsoClass(QueryWithLogin):
             this allows to request all the objects included the already
             downloaded ones, to be sure to retrieve all calibration files.
             This is useful when the download was interrupted. `False` by
+            default.
+        unzip : bool
+            Unzip compressed files from the archive after download. `True` by
             default.
 
         Returns
@@ -812,7 +815,7 @@ class EsoClass(QueryWithLogin):
                 filename = self._request("GET", fileLink, save=True,
                                          continuation=True)
 
-                if filename.endswith(('.gz', '.7z', '.bz2', '.xz', '.Z')):
+                if filename.endswith(('.gz', '.7z', '.bz2', '.xz', '.Z')) and unzip:
                     log.info("Unzipping file {0}...".format(fileId))
                     filename = system_tools.gunzip(filename)
 


### PR DESCRIPTION
fix https://github.com/astropy/astroquery/issues/1631

having the new option `unzip=True` by default will ensure backward compatibility.