### PR TITLE
MNT: Use pytest-remotedata plugin

### DIFF
--- a/astroquery/alma/tests/test_alma.py
+++ b/astroquery/alma/tests/test_alma.py
@@ -1,5 +1,4 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
-import numpy as np
 import os
 
 import pytest

--- a/astroquery/alma/tests/test_alma_remote.py
+++ b/astroquery/alma/tests/test_alma_remote.py
@@ -5,7 +5,6 @@ import numpy as np
 import os
 import pytest
 
-from astropy.tests.helper import remote_data
 from astropy import coordinates
 from astropy import units as u
 from six.moves.urllib_parse import urlparse
@@ -26,7 +25,7 @@ all_colnames = {'Project code', 'Source name', 'RA', 'Dec', 'Band',
                 'QA2 Status', 'Group ous id', 'Pub'}
 
 
-@remote_data
+@pytest.mark.remote_data
 class TestAlma:
 
     def setup_class(cls):
@@ -287,14 +286,14 @@ class TestAlma:
         assert 'Orion_Source_I' in result['Source name']
 
 
-@remote_data
+@pytest.mark.remote_data
 def test_project_metadata():
     alma = Alma()
     metadata = alma.get_project_metadata('2013.1.00269.S')
     assert metadata == ['Sgr B2, a high-mass molecular cloud in our Galaxy\'s Central Molecular Zone, is the most extreme site of ongoing star formation in the Local Group in terms of its gas content, temperature, and velocity dispersion. If any cloud in our galaxy is analogous to the typical cloud at the universal peak of star formation at z~2, this is it. We propose a 6\'x6\' mosaic in the 3mm window targeting gas thermometer lines, specifically CH3CN and its isotopologues. We will measure the velocity dispersion and temperature of the molecular gas on all scales (0.02 - 12 pc, 0.5" - 5\') within the cloud, which will yield resolved measurements of the Mach number and the sonic scale of the gas. We will assess the relative importance of stellar feedback and turbulence on the star-forming gas, determining how extensive the feedback effects are within an ultradense environment. The observations will provide constraints on the inputs to star formation theories and will determine their applicability in extremely dense, turbulent, and hot regions. Sgr B2 will be used as a testing ground for star formation theories in an environment analogous to high-z starburst clouds in which they must be applied.']
 
 
-@remote_data
+@pytest.mark.remote_data
 @pytest.mark.parametrize('dataarchive_url', _test_url_list)
 def test_staging_postfeb2020(dataarchive_url):
 
@@ -307,7 +306,7 @@ def test_staging_postfeb2020(dataarchive_url):
     assert '2013.1.00269.S_uid___A002_X9de499_X3d6c.asdm.sdm.tar' in tbl['name']
 
 
-@remote_data
+@pytest.mark.remote_data
 @pytest.mark.parametrize('dataarchive_url', _url_list)
 def test_staging_uptofeb2020(dataarchive_url):
 

--- a/astroquery/alma/tests/test_alma_utils.py
+++ b/astroquery/alma/tests/test_alma_utils.py
@@ -5,7 +5,6 @@ import warnings
 
 from astropy import wcs
 from astropy import units as u
-from astropy.tests.helper import remote_data
 try:
     from pyregion.parser_helper import Shape
     pyregion_OK = True
@@ -66,7 +65,7 @@ def approximate_primary_beam_sizes(frq_sup_str=frq_sup_str,
     assert np.all(utils.approximate_primary_beam_sizes(frq_sup_str) == beamsizes)
 
 
-@remote_data
+@pytest.mark.remote_data
 @pytest.mark.skipif('not pyregion_OK')
 def test_make_finder_chart():
     import matplotlib

--- a/astroquery/astrometry_net/tests/test_astrometry_net_remote.py
+++ b/astroquery/astrometry_net/tests/test_astrometry_net_remote.py
@@ -9,7 +9,6 @@ import os
 # remote_data decorator from astropy:
 import pytest
 
-from astropy.tests.helper import remote_data
 from astropy.table import Table
 from astropy.io import fits
 
@@ -18,7 +17,7 @@ from ..core import _HAVE_SOURCE_DETECTION
 from ...exceptions import TimeoutError
 
 try:
-    import scipy
+    import scipy  # noqa
 except ImportError:
     HAVE_SCIPY = False
 else:
@@ -35,7 +34,7 @@ api_key = conf.api_key or os.environ.get('ASTROMETRY_NET_API_KEY')
 
 
 @pytest.mark.skipif(not api_key, reason='API key not set.')
-@remote_data
+@pytest.mark.remote_data
 def test_solve_by_source_list():
     a = AstrometryNet()
     a.api_key = api_key
@@ -58,7 +57,7 @@ def test_solve_by_source_list():
 
 
 @pytest.mark.skipif(not api_key, reason='API key not set.')
-@remote_data
+@pytest.mark.remote_data
 def test_solve_image_upload():
     # Test that solving by uploading an image works
     a = AstrometryNet()
@@ -79,7 +78,7 @@ def test_solve_image_upload():
 
 
 @pytest.mark.skipif(not api_key, reason='API key not set.')
-@remote_data
+@pytest.mark.remote_data
 def test_solve_image_upload_expected_failure():
     # Test that a solve failure is returned as expected
     a = AstrometryNet()
@@ -98,7 +97,7 @@ def test_solve_image_upload_expected_failure():
                     reason='photutils not installed')
 @pytest.mark.skipif(not HAVE_SCIPY,
                     reason='no scipy, which photutils needs')
-@remote_data
+@pytest.mark.remote_data
 def test_solve_image_detect_source_local():
     # Test that solving by uploading an image works
     a = AstrometryNet()
@@ -124,7 +123,7 @@ def test_solve_image_detect_source_local():
 
 
 @pytest.mark.skipif(not api_key, reason='API key not set.')
-@remote_data
+@pytest.mark.remote_data
 def test_solve_timeout_behavior():
     a = AstrometryNet()
     a.api_key = api_key

--- a/astroquery/atomic/tests/test_atomic_remote.py
+++ b/astroquery/atomic/tests/test_atomic_remote.py
@@ -1,13 +1,13 @@
 import numpy as np
+import pytest
 from bs4 import BeautifulSoup
 from astropy import units as u
 from astropy.table import Table
-from astropy.tests.helper import remote_data
 
 from ...atomic import AtomicLineList
 
 
-@remote_data
+@pytest.mark.remote_data
 def test_default_form_values():
     default_response = AtomicLineList._request(
         method="GET", url=AtomicLineList.FORM_URL,
@@ -28,7 +28,7 @@ def test_default_form_values():
         'wave': u'Angstrom'}
 
 
-@remote_data
+@pytest.mark.remote_data
 def test_query_with_default_params():
     table = AtomicLineList.query_object()
     assert isinstance(table, Table)
