### PR TITLE
Vizier: catalog with specific columns request

### DIFF
--- a/astroquery/vizier/core.py
+++ b/astroquery/vizier/core.py
@@ -538,7 +538,7 @@ class VizierClass(BaseQuery):
             columns = self.columns + columns
             # filter columns to _unique_ columns, preserving order in python >3.6
             # note that "set" does not preserve order, but dict.keys does
-            columns = list(dict(columns).keys())
+            columns = list(dict.fromkeys(columns, ).keys())
 
         # special keywords need to be treated separately
         # keyword names that can mean 'all'

--- a/astroquery/vizier/core.py
+++ b/astroquery/vizier/core.py
@@ -536,6 +536,9 @@ class VizierClass(BaseQuery):
 
         if columns is not None:
             columns = self.columns + columns
+            # filter columns to _unique_ columns, preserving order in python >3.6
+            # note that "set" does not preserve order, but dict.keys does
+            columns = list(dict(columns).keys())
 
         # special keywords need to be treated separately
         # keyword names that can mean 'all'


### PR DESCRIPTION
This doesn't fix issue #1691 at present, but it is intended to.  We presently include duplicate keys when querying vizier.  However, the issue noted in #1691 still occurs with this fix