### PR TITLE
BUG: MOC write fails when file exists

### DIFF
--- a/astroquery/cds/core.py
+++ b/astroquery/cds/core.py
@@ -254,6 +254,8 @@ class CdsClass(BaseQuery):
             region = kwargs['region']
             if isinstance(region, MOC):
                 self.path_moc_file = os.path.join(os.getcwd(), 'moc.fits')
+                if os.path.isfile(self.path_moc_file):  # Silent overwrite
+                    os.remove(self.path_moc_file)
                 region.write(self.path_moc_file, format="fits")
                 # add the moc region payload to the request payload
             elif isinstance(region, CircleSkyRegion):


### PR DESCRIPTION
I am not sure if this is the correct way to fix this, but I see this failure in the remote data tests. Maybe CDS maintainer can have a look at this.
```
_________________ TestMOCServerRemote.test_moc_order_param[10] _________________
self = <astroquery.cds.tests.test_mocserver_remote.TestMOCServerRemote object at 0x7f16db4b7710>
moc_order = 10
    @pytest.mark.skipif('mocpy' not in sys.modules,
                        reason="requires MOCPy")
    @pytest.mark.parametrize('moc_order', [5, 10])
    def test_moc_order_param(self, moc_order):
        moc_region = MOC.from_json({'0': [1]})
    
        result = cds.query_region(region=moc_region,
                                  # return a mocpy obj
                                  return_moc=True,
                                  max_norder=moc_order,
>                                 get_query_payload=False)
astroquery/cds/tests/test_mocserver_remote.py:79: 
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 
astroquery/cds/core.py:122: in query_region
    response = self.query_region_async(get_query_payload=get_query_payload, region=region, **kwargs)
astroquery/cds/core.py:203: in query_region_async
    request_payload = self._args_to_payload(**kwargs)
astroquery/cds/core.py:257: in _args_to_payload
    region.write(self.path_moc_file, format="fits")
/home/travis/miniconda/envs/test/lib/python3.7/site-packages/mocpy/serializer.py:91: in write
    serialization.writeto(path, overwrite=overwrite)
/home/travis/miniconda/envs/test/lib/python3.7/site-packages/astropy/utils/decorators.py:525: in wrapper
    return function(*args, **kwargs)
/home/travis/miniconda/envs/test/lib/python3.7/site-packages/astropy/io/fits/hdu/hdulist.py:926: in writeto
    fileobj = _File(fileobj, mode=mode, overwrite=overwrite)
/home/travis/miniconda/envs/test/lib/python3.7/site-packages/astropy/utils/decorators.py:525: in wrapper
    return function(*args, **kwargs)
/home/travis/miniconda/envs/test/lib/python3.7/site-packages/astropy/io/fits/file.py:193: in __init__
    self._open_filename(fileobj, mode, overwrite)
/home/travis/miniconda/envs/test/lib/python3.7/site-packages/astropy/io/fits/file.py:563: in _open_filename
    self._overwrite_existing(overwrite, None, True)
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 
self = <[AttributeError("'_File' object has no attribute '_file'") raised in repr()] _File object at 0x7f16dabce810>
overwrite = False, fileobj = None, closed = True
    def _overwrite_existing(self, overwrite, fileobj, closed):
        """Overwrite an existing file if ``overwrite`` is ``True``, otherwise
        raise an OSError.  The exact behavior of this method depends on the
        _File object state and is only meant for use within the ``_open_*``
        internal methods.
        """
    
        # The file will be overwritten...
        if ((self.file_like and hasattr(fileobj, 'len') and fileobj.len > 0) or
                (os.path.exists(self.name) and os.path.getsize(self.name) != 0)):
            if overwrite:
                if self.file_like and hasattr(fileobj, 'truncate'):
                    fileobj.truncate(0)
                else:
                    if not closed:
                        fileobj.close()
                    os.remove(self.name)
            else:
>               raise OSError(f"File {self.name!r} already exists.")
E               OSError: File '/tmp/astroquery-test-mv1hn19v/lib/python3.7/site-packages/moc.fits' already exists.
/home/travis/miniconda/envs/test/lib/python3.7/site-packages/astropy/io/fits/file.py:453: OSError
```