### PR TITLE
Add flexible parameters to criteria

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -14,6 +14,12 @@ gaia
 - Allow for setting row limits in query submissions through class
   attribute. [#1641]
 
+gemini
+^^^^^^
+
+- Allow for additional search terms to be sent to query_criteria and passed to
+  the raw web query against the Gemini Archive [#1659]
+
 jplhorizons
 ^^^^^^^^^^^
 

--- a/astroquery/gemini/tests/test_gemini.py
+++ b/astroquery/gemini/tests/test_gemini.py
@@ -63,6 +63,7 @@ def test_observations_query_region(patch_get):
     """ test query against a region of the sky """
     result = gemini.Observations.query_region(coords, radius=0.3 * units.deg)
     assert isinstance(result, Table)
+    assert len(result) > 0
 
 
 def test_observations_query_criteria(patch_get):
@@ -70,12 +71,14 @@ def test_observations_query_criteria(patch_get):
     result = gemini.Observations.query_criteria(instrument='GMOS-N', program_id='GN-CAL20191122',
                                                 observation_type='BIAS')
     assert isinstance(result, Table)
+    assert len(result) > 0
 
 
 def test_observations_query_raw(patch_get):
     """ test querying raw """
     result = gemini.Observations.query_raw('GMOS-N', 'BIAS', progid='GN-CAL20191122')
     assert isinstance(result, Table)
+    assert len(result) > 0
 
 
 def test_url_helper_arg():

--- a/astroquery/gemini/tests/test_remote.py
+++ b/astroquery/gemini/tests/test_remote.py
@@ -1,0 +1,63 @@
+""" Test Gemini Astroquery module.
+
+Remote tests to exercise interaction with the actual REST service.
+
+For information on how/why this test is built the way it is, see the astroquery
+documentation at:
+
+https://astroquery.readthedocs.io/en/latest/testing.html
+"""
+
+from astropy import units
+from astropy.coordinates import SkyCoord
+from astropy.table import Table
+from astropy.tests.helper import remote_data
+
+from astroquery import gemini
+
+
+""" Coordinates to use for testing """
+coords = SkyCoord(210.80242917, 54.34875, unit="deg")
+
+
+@remote_data
+class TestGemini(object):
+    def test_observations_query_region(self):
+        """ test query against a region of the sky against actual archive """
+        result = gemini.Observations.query_region(coords, radius=0.3 * units.deg)
+        assert isinstance(result, Table)
+        assert len(result) > 0
+
+    def test_observations_query_criteria(self):
+        """ test query against an instrument/program via criteria against actual archive """
+        result = gemini.Observations.query_criteria(instrument='GMOS-N', program_id='GN-CAL20191122',
+                                                    observation_type='BIAS')
+        assert isinstance(result, Table)
+        assert len(result) > 0
+
+    def test_observations_query_criteria_ascending_sort(self):
+        """ test query against an instrument/program via criteria against actual archive """
+        result = gemini.Observations.query_criteria(instrument='GMOS-N', program_id='GN-CAL20191122',
+                                                    observation_type='BIAS', orderby='filename_asc')
+        assert isinstance(result, Table)
+        assert len(result) > 0
+        last = None
+        for row in result:
+            assert last is None or last <= row['filename']
+            last = row['filename']
+
+    def test_observations_query_criteria_descending_sort(self):
+        """ test query against an instrument/program via criteria against actual archive """
+        result = gemini.Observations.query_criteria(instrument='GMOS-N', program_id='GN-CAL20191122',
+                                                    observation_type='BIAS', orderby='filename_desc')
+        assert isinstance(result, Table)
+        assert len(result) > 0
+        # server is not respecting descending filename sort.  This is not an issue with the
+        # astroquery side, but for now I am not validating the results until it gets fixed
+        # in the webservice.
+
+    def test_observations_query_raw(self):
+        """ test querying raw against actual archive """
+        result = gemini.Observations.query_raw('GMOS-N', 'BIAS', progid='GN-CAL20191122')
+        assert isinstance(result, Table)
+        assert len(result) > 0

--- a/astroquery/gemini/urlhelper.py
+++ b/astroquery/gemini/urlhelper.py
@@ -79,6 +79,9 @@ class URLHelper(object):
         for arg in args:
             url = "%s/%s" % (url, arg)
         for key, value in kwargs.items():
-            handler = handlers.get(key, handle_keyword_arg)
-            url = handler(url, key, value)
+            if key != "orderby":
+                handler = handlers.get(key, handle_keyword_arg)
+                url = handler(url, key, value)
+        if "orderby" in kwargs:
+            url = "%s?orderby=%s" % (url, kwargs["orderby"])
         return url

--- a/docs/gemini/gemini.rst
+++ b/docs/gemini/gemini.rst
@@ -83,6 +83,22 @@ and the program ID.  For a complete list of available search fields, see
                           0.0           Full Frame                         -- Gemini-North    True ...
                           0.0           Full Frame                         -- Gemini-North    True ...
 
+In addition, the criteria query can accept additional parameters via the ``*rawqueryargs`` and ``**rawquerykwargs`` 
+optional parameters.
+
+The ``orderby`` parameter can be used to pass the desired sort order.
+
+.. code-block:: python
+
+                >>> from astroquery.gemini import Observations
+
+                >>> data = Observations.query_criteria('centralspectrum',
+                ...                                    instrument='GMOS-N',
+                ...                                    program_id='GN-CAL20191122',
+                ...                                    observation_type='BIAS',
+                ...                                    filter='r',
+                ...                                    orderby='data_label_desc')
+
 
 Observation Raw Queries
 -----------------------
@@ -93,7 +109,7 @@ for values or even new fields that were not present at the time this module was 
 
 Regular *args* search terms are sent down as part of the URL path.  Any *kwargs* are then sent down with
 key=value also in the URL path.  You can infer what to pass the function by inspecting the URL after a search in the
-Gemini website.
+Gemini website.  This call also supports the ``orderby`` kwarg for requesting the sort order.
 
 This example is equivalent to doing a web search with 
 `this example search <https://archive.gemini.edu/searchform/RAW/cols=CTOWEQ/notengineering/GMOS-N/PIname=Hirst/NotFail>`_ .


### PR DESCRIPTION
This enhances query_criteria to allow additional arguments to pass through to the raw query.  This enables users to call the helper method (query_criteria) but still have access to any new or less common parameters in the webservice.

https://github.com/astropy/astroquery/issues/1658
