### PR TITLE
keep original extension for data download

### DIFF
--- a/astroquery/esa/xmm_newton/tests/test_xmm_newton.py
+++ b/astroquery/esa/xmm_newton/tests/test_xmm_newton.py
@@ -34,9 +34,28 @@ class TestXMMNewton():
                       'verbose': False}
         xsa = XMMNewtonClass(self.get_dummy_tap_handler())
         xsa.download_data(parameters['observation_id'],
-                          parameters['filename'],
-                          parameters['verbose'],
+                          filename=parameters['filename'],
+                          verbose=parameters['verbose'],
                           level=parameters['level']
+                          )
+
+    @pytest.mark.remote_data
+    def test_download_data_single_file(self):
+        parameters = {'observation_id': "0762470101",
+                      'level': "PPS",
+                      'name': 'OBSMLI',
+                      'filename': 'single',
+                      'instname': 'OM',
+                      'extension': 'FTZ',
+                      'verbose': False}
+        xsa = XMMNewtonClass(self.get_dummy_tap_handler())
+        xsa.download_data(parameters['observation_id'],
+                          filename=parameters['filename'],
+                          verbose=parameters['verbose'],
+                          level=parameters['level'],
+                          extension=parameters['extension'],
+                          instname=parameters['instname'],
+                          name=parameters['name']
                           )
 
     @pytest.mark.remote_data


### PR DESCRIPTION
Currently download files are encapsulated in a tar. We don't want that,it's strange for the user

We want to keep the original format, that is, the downloaded file has to keep its structure, extension, if we download it from here or if we download it from curl for example. This PR fix this.


**Changes**

- The downloaded data keep the same extension as the original download via curl for example or https.
- A new test has been added to test the download of a single file. `test_download_data_single_file`
