### PR TITLE
Fix some bytes vs unicode cases

### DIFF
--- a/astroquery/alma/tests/test_alma_remote.py
+++ b/astroquery/alma/tests/test_alma_remote.py
@@ -9,6 +9,7 @@ from astropy import coordinates
 from astropy import units as u
 from six.moves.urllib_parse import urlparse
 
+from astroquery.utils.commons import ASTROPY_LT_4_1
 from .. import Alma
 from .. import _url_list, _test_url_list
 
@@ -58,15 +59,24 @@ class TestAlma:
         alma.cache_location = temp_dir
 
         result_s = alma.query_object('Sgr A*')
-        # cycle 1 data are missing from the archive assert b'2011.0.00887.S' in result_s['Project code']
-        assert b'2013.1.00857.S' in result_s['Project code']
+
         c = coordinates.SkyCoord(266.41681662 * u.deg, -29.00782497 * u.deg,
                                  frame='fk5')
         result_c = alma.query_region(c, 1 * u.deg)
-        assert b'2013.1.00857.S' in result_c['Project code']
-        # "The Brick", g0.253, is in this one
-        # assert b'2011.0.00217.S' in result_c['Project code'] # missing cycle 1 data
-        assert b'2012.1.00932.S' in result_c['Project code']
+
+        if ASTROPY_LT_4_1:
+            # cycle 1 data are missing from the archive
+            # assert b'2011.0.00887.S' in result_s['Project code']
+            # "The Brick", g0.253, is in this one
+            # assert b'2011.0.00217.S' in result_c['Project code']
+
+            assert b'2013.1.00857.S' in result_s['Project code']
+            assert b'2013.1.00857.S' in result_c['Project code']
+            assert b'2012.1.00932.S' in result_c['Project code']
+        else:
+            assert '2013.1.00857.S' in result_s['Project code']
+            assert '2013.1.00857.S' in result_c['Project code']
+            assert '2012.1.00932.S' in result_c['Project code']
 
     @pytest.mark.skipif("SKIP_SLOW")
     def test_m83(self, temp_dir, recwarn):
@@ -220,7 +230,7 @@ class TestAlma:
 def test_project_metadata():
     alma = Alma()
     metadata = alma.get_project_metadata('2013.1.00269.S')
-    assert metadata == ['Sgr B2, a high-mass molecular cloud in our Galaxy\'s Central Molecular Zone, is the most extreme site of ongoing star formation in the Local Group in terms of its gas content, temperature, and velocity dispersion. If any cloud in our galaxy is analogous to the typical cloud at the universal peak of star formation at z~2, this is it. We propose a 6\'x6\' mosaic in the 3mm window targeting gas thermometer lines, specifically CH3CN and its isotopologues. We will measure the velocity dispersion and temperature of the molecular gas on all scales (0.02 - 12 pc, 0.5" - 5\') within the cloud, which will yield resolved measurements of the Mach number and the sonic scale of the gas. We will assess the relative importance of stellar feedback and turbulence on the star-forming gas, determining how extensive the feedback effects are within an ultradense environment. The observations will provide constraints on the inputs to star formation theories and will determine their applicability in extremely dense, turbulent, and hot regions. Sgr B2 will be used as a testing ground for star formation theories in an environment analogous to high-z starburst clouds in which they must be applied.']
+    assert metadata == ['Sgr B2, a high-mass molecular cloud in our Galaxy\'s Central Molecular Zone, is the most extreme site of ongoing star formation in the Local Group in terms of its gas content, temperature, and velocity dispersion. If any cloud in our galaxy is analogous to the typical cloud at the universal peak of star formation at z~2, this is it. We propose a 6\'x6\' mosaic in the 3mm window targeting gas thermometer lines, specifically CH3CN and its isotopologues. We will measure the velocity dispersion and temperature of the molecular gas on all scales (0.02 - 12 pc, 0.5" - 5\') within the cloud, which will yield resolved measurements of the Mach number and the sonic scale of the gas. We will assess the relative importance of stellar feedback and turbulence on the star-forming gas, determining how extensive the feedback effects are within an ultradense environment. The observations will provide constraints on the inputs to star formation theories and will determine their applicability in extremely dense, turbulent, and hot regions. Sgr B2 will be used as a testing ground for star formation theories in an environment analogous to high-z starburst clouds in which they must be applied.']  # noqa
 
 
 @pytest.mark.remote_data

