### PR TITLE
ALMA: use auth in HEAD request

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -52,6 +52,8 @@ alma
   several columns have been added [#1644,#1665,#1683]
 - The contents of tarfiles can be shown with the ``expand_tarfiles`` keyword
   to ``stage_data`` [#1683]
+- Bugfix: when accessing private data, auth credentials were not being passed
+  to the HEAD request used to acquire header data [#1698]
 
 vizier
 ^^^^^^

--- a/astroquery/alma/core.py
+++ b/astroquery/alma/core.py
@@ -376,12 +376,28 @@ class AlmaClass(QueryWithLogin):
 
         return data_sizes, totalsize.to(u.GB)
 
-    def download_files(self, files, savedir=None, cache=True, continuation=True):
+    def download_files(self, files, savedir=None, cache=True,
+                       continuation=True, skip_unauthorized=True):
         """
         Given a list of file URLs, download them
 
         Note: Given a list with repeated URLs, each will only be downloaded
         once, so the return may have a different length than the input list
+
+        Parameters
+        ----------
+        files : list
+            List of URLs to download
+        savedir : None or str
+            The directory to save to.  Default is the cache location.
+        cache : bool
+            Cache the download?
+        continuation : bool
+            Attempt to continue where the download left off (if it was broken)
+        skip_unauthorized : bool
+            If you receive "unauthorized" responses for some of the download
+            requests, skip over them.  If this is False, an exception will be
+            raised.
         """
 
         if self.USERNAME:
@@ -411,9 +427,12 @@ class AlmaClass(QueryWithLogin):
                 downloaded_files.append(filename)
             except requests.HTTPError as ex:
                 if ex.response.status_code == 401:
-                    log.info("Access denied to {url}.  Skipping to"
-                             " next file".format(url=fileLink))
-                    continue
+                    if skip_unauthorized:
+                        log.info("Access denied to {url}.  Skipping to"
+                                 " next file".format(url=fileLink))
+                        continue
+                    else:
+                        raise(ex)
                 elif ex.response.status_code == 403:
                     log.error("Access denied to {url}".format(url=fileLink))
                     if 'dataPortal' in fileLink and 'sso' not in fileLink:

--- a/astroquery/alma/core.py
+++ b/astroquery/alma/core.py
@@ -411,7 +411,8 @@ class AlmaClass(QueryWithLogin):
         for fileLink in unique(files):
             try:
                 log.debug("Downloading {0} to {1}".format(fileLink, savedir))
-                check_filename = self._request('HEAD', fileLink, stream=True)
+                check_filename = self._request('HEAD', fileLink, auth=auth,
+                                               stream=True)
                 check_filename.raise_for_status()
                 if 'text/html' in check_filename.headers['Content-Type']:
                     raise ValueError("Bad query.  This can happen if you "


### PR DESCRIPTION
A HEAD request is made before the GET request, and it needs to be authorized too.

Also, there are even more URLs to try...