### PR TITLE
MNT: Compatibility with astropy.utils.data refactoring for astropy 4.0.2

### DIFF
--- a/astroquery/utils/commons.py
+++ b/astroquery/utils/commons.py
@@ -396,7 +396,8 @@ class FileContainer(object):
             raise IOError("Cached file not found / does not exist.")
 
         # There has been some internal refactoring in astropy.utils.data
-        # so we do this check. See https://github.com/astropy/astropy/pull/10437
+        # so we do this check. Remove when minimum required astropy is 4.1.
+        # See https://github.com/astropy/astropy/pull/10437
         if hasattr(aud, '_get_download_cache_locs'):
             import shelve
             dldir, urlmapfn = aud._get_download_cache_locs()


### PR DESCRIPTION
Compatibility with astropy/astropy#10437 . This patch is needed because `save_fits` accesses hidden thingies that were refactored without any deprecation. The `_open_shelve` patch looks like it was copied out of a very old version of `astropy` and I don't think it is needed anymore regardless.

**Note to reviewer:** You should check out this branch and play around with it because I have no idea how `save_fits` is intended to be used properly.

astropy/astropy#10437 is milestoned for LTS because it fixes a fundamental problem with caching in cluster computing. If I am able to fix things up here without affecting your public API, I think that is acceptable to keep that PR in LTS. One thing that might be surprising to you but is not visible to the user is where the cache is going to be; see the last paragraph in https://docs.astropy.org/en/latest/utils/data.html#cache-management . Unless you keep using `astroquery` on the same machine while switching astropy versions back and forth (which is not recommended anyway), this change should be a one-time thing.

When testing `python setup.py test -t astroquery/utils/tests/test_utils.py` (both with and without `--remote-data`) locally, everything passed on my end. ~But when I run `python setup.py test`, I get 48 failures (expand the "Failure summary" to see them). Are these known failures? They don't make sense to me.~ (Turns out I had outdated PyVO 1.0, not a problem with PyVO 1.1.)

<details>
  <summary>Failure summary (PyVO 1.0)</summary>
  