--- a/astroquery/cadc/core.py
+++ b/astroquery/cadc/core.py
@@ -461,10 +461,10 @@ class CadcClass(BaseQuery):
                 '{}?{}'.format(self.data_link_url,
                                urlencode({'ID': pid_sublist}, True)))
             for service_def in datalink.bysemantics('#cutout'):
-                if isinstance(service_def.access_url, str):
-                    access_url = service_def.access_url
-                else:
+                if commons.ASTROPY_LT_4_1:
                     access_url = service_def.access_url.decode('ascii')
+                else:
+                    access_url = service_def.access_url
                 if '/sync' in access_url:
                     service_params = service_def.input_params
                     input_params = {param.name: param.value

--- a/astroquery/cadc/core.py
+++ b/astroquery/cadc/core.py
@@ -461,10 +461,9 @@ class CadcClass(BaseQuery):
                 '{}?{}'.format(self.data_link_url,
                                urlencode({'ID': pid_sublist}, True)))
             for service_def in datalink.bysemantics('#cutout'):
-                if commons.ASTROPY_LT_4_1:
-                    access_url = service_def.access_url.decode('ascii')
-                else:
-                    access_url = service_def.access_url
+                access_url = service_def.access_url
+                if isinstance(access_url, bytes):  # ASTROPY_LT_4_1
+                    access_url = access_url.decode('ascii')
                 if '/sync' in access_url:
                     service_params = service_def.input_params
                     input_params = {param.name: param.value

--- a/astroquery/esasky/core.py
+++ b/astroquery/esasky/core.py
@@ -532,12 +532,17 @@ class ESASkyClass(BaseQuery):
             log.info("Starting download of {} data. ({} files)".format(
                 mission, len(maps_table[self.__PRODUCT_URL_STRING])))
             for index in range(len(maps_table)):
-                product_url = maps_table[self.__PRODUCT_URL_STRING][index].decode('utf-8')
+                product_url = maps_table[self.__PRODUCT_URL_STRING][index]
+                if commons.ASTROPY_LT_4_1:
+                    product_url = product_url.decode('utf-8')
                 if(mission.lower() == self.__HERSCHEL_STRING):
-                    observation_id = maps_table["observation_id"][index].decode('utf-8')
+                    observation_id = maps_table["observation_id"][index]
+                    if commons.ASTROPY_LT_4_1:
+                        observation_id = observation_id.decode('utf-8')
                 else:
-                    observation_id = (maps_table[self._get_tap_observation_id(mission)][index]
-                                      .decode('utf-8'))
+                    observation_id = maps_table[self._get_tap_observation_id(mission)][index]
+                    if commons.ASTROPY_LT_4_1:
+                        observation_id = observation_id.decode('utf-8')
                 log.info("Downloading Observation ID: {} from {}"
                          .format(observation_id, product_url))
                 sys.stdout.flush()

--- a/astroquery/nrao/tests/test_nrao.py
+++ b/astroquery/nrao/tests/test_nrao.py
@@ -2,10 +2,8 @@
 from __future__ import print_function
 import os
 import requests
-from distutils.version import LooseVersion
 
 import pytest
-import astropy
 import astropy.units as u
 from astropy.table import Table
 
@@ -83,10 +81,10 @@ def test_query_region(patch_post, patch_parse_coordinates):
     assert isinstance(result, Table)
     assert len(result) > 0
     if 'Start Time' in result.colnames:
-        truth = '83-Sep-27 09:19:30' if LooseVersion(astropy.__version__) >= '4.1' else b'83-Sep-27 09:19:30'
+        truth = b'83-Sep-27 09:19:30' if commons.ASTROPY_LT_4_1 else '83-Sep-27 09:19:30'
         assert result['Start Time'][0] == truth
 
-    truth = '04h33m11.096s' if LooseVersion(astropy.__version__) >= '4.1' else b'04h33m11.096s'
+    truth = b'04h33m11.096s' if commons.ASTROPY_LT_4_1 else '04h33m11.096s'
     assert result['RA'][0] == truth
 
 

--- a/astroquery/nrao/tests/test_nrao_remote.py
+++ b/astroquery/nrao/tests/test_nrao_remote.py
@@ -6,6 +6,7 @@ import astropy.coordinates as coord
 from astropy.table import Table
 from astropy import units as u
 
+from astroquery.utils.commons import ASTROPY_LT_4_1
 from ... import nrao
 
 
@@ -24,8 +25,7 @@ class TestNrao:
             coord.SkyCoord("04h33m11.1s 05d21m15.5s"),
             retry=5)
         assert isinstance(result, Table)