@@ -43,7 +43,7 @@ LAMBDA VAC ANG SPECTRUM  TT CONFIGURATION TERM  J J    A_ki   LEVEL ENERGY  CM 1
        1.02916   Zn XXX  E1         1*-6*  1-6 1/2-* 1.33E+12 0.00 - 97174700.00'''.strip()
 
 
-@remote_data
+@pytest.mark.remote_data
 def test_query_with_wavelength_params():
     result = AtomicLineList.query_object(
         wavelength_range=(15 * u.nm, 200 * u.Angstrom),
@@ -65,7 +65,7 @@ def test_query_with_wavelength_params():
                             '0.00 -   502481.80']))
 
 
-@remote_data
+@pytest.mark.remote_data
 def test_empty_result_set():
     result = AtomicLineList.query_object(wavelength_accuracy=0)
     assert isinstance(result, Table)
@@ -73,7 +73,7 @@ def test_empty_result_set():
     assert len(result) == 0
 
 
-@remote_data
+@pytest.mark.remote_data
 def test_lower_upper_ranges():
     result = AtomicLineList.query_object(
         lower_level_energy_range=u.Quantity((600 * u.cm**(-1), 1000 * u.cm**(-1))),

--- a/astroquery/cadc/tests/test_cadctap_remote.py
+++ b/astroquery/cadc/tests/test_cadctap_remote.py
@@ -11,7 +11,6 @@ import requests
 from datetime import datetime
 from astropy.coordinates import SkyCoord
 from astropy.io import fits
-from astropy.tests.helper import remote_data
 from astropy import units as u
 
 from astroquery.cadc import Cadc
@@ -37,7 +36,7 @@ one_test = False
 skip_slow = True
 
 
-@remote_data
+@pytest.mark.remote_data
 class TestCadcClass:
     # now write tests for each method here
     @pytest.mark.skipif(not pyvo_OK, reason='not pyvo_OK')

--- a/astroquery/casda/tests/test_casda_remote.py
+++ b/astroquery/casda/tests/test_casda_remote.py
@@ -5,14 +5,13 @@
 import math
 import pytest
 
-from astropy.tests.helper import remote_data
 import astropy.units as u
 from astropy.table import Table
 
 from astroquery.casda import Casda
 
 
-@remote_data
+@pytest.mark.remote_data
 class TestCasda:
 
     def test_query_region_text_radius(self):

--- a/astroquery/cds/tests/test_mocserver_remote.py
+++ b/astroquery/cds/tests/test_mocserver_remote.py
@@ -14,7 +14,7 @@ except ImportError:
     pass
 
 try:
-    from regions import CircleSkyRegion, PolygonSkyRegion
+    from regions import CircleSkyRegion
 except ImportError:
     pass
 

--- a/astroquery/cds/tests/test_mocserver_remote.py
+++ b/astroquery/cds/tests/test_mocserver_remote.py
@@ -4,7 +4,6 @@
 import sys
 import pytest
 
-from astropy.tests.helper import remote_data
 from astropy import coordinates
 from astropy.table import Table
 
@@ -21,7 +20,7 @@ except ImportError:
 from ..core import cds
 
 
-@remote_data
+@pytest.mark.remote_data
 class TestMOCServerRemote(object):
     """
     Tests requiring regions

--- a/astroquery/dace/tests/test_dace_remote.py
+++ b/astroquery/dace/tests/test_dace_remote.py
@@ -1,12 +1,11 @@
-import unittest
-from astropy.tests.helper import remote_data
+import pytest
 from astroquery.dace import Dace
 
 HARPS_PUBLICATION = '2009A&A...493..639M'
 
 
-@remote_data
-class TestDaceClassRemote(unittest.TestCase):
+@pytest.mark.remote_data
+class TestDaceClassRemote(object):
 
     def test_should_get_radial_velocities(self):
         radial_velocities_table = Dace.query_radial_velocities('HD40307')
@@ -18,7 +17,3 @@ class TestDaceClassRemote(unittest.TestCase):
         public_harps_data = [row for row in radial_velocities_table['pub_bibcode'] if HARPS_PUBLICATION in row]
         assert len(public_harps_data) > 100
         assert len(radial_velocities_table['rv_err']) > 100
-
-
-if __name__ == "__main__":
-    unittest.main()

--- a/astroquery/esasky/tests/test_esasky_remote.py
+++ b/astroquery/esasky/tests/test_esasky_remote.py
@@ -5,14 +5,13 @@ import shutil
 import pytest
 
 from astroquery.utils.commons import TableList
-from astropy.tests.helper import remote_data
 
 from ... import esasky
 
 ESASkyClass = esasky.core.ESASkyClass()
 
 
-@remote_data
+@pytest.mark.remote_data
 class TestESASky:
 
     ESASkyClass._isTest = "Remote Test"

--- a/astroquery/eso/tests/test_eso_remote.py
+++ b/astroquery/eso/tests/test_eso_remote.py
@@ -3,7 +3,6 @@ import numpy as np
 import pytest
 import tempfile
 import shutil
-from astropy.tests.helper import remote_data
 import six
 from ...exceptions import LoginError
 
@@ -20,7 +19,7 @@ instrument_list = [u'fors1', u'fors2', u'sphere', u'vimos', u'omegacam',
 SKIP_SLOW = True
 
 
-@remote_data
+@pytest.mark.remote_data
 class TestEso:
     @pytest.fixture()
     def temp_dir(self, request):

--- a/astroquery/exoplanet_orbit_database/tests/test_exoplanet_orbit_database.py
+++ b/astroquery/exoplanet_orbit_database/tests/test_exoplanet_orbit_database.py
@@ -1,8 +1,10 @@
 from __future__ import (absolute_import, division, print_function,
                         unicode_literals)
 import os
+
+import pytest
 import astropy.units as u
-from astropy.tests.helper import assert_quantity_allclose, remote_data, pytest
+from astropy.tests.helper import assert_quantity_allclose
 from astropy.utils import minversion
 from astropy.coordinates import SkyCoord
 
@@ -13,7 +15,7 @@ LOCAL_TABLE_PATH = os.path.join(os.path.abspath(os.path.dirname(__file__)),
                                 'data', 'exoplanet_orbit_database.csv')
 
 
-@remote_data
+@pytest.mark.remote_data
 def test_exoplanet_orbit_database_table():
     table = ExoplanetOrbitDatabase.get_table()
 
@@ -38,7 +40,7 @@ def test_parameter_units():
     assert param_units['DEC'] == u.Unit('degree')
 
 
-@remote_data
+@pytest.mark.remote_data
 def test_hd209458b_exoplanet_orbit_database():
     # Testing intentionally un-stripped string:
     params = ExoplanetOrbitDatabase.query_planet('HD 209458 b ')
@@ -54,7 +56,7 @@ def test_hd209458b_exoplanet_orbit_database():
     assert params['TRANSIT']
 
 
-@remote_data
+@pytest.mark.remote_data
 @pytest.mark.skipif('APY_LT12')
 def test_hd209458b_exoplanet_orbit_database_apy_lt12():
     # Testing intentionally un-stripped string:
@@ -63,7 +65,7 @@ def test_hd209458b_exoplanet_orbit_database_apy_lt12():
                              atol=0.1 * u.Unit('R_jup'))
 
 
-@remote_data
+@pytest.mark.remote_data
 @pytest.mark.skipif('not APY_LT12')
 def test_hd209458b_exoplanet_orbit_database_apy_gt12():
     # Testing intentionally un-stripped string:
@@ -73,7 +75,7 @@ def test_hd209458b_exoplanet_orbit_database_apy_gt12():
                                  atol=0.1 * u.Unit('R_jup'))
 
 
-@remote_data
+@pytest.mark.remote_data
 def test_hd209458b_exoplanet_orbit_database_coords():
     params = ExoplanetOrbitDatabase.query_planet('HD 209458 b ')
     simbad_coords = SkyCoord(ra='22h03m10.77207s', dec='+18d53m03.5430s')
@@ -84,7 +86,7 @@ def test_hd209458b_exoplanet_orbit_database_coords():
     assert abs(sep) < 5 * u.arcsec
 
 
-def test_hd209458b_exoplanet_orbit_database():
+def test_hd209458b_exoplanet_orbit_database_local():
     # Testing intentionally un-stripped string:
     params = ExoplanetOrbitDatabase.query_planet('HD 209458 b ',
                                                  table_path=LOCAL_TABLE_PATH)
@@ -101,7 +103,7 @@ def test_hd209458b_exoplanet_orbit_database():
 
 
 @pytest.mark.skipif('APY_LT12')
-def test_hd209458b_exoplanet_orbit_database_apy_lt12():
+def test_hd209458b_exoplanet_orbit_database_apy_lt12_local():
     # Testing intentionally un-stripped string:
     params = ExoplanetOrbitDatabase.query_planet('HD 209458 b ',
                                                  table_path=LOCAL_TABLE_PATH)
@@ -110,7 +112,7 @@ def test_hd209458b_exoplanet_orbit_database_apy_lt12():
 
 
 @pytest.mark.skipif('not APY_LT12')
-def test_hd209458b_exoplanet_orbit_database_apy_gt12():
+def test_hd209458b_exoplanet_orbit_database_apy_gt12_local():
     # Testing intentionally un-stripped string:
     with pytest.raises(ValueError):
         params = ExoplanetOrbitDatabase.query_planet('HD 209458 b ',
@@ -119,7 +121,7 @@ def test_hd209458b_exoplanet_orbit_database_apy_gt12():
                                  atol=0.1 * u.Unit('R_jup'))
 
 
-def test_hd209458b_exoplanet_orbit_database_coords():
+def test_hd209458b_exoplanet_orbit_database_coords_local():
     params = ExoplanetOrbitDatabase.query_planet('HD 209458 b ',
                                                  table_path=LOCAL_TABLE_PATH)
     simbad_coords = SkyCoord(ra='22h03m10.77207s', dec='+18d53m03.5430s')

--- a/astroquery/fermi/tests/test_fermi_remote.py
+++ b/astroquery/fermi/tests/test_fermi_remote.py
@@ -1,13 +1,15 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 from __future__ import print_function
+
+import pytest
 import astropy.coordinates as coord
-from astropy.tests.helper import remote_data
+
 from ... import fermi
 
 FK5_COORDINATES = coord.SkyCoord(10.68471, 41.26875, unit=('deg', 'deg'))
 
 
-@remote_data
+@pytest.mark.remote_data
 def test_FermiLAT_query_async():
     result = fermi.core.FermiLAT.query_object_async(
         FK5_COORDINATES, energyrange_MeV='1000, 100000',
@@ -15,7 +17,7 @@ def test_FermiLAT_query_async():
     assert 'https://fermi.gsfc.nasa.gov/cgi-bin/ssc/LAT/QueryResults.cgi?' in result
 
 
-@remote_data
+@pytest.mark.remote_data
 def test_FermiLAT_query():
     # Make a query that results in small SC and PH file sizes
     result = fermi.core.FermiLAT.query_object(

--- a/astroquery/gaia/tests/test_gaia_remote.py
+++ b/astroquery/gaia/tests/test_gaia_remote.py
@@ -1,12 +1,11 @@
 import astropy.units as u
 import pytest
 from astropy.coordinates import SkyCoord
-from astropy.tests.helper import remote_data
 
 from .. import GaiaClass
 
 
-@remote_data
+@pytest.mark.remote_data
 def test_query_object_row_limit():
     Gaia = GaiaClass()
     coord = SkyCoord(ra=280, dec=-60, unit=(u.degree, u.degree), frame='icrs')
@@ -27,7 +26,7 @@ def test_query_object_row_limit():
     assert len(r) == 176
 
 
-@remote_data
+@pytest.mark.remote_data
 def test_cone_search_row_limit():
     Gaia = GaiaClass()
     coord = SkyCoord(ra=280, dec=-60, unit=(u.degree, u.degree), frame='icrs')

--- a/astroquery/gama/tests/test_gama_remote.py
+++ b/astroquery/gama/tests/test_gama_remote.py
@@ -1,5 +1,5 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
-from astropy.tests.helper import remote_data
+import pytest
 from astropy.table import Table
 from ... import gama
 
@@ -7,14 +7,14 @@ SQL_QUERY = "SELECT * FROM SpecAll LIMIT 5"
 GAMA_URL = "http://www.gama-survey.org/"
 
 
-@remote_data
+@pytest.mark.remote_data
 def test_GAMA_query_sql_async():
     """Tests that a URL to the GAMA website is returned."""
     result = gama.core.GAMA.query_sql_async(SQL_QUERY)
     assert result.startswith(GAMA_URL)
 
 
-@remote_data
+@pytest.mark.remote_data
 def test_GAMA_query_sql():
     """Tests that a valid HDUList object is returned."""
     result = gama.core.GAMA.query_sql(SQL_QUERY)

--- a/astroquery/gemini/tests/test_remote.py
+++ b/astroquery/gemini/tests/test_remote.py
@@ -7,11 +7,10 @@ documentation at:
 
 https://astroquery.readthedocs.io/en/latest/testing.html
 """
-
+import pytest
 from astropy import units
 from astropy.coordinates import SkyCoord
 from astropy.table import Table
-from astropy.tests.helper import remote_data
 
 from astroquery import gemini
 
@@ -20,7 +19,7 @@ from astroquery import gemini
 coords = SkyCoord(210.80242917, 54.34875, unit="deg")
 
 
-@remote_data
+@pytest.mark.remote_data
 class TestGemini(object):
     def test_observations_query_region(self):
         """ test query against a region of the sky against actual archive """

--- a/astroquery/heasarc/tests/test_heasarc_remote.py
+++ b/astroquery/heasarc/tests/test_heasarc_remote.py
@@ -1,13 +1,14 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 from __future__ import print_function
 
-from astropy.tests.helper import remote_data
-from ...heasarc import Heasarc
-from ...utils import commons
+import pytest
 import requests
 
+from ...heasarc import Heasarc
+from ...utils import commons
 
-@remote_data
+
+@pytest.mark.remote_data
 class TestHeasarc:
 
     def test_basic_example(self):

--- a/astroquery/hitran/tests/test_hitran_remote.py
+++ b/astroquery/hitran/tests/test_hitran_remote.py
@@ -1,12 +1,12 @@
 import numpy as np
+import pytest
 from astropy import units as u
 from astropy.table import Table
-from astropy.tests.helper import remote_data
 
 from ...hitran import Hitran
 
 
-@remote_data
+@pytest.mark.remote_data
 def test_query_remote():
     tbl = Hitran.query_lines(molecule_number=1, isotopologue_number=1,
                              min_frequency=0. / u.cm, max_frequency=10. / u.cm)

--- a/astroquery/ibe/tests/test_ibe_remote.py
+++ b/astroquery/ibe/tests/test_ibe_remote.py
@@ -2,15 +2,15 @@
 import pytest
 from astropy.coordinates import SkyCoord
 import astropy.units as u
-from astropy.tests.helper import remote_data
 from astropy.table import Table
+
 from ... import ibe
 
 # Some very basic remote tests based on examples from
 # http://www.ptf.caltech.edu/system/media_files/binaries/5/original/ptf_irsaibeguide.pdf
 
 
-@remote_data
+@pytest.mark.remote_data
 def test_ibe_pos():
     table = ibe.Ibe.query_region(
         SkyCoord(148.969687 * u.deg, 69.679383 * u.deg),
@@ -19,7 +19,7 @@ def test_ibe_pos():
     assert len(table) == 21
 
 
-@remote_data
+@pytest.mark.remote_data
 def test_ibe_field_id():
     table = ibe.Ibe.query_region(
         where="ptffield = 4808 and filter='R'")

--- a/astroquery/imcce/tests/test_miriade_remote.py
+++ b/astroquery/imcce/tests/test_miriade_remote.py
@@ -1,13 +1,13 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 from __future__ import print_function
 
-from astropy.tests.helper import remote_data
 import numpy.testing as npt
+import pytest
 
 from .. import core
 
 
-@remote_data
+@pytest.mark.remote_data
 class TestMiriadeClass:
 
     def test_ephemerides(self):

--- a/astroquery/imcce/tests/test_skybot_remote.py
+++ b/astroquery/imcce/tests/test_skybot_remote.py
@@ -2,13 +2,12 @@
 
 import pytest
 
-from astropy.tests.helper import remote_data
 import astropy.units as u
 
 from .. import Skybot
 
 
-@remote_data
+@pytest.mark.remote_data
 class TestSBDBClass:
 
     def general_query(self):
@@ -17,7 +16,7 @@ class TestSBDBClass:
 
     def failed_query(self):
         with pytest.raises(RuntimeError):
-            a = Skybot.cone_search((0, 90), 0.00000001, 2451200)
+            Skybot.cone_search((0, 90), 0.00000001, 2451200)
 
     def planet_moons(self):
         a = Skybot.cone_search((221.48552, -14.82952), 0.1,

--- a/astroquery/irsa/tests/test_irsa_remote.py
+++ b/astroquery/irsa/tests/test_irsa_remote.py
@@ -1,20 +1,20 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 from __future__ import print_function
 
-from astropy.tests.helper import remote_data
+import pytest
+import astropy.units as u
 from astropy.table import Table
 from astropy.coordinates import SkyCoord
-import astropy.units as u
 
 from ... import irsa
 
 
 OBJ_LIST = ["m31", "00h42m44.330s +41d16m07.50s",
-            SkyCoord(l=121.1743, b=-21.5733, unit=(u.deg, u.deg),
+            SkyCoord(l=121.1743, b=-21.5733, unit=(u.deg, u.deg),  # noqa
                      frame='galactic')]
 
 
-@remote_data
+@pytest.mark.remote_data
 class TestIrsa:
 
     def test_query_region_cone_async(self):

--- a/astroquery/irsa_dust/tests/test_irsa_dust_remote.py
+++ b/astroquery/irsa_dust/tests/test_irsa_dust_remote.py
@@ -3,11 +3,10 @@ import os
 import pytest
 import requests
 
-from astropy.tests.helper import remote_data
 from astropy.table import Table
 import astropy.units as u
-from ... import irsa_dust
 
+from ... import irsa_dust
 
 M31_XML = "dustm31.xml"
 M81_XML = "dustm81.xml"
@@ -41,7 +40,7 @@ class DustTestCase(object):
         return os.path.join(data_dir, filename)
 
 
-@remote_data
+@pytest.mark.remote_data
 class TestDust(DustTestCase):
 
     def test_xml_ok(self):

--- a/astroquery/jplhorizons/tests/test_jplhorizons_remote.py
+++ b/astroquery/jplhorizons/tests/test_jplhorizons_remote.py
@@ -1,14 +1,14 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 from __future__ import print_function
 
-from astropy.tests.helper import remote_data, assert_quantity_allclose
+import pytest
+from astropy.tests.helper import assert_quantity_allclose
 from numpy.ma import is_masked
-
 
 from ... import jplhorizons
 
 
-@remote_data
+@pytest.mark.remote_data
 class TestHorizonsClass:
 
     def test_ephemerides_query(self):

--- a/astroquery/jplsbdb/tests/test_jplsbdb_remote.py
+++ b/astroquery/jplsbdb/tests/test_jplsbdb_remote.py
@@ -1,12 +1,12 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 
-from astropy.tests.helper import remote_data
+import pytest
 import astropy.units as u
 
 from .. import SBDB
 
 
-@remote_data
+@pytest.mark.remote_data
 class TestSBDBClass:
 
     def test_id_types(self):

--- a/astroquery/jplspec/tests/test_jplspec_remote.py
+++ b/astroquery/jplspec/tests/test_jplspec_remote.py
@@ -1,11 +1,11 @@
+import pytest
 from astropy import units as u
 from astropy.table import Table
-from astropy.tests.helper import remote_data
 
 from ...jplspec import JPLSpec
 
 
-@remote_data
+@pytest.mark.remote_data
 def test_remote():
     tbl = JPLSpec.query_lines(min_frequency=500 * u.GHz,
                               max_frequency=1000 * u.GHz,
@@ -23,7 +23,7 @@ def test_remote():
     assert tbl['FREQ'][35] == 987926.7590
 
 
-@remote_data
+@pytest.mark.remote_data
 def test_remote_regex():
     tbl = JPLSpec.query_lines(min_frequency=500 * u.GHz,
                               max_frequency=1000 * u.GHz,

--- a/astroquery/lamda/tests/test_lamda_remote.py
+++ b/astroquery/lamda/tests/test_lamda_remote.py
@@ -1,9 +1,10 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
-from astropy.tests.helper import remote_data
+import pytest
+
 from ... import lamda
 
 
-@remote_data
+@pytest.mark.remote_data
 def test_query():
     result = lamda.Lamda.query(mol='co')
     assert [len(r) for r in result] == [2, 40, 41]

--- a/astroquery/lcogt/tests/test_lcogt_remote.py
+++ b/astroquery/lcogt/tests/test_lcogt_remote.py
@@ -15,8 +15,8 @@ OBJ_LIST = ["m31", "00h42m44.330s +41d16m07.50s",
 
 
 @pytest.mark.remote_data
-@pytest.mark.xfail(reason="Changed remote API, xfailing until fixing"
-                   "https://github.com/astropy/astroquery/issues/725")
+@pytest.mark.skip(reason="Changed remote API, xfailing until fixing"
+                  "https://github.com/astropy/astroquery/issues/725")
 class TestLcogt:
 
     def test_query_object_meta(self):

--- a/astroquery/lcogt/tests/test_lcogt_remote.py
+++ b/astroquery/lcogt/tests/test_lcogt_remote.py
@@ -3,7 +3,6 @@ from __future__ import print_function
 
 import pytest
 
-from astropy.tests.helper import remote_data
 from astropy.table import Table
 from astropy.coordinates import SkyCoord
 import astropy.units as u
@@ -11,13 +10,13 @@ import astropy.units as u
 from ... import lcogt
 
 OBJ_LIST = ["m31", "00h42m44.330s +41d16m07.50s",
-            SkyCoord(l=121.1743, b=-21.5733, unit=(u.deg, u.deg),
+            SkyCoord(l=121.1743, b=-21.5733, unit=(u.deg, u.deg),  # noqa
                      frame='galactic')]
 
 
-@remote_data
-@pytest.mark.skip(reason="Changed remote API, xfailing until fixing"
-                  "https://github.com/astropy/astroquery/issues/725")
+@pytest.mark.remote_data
+@pytest.mark.xfail(reason="Changed remote API, xfailing until fixing"
+                   "https://github.com/astropy/astroquery/issues/725")
 class TestLcogt:
 
     def test_query_object_meta(self):

--- a/astroquery/magpis/tests/test_magpis_remote.py
+++ b/astroquery/magpis/tests/test_magpis_remote.py
@@ -1,14 +1,14 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 from __future__ import print_function
 
-from astropy.coordinates import SkyCoord
+import pytest
 import astropy.units as u
-from astropy.tests.helper import remote_data
+from astropy.coordinates import SkyCoord
 
 from ... import magpis
 
 
-@remote_data
+@pytest.mark.remote_data
 class TestMagpis:
 
     def test_get_images_async(self):

--- a/astroquery/mast/tests/test_mast_remote.py
+++ b/astroquery/mast/tests/test_mast_remote.py
@@ -5,7 +5,6 @@ import numpy as np
 import os
 import pytest
 
-from astropy.tests.helper import remote_data
 from astropy.table import Table
 from astropy.coordinates import SkyCoord
 from astropy.io import fits
@@ -19,7 +18,7 @@ from ... import mast
 from ...exceptions import RemoteServiceError
 
 
-@remote_data
+@pytest.mark.remote_data
 class TestMast(object):
 
     ###################

--- a/astroquery/mpc/tests/test_mpc_remote.py
+++ b/astroquery/mpc/tests/test_mpc_remote.py
@@ -2,12 +2,11 @@
 import requests
 import pytest
 
-from astropy.tests.helper import remote_data
 from ...exceptions import InvalidQueryError
 from ... import mpc
 
 
-@remote_data
+@pytest.mark.remote_data
 class TestMPC(object):
 
     @pytest.mark.parametrize('type, name', [

--- a/astroquery/nasa_exoplanet_archive/tests/test_nasa_exoplanet_archive_remote.py
+++ b/astroquery/nasa_exoplanet_archive/tests/test_nasa_exoplanet_archive_remote.py
@@ -1,8 +1,9 @@
 from __future__ import (absolute_import, division, print_function,
                         unicode_literals)
 import os
+import pytest
 import astropy.units as u
-from astropy.tests.helper import assert_quantity_allclose, remote_data, pytest
+from astropy.tests.helper import assert_quantity_allclose
 from astropy.utils import minversion
 from astropy.coordinates import SkyCoord
 
@@ -13,7 +14,7 @@ LOCAL_TABLE_PATH = os.path.join(os.path.abspath(os.path.dirname(__file__)),
                                 'data', 'nasa_exoplanet_archive.csv')
 
 
-@remote_data
+@pytest.mark.remote_data
 @pytest.mark.skipif('APY_LT12')
 def test_hd209458b_exoplanets_archive_apy_lt12():
     # Testing intentionally un-stripped string:
@@ -22,7 +23,7 @@ def test_hd209458b_exoplanets_archive_apy_lt12():
                              atol=0.1 * u.Unit('R_jup'))
 
 
-@remote_data
+@pytest.mark.remote_data
 @pytest.mark.skipif('not APY_LT12')
 def test_hd209458b_exoplanets_archive_apy_gt12():
     # Testing intentionally un-stripped string:
@@ -32,7 +33,7 @@ def test_hd209458b_exoplanets_archive_apy_gt12():
                                  atol=0.1 * u.Unit('R_jup'))
 
 
-@remote_data
+@pytest.mark.remote_data
 def test_hd209458b_exoplanet_archive_coords():
     params = NasaExoplanetArchive.query_planet('HD 209458 b ')
     simbad_coords = SkyCoord(ra='22h03m10.77207s', dec='+18d53m03.5430s')
@@ -68,7 +69,7 @@ def test_hd209458b_exoplanet_archive_coords_local():
     assert abs(sep) < 5 * u.arcsec
 
 
-@remote_data
+@pytest.mark.remote_data
 def test_hd209458_stellar_exoplanet_archive():
     # Testing intentionally un-stripped string, no spaced:
     params = NasaExoplanetArchive.query_star('HD 209458')
@@ -82,7 +83,7 @@ def test_hd209458_stellar_exoplanet_archive():
     assert not params['pl_ttvflag']
 
 
-@remote_data
+@pytest.mark.remote_data
 def test_hd136352_stellar_exoplanet_archive():
     # Check for all planets around specific star
     params = NasaExoplanetArchive.query_star('HD 136352')
@@ -96,7 +97,7 @@ def test_hd136352_stellar_exoplanet_archive():
     assert 'pl_trandep' not in params.colnames
 
 
-@remote_data
+@pytest.mark.remote_data
 @pytest.mark.skipif('APY_LT12')
 def test_hd209458_stellar_exoplanets_archive_apy_lt12():
     # Testing intentionally un-stripped string:
@@ -105,7 +106,7 @@ def test_hd209458_stellar_exoplanets_archive_apy_lt12():
                              atol=0.1 * u.Unit('R_jup'))
 
 
-@remote_data
+@pytest.mark.remote_data
 @pytest.mark.skipif('not APY_LT12')
 def test_hd209458_stellar_exoplanets_archive_apy_gt12():
     # Testing intentionally un-stripped string:
@@ -115,7 +116,7 @@ def test_hd209458_stellar_exoplanets_archive_apy_gt12():
                                  atol=0.1 * u.Unit('R_jup'))
 
 
-@remote_data
+@pytest.mark.remote_data
 def test_hd209458_exoplanet_archive_coords():
     params = NasaExoplanetArchive.query_star('HD 209458')
     simbad_coords = SkyCoord(ra='22h03m10.77207s', dec='+18d53m03.5430s')
@@ -125,7 +126,7 @@ def test_hd209458_exoplanet_archive_coords():
     assert abs(sep) < 5 * u.arcsec
 
 
-@remote_data
+@pytest.mark.remote_data
 def test_exoplanet_archive_query_all_columns():
     # Get all the columns from planet query
     params = NasaExoplanetArchive.query_planet('HD 209458 b ', cache=False, all_columns=True)
@@ -134,7 +135,7 @@ def test_exoplanet_archive_query_all_columns():
     assert 'pl_tranflag' in params.columns
 
 
-@remote_data
+@pytest.mark.remote_data
 def test_stellar_exoplanet_archive_query_all_columns():
     # Get all the columns from star query
     params = NasaExoplanetArchive.query_star('HD 209458 b ', cache=False, all_columns=True)
@@ -143,7 +144,7 @@ def test_stellar_exoplanet_archive_query_all_columns():
     assert 'pl_tranflag' in params.columns
 
 
-@remote_data
+@pytest.mark.remote_data
 @pytest.mark.skipif('APY_LT12')
 def test_hd209458_stellar_exoplanets_archive_apy_lt12_local():
     # Testing intentionally un-stripped string:
@@ -152,7 +153,7 @@ def test_hd209458_stellar_exoplanets_archive_apy_lt12_local():
                              atol=0.1 * u.Unit('R_jup'))
 
 
-@remote_data
+@pytest.mark.remote_data
 @pytest.mark.skipif('not APY_LT12')
 def test_hd209458_stellar_exoplanets_archive_apy_gt12_local():
     # Testing intentionally un-stripped string:
@@ -162,7 +163,7 @@ def test_hd209458_stellar_exoplanets_archive_apy_gt12_local():
                                  atol=0.1 * u.Unit('R_jup'))
 
 
-@remote_data
+@pytest.mark.remote_data
 def test_hd209458_exoplanet_archive_coords_local():
     params = NasaExoplanetArchive.query_star('HD 209458', table_path=LOCAL_TABLE_PATH)
     simbad_coords = SkyCoord(ra='22h03m10.77207s', dec='+18d53m03.5430s')

--- a/astroquery/ned/tests/test_ned_remote.py
+++ b/astroquery/ned/tests/test_ned_remote.py
@@ -1,13 +1,13 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 from __future__ import print_function
 
-from astropy.tests.helper import remote_data
+import pytest
 from astropy.table import Table
 
 from ... import ned
 
 
-@remote_data
+@pytest.mark.remote_data
 class TestNed:
 
     def test_get_references(self):

--- a/astroquery/nist/tests/test_nist_remote.py
+++ b/astroquery/nist/tests/test_nist_remote.py
@@ -5,6 +5,7 @@ import numpy as np
 
 from astropy.table import Table
 import astropy.units as u
+from six import PY2  # noqa
 
 import pytest
 

--- a/astroquery/nist/tests/test_nist_remote.py
+++ b/astroquery/nist/tests/test_nist_remote.py
@@ -3,16 +3,15 @@ from __future__ import print_function
 
 import numpy as np
 
-from astropy.tests.helper import remote_data
 from astropy.table import Table
 import astropy.units as u
-from six import PY2
+
 import pytest
 
 from ... import nist
 
 
-@remote_data
+@pytest.mark.remote_data
 class TestNist:
 
     def test_query_async(self):

--- a/astroquery/nrao/tests/test_nrao_remote.py
+++ b/astroquery/nrao/tests/test_nrao_remote.py
@@ -1,15 +1,15 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 from __future__ import print_function
 
-from astropy.tests.helper import remote_data
-from astropy.table import Table
+import pytest
 import astropy.coordinates as coord
+from astropy.table import Table
 from astropy import units as u
 
 from ... import nrao
 
 
-@remote_data
+@pytest.mark.remote_data
 class TestNrao:
 
     def test_query_region_async(self):

--- a/astroquery/nvas/tests/test_nvas_remote.py
+++ b/astroquery/nvas/tests/test_nvas_remote.py
@@ -1,14 +1,14 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 from __future__ import print_function
 
-from astropy.coordinates import SkyCoord
+import pytest
 import astropy.units as u
-from astropy.tests.helper import remote_data
+from astropy.coordinates import SkyCoord
 
 from ...import nvas
 
 
-@remote_data
+@pytest.mark.remote_data
 class TestNvas:
 
     def test_get_images_async(self):

--- a/astroquery/oac/tests/test_oac_remote.py
+++ b/astroquery/oac/tests/test_oac_remote.py
@@ -6,12 +6,11 @@ import pytest
 from astropy import coordinates as coord
 from astropy.table import Table
 import astropy.units as u
-from astropy.tests.helper import remote_data
 
 from .. import OAC
 
 
-@remote_data
+@pytest.mark.remote_data
 class TestOACClass:
     """Test methods to verify the functionality of methods in the
     OAC API astroquery module.

--- a/astroquery/open_exoplanet_catalogue/tests/test_open_exoplanet_catalogue_remote.py
+++ b/astroquery/open_exoplanet_catalogue/tests/test_open_exoplanet_catalogue_remote.py
@@ -1,9 +1,9 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
-from astropy.tests.helper import remote_data
+import pytest
 from ... import open_exoplanet_catalogue as oec
 
 
-@remote_data
+@pytest.mark.remote_data
 def test_function():
 
     cata = oec.get_catalogue()

--- a/astroquery/sdss/tests/test_sdss_remote.py
+++ b/astroquery/sdss/tests/test_sdss_remote.py
@@ -5,7 +5,6 @@ import pytest
 
 from astropy import coordinates
 from astropy.table import Table
-from astropy.tests.helper import remote_data
 
 from six.moves.urllib_error import URLError
 
@@ -13,7 +12,7 @@ from ... import sdss
 from ...exceptions import TimeoutError
 
 
-@remote_data
+@pytest.mark.remote_data
 class TestSDSSRemote:
     # Test Case: A Seyfert 1 galaxy
     coords = coordinates.SkyCoord('0h8m05.63s +14d50m23.3s')

--- a/astroquery/simbad/tests/test_simbad_remote.py
+++ b/astroquery/simbad/tests/test_simbad_remote.py
@@ -1,7 +1,6 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 import pytest
 
-from astropy.tests.helper import remote_data
 import astropy.coordinates as coord
 import astropy.units as u
 from astropy.table import Table
@@ -15,7 +14,7 @@ ICRS_COORDS_SgrB2 = coord.SkyCoord(266.835*u.deg, -28.38528*u.deg, frame='icrs')
 multicoords = coord.SkyCoord([ICRS_COORDS_M42, ICRS_COORDS_SgrB2])
 
 
-@remote_data
+@pytest.mark.remote_data
 class TestSimbad(object):
 
     @classmethod

--- a/astroquery/skyview/tests/test_skyview_remote.py
+++ b/astroquery/skyview/tests/test_skyview_remote.py
@@ -2,14 +2,13 @@
 import pytest
 import json
 
-from astropy.tests.helper import remote_data
 from astropy.io.fits import HDUList
 
 from ...skyview import SkyView
 from .test_skyview import data_path
 
 
-@remote_data
+@pytest.mark.remote_data
 def test_get_image_list():
     urls = SkyView().get_image_list(position='Eta Carinae',
                                     survey=['Fermi 5', 'HRI', 'DSS'])
@@ -18,14 +17,14 @@ def test_get_image_list():
         assert url.startswith('https://skyview.gsfc.nasa.gov/tempspace/fits/')
 
 
-@remote_data
+@pytest.mark.remote_data
 def test_get_images():
     images = SkyView().get_images(position='Eta Carinae', survey=['2MASS-J'])
     assert len(images) == 1
     assert isinstance(images[0], HDUList)
 
 
-@remote_data
+@pytest.mark.remote_data
 class TestSkyviewRemote(object):
 
     @classmethod

--- a/astroquery/splatalogue/tests/test_splatalogue.py
+++ b/astroquery/splatalogue/tests/test_splatalogue.py
@@ -5,7 +5,6 @@ import pytest
 import requests
 
 from astropy import units as u
-from astropy.tests.helper import remote_data
 
 from ... import splatalogue
 from ...utils.testing_tools import MockResponse
@@ -42,7 +41,7 @@ def test_simple(patch_post):
                                         chemical_name=' CO ')
 
 
-@remote_data
+@pytest.mark.remote_data
 def test_init(patch_post):
     x = splatalogue.Splatalogue.query_lines(114 * u.GHz, 116 * u.GHz,
                                             chemical_name=' CO ')
@@ -118,7 +117,7 @@ def test_band_crashorno():
 # # regression test : version selection should work
 # # Unfortunately, it looks like version1 = version2 on the web page now, so this
 # # may no longer be a valid test
-# @remote_data
+# @pytest.mark.remote_data
 # def test_version_selection():
 #     results = splatalogue.Splatalogue.query_lines(
 # 			    min_frequency= 703*u.GHz,
@@ -154,7 +153,7 @@ def test_exclude(patch_post):
         assert k[:3] != 'no_'
 
 
-@remote_data
+@pytest.mark.remote_data
 def test_exclude_remote():
     # regression test for issue 616
     # only entry should be  "D213CO  Formaldehyde 351.96064  3.9e-06   ...."

--- a/astroquery/template_module/tests/test_module_remote.py
+++ b/astroquery/template_module/tests/test_module_remote.py
@@ -7,10 +7,9 @@ from __future__ import print_function
 # remote_data decorator from astropy:
 
 import pytest
-from astropy.tests.helper import remote_data
 
 
-@remote_data
+@pytest.mark.remote_data
 class TestTemplateClass:
     # now write tests for each method here
     def test_this(self):

--- a/astroquery/tests/test_internet.py
+++ b/astroquery/tests/test_internet.py
@@ -1,11 +1,11 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
-from astropy.tests.helper import remote_data
+import pytest
 import requests
 
 from .. import version
 
 
-@remote_data
+@pytest.mark.remote_data
 def test_net_connection():
     R = requests.post('http://httpbin.org/post',
                       headers={'User-Agent':

--- a/astroquery/ukidss/tests/test_ukidss_remote.py
+++ b/astroquery/ukidss/tests/test_ukidss_remote.py
@@ -1,16 +1,15 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 from __future__ import print_function
 
-from astropy.tests.helper import remote_data
+import pytest
+import astropy.units as u
 from astropy.table import Table
 from astropy.coordinates import SkyCoord
-import astropy.units as u
-import requests
 
 from ... import ukidss
 
 
-@remote_data
+@pytest.mark.remote_data
 class TestUkidss:
     ukidss.core.Ukidss.TIMEOUT = 20
 

--- a/astroquery/utils/tests/test_utils.py
+++ b/astroquery/utils/tests/test_utils.py
@@ -14,7 +14,6 @@ from astropy.io import fits
 import astropy.io.votable as votable
 import astropy.units as u
 from astropy.table import Table
-from astropy.tests.helper import remote_data
 import astropy.utils.data as aud
 
 from ...utils import chunk_read, chunk_report, class_or_instance, commons
@@ -35,7 +34,7 @@ class SimpleQueryClass(object):
             return "instance"
 
 
-@remote_data
+@pytest.mark.remote_data
 def test_chunk_read():
     datasize = 50000
     response = urllib.request.urlopen('http://httpbin.org/stream-bytes/{0}'.format(datasize))
@@ -59,7 +58,7 @@ def test_parse_coordinates_1(coordinates):
     assert c is not None
 
 
-@remote_data
+@pytest.mark.remote_data
 @pytest.mark.parametrize(('coordinates'),
                          ["00h42m44.3s +41d16m9s",
                           "m81"])

--- a/astroquery/vamdc/tests/test_vamdc_remote.py
+++ b/astroquery/vamdc/tests/test_vamdc_remote.py
@@ -8,18 +8,16 @@ from __future__ import print_function
 
 import pytest
 
-from astropy.tests.helper import remote_data
-
 try:
     from ... import vamdc
-    import vamdclib
+    import vamdclib  # noqa
     HAS_VAMDCLIB = True
 except ImportError:
     HAS_VAMDCLIB = False
 
 
 @pytest.mark.skipif('not HAS_VAMDCLIB')
-@remote_data
+@pytest.mark.remote_data
 class TestVamdcClass:
     # now write tests for each method here
     def test_query_molecule(self):

--- a/astroquery/vizier/tests/test_vizier_remote.py
+++ b/astroquery/vizier/tests/test_vizier_remote.py
@@ -1,14 +1,13 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 import pytest
 
-from astropy.tests.helper import remote_data
 import astropy.units as u
 from astropy import coordinates
 from ... import vizier
 from ...utils import commons
 
 
-@remote_data
+@pytest.mark.remote_data
 class TestVizierRemote(object):
 
     target = commons.ICRSCoordGenerator(ra=299.590, dec=35.201,

--- a/astroquery/vo_conesearch/tests/test_conesearch.py
+++ b/astroquery/vo_conesearch/tests/test_conesearch.py
@@ -14,7 +14,6 @@ from astropy import units as u
 from astropy.coordinates import ICRS, SkyCoord
 from astropy.io.votable.tree import Table as VOTable
 from astropy.table import Table
-from astropy.tests.helper import remote_data
 from astropy.utils.data import get_pkg_data_filename
 from astropy.utils import data
 
@@ -35,7 +34,7 @@ SCS_CENTER = ICRS(SCS_RA * u.degree, SCS_DEC * u.degree)
 SCS_RADIUS = SCS_SR * u.degree
 
 
-@remote_data
+@pytest.mark.remote_data
 class TestConeSearch(object):
     """
     Test Cone Search on a pre-defined access URL.

--- a/astroquery/vo_conesearch/tests/test_vos_catalog.py
+++ b/astroquery/vo_conesearch/tests/test_vos_catalog.py
@@ -15,7 +15,6 @@ import os
 import pytest
 
 # ASTROPY
-from astropy.tests.helper import remote_data
 from astropy.utils.data import get_pkg_data_filename
 
 # LOCAL
@@ -188,7 +187,7 @@ def test_write_json(tmpdir):
     assert db.list_catalogs_by_url() == db2.list_catalogs_by_url()
 
 
-@remote_data
+@pytest.mark.remote_data
 def test_db_from_registry():
     """Test database created from VO registry.
 

--- a/astroquery/vo_conesearch/validator/tests/test_validate.py
+++ b/astroquery/vo_conesearch/validator/tests/test_validate.py
@@ -18,7 +18,7 @@ import pytest
 from numpy.testing import assert_allclose
 
 # ASTROPY
-from astropy.tests.helper import remote_data, catch_warnings
+from astropy.tests.helper import catch_warnings
 from astropy.utils.data import get_pkg_data_filename
 
 # LOCAL
@@ -28,7 +28,7 @@ from ...vos_catalog import VOSDatabase
 __doctest_skip__ = ['*']
 
 
-@remote_data
+@pytest.mark.remote_data
 class TestConeSearchValidation(object):
     """Validation on a small subset of Cone Search sites."""
 
@@ -81,7 +81,7 @@ class TestConeSearchValidation(object):
         conf.reset('conesearch_master_list')
 
 
-@remote_data
+@pytest.mark.remote_data
 def test_tstquery():
     with catch_warnings() as w:
         d = tstquery.parse_cs('ivo://cds.vizier/i/252', cap_index=4)

--- a/astroquery/vsa/tests/test_vista_remote.py
+++ b/astroquery/vsa/tests/test_vista_remote.py
@@ -3,7 +3,6 @@ from __future__ import print_function
 
 import pytest
 
-from astropy.tests.helper import remote_data
 from astropy.table import Table
 from astropy.coordinates import SkyCoord
 import astropy.units as u
@@ -14,7 +13,7 @@ from ... import vsa
 vista = vsa.core.VsaClass()
 
 
-@remote_data
+@pytest.mark.remote_data
 class TestVista:
 
     @pytest.mark.dependency(name='vsa_up')

--- a/astroquery/xmatch/tests/test_xmatch_remote.py
+++ b/astroquery/xmatch/tests/test_xmatch_remote.py
@@ -6,7 +6,6 @@ import pytest
 import requests
 from requests import ReadTimeout
 
-from astropy.tests.helper import remote_data
 from astropy.table import Table
 from astropy.units import arcsec, arcmin
 from astropy.io import ascii
@@ -24,7 +23,7 @@ from ...xmatch import XMatch
 DATA_DIR = os.path.join(os.path.dirname(__file__), 'data')
 
 
-@remote_data
+@pytest.mark.remote_data
 @pytest.mark.dependency(name='xmatch_up')
 def test_is_xmatch_up():
     try:
@@ -33,7 +32,7 @@ def test_is_xmatch_up():
         pytest.xfail("XMATCH appears to be down.  Exception was: {0}".format(ex))
 
 
-@remote_data
+@pytest.mark.remote_data
 @pytest.mark.dependency(depends=["xmatch_up"])
 class TestXMatch:
     # fixture only used here to save creating XMatch instances in each

--- a/setup.cfg
+++ b/setup.cfg
@@ -16,7 +16,9 @@ show-response = 1
 minversion = 3.0
 norecursedirs = build docs/_build docs/gallery-examples
 doctest_plus = enabled
+text_file_format = rst
 addopts = -p no:warnings
+xfail_strict = true
 remote_data_strict = true
 
 [ah_bootstrap]
@@ -87,6 +89,14 @@ ignore = E402
 
 # Excluding files that are directly copied from the package template or
 # generated
+exclude = _astropy_init.py,version.py
+
+# E402 module level import not at top of file
+# E501 line too long
+# W504 line break after operator
+# Stricter settings for people who use flake8 in their editors
+[flake8]
+ignore = E402,E501,W504
 exclude = _astropy_init.py,version.py
 
 [entry_points]

--- a/setup.cfg
+++ b/setup.cfg
@@ -91,12 +91,13 @@ ignore = E402
 # generated
 exclude = _astropy_init.py,version.py
 
+# E226 missing whitespace around operators
 # E402 module level import not at top of file
 # E501 line too long
 # W504 line break after operator
 # Stricter settings for people who use flake8 in their editors
 [flake8]
-ignore = E402,E501,W504
+ignore = E226,E402,E501,W504
 exclude = _astropy_init.py,version.py
 
 [entry_points]

--- a/setup.cfg
+++ b/setup.cfg
@@ -93,11 +93,11 @@ exclude = _astropy_init.py,version.py
 
 # E226 missing whitespace around operators
 # E402 module level import not at top of file
-# E501 line too long
-# W504 line break after operator
+# W503 line break before operator
 # Stricter settings for people who use flake8 in their editors
 [flake8]
-ignore = E226,E402,E501,W504
+max-line-length = 120
+ignore = E226,E402,W503
 exclude = _astropy_init.py,version.py
 
 [entry_points]

--- a/setup.py
+++ b/setup.py
@@ -136,6 +136,6 @@ setup(name=PACKAGENAME,
       use_2to3=False,
       entry_points=entry_points,
       extras_require=extras_require,
-      tests_require=['pytest_astropy'],
+      tests_require=['pytest-astropy'],
       **package_info
 )


### PR DESCRIPTION
Fix #1660 

* Use `pytest-remotedata` plugin.
* Add `flake8` config in `setup.cfg`. (This is for my own sanity when I edit stuff but can benefit others too.)
* ~Mark `lcogt` test as `xfail` as the reason stated and~ make `xfail` strict.
* Minor import clean-ups in tests.
* Minor clean-ups in setup.

**TODO**

- [x] Replace the rest of `@remote_data` in remaining modules. (I was distracted and forgot I wasn't done yet as I am typing this.)