### PR TITLE
TST: Prevent blocking error in Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -149,7 +149,7 @@ install:
     - source ci-helpers/travis/setup_conda.sh
 
     # https://github.com/travis-ci/travis-ci/issues/8982#issuecomment-354357640
-    - python -c "import fcntl; fcntl.fcntl(1, fcntl.F_SETFL, 0)"
+    - if [ $TRAVIS_OS_NAME != windows ]; then python -c "import fcntl; fcntl.fcntl(1, fcntl.F_SETFL, 0)"; fi
 
 script:
    - $RUN_HTTPBIN

--- a/.travis.yml
+++ b/.travis.yml
@@ -144,10 +144,12 @@ matrix:
                SETUP_CMD='test -R -V -a "--durations=50"'
                CONDA_DEPENDENCIES=$CONDA_DEPENDENCIES_REMOTE
 
-
 install:
     - git clone git://github.com/astropy/ci-helpers.git
     - source ci-helpers/travis/setup_conda.sh
+
+    # https://github.com/travis-ci/travis-ci/issues/8982#issuecomment-354357640
+    - python -c "import fcntl; fcntl.fcntl(1, fcntl.F_SETFL, 0)"
 
 script:
    - $RUN_HTTPBIN


### PR DESCRIPTION
The error on Travis CI:
```
error: [Errno 11] write could not complete without blocking
Exception ignored in: <_io.TextIOWrapper name='<stdout>' mode='w' encoding='UTF8'>
BlockingIOError: [Errno 11] write could not complete without blocking
```

I am not sure if this will fix your problem or not but it's worth a try? If this doesn't work, be sure to revert the change. Solution based on https://github.com/travis-ci/travis-ci/issues/8982#issuecomment-354357640 .

Others mentioned they put it in `before_install` but given that you use `ci-helpers`, I moved it to after you activated the `conda` env.

🤷‍♀ 