-        # I don't know why this is byte-typed
-        assert b'0430+052' in result['Source']
+        assert (b'0430+052' if ASTROPY_LT_4_1 else '0430+052') in result['Source']
 
     def test_query_region_project_code(self):
         result = nrao.core.Nrao.query_region(
@@ -50,7 +50,7 @@ class TestNrao:
                                              telescope='jansky_vla',
                                              telescope_config=['A', 'AB', 'B'],
                                              obs_band=['K', 'Ka', 'Q'])
-        assert b'ORION-KL' in [x.strip() for x in result['Source']]
+        assert (b'ORION-KL' if ASTROPY_LT_4_1 else 'ORION-KL') in [x.strip() for x in result['Source']]
 
         # NOTE: This could change if future observations in AB config are ever
         # taken, or A- or B- config observations with fewer antennae.  Neither

--- a/astroquery/simbad/tests/test_simbad.py
+++ b/astroquery/simbad/tests/test_simbad.py
@@ -1,11 +1,9 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 import os
 import re
-from distutils.version import LooseVersion
 
 import six
 import pytest
-import astropy
 import astropy.units as u
 from astropy.table import Table
 import numpy as np
@@ -435,6 +433,6 @@ def test_regression_issue388():
         response.content = f.read()
     parsed_table = simbad.Simbad._parse_result(response,
                                                simbad.core.SimbadVOTableResult)
-    truth = 'M   1' if LooseVersion(astropy.__version__) >= '4.1' else b'M   1'
+    truth = b'M   1' if commons.ASTROPY_LT_4_1 else 'M   1'
     assert parsed_table['MAIN_ID'][0] == truth
     assert len(parsed_table) == 1

--- a/astroquery/utils/commons.py
+++ b/astroquery/utils/commons.py
@@ -16,6 +16,7 @@ import six
 import astropy.units as u
 from astropy import coordinates as coord
 from collections import OrderedDict
+from astropy.utils import minversion
 import astropy.utils.data as aud
 from astropy.io import fits, votable
 
