### PR TITLE
MAINT: fix travis config issues

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,17 +6,12 @@ language: c
 os:
     - linux
 
-# Setting sudo to false opts in to Travis-CI container-based builds.
-sudo: false
-
 # The apt packages below are needed for sphinx builds, which can no longer
 # be installed with sudo apt-get.
 addons:
     apt:
         packages:
             - graphviz
-
-stage: Initial tests
 
 stages:
    - name: Initial tests
@@ -51,10 +46,8 @@ env:
         # astrometry.net API key
         - secure: "al9u/QSQfrwNljdu8gYUaT9z4BxEL1FlE4ntsn6eqtN2Y0rurqll+gq46quYjtE6zgcpb0uYtGIubusJkp7ceE6IBGhQdsel4UY16VIqeEuQ3GpVDb4RiJgU51SAjbmXYV1dMAJnOm4Ra41WzxokStKRDdoRraAsae9zK3H6AnI="
 
-    matrix:
-        - PYTHON_VERSION=3.7 SETUP_CMD='egg_info'
 
-matrix:
+jobs:
 
     # Don't wait for allowed failures
     fast_finish: true
@@ -70,6 +63,9 @@ matrix:
                SETUP_CMD='test -R -V -a "--durations=50"'
                CONDA_DEPENDENCIES=$CONDA_DEPENDENCIES_REMOTE
 
+        - stage: Initial tests
+          env: PYTHON_VERSION=3.7 SETUP_CMD='egg_info'
+
         # No need to run it from cron
         # Try MacOS X
         - os: osx
@@ -77,6 +73,7 @@ matrix:
           env: EVENT_TYPE='cron'
 
         - os: linux
+          stage: Initial tests
           env: SETUP_CMD='test --coverage'
 
         # Check for sphinx doc build warnings - we do this first because it
@@ -115,6 +112,7 @@ matrix:
 
         # Do a PEP8 test with pycodestyle
         - os: linux
+          stage: Initial tests
           env: MAIN_CMD='pycodestyle astroquery --count'
                SETUP_CMD='' EVENT_TYPE='push pull_request'
 
@@ -129,7 +127,7 @@ matrix:
           env: SETUP_CMD='sdist' EVENT_TYPE='push'
           deploy:
             provider: pypi
-            user: astroquery
+            username: astroquery
             password:
               secure: DtqyQkllGcWuKOVMsu9RWRiobeL8bdpMxwdSYpob4Cqj0D2hLLx3w50qr0qpDCFzioB3rXnhbtPKEzHB+4fTFT/Rjito32fFPUtee2Rw4SCe4YIlS0ksPOTmxkeoh2TQLIYcNPPoI7UpUX6uC65nzgCUTmZVoiCweQE+i5GhEBI=
             on:


### PR DESCRIPTION
In the past week, jobs have disappeared from our travis matrix, so it's rather timely to do this config cleanup to get rid of all warnings and issues.