### PR TITLE
MNT: Ignore import error in pytest collection

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -17,7 +17,7 @@ minversion = 3.0
 norecursedirs = build docs/_build docs/gallery-examples
 doctest_plus = enabled
 text_file_format = rst
-addopts = -p no:warnings
+addopts = -p no:warnings --doctest-ignore-import-errors
 xfail_strict = true
 remote_data_strict = true
 


### PR DESCRIPTION
This is an automated update made by the `batchpr` tool :robot: to future-proof test collection behavior `pytest-doctestplus` - feel free to close if it doesn't look good or isn't relevant! You can report issues to @pllim.