### PR TITLE
Add optional_settings param to JPL Horizon Ephemerides

### DIFF
--- a/astroquery/jplhorizons/core.py
+++ b/astroquery/jplhorizons/core.py
@@ -149,6 +149,7 @@ class HorizonsClass(BaseQuery):
                           refsystem='J2000',
                           closest_apparition=False, no_fragments=False,
                           quantities=conf.eph_quantities,
+                          optional_settings=None,
                           get_query_payload=False,
                           get_raw_response=False, cache=True,
                           extra_precision=False):
@@ -445,6 +446,10 @@ class HorizonsClass(BaseQuery):
             Observer Table Quantities
             <https://ssd.jpl.nasa.gov/?horizons_doc#table_quantities>`_;
             default: all quantities
+        optional_settings: dict, optional
+            key-value based dictionary to inject some additional optional settings
+            See `Optional observer-table settings" <https://ssd.jpl.nasa.gov/horizons.cgi?s_tset=1>`_;
+            default: empty optional setting
         get_query_payload : boolean, optional
             When set to `True` the method returns the HTTP request
             parameters as a dict, default: False
@@ -593,6 +598,14 @@ class HorizonsClass(BaseQuery):
         # set return_raw flag, if raw response desired
         if get_raw_response:
             self.return_raw = True
+
+        # inject optional settings if provided
+        if optional_settings:
+            assert isinstance(
+                optional_settings, dict
+            ), "optional_settings should be a dict"
+            for key, value in optional_settings.items():
+                request_payload[key] = value
 
         # query and parse
         response = self._request('GET', URL, params=request_payload,

--- a/docs/jplhorizons/jplhorizons.rst
+++ b/docs/jplhorizons/jplhorizons.rst
@@ -170,7 +170,7 @@ allows to reject targets with sky motion rates higher than provided
 (in units of arcsec/h), ``refraction`` accounts for refraction in the
 computation of the ephemerides (disabled by default), and
 ``refsystem`` defines the coordinate reference system used (J2000 by
-default).. For comets, the options ``closest_apparation`` and
+default). For comets, the options ``closest_apparation`` and
 ``no_fragments`` are available, which select the closest apparition in
 time and reject fragments, respectively. Note that these options
 should only be used for comets and will crash the query for other
@@ -178,7 +178,9 @@ object types. Extra precision in the queried properties can be
 requested using the ``extra_precision`` option. Furthermore,
 ``get_query_payload=True`` skips the query and only returns the query
 payload, whereas ``get_raw_response=True`` the raw query response
-instead of the astropy table returns.
+instead of the astropy table returns. To pass additional settings
+to the request use the ``optional_settings`` passing a key-value
+dictionary.
 
 :meth:`~astroquery.jplhorizons.HorizonsClass.ephemerides` queries by
 default all available quantities from the JPL Horizons servers. This


### PR DESCRIPTION
It permits to easily extend the Ephemerides behavior being able to pass some non-hardcoded settings.

The idea is to be able to pass a key-value based dictionary to inject some additional payload to the Ephemerides request.

This will simplify the process to change optional settings without the need to touch any line of code :)

It will also work for any table setting, or some other setting that needs to define/change the `request_payload`

More info about possible settings at https://ssd.jpl.nasa.gov/horizons.cgi?s_tset=1

### Example use case

Quick change of time digits precision from minutes (default) to seconds:

```python
# it sets `optional_settings` `time_digits = "SECONDS"`

from astroquery.jplhorizons import Horizons
from astropy.time import Time

time = ["2020-08-20T00:00:00"]
t = Time(time, format="isot", scale="utc")

ordino = {"lon": 1.532610, "lat": 42.556761, "elevation": 0.3}

horizons_params = {
    "id_type": "majorbody",
    "location": ordino,
    "epochs": {
        "start": t.to_datetime()[0].__str__(),
        "stop": (t + 1).to_datetime()[0].__str__(),
        "step": "1m",
    },
}
ephemerides_params = {
    "quantities": "4",
    "refraction": True,
    "optional_settings": {"time_digits": "SECONDS"},
}

sun = Horizons(id=10, **horizons_params,)
ephemerides = sun.ephemerides(**ephemerides_params)
```

```
targetname     datetime_str        datetime_jd    solar_presence flags      AZ          EL    
   ---             ---                  d              ---        ---      deg         deg    
---------- -------------------- ----------------- -------------- ----- ----------- -----------
  Sun (10) 2020-Aug-20 00:00:00         2459081.5                        0.8156194 -34.4351463
...
```

To use fractions of second just set `time_digits = "FRACSEC"`

```
targetname       datetime_str          datetime_jd    solar_presence flags      AZ          EL    
   ---               ---                    d              ---        ---      deg         deg    
---------- ------------------------ ----------------- -------------- ----- ----------- -----------
  Sun (10) 2020-Aug-20 00:00:00.000         2459081.5                        0.8156194 -34.4351463
...
```

Fix #1801