```
FAILED astroquery/nasa_exoplanet_archive/tests/test_nasa_exoplanet_archive.py::test_format - DeprecationWarning: tostring() is deprecated. Use tobytes() instead.
FAILED astroquery/ned/tests/test_ned.py::test_get_positions - astroquery.exceptions.TableParseError: Failed to parse NED result! The raw response can be found in self.response, and the error in self.table_par...
FAILED astroquery/ned/tests/test_ned.py::test_get_redshifts - astroquery.exceptions.TableParseError: Failed to parse NED result! The raw response can be found in self.response, and the error in self.table_par...
FAILED astroquery/ned/tests/test_ned.py::test_photometry - astroquery.exceptions.TableParseError: Failed to parse NED result! The raw response can be found in self.response, and the error in self.table_parse_...
FAILED astroquery/ned/tests/test_ned.py::test_query_refcode - astroquery.exceptions.TableParseError: Failed to parse NED result! The raw response can be found in self.response, and the error in self.table_par...
FAILED astroquery/ned/tests/test_ned.py::test_query_region_iau - astroquery.exceptions.TableParseError: Failed to parse NED result! The raw response can be found in self.response, and the error in self.table_...
FAILED astroquery/ned/tests/test_ned.py::test_query_region - astroquery.exceptions.TableParseError: Failed to parse NED result! The raw response can be found in self.response, and the error in self.table_pars...
FAILED astroquery/ned/tests/test_ned.py::test_query_object - astroquery.exceptions.TableParseError: Failed to parse NED result! The raw response can be found in self.response, and the error in self.table_pars...
FAILED astroquery/nrao/tests/test_nrao.py::test_query_region - astroquery.exceptions.TableParseError: Failed to parse NRAO votable result! The raw response can be found in self.response, and the error in self...
FAILED astroquery/simbad/tests/test_simbad.py::test_parse_result - astroquery.exceptions.TableParseError: Failed to parse SIMBAD result! The raw response can be found in self.last_response, and the error in s...
FAILED astroquery/simbad/tests/test_simbad.py::test_query_bibobj - astroquery.exceptions.TableParseError: Failed to parse SIMBAD result! The raw response can be found in self.last_response, and the error in s...
FAILED astroquery/simbad/tests/test_simbad.py::test_query_catalog - astroquery.exceptions.TableParseError: Failed to parse SIMBAD result! The raw response can be found in self.last_response, and the error in ...
FAILED astroquery/simbad/tests/test_simbad.py::test_query_region[coordinates0-None-2000.0-J2000] - astroquery.exceptions.TableParseError: Failed to parse SIMBAD result! The raw response can be found in self.l...
FAILED astroquery/simbad/tests/test_simbad.py::test_query_region[coordinates1-radius1-2000.0-J2000] - astroquery.exceptions.TableParseError: Failed to parse SIMBAD result! The raw response can be found in sel...
FAILED astroquery/simbad/tests/test_simbad.py::test_query_region[coordinates2-5d0m0s-2000.0-J2000] - astroquery.exceptions.TableParseError: Failed to parse SIMBAD result! The raw response can be found in self...
FAILED astroquery/simbad/tests/test_simbad.py::test_query_region[coordinates3-None-2000.0-J2000] - astroquery.exceptions.TableParseError: Failed to parse SIMBAD result! The raw response can be found in self.l...
FAILED astroquery/simbad/tests/test_simbad.py::test_query_region_small_radius[coordinates0-0d-2000.0-J2000] - astroquery.exceptions.TableParseError: Failed to parse SIMBAD result! The raw response can be foun...
FAILED astroquery/simbad/tests/test_simbad.py::test_query_region_small_radius[coordinates1-radius1-2000.0-J2000] - astroquery.exceptions.TableParseError: Failed to parse SIMBAD result! The raw response can be...
FAILED astroquery/simbad/tests/test_simbad.py::test_query_object[m1-None] - astroquery.exceptions.TableParseError: Failed to parse SIMBAD result! The raw response can be found in self.last_response, and the e...
FAILED astroquery/simbad/tests/test_simbad.py::test_query_object[m [0-9]-True] - astroquery.exceptions.TableParseError: Failed to parse SIMBAD result! The raw response can be found in self.last_response, and ...
FAILED astroquery/simbad/tests/test_simbad.py::test_query_criteria1 - astroquery.exceptions.TableParseError: Failed to parse SIMBAD result! The raw response can be found in self.last_response, and the error i...
FAILED astroquery/simbad/tests/test_simbad.py::test_query_criteria2 - astroquery.exceptions.TableParseError: Failed to parse SIMBAD result! The raw response can be found in self.last_response, and the error i...
FAILED astroquery/simbad/tests/test_simbad.py::test_regression_issue388 - astroquery.exceptions.TableParseError: Failed to parse SIMBAD result! The raw response can be found in self.last_response, and the err...
FAILED astroquery/svo_fps/tests/test_svo_fps.py::test_get_filter_index - DeprecationWarning: tostring() is deprecated. Use tobytes() instead.
FAILED astroquery/svo_fps/tests/test_svo_fps.py::test_get_transmission_data - DeprecationWarning: tostring() is deprecated. Use tobytes() instead.
FAILED astroquery/svo_fps/tests/test_svo_fps.py::test_get_filter_list - DeprecationWarning: tostring() is deprecated. Use tobytes() instead.
FAILED astroquery/ukidss/tests/test_ukidss.py::test_query_region - DeprecationWarning: tostring() is deprecated. Use tobytes() instead.
FAILED astroquery/utils/tap/model/tests/test_job.py::TestJob::test_job_get_results - DeprecationWarning: tostring() is deprecated. Use tobytes() instead.
FAILED astroquery/utils/tap/tests/test_tap.py::TestTap::test_data - DeprecationWarning: tostring() is deprecated. Use tobytes() instead.
FAILED astroquery/utils/tap/tests/test_tap.py::TestTap::test_datalink - DeprecationWarning: tostring() is deprecated. Use tobytes() instead.
FAILED astroquery/utils/tap/tests/test_tap.py::TestTap::test_launch_async_job - DeprecationWarning: tostring() is deprecated. Use tobytes() instead.
FAILED astroquery/utils/tap/tests/test_tap.py::TestTap::test_launch_sync_job - DeprecationWarning: tostring() is deprecated. Use tobytes() instead.
FAILED astroquery/utils/tap/tests/test_tap.py::TestTap::test_launch_sync_job_redirect - DeprecationWarning: tostring() is deprecated. Use tobytes() instead.
FAILED astroquery/utils/tap/tests/test_tap.py::TestTap::test_start_job - DeprecationWarning: tostring() is deprecated. Use tobytes() instead.
FAILED astroquery/utils/tap/xmlparser/tests/test_xmlparser.py::XmlParserTest::test_job_results_parser - DeprecationWarning: tostring() is deprecated. Use tobytes() instead.
FAILED astroquery/vizier/tests/test_vizier.py::test_parse_result_verbose[afgl2591_iram.xml] - astroquery.exceptions.TableParseError: Failed to parse VIZIER result! The raw response can be found in self.respon...
FAILED astroquery/vizier/tests/test_vizier.py::test_parse_result_verbose[viz.xml] - astroquery.exceptions.TableParseError: Failed to parse VIZIER result! The raw response can be found in self.response, and th...
FAILED astroquery/vizier/tests/test_vizier.py::test_parse_result_verbose[kang2010.xml] - astroquery.exceptions.TableParseError: Failed to parse VIZIER result! The raw response can be found in self.response, a...
FAILED astroquery/vizier/tests/test_vizier.py::test_parse_result_verbose[find_kangapj70683.xml] - astroquery.exceptions.TableParseError: Failed to parse VIZIER result! The raw response can be found in self.re...
FAILED astroquery/vizier/tests/test_vizier.py::test_parse_result[viz.xml-231] - astroquery.exceptions.TableParseError: Failed to parse VIZIER result! The raw response can be found in self.response, and the er...
FAILED astroquery/vizier/tests/test_vizier.py::test_parse_result[afgl2591_iram.xml-1] - astroquery.exceptions.TableParseError: Failed to parse VIZIER result! The raw response can be found in self.response, an...
FAILED astroquery/vizier/tests/test_vizier.py::test_parse_result[kang2010.xml-1] - astroquery.exceptions.TableParseError: Failed to parse VIZIER result! The raw response can be found in self.response, and the...
FAILED astroquery/vizier/tests/test_vizier.py::test_query_region - astroquery.exceptions.TableParseError: Failed to parse VIZIER result! The raw response can be found in self.response, and the error in self.t...
FAILED astroquery/vizier/tests/test_vizier.py::test_query_regions - astroquery.exceptions.TableParseError: Failed to parse VIZIER result! The raw response can be found in self.response, and the error in self....
FAILED astroquery/vizier/tests/test_vizier.py::test_query_object - astroquery.exceptions.TableParseError: Failed to parse VIZIER result! The raw response can be found in self.response, and the error in self.t...
FAILED astroquery/vizier/tests/test_vizier.py::test_query_another_object - astroquery.exceptions.TableParseError: Failed to parse VIZIER result! The raw response can be found in self.response, and the error i...
FAILED astroquery/vizier/tests/test_vizier.py::test_get_catalogs - astroquery.exceptions.TableParseError: Failed to parse VIZIER result! The raw response can be found in self.response, and the error in self.t...
FAILED astroquery/vizier/tests/test_vizier.py::test_find_resource_then_get - astroquery.exceptions.TableParseError: Failed to parse VIZIER result! The raw response can be found in self.response, and the error...
```
</details>

I c/c @aarchiba for extra pairs of eyes.