### PR TITLE
Update gaia.rst

### DIFF
--- a/docs/gaia/gaia.rst
+++ b/docs/gaia/gaia.rst
@@ -492,7 +492,7 @@ To remove asynchronous
 .. code-block:: python
 
   >>> from astroquery.gaia import Gaia
-  >>> job = Gaia.remove_jobs(["job_id_1","job_id_2",...])
+  >>> Gaia.remove_jobs(["job_id_1","job_id_2",...])
 
 
 ---------------------------

--- a/docs/gaia/gaia.rst
+++ b/docs/gaia/gaia.rst
@@ -492,7 +492,7 @@ To remove asynchronous
 .. code-block:: python
 
   >>> from astroquery.gaia import Gaia
-  >>> Gaia.remove_jobs(["job_id_1","job_id_2",...])
+  >>> Gaia.remove_jobs([job1.job_id, job2.job_id, ...])
 
 
 ---------------------------

--- a/docs/gaia/gaia.rst
+++ b/docs/gaia/gaia.rst
@@ -246,8 +246,8 @@ Once a table is loaded, columns can be inspected
 
   >>> from astroquery.gaia import Gaia
   >>> gaiadr1_table = Gaia.load_table('gaiadr1.gaia_source')
-  >>> for column in (gaiadr1_table.get_columns()):
-  >>>   print(column.get_name())
+  >>> for column in (gaiadr1_table.columns):
+  >>>   print(column.name)
 
   solution_id
   source_id


### PR DESCRIPTION
```
>>> for column in (gaiadr1_table.get_columns()):
>>>   print(column.get_name())
```

It looks like the `get_columns()` method has been replaced with a `columns` property and `get_name()` has been replaced with `name`

So this works for me:

```
for column in table.columns:
    print(column.name)
```