### PR TITLE
BUG: set_top_in_query() fails when SELECT is followed by \n

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -45,6 +45,12 @@ alma
 Infrastructure, Utility and Other Changes and Additions
 -------------------------------------------------------
 
+utils
+^^^^^
+
+- Fixed a bug that would prevent the TOP statement from being properly added
+  to a TAP query containing valid '\n'. The bug was revealed by changes
+  to the gaia module, introduced in version 0.4. [#1680]
 
 
 

--- a/astroquery/utils/tap/taputils.py
+++ b/astroquery/utils/tap/taputils.py
@@ -99,7 +99,7 @@ def set_top_in_query(query, top):
             nq = query[0:endPos] + " TOP " + str(top) + " " + query[endPos:]
         else:
             # no all nor distinct: add top after select
-            p = q.find("SELECT ")
+            p = q.replace("\n", " ").find("SELECT ")
             nq = query[0:p+7] + " TOP " + str(top) + " " + query[p+7:]
         return nq
 


### PR DESCRIPTION
A valid TAP query can have its SELECT keyword followed by a newline (\n). set_top_in_query() assumes that it is always followed by a space, and therefore can fail to inject a TOP statement at the right location. This bug is triggered by astroquery.gaia's cone_search() (see https://github.com/astropy/astroquery/blob/master/astroquery/gaia/core.py#L334, where SELECT is followed by a newline).