### PR TITLE
Fix NRAO project_code query

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -65,6 +65,10 @@ vizier
 mast
 ^^^^
 
+nrao
+^^^^
+
+- Fixed passing ``project_code`` to the query [#1720]
 
 Infrastructure, Utility and Other Changes and Additions
 -------------------------------------------------------

--- a/astroquery/nrao/core.py
+++ b/astroquery/nrao/core.py
@@ -396,11 +396,12 @@ class NraoClass(QueryWithLogin):
                                 freq_up=freq_up,
                                 telescope_config=telescope_config,
                                 obs_band=obs_band,
-                                sub_array=sub_array,
                                 querytype=querytype,
+                                sub_array=sub_array,
+                                project_code=project_code,
                                 protocol=protocol,
-                                get_query_payload=get_query_payload,
                                 retry=retry,
+                                get_query_payload=get_query_payload,
                                 cache=cache)
 
     def _parse_result(self, response, verbose=False):

--- a/astroquery/nrao/tests/test_nrao_remote.py
+++ b/astroquery/nrao/tests/test_nrao_remote.py
@@ -27,6 +27,14 @@ class TestNrao:
         # I don't know why this is byte-typed
         assert b'0430+052' in result['Source']
 
+    def test_query_region_project_code(self):
+        result = nrao.core.Nrao.query_region(
+            coord.SkyCoord("04h33m11.1s 05d21m15.5s"),
+            project_code="AD0094", retry=5)
+        assert len(result) == 42
+        assert len(set(result['Project'])) == 1
+        assert "AD0094" in list(set(result['Project']))[0]
+
     def test_query_region_archive(self):
         result = nrao.core.Nrao.query_region(
             coord.SkyCoord("05h35.8m 35d43m"), querytype='ARCHIVE',


### PR DESCRIPTION
The `project_code` was not being passed to `NraoClass.query_async`. I added a test using the oldest archival project from the existing reqion queried in other tests.