### PR TITLE
Fix for alma issue: show all files

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -33,7 +33,9 @@ alma
   refactor.  The user-facing API should remain mostly the same, but some
   service interruption may have occurred.  Note that the ``stage_data`` column
   ``uid`` has been renamed ``mous_uid``, which is a technical correction, and
-  several columns have been added [#1644,#1665]
+  several columns have been added [#1644,#1665,#1683]
+- The contents of tarfiles can be shown with the ``expand_tarfiles`` keyword
+  to ``stage_data`` [#1683]
 
 
 Infrastructure, Utility and Other Changes and Additions

--- a/astroquery/alma/core.py
+++ b/astroquery/alma/core.py
@@ -250,7 +250,7 @@ class AlmaClass(QueryWithLogin):
             A list of valid UIDs or a single UID.
             UIDs should have the form: 'uid://A002/X391d0b/X7b'
         expand_tarfiles : bool
-            Expand the tarfiles to obtain lists of all contained files?  If
+            Expand the tarfiles to obtain lists of all contained files.  If
             this is specified, the parent tarfile will *not* be included
         return_json : bool
             Return a list of the JSON data sets returned from the query.  This

--- a/astroquery/alma/core.py
+++ b/astroquery/alma/core.py
@@ -240,7 +240,7 @@ class AlmaClass(QueryWithLogin):
                              "on github.")
         return self.dataarchive_url
 
-    def stage_data(self, uids):
+    def stage_data(self, uids, expand_tarfiles=False, return_json=False):
         """
         Obtain table of ALMA files
 
@@ -249,6 +249,13 @@ class AlmaClass(QueryWithLogin):
         uids : list or str
             A list of valid UIDs or a single UID.
             UIDs should have the form: 'uid://A002/X391d0b/X7b'
+        expand_tarfiles : bool
+            Expand the tarfiles to obtain lists of all contained files?  If
+            this is specified, the parent tarfile will *not* be included
+        return_json : bool
+            Return a list of the JSON data sets returned from the query.  This
+            is primarily intended as a debug routine, but may be useful if there
+            are unusual scheduling block layouts.
 
         Returns
         -------
@@ -280,32 +287,49 @@ class AlmaClass(QueryWithLogin):
                     # this indicates a wrong server is being used;
                     # the "pre-feb2020" stager will be phased out
                     # when the new services are deployed
-                    return self.stage_data_prefeb2020(uids)
+                    raise ValueError("Failed query!  This shouldn't happen - please "
+                                     "report the issue as it may indicat a change in "
+                                     "the ALMA servers.")
                 else:
                     raise
-            if jdata['type'] != 'PROJECT':
-                log.error("Skipped uid {uu} because it is not a project and"
-                          "lacks the appropriate metadata; it is a "
-                          "{jdata}".format(uu=uu, jdata=jdata['type']))
-                continue
-            table = uid_json_to_table(jdata)
-            table['sizeInBytes'].unit = u.B
-            table.rename_column('sizeInBytes', 'size')
-            table.add_column(Column(data=['{dataarchive_url}/dataPortal/{name}'
-                                          .format(dataarchive_url=dataarchive_url,
-                                                  name=name)
-                                          for name in table['name']],
-                                    name='URL'))
 
-            isp = self.is_proprietary(uid)
-            table.add_column(Column(data=[isp for row in table],
-                                    name='isProprietary'))
+            if return_json:
+                tables.append(jdata)
+            else:
+                if jdata['type'] != 'PROJECT':
+                    log.error("Skipped uid {uu} because it is not a project and"
+                              "lacks the appropriate metadata; it is a "
+                              "{jdata}".format(uu=uu, jdata=jdata['type']))
+                    continue
+                if expand_tarfiles:
+                    table = uid_json_to_table(jdata, productlist=['ASDM',
+                                                                  'PIPELINE_PRODUCT'])
+                else:
+                    table = uid_json_to_table(jdata,
+                                              productlist=['ASDM',
+                                                           'PIPELINE_PRODUCT'
+                                                           'PIPELINE_PRODUCT_TARFILE',
+                                                           'PIPELINE_AUXILIARY_TARFILE'])
+                table['sizeInBytes'].unit = u.B
+                table.rename_column('sizeInBytes', 'size')
+                table.add_column(Column(data=['{dataarchive_url}/dataPortal/{name}'
+                                              .format(dataarchive_url=dataarchive_url,
+                                                      name=name)
+                                              for name in table['name']],
+                                        name='URL'))
 
-            tables.append(table)
-            log.debug("Completed metadata retrieval for {0}".format(uu))
+                isp = self.is_proprietary(uid)
+                table.add_column(Column(data=[isp for row in table],
+                                        name='isProprietary'))
+
+                tables.append(table)
+                log.debug("Completed metadata retrieval for {0}".format(uu))
 
         if len(tables) == 0:
             raise ValueError("No valid UIDs supplied.")
+
+        if return_json:
+            return table
 
         table = table_vstack(tables)
 
@@ -329,167 +353,6 @@ class AlmaClass(QueryWithLogin):
         isp = is_proprietary.json()['isProprietary']
 
         return isp
-
-    def stage_data_prefeb2020(self, uids):
-        """
-        Stage ALMA data - old server style
-
-        NOTE: this method will be removed when a new ALMA service is deployed
-        in March 2020
-
-        Parameters
-        ----------
-        uids : list or str
-            A list of valid UIDs or a single UID.
-            UIDs should have the form: 'uid://A002/X391d0b/X7b'
-
-        Returns
-        -------
-        data_file_table : Table
-            A table containing 3 columns: the UID, the file URL (for future
-            downloading), and the file size
-        """
-
-        """
-        With log.set_level(10)
-        INFO: Staging files... [astroquery.alma.core]
-        DEBUG: First request URL: https://almascience.eso.org/rh/submission [astroquery.alma.core]
-        DEBUG: First request payload: {'dataset': [u'ALMA+uid___A002_X3b3400_X90f']} [astroquery.alma.core]
-        DEBUG: First response URL: https://almascience.eso.org/rh/checkAuthenticationStatus/3f98de33-197e-4692-9afa-496842032ea9/submission [astroquery.alma.core]
-        DEBUG: Request ID: 3f98de33-197e-4692-9afa-496842032ea9 [astroquery.alma.core]
-        DEBUG: Submission URL: https://almascience.eso.org/rh/submission/3f98de33-197e-4692-9afa-496842032ea9 [astroquery.alma.core]
-        .DEBUG: Data list URL: https://almascience.eso.org/rh/requests/anonymous/786823226 [astroquery.alma.core]
-        """
-
-        import time
-        from requests import HTTPError
-        from ..utils import url_helpers
-        import sys
-        from six.moves.urllib_parse import urlparse
-
-        if isinstance(uids, six.string_types + (np.bytes_,)):
-            uids = [uids]
-        if not isinstance(uids, (list, tuple, np.ndarray)):
-            raise TypeError("Datasets must be given as a list of strings.")
-
-        log.info("Staging files...")
-
-        self._get_dataarchive_url()
-
-        url = urljoin(self._get_dataarchive_url(), 'rh/submission')
-        log.debug("First request URL: {0}".format(url))
-        # 'ALMA+uid___A002_X391d0b_X7b'
-        payload = {'dataset': ['ALMA+' + clean_uid(uid) for uid in uids]}
-        log.debug("First request payload: {0}".format(payload))
-
-        self._staging_log = {'first_post_url': url}
-
-        # Request staging for the UIDs
-        # This component cannot be cached, since the returned data can change
-        # if new data are uploaded
-        response = self._request('POST', url, data=payload,
-                                 timeout=self.TIMEOUT, cache=False)
-        self._staging_log['initial_response'] = response
-        log.debug("First response URL: {0}".format(response.url))
-        if 'login' in response.url:
-            raise ValueError("You must login before downloading this data set.")
-
-        if response.status_code == 405:
-            if hasattr(self, '_last_successful_staging_log'):
-                log.warning("Error 405 received.  If you have previously staged "
-                            "the same UIDs, the result returned is probably "
-                            "correct, otherwise you may need to create a fresh "
-                            "astroquery.Alma instance.")
-                return self._last_successful_staging_log['result']
-            else:
-                raise HTTPError("Received an error 405: this may indicate you "
-                                "have already staged the data.  Try downloading "
-                                "the file URLs directly with download_files.")
-        response.raise_for_status()
-
-        if 'j_spring_cas_security_check' in response.url:
-            time.sleep(1)
-            # CANNOT cache this stage: it not a real data page!  results in
-            # infinite loops
-            response = self._request('POST', url, data=payload,
-                                     timeout=self.TIMEOUT, cache=False)
-            self._staging_log['initial_response'] = response
-            if 'j_spring_cas_security_check' in response.url:
-                log.warning("Staging request was not successful.  Try again?")
-            response.raise_for_status()
-
-        if 'j_spring_cas_security_check' in response.url:
-            raise RemoteServiceError("Could not access data.  This error "
-                                     "can arise if the data are private and "
-                                     "you do not have access rights or are "
-                                     "not logged in.")
-
-        # make sure the URL is formatted as expected, otherwise the request ID
-        # will be wrong
-        # (the request ID can also be found from the javascript in the request
-        # response)
-        if response.url.split("/")[-1] == 'submission':
-            request_id = response.url.split("/")[-2]
-            self._staging_log['request_id'] = request_id
-            log.debug("Request ID: {0}".format(request_id))
-
-            # Submit a request for the specific request ID identified above
-            submission_url = urljoin(self._get_dataarchive_url(),
-                                     url_helpers.join('rh/submission', request_id))
-            log.debug("Submission URL: {0}".format(submission_url))
-            self._staging_log['submission_url'] = submission_url
-            staging_submission = self._request('GET', submission_url, cache=True)
-            self._staging_log['staging_submission'] = staging_submission
-            staging_submission.raise_for_status()
-
-            data_page_url = staging_submission.url
-        elif response.url.split("/")[-3] == 'requests':
-            data_page_url = response.url
-
-        self._staging_log['data_page_url'] = data_page_url
-        dpid = data_page_url.split("/")[-1]
-        self._staging_log['staging_page_id'] = dpid
-
-        # CANNOT cache this step: please_wait will happen infinitely
-        data_page = self._request('GET', data_page_url, cache=False)
-        self._staging_log['data_page'] = data_page
-        data_page.raise_for_status()
-
-        has_completed = False
-        while not has_completed:
-            time.sleep(1)
-            summary = self._request('GET', url_helpers.join(data_page_url,
-                                                            'summary'),
-                                    cache=False)
-            summary.raise_for_status()
-            print(".", end='')
-            sys.stdout.flush()
-            has_completed = summary.json()['complete']
-
-        self._staging_log['summary'] = summary
-        summary.raise_for_status()
-        self._staging_log['json_data'] = json_data = summary.json()
-
-        username = self.USERNAME if self.USERNAME else 'anonymous'
-
-        # templates:
-        # https://almascience.eso.org/dataPortal/requests/keflavich/946895898/ALMA/
-        # 2013.1.00308.S_uid___A001_X196_X93_001_of_001.tar/2013.1.00308.S_uid___A001_X196_X93_001_of_001.tar
-        # uid___A002_X9ee74a_X26f0/2013.1.00308.S_uid___A002_X9ee74a_X26f0.asdm.sdm.tar
-
-        url_decomposed = urlparse(data_page_url)
-        base_url = ('{uri.scheme}://{uri.netloc}/'
-                    'dataPortal/requests/{username}/'
-                    '{staging_page_id}/ALMA'.format(uri=url_decomposed,
-                                                    staging_page_id=dpid,
-                                                    username=username,
-                                                    ))
-        tbl = self._json_summary_to_table(json_data, base_url=base_url)
-        self._staging_log['result'] = tbl
-        self._staging_log['file_urls'] = tbl['URL']
-        self._last_successful_staging_log = self._staging_log
-
-        return tbl
 
     def _HEADER_data_size(self, files):
         """
@@ -1087,53 +950,6 @@ class AlmaClass(QueryWithLogin):
             raise InvalidQueryError("The following parameters are not accepted"
                                     " by the ALMA query service:"
                                     " {0}".format(invalid_params))
-
-    def _json_summary_to_table(self, data, base_url):
-        """
-        Special tool to convert some JSON metadata to a table Obsolete as of
-        March 2020 - should be removed along with stage_data_prefeb2020
-        """
-        from ..utils import url_helpers
-        from six import iteritems
-        columns = {'mous_uid': [], 'URL': [], 'size': []}
-        for entry in data['node_data']:
-            # de_type can be useful (e.g., MOUS), but it is not necessarily
-            # specified
-            # file_name and file_key *must* be specified.
-            is_file = (entry['file_name'] != 'null' and
-                       entry['file_key'] != 'null')
-            if is_file:
-                # "de_name": "ALMA+uid://A001/X122/X35e",
-                columns['mous_uid'].append(entry['de_name'][5:])
-                if entry['file_size'] == 'null':
-                    columns['size'].append(np.nan * u.Gbyte)
-                else:
-                    columns['size'].append(
-                        (int(entry['file_size']) * u.B).to(u.Gbyte))
-                # example template for constructing url:
-                # https://almascience.eso.org/dataPortal/requests/keflavich/940238268/ALMA/
-                # uid___A002_X9d6f4c_X154/2013.1.00546.S_uid___A002_X9d6f4c_X154.asdm.sdm.tar
-                # above is WRONG... except for ASDMs, when it's right
-                # should be:
-                # 2013.1.00546.S_uid___A002_X9d6f4c_X154.asdm.sdm.tar/2013.1.00546.S_uid___A002_X9d6f4c_X154.asdm.sdm.tar
-                #
-                # apparently ASDMs are different from others:
-                # templates:
-                # https://almascience.eso.org/dataPortal/requests/keflavich/946895898/ALMA/
-                # 2013.1.00308.S_uid___A001_X196_X93_001_of_001.tar/2013.1.00308.S_uid___A001_X196_X93_001_of_001.tar
-                # uid___A002_X9ee74a_X26f0/2013.1.00308.S_uid___A002_X9ee74a_X26f0.asdm.sdm.tar
-                url = url_helpers.join(base_url,
-                                       entry['file_key'],
-                                       entry['file_name'])
-                if 'null' in url:
-                    raise ValueError("The URL {0} was created containing "
-                                     "'null', which is invalid.".format(url))
-                columns['URL'].append(url)
-
-        columns['size'] = u.Quantity(columns['size'], u.Gbyte)
-
-        tbl = Table([Column(name=k, data=v) for k, v in iteritems(columns)])
-        return tbl
 
     def get_project_metadata(self, projectid, cache=True):
         """

--- a/astroquery/alma/core.py
+++ b/astroquery/alma/core.py
@@ -287,9 +287,9 @@ class AlmaClass(QueryWithLogin):
                     # this indicates a wrong server is being used;
                     # the "pre-feb2020" stager will be phased out
                     # when the new services are deployed
-                    raise ValueError("Failed query!  This shouldn't happen - please "
-                                     "report the issue as it may indicat a change in "
-                                     "the ALMA servers.")
+                    raise RemoteServiceError("Failed query!  This shouldn't happen - please "
+                                             "report the issue as it may indicate a change in "
+                                             "the ALMA servers.")
                 else:
                     raise
 

--- a/astroquery/alma/core.py
+++ b/astroquery/alma/core.py
@@ -329,7 +329,7 @@ class AlmaClass(QueryWithLogin):
             raise ValueError("No valid UIDs supplied.")
 
         if return_json:
-            return table
+            return tables
 
         table = table_vstack(tables)
 

--- a/astroquery/alma/tests/test_alma_remote.py
+++ b/astroquery/alma/tests/test_alma_remote.py
@@ -151,7 +151,6 @@ class TestAlma:
                                           'permission', 'children',
                                           'allMousUids'}
 
-
     def test_doc_example(self, temp_dir):
         alma = Alma()
         alma.cache_location = temp_dir

--- a/astroquery/alma/tests/test_alma_remote.py
+++ b/astroquery/alma/tests/test_alma_remote.py
@@ -132,7 +132,6 @@ class TestAlma:
         assert 'PIPELINE_PRODUCT' in result2['type']
         assert 'PIPELINE_AUXILIARY_TARFILE' in result1['type']
 
-
     def test_doc_example(self, temp_dir):
         alma = Alma()
         alma.cache_location = temp_dir
@@ -166,7 +165,6 @@ class TestAlma:
         # file sizes are replaced with -1
         assert (totalsize_mous.to(u.GB).value > 52)
 
-
     def test_query(self, temp_dir):
         alma = Alma()
         alma.cache_location = temp_dir
@@ -183,8 +181,6 @@ class TestAlma:
         result = alma.query(payload={'member_ous_id': 'uid://A001/X11a2/X11'},
                             science=True)
         assert len(result) == 1
-
-
 
     def test_keywords(self, temp_dir):
 

--- a/astroquery/alma/tests/test_alma_remote.py
+++ b/astroquery/alma/tests/test_alma_remote.py
@@ -96,7 +96,6 @@ class TestAlma:
         #                           'same UIDs, the result returned is probably correct,'
         #                           ' otherwise you may need to create a fresh astroquery.Alma instance.'))
 
-    @pytest.mark.skipif("SKIP_SLOW")
     def test_stage_data(self, temp_dir, recwarn):
         alma = Alma()
         alma.cache_location = temp_dir
@@ -105,31 +104,36 @@ class TestAlma:
         # assert b'2011.0.00887.S' in result_s['Project code']
         assert b'2013.1.00857.S' in result_s['Project code']
         # assert b'uid://A002/X40d164/X1b3' in result_s['Asdm uid']
-        assert b'uid://A002/X651f57/Xade' in result_s['Asdm uid']
-        # match = result_s['Asdm uid'] == b'uid://A002/X40d164/X1b3'
-        match = result_s['Asdm uid'] == b'uid://A002/X651f57/Xade'
-        uid = result_s['Asdm uid'][match]
+        assert b'uid://A002/X40d164/X1b3' in result_s['Asdm uid']
+        assert b'uid://A002/X391d0b/X23d' in result_s['Member ous id']
+        match = result_s['Asdm uid'] == b'uid://A002/X40d164/X1b3'
+        uid = result_s['Member ous id'][match]
 
         result = alma.stage_data(uid)
 
-        assert ('uid___A002_X651f57_Xade' in
-                os.path.split(result['URL'][0])[1])
+        assert ('uid___A002_X40d164_X1b3' in result['URL'][0])
 
-        # test re-staging
-        # with pytest.raises(requests.HTTPError) as ex:
-        #    result = alma.stage_data([uid])
-        # assert ex.value.args[0] == ('Received an error 405: this may indicate you have '
-        #                            'already staged the data.  Try downloading the '
-        #                            'file URLs directly with download_files.')
 
-        # log.warning doesn't actually make a warning
-        # result = alma.stage_data([uid])
-        # w = recwarn.pop()
-        # assert (str(w.message) == ('Error 405 received.  If you have previously staged the '
-        #                           'same UIDs, the result returned is probably correct,'
-        #                           ' otherwise you may need to create a fresh astroquery.Alma instance.'))
+    def test_stage_data_listall(self, temp_dir, recwarn):
+        """
+        test for expanded capability created in #1683
+        """
+        alma = Alma()
+        alma.cache_location = temp_dir
 
-    @pytest.mark.skipif("SKIP_SLOW")
+        result_s = alma.query_object('Sgr A*')
+        uid = 'uid://A001/X12a3/Xe9'
+        assert uid in result_s['Member ous id']
+
+        result1 = alma.stage_data(uid, expand_tarfiles=False)
+        result2 = alma.stage_data(uid, expand_tarfiles=True)
+
+        assert len(result2) > len(result1)
+
+        assert 'PIPELINE_PRODUCT' in result2['type']
+        assert 'PIPELINE_AUXILIARY_TARFILE' in result1['type']
+
+
     def test_doc_example(self, temp_dir):
         alma = Alma()
         alma.cache_location = temp_dir
@@ -145,23 +149,24 @@ class TestAlma:
         # assert len(gc_data) >= 425 # Feb 8, 2016
         assert len(gc_data) >= 50  # Nov 16, 2016
 
-        uids = np.unique(m83_data['Asdm uid'])
-        assert b'uid://A002/X3b3400/X90f' in uids
-        X90f = (m83_data['Asdm uid'] == b'uid://A002/X3b3400/X90f')
-        assert X90f.sum() == 2  # Jul 2, 2017: increased from 1
+        uids = np.unique(m83_data['Member ous id'])
+        assert b'uid://A001/X11f/X30' in uids
+        X30 = (m83_data['Member ous id'] == b'uid://A001/X11f/X30')
+        assert X30.sum() == 1  # Apr 2, 2020
         X31 = (m83_data['Member ous id'] == b'uid://A002/X3216af/X31')
         assert X31.sum() == 2  # Jul 2, 2017: increased from 1
 
-        asdm = alma.stage_data('uid://A002/X3b3400/X90f')
-        totalsize_asdm = asdm['size'].sum() * u.Unit(asdm['size'].unit)
-        assert (totalsize_asdm.to(u.B).value == 0.0)
+        mous1 = alma.stage_data('uid://A001/X11f/X30')
+        totalsize_mous1 = mous1['size'].sum() * u.Unit(mous1['size'].unit)
+        assert (totalsize_mous1.to(u.B) > 1.9*u.GB)
 
         mous = alma2.stage_data('uid://A002/X3216af/X31')
         totalsize_mous = mous['size'].sum() * u.Unit(mous['size'].unit)
         # More recent ALMA request responses do not include any information
         # about file size, so we have to allow for the possibility that all
         # file sizes are replaced with -1
-        assert (totalsize_mous.to(u.GB).value > 159)
+        assert (totalsize_mous.to(u.GB).value > 52)
+
 
     def test_query(self, temp_dir):
         alma = Alma()
@@ -180,96 +185,7 @@ class TestAlma:
                             science=True)
         assert len(result) == 1
 
-    # As of April 2017, these data are *MISSING FROM THE ARCHIVE*.
-    # This has been reported, as it is definitely a bug.
-    @pytest.mark.xfail
-    @pytest.mark.bigdata
-    @pytest.mark.skipif("SKIP_SLOW")
-    def test_cycle1(self, temp_dir):
-        # About 500 MB
-        alma = Alma()
-        alma.cache_location = temp_dir
 
-        target = 'NGC4945'
-        project_code = '2012.1.00912.S'
-
-        payload = {'project_code': project_code,
-                   'source_name_alma': target, }
-        result = alma.query(payload=payload)
-        assert len(result) == 1
-
-        # Need new Alma() instances each time
-        a1 = alma()
-        uid_url_table_mous = a1.stage_data(result['Member ous id'])
-        a2 = alma()
-        uid_url_table_asdm = a2.stage_data(result['Asdm uid'])
-        # I believe the fixes as part of #495 have resulted in removal of a
-        # redundancy in the table creation, so a 1-row table is OK here.
-        # A 2-row table may not be OK any more, but that's what it used to
-        # be...
-        assert len(uid_url_table_asdm) == 1
-        assert len(uid_url_table_mous) >= 2  # now is len=3 (Nov 17, 2016)
-
-        # URL should look like:
-        # https://almascience.eso.org/dataPortal/requests/anonymous/944120962/ALMA/2012.1.00912.S_uid___A002_X5a9a13_X528_001_of_001.tar/2012.1.00912.S_uid___A002_X5a9a13_X528_001_of_001.tar
-        # https://almascience.eso.org/rh/requests/anonymous/944222597/2012.1.00912.S_uid___A002_X5a9a13_X528_001_of_001.tar/2012.1.00912.S_uid___A002_X5a9a13_X528_001_of_001.tar
-
-        small = uid_url_table_mous['size'] < 1
-
-        urls_to_download = uid_url_table_mous[small]['URL']
-
-        uri = urlparse(urls_to_download[0])
-        assert uri.path == ('/dataPortal/requests/anonymous/{0}/ALMA/2012.1.00912.S_uid___A002_X5a9a13_X528_001_of_001.tar/2012.1.00912.S_uid___A002_X5a9a13_X528_001_of_001.tar'  # noqa
-                            .format(a1._staging_log['staging_page_id']))
-
-        # THIS IS FAIL
-        # '2012.1.00912.S_uid___A002_X5a9a13_X528_001_of_001.tar'
-        left = uid_url_table_mous['URL'][0].split("/")[-1]
-        assert left == '2012.1.00912.S_uid___A002_X5a9a13_X528_001_of_001.tar'
-        right = uid_url_table_mous['uid'][0]
-        assert right == 'uid://A002/X5a9a13/X528'
-        assert left[15:-15] == right.replace(":", "_").replace("/", "_")
-        data = alma.download_and_extract_files(urls_to_download)
-
-        assert len(data) == 6
-
-    @pytest.mark.skipif("SKIP_SLOW")
-    def test_cycle0(self, temp_dir):
-        # About 20 MB
-
-        alma = Alma()
-        alma.cache_location = temp_dir
-
-        target = 'NGC4945'
-        project_code = '2011.0.00121.S'
-
-        payload = {'project_code': project_code,
-                   'source_name_alma': target, }
-        result = alma.query(payload=payload)
-        assert len(result) == 1
-
-        alma1 = alma()
-        alma2 = alma()
-        uid_url_table_mous = alma1.stage_data(result['Member ous id'])
-        uid_url_table_asdm = alma2.stage_data(result['Asdm uid'])
-        assert len(uid_url_table_asdm) == 1
-        assert len(uid_url_table_mous) == 32
-
-        assert uid_url_table_mous[0]['URL'].split("/")[-1] == '2011.0.00121.S_2012-08-16_001_of_002.tar'
-        assert uid_url_table_mous[0]['uid'] == 'uid://A002/X327408/X246'
-
-        small = uid_url_table_mous['size'] < 1
-
-        urls_to_download = uid_url_table_mous[small]['URL']
-        # Check that all URLs show up in the Cycle 0 table
-        for url in urls_to_download:
-            tarfile_name = os.path.split(url)[-1]
-            assert tarfile_name in alma._cycle0_tarfile_content['ID']
-
-        data = alma.download_and_extract_files(urls_to_download)
-
-        # There are 10 small files, but only 8 unique
-        assert len(data) == 8
 
     def test_keywords(self, temp_dir):
 

--- a/astroquery/alma/tests/test_alma_remote.py
+++ b/astroquery/alma/tests/test_alma_remote.py
@@ -132,6 +132,26 @@ class TestAlma:
         assert 'PIPELINE_PRODUCT' in result2['type']
         assert 'PIPELINE_AUXILIARY_TARFILE' in result1['type']
 
+    def test_stage_data_json(self, temp_dir, recwarn):
+        """
+        test for json returns
+        """
+        alma = Alma()
+        alma.cache_location = temp_dir
+
+        result_s = alma.query_object('Sgr A*')
+        uid = 'uid://A001/X12a3/Xe9'
+        assert uid in result_s['Member ous id']
+
+        result1 = alma.stage_data(uid, return_json=False)
+        result2 = alma.stage_data(uid, return_json=True)
+
+        assert len(result1) > 0
+        assert set(result2[0].keys()) == {'id', 'name', 'type', 'sizeInBytes',
+                                          'permission', 'children',
+                                          'allMousUids'}
+
+
     def test_doc_example(self, temp_dir):
         alma = Alma()
         alma.cache_location = temp_dir

--- a/astroquery/alma/tests/test_alma_remote.py
+++ b/astroquery/alma/tests/test_alma_remote.py
@@ -113,7 +113,6 @@ class TestAlma:
 
         assert ('uid___A002_X40d164_X1b3' in result['URL'][0])
 
-
     def test_stage_data_listall(self, temp_dir, recwarn):
         """
         test for expanded capability created in #1683


### PR DESCRIPTION
Issue #1681 notes that we don't show all the files in the tarball, but we optionally can do that.

Now that the deployment was "succesful", this PR also cleans out the old cruft...
(I should have done this in two commits...)