### PR TITLE
Add rts_flag to JPL Horizons ephemerides

### DIFF
--- a/astroquery/jplhorizons/core.py
+++ b/astroquery/jplhorizons/core.py
@@ -149,6 +149,7 @@ class HorizonsClass(BaseQuery):
                           refsystem='J2000',
                           closest_apparition=False, no_fragments=False,
                           quantities=conf.eph_quantities,
+                          rts_flag=None,
                           get_query_payload=False,
                           get_raw_response=False, cache=True,
                           extra_precision=False):
@@ -445,6 +446,11 @@ class HorizonsClass(BaseQuery):
             Observer Table Quantities
             <https://ssd.jpl.nasa.gov/?horizons_doc#table_quantities>`_;
             default: all quantities
+        rts_flag: string, optional
+            Output data only at target rise/transit/set (RTS)
+            `RTS only print mode
+            <https://ssd.jpl.nasa.gov/?horizons_doc#rts>`_;
+            default: disabled
         get_query_payload : boolean, optional
             When set to `True` the method returns the HTTP request
             parameters as a dict, default: False
@@ -583,6 +589,9 @@ class HorizonsClass(BaseQuery):
             request_payload['SKIP_DAYLT'] = 'YES'
         else:
             request_payload['SKIP_DAYLT'] = 'NO'
+
+        if rts_flag:
+            request_payload['R_T_S_ONLY'] = rts_flag
 
         self.query_type = 'ephemerides'
 

--- a/astroquery/jplhorizons/tests/test_jplhorizons.py
+++ b/astroquery/jplhorizons/tests/test_jplhorizons.py
@@ -182,6 +182,47 @@ def test_ephemerides_query_payload():
         ('SKIP_DAYLT', 'YES')])
 
 
+def test_ephemerides_query_payload_with_rts_flag():
+    """
+    Assert that R_T_S_ONLY flag is provided at query payload
+    """
+    obj = jplhorizons.Horizons(id='Halley', id_type='comet_name',
+                               location='290',
+                               epochs={'start': '2080-01-01',
+                                       'stop': '2080-02-01',
+                                       'step': '3h'})
+    res = obj.ephemerides(airmass_lessthan=1.2, skip_daylight=True,
+                          closest_apparition=True,
+                          max_hour_angle=10,
+                          solar_elongation=(150, 180),
+                          get_query_payload=True,
+                          rts_flag="TVH")
+
+    assert res == OrderedDict([
+        ('batch', 1),
+        ('TABLE_TYPE', 'OBSERVER'),
+        ('QUANTITIES', "'1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,"
+                       "18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,"
+                       "33,34,35,36,37,38,39,40,41,42,43'"),
+        ('COMMAND', '"COMNAM=Halley; CAP;"'),
+        ('SOLAR_ELONG', '"150,180"'),
+        ('LHA_CUTOFF', '10'),
+        ('CSV_FORMAT', 'YES'),
+        ('CAL_FORMAT', 'BOTH'),
+        ('ANG_FORMAT', 'DEG'),
+        ('APPARENT', 'AIRLESS'),
+        ('REF_SYSTEM', 'J2000'),
+        ('EXTRA_PREC', 'NO'),
+        ('CENTER', "'290'"),
+        ('START_TIME', '"2080-01-01"'),
+        ('STOP_TIME', '"2080-02-01"'),
+        ('STEP_SIZE', '"3h"'),
+        ('AIRMASS', '1.2'),
+        ('SKIP_DAYLT', 'YES'),
+        ('R_T_S_ONLY', 'TVH'),
+        ])
+
+
 def test_elements_query_payload():
     res = (jplhorizons.Horizons(id='Ceres', location='500@10',
                                 epochs=2451544.5).elements(

--- a/docs/jplhorizons/jplhorizons.rst
+++ b/docs/jplhorizons/jplhorizons.rst
@@ -170,7 +170,8 @@ allows to reject targets with sky motion rates higher than provided
 (in units of arcsec/h), ``refraction`` accounts for refraction in the
 computation of the ephemerides (disabled by default), and
 ``refsystem`` defines the coordinate reference system used (J2000 by
-default).. For comets, the options ``closest_apparation`` and
+default). To output data only at target RTS (rise-transit-set) use the 
+optional ``rts_flag``. For comets, the options ``closest_apparation`` and
 ``no_fragments`` are available, which select the closest apparition in
 time and reject fragments, respectively. Note that these options
 should only be used for comets and will crash the query for other


### PR DESCRIPTION
It ensures to output data only at target RTS (rise-transit-set) passing the needed `RTS ONLY` flag to the CGI

It provides the new `rts_flag` optional parameter for the Horizons.ephemeris method

See https://ssd.jpl.nasa.gov/?horizons_doc#rts for more information

If activated, returns:

```
# example with `rts_flag = "TVH`  //true visual horizon plane

targetname    datetime_str      datetime_jd    solar_presence flags      AZ         EL    
   ---            ---                d              ---        ---      deg        deg    
---------- ----------------- ----------------- -------------- ----- ----------- ----------
  Sun (10) 2020-Aug-20 05:03 2459081.710416667              *     r  71.8343523 -0.7719307
  Sun (10) 2020-Aug-20 11:57 2459081.997916667              *     t 179.9287244 59.6468702
  Sun (10) 2020-Aug-20 18:51 2459082.285416667              C     s 287.9787747 -0.8537235
```

### Full example

```python
from astroquery.jplhorizons import Horizons
from astropy.time import Time

time = ["2020-08-20T00:00:00"]
t = Time(time, format="isot", scale="utc")

ordino = {"lon": 1.532610, "lat": 42.556761, "elevation": 0.3}

horizons_params = {
    "id_type": "majorbody",
    "location": ordino,
    "epochs": {
        "start": t.to_datetime()[0].__str__(),
        "stop": (t + 1).to_datetime()[0].__str__(),
        "step": "1m",
    },
}
ephemerides_params = {
    "quantities": "4",
    "refraction": True,
    "rts_flag": "TVH",
}

sun = Horizons(id=10, **horizons_params,)
ephemerides = sun.ephemerides(**ephemerides_params)
```

Fix #1799