### PR TITLE
SDSS: Check if fields are valid without forcing to lowercase

### DIFF
--- a/astroquery/sdss/core.py
+++ b/astroquery/sdss/core.py
@@ -981,9 +981,11 @@ class SDSSClass(BaseQuery):
                     specobj_fields = specobj_defs
             else:
                 for sql_field in fields:
-                    if sql_field.lower() in photoobj_all:
+                    if (sql_field in photoobj_all
+                            or sql_field.lower() in photoobj_all):
                         q_select_field.append('p.{0}'.format(sql_field))
-                    elif sql_field.lower() in specobj_all:
+                    elif (sql_field in specobj_all
+                            or sql_field.lower() in specobj_all):
                         q_select_field.append('s.{0}'.format(sql_field))
 
         if photoobj_fields is not None:

--- a/astroquery/sdss/tests/test_sdss_remote.py
+++ b/astroquery/sdss/tests/test_sdss_remote.py
@@ -148,13 +148,13 @@ class TestSDSSRemote:
 
     def test_query_non_default_field(self):
         # A regression test for #469
-        query1 = sdss.SDSS.query_region(self.coords, fields=['r'])
+        query1 = sdss.SDSS.query_region(self.coords, fields=['r', 'psfMag_r'])
 
         query2 = sdss.SDSS.query_region(self.coords, fields=['ra', 'dec', 'r'])
         assert isinstance(query1, Table)
         assert isinstance(query2, Table)
 
-        assert query1.colnames == ['r']
+        assert query1.colnames == ['r', 'psfMag_r']
         assert query2.colnames == ['ra', 'dec', 'r']
 
     def test_query_crossid(self):


### PR DESCRIPTION
Querying fields like ``modelMag`` or ``psfMag`` does not work because in `photoobj_all` they are not converted to lowercase.
Not sure if the `.lower()` is actually useful, since fields are then used in the query without forcing them to lowercase.