### PR TITLE
Change splatalogue url

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -22,6 +22,9 @@ Splatalogue
   directory (Issue [#423]) The scraping function has also been updated to reflect
   the Splatalogue webpage. [#1772]
 
+- The splatalogue URL has changed to https://splatalogue.online, as the old site
+  stopped functioning in September 2020 [#1817]
+
 UKIDSS
 ^^^^^^
 

--- a/astroquery/splatalogue/__init__.py
+++ b/astroquery/splatalogue/__init__.py
@@ -20,7 +20,9 @@ class Conf(_config.ConfigNamespace):
         'https://find.nrao.edu/splata-slap/slap',
         'Splatalogue SLAP interface URL (not used).')
     query_url = _config.ConfigItem(
-        'https://www.cv.nrao.edu/php/splat/c_export.php',
+        'https://splatalogue.online/c_export.php',
+        # defunct as of Sep 4, 2020?  (keeping because this is likely the true host)
+        # 'https://www.cv.nrao.edu/php/splat/c_export.php',
         'Splatalogue web interface URL.')
     timeout = _config.ConfigItem(
         60,

--- a/astroquery/splatalogue/__init__.py
+++ b/astroquery/splatalogue/__init__.py
@@ -19,8 +19,9 @@ class Conf(_config.ConfigNamespace):
     slap_url = _config.ConfigItem(
         'https://find.nrao.edu/splata-slap/slap',
         'Splatalogue SLAP interface URL (not used).')
+    base_url = 'https://splatalogue.online'
     query_url = _config.ConfigItem(
-        'https://splatalogue.online/c_export.php',
+        f'{base_url}/c_export.php',
         # defunct as of Sep 4, 2020?  (keeping because this is likely the true host)
         # 'https://www.cv.nrao.edu/php/splat/c_export.php',
         'Splatalogue web interface URL.')

--- a/astroquery/splatalogue/build_species_table.py
+++ b/astroquery/splatalogue/build_species_table.py
@@ -11,6 +11,8 @@ import requests
 
 from astropy.config import paths
 
+from . import conf
+
 
 def data_path(filename: str):
     """
@@ -32,7 +34,7 @@ def data_path(filename: str):
     return os.path.join(data_dir, filename)
 
 
-def get_json_species_ids(outfile='splat-species.json'):
+def get_json_species_ids(outfile='splat-species.json', base_url=conf.base_url):
     """
     Uses BeautifulSoup to scrape the NRAO Splatalogue species
     selector form, and caches the result as JSON. The file
@@ -50,7 +52,7 @@ def get_json_species_ids(outfile='splat-species.json'):
     """
     import bs4
 
-    result = requests.get('https://www.cv.nrao.edu/php/splat/b.php')
+    result = requests.get(f'{base_url}/b.php')
     page = bs4.BeautifulSoup(result.content, 'html5lib')
     # The ID needs to be checked periodically if Splatalogue is updated
     sid = page.findAll('select', attrs={'id': 'speciesselectbox'})[0]

--- a/astroquery/splatalogue/tests/test_splatalogue.py
+++ b/astroquery/splatalogue/tests/test_splatalogue.py
@@ -61,12 +61,6 @@ def test_load_species_table():
     assert len(CO) == 4
 
 
-# regression test: ConfigItems were in wrong order at one point
-def test_url():
-    assert 'https://' in splatalogue.core.Splatalogue.QUERY_URL
-    assert 'cv.nrao.edu' in splatalogue.core.Splatalogue.QUERY_URL
-
-
 # regression test: get_query_payload should work (#308)
 def test_get_payload():
     q = splatalogue.core.Splatalogue.query_lines_async(1 * u.GHz, 10 * u.GHz,


### PR DESCRIPTION
Splatalogue's 'old' URL stopped functioning over the weekend.  This new URL appears to work.