@@ -49,7 +50,10 @@ __all__ = ['send_request',
            'parse_coordinates',
            'TableList',
            'suppress_vo_warnings',
-           'validate_email']
+           'validate_email',
+           'ASTROPY_LT_4_1']
+
+ASTROPY_LT_4_1 = not minversion('astropy', '4.1')
 
 
 def send_request(url, data, timeout, request_type='POST', headers={},
@@ -405,7 +409,7 @@ class FileContainer(object):
         if link_cache == 'hard':
             try:
                 os.link(target, savepath)
-            except (IOError, OSError, AttributeError) as e:
+            except (IOError, OSError, AttributeError):
                 shutil.copy(target, savepath)
         elif link_cache == 'sym':
             try:

--- a/astroquery/vo_conesearch/validator/tstquery.py
+++ b/astroquery/vo_conesearch/validator/tstquery.py
@@ -18,10 +18,15 @@ from astropy.table import Table
 from astropy.utils.data import get_readable_fileobj
 from astropy.utils.exceptions import AstropyUserWarning
 
+# LOCAL
+from astroquery.utils.commons import ASTROPY_LT_4_1
+
+__all__ = ['parse_cs']
+
 
 def parse_cs(ivoid, cap_index=1):
     """Return test query pars as dict for given IVO ID and capability index."""
-    if isinstance(ivoid, bytes):  # pragma: py3
+    if isinstance(ivoid, bytes):  # ASTROPY_LT_4_1
         ivoid = ivoid.decode('ascii')
 
     # Production server.
@@ -48,12 +53,20 @@ def parse_cs(ivoid, cap_index=1):
     if not urls_failed:
         try:
             xpath = t_query['detail_xpath']
-            ra = float(
-                t_query[xpath == b'/capability/testQuery/ra']['detail_value'])
-            dec = float(
-                t_query[xpath == b'/capability/testQuery/dec']['detail_value'])
-            sr = float(
-                t_query[xpath == b'/capability/testQuery/sr']['detail_value'])
+            if ASTROPY_LT_4_1:
+                ra = float(
+                    t_query[xpath == b'/capability/testQuery/ra']['detail_value'])
+                dec = float(
+                    t_query[xpath == b'/capability/testQuery/dec']['detail_value'])
+                sr = float(
+                    t_query[xpath == b'/capability/testQuery/sr']['detail_value'])
+            else:
+                ra = float(
+                    t_query[xpath == '/capability/testQuery/ra']['detail_value'])
+                dec = float(
+                    t_query[xpath == '/capability/testQuery/dec']['detail_value'])
+                sr = float(
+                    t_query[xpath == '/capability/testQuery/sr']['detail_value'])
 
             # Handle big SR returning too big a table for some queries, causing
             # tests to fail due to timeout.
@@ -65,10 +78,10 @@ def parse_cs(ivoid, cap_index=1):
 
             d = OrderedDict({'RA': ra, 'DEC': dec, 'SR': sr})
 
-        except Exception:  # pragma: no cover
+        except Exception as e:  # pragma: no cover
             urls_failed = True
             urls_errmsg = ('Failed to retrieve test query parameters for '
-                           '{0},{1}, using default'.format(ivoid, cap_index))
+                           '{0},{1}, using default: {2}'.format(ivoid, cap_index, str(e)))
 
     # If no test query found, use default
     if urls_failed:  # pragma: no cover

--- a/astroquery/vo_conesearch/vos_catalog.py
+++ b/astroquery/vo_conesearch/vos_catalog.py
@@ -597,10 +597,10 @@ class VOSDatabase(VOSBase):
                     cur_title = arr['res_title']
                     title_counter[cur_title] += 1  # Starts with 1
 
-                    if isinstance(cur_title, bytes):  # pragma: py3
+                    if isinstance(cur_title, bytes):  # ASTROPY_LT_4_1
                         cur_key = title_fmt.format(cur_title.decode('utf-8'),
                                                    title_counter[cur_title])
-                    else:  # pragma: py2
+                    else:
                         cur_key = title_fmt.format(cur_title,
                                                    title_counter[cur_title])
 
@@ -608,7 +608,7 @@ class VOSDatabase(VOSBase):
                 # otherwise no change.
                 if field == 'access_url':
                     s = unescape_all(arr['access_url'])
-                    if isinstance(s, bytes):
+                    if isinstance(s, bytes):  # ASTROPY_LT_4_1
                         s = s.decode('utf-8')
                     cur_cat['url'] = s
                 elif field == 'res_title':
@@ -697,8 +697,8 @@ def _get_catalogs(service_type, catalog_db, **kwargs):
         catalogs = [(None, catalog_db)]
     elif isinstance(catalog_db, list):
         for x in catalog_db:
-            assert (isinstance(x, (VOSCatalog, str)) and
-                    not isinstance(x, VOSDatabase))
+            assert (isinstance(x, (VOSCatalog, str))
+                    and not isinstance(x, VOSDatabase))
         catalogs = [(None, x) for x in catalog_db]
     else:  # pragma: no cover
         raise VOSError('catalog_db must be a catalog database, '
@@ -780,8 +780,8 @@ def vo_tab_parse(tab, url, kwargs):
         vo_raise(E19)
 
     for info in tab.resources[0].infos:
-        if ((info.name == 'QUERY_STATUS' and info.value != 'OK') or
-                (info.name is not None and info.name.lower() == 'error')):
+        if ((info.name == 'QUERY_STATUS' and info.value != 'OK')
+                or (info.name is not None and info.name.lower() == 'error')):
             if info.content is not None:  # pragma: no cover
                 long_descr = ':\n{0}'.format(info.content)
             else:

--- a/docs/vo_conesearch/client.rst
+++ b/docs/vo_conesearch/client.rst
@@ -157,7 +157,7 @@ Extract a catalog titled ``'USNO-A2 Catalogue 1'`` from the registry:
 
 >>> usno_a2 = registry_db.get_catalog('USNO-A2 Catalogue 1')  # doctest: +REMOTE_DATA
 >>> print(usno_a2)  # doctest: +REMOTE_DATA
-title: b'USNO-A2 Catalogue'
+title: 'USNO-A2 Catalogue'
 url: http://www.nofs.navy.mil/cgi-bin/vo_cone.cgi?CAT=USNO-A2&
 
 Extract a catalog by known access URL from the registry (the iterator version
@@ -168,7 +168,7 @@ which is useful in the case of multiple entries with same access URL):
 >>> gsc_url = 'http://vizier.u-strasbg.fr/viz-bin/conesearch/I/305/out?'
 >>> gsc = registry_db.get_catalog_by_url(gsc_url)  # doctest: +REMOTE_DATA
 >>> print(gsc)  # doctest: +REMOTE_DATA
-title: b'The Guide Star Catalog, Version 2.3.2 (GSC2.3) (STScI, 2006)'
+title: 'The Guide Star Catalog, Version 2.3.2 (GSC2.3) (STScI, 2006)'
 url: http://vizier.u-strasbg.fr/viz-bin/conesearch/I/305/out?
 
 Add all ``'usno*a2'`` catalogs from registry to your database:


### PR DESCRIPTION
Fix #1666 for remote data tests.

Fix #1471 

Follow-up of #1669 .

xref astropy/astropy#9505

**TODO**

- [x] Do we need a change log? No.
- [x] Fix the remaining cases. Tried to run all the remote data tests locally but had to kill it because it was taking too long. And it timed out on Travis CI (https://travis-ci.org/astropy/astroquery/jobs/658871357). So I apply this patch according to the log at https://travis-ci.org/astropy/astroquery/jobs/658776077 .
- [x] Check to see if #1637 is in scope. No.
- [x] Check to see if #1675 is in scope. No.
- [x] Test all the affected modules locally. (See below.)

**Local testing**

It takes too long, so I only tested the modules I touched.

- [x] python setup.py test --remote-data -P alma
- [x] python setup.py test --remote-data -P cadc (~all `test_cadctap_remote.py` skipped anyway~ fixed a bug after installing the missing `pyvo` and reran the tests but there is still a failure in `test_list_tables` that gives me `urllib3.exceptions.MaxRetryError: HTTPSConnectionPool(host='www.cadc-ccda.hia-iha.nrc-cnrc.gc.ca', port=443): Max retries exceeded with url: /argus//tables/caom2.ProvenanceInput (Caused by SSLError(SSLError("bad handshake: SysCallError(104, 'ECONNRESET')")))` error that seems out of scope, maybe even related to #1651)
- [x] python setup.py test --remote-data -P esasky (~some failed or timed out, need to investigate~ everything passed on re-run later)
- [x] python setup.py test --remote-data -P nrao
- [x] python setup.py test --remote-data -P simbad (see #1674 for unrelated time out problem)
- [x] python setup.py test --remote-data -P utils
- [x] python setup.py test --remote-data -P vo_conesearch