### PR TITLE
MAST: added ability to download a single file

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,12 @@
 Service fixes and enhancements
 ------------------------------
 
+mast
+^^^^
+
+- Added ``Observations.download_file`` method to download a single file from MAST given an input
+  data URI. [#1825]
+
 esa/hubble
 ^^^^^^^^^^
 

--- a/astroquery/mast/observations.py
+++ b/astroquery/mast/observations.py
@@ -526,7 +526,7 @@ class ObservationsClass(MastQueryWithLogin):
         Parameters
         ----------
         uri : str
-            The product dataURI, e.g. `mast:JWST/product/jw00736-o039_t001_miri_ch1-long_x1d.fits`
+            The product dataURI, e.g. mast:JWST/product/jw00736-o039_t001_miri_ch1-long_x1d.fits
         local_path : str
             Directory in which the files will be downloaded.  Defaults to current working directory.
         base_url: str

--- a/astroquery/mast/tests/test_mast.py
+++ b/astroquery/mast/tests/test_mast.py
@@ -372,6 +372,16 @@ def test_observations_download_products(patch_post, tmpdir):
     assert isinstance(result, Table)
 
 
+def test_observations_download_file(patch_post, tmpdir):
+    # pull a single data product
+    products = mast.Observations.get_product_list('2003738726')
+    uri = products['dataURI'][0]
+
+    # download it
+    result = mast.Observations.download_file(uri)
+    assert result == ('COMPLETE', None, None)
+
+
 ######################
 # CatalogClass tests #
 ######################

--- a/astroquery/mast/tests/test_mast.py
+++ b/astroquery/mast/tests/test_mast.py
@@ -68,6 +68,7 @@ def patch_post(request):
     mp.setattr(mast.auth.MastAuth, 'session_info', session_info_mockreturn)
 
     mp.setattr(mast.Observations, '_download_file', download_mockreturn)
+    mp.setattr(mast.Observations, 'download_file', download_mockreturn)
     mp.setattr(mast.Catalogs, '_download_file', download_mockreturn)
     mp.setattr(mast.Tesscut, '_download_file', tess_download_mockreturn)
 
@@ -122,7 +123,7 @@ def resolver_mockreturn(*args, **kwargs):
 
 
 def download_mockreturn(*args, **kwargs):
-    return
+    return ('COMPLETE', None, None)
 
 
 def session_info_mockreturn(self, silent=False):

--- a/astroquery/mast/tests/test_mast_remote.py
+++ b/astroquery/mast/tests/test_mast_remote.py
@@ -286,6 +286,17 @@ class TestMast(object):
         assert isinstance(result, Table)
         assert os.path.isfile(result['Local Path'][0])
 
+    def test_observations_download_file(self, tmpdir):
+        test_obs_id = '2003600312'
+
+        # pull a single data product
+        products = mast.Observations.get_product_list(test_obs_id)
+        uri = products['dataURI'][0]
+
+        # download it
+        result = mast.Observations.download_file(uri)
+        assert result == ('COMPLETE', None, None)
+
     ######################
     # CatalogClass tests #
     ######################

--- a/docs/mast/mast.rst
+++ b/docs/mast/mast.rst
@@ -327,18 +327,19 @@ Product filtering can also be applied directly to a table of products without pr
 Downloading a Single File
 -------------------------
 
-You can download a single data product file using the ``Observation.download_file`` method, and passing in
+You can download a single data product file using the `~astroquery.mast.ObservationsClass.download_file` method, and passing in
 a MAST dataURL.  The default is to download the file the current working directory, which can be changed with
-the `local_path` keyword argument.
+the *local_path* keyword argument.
 
-.. code-block: python
+.. code-block:: python
 
                 >>> from astroquery.mast import Observations
 
                 >>> product = 'mast:IUE/url/pub/iue/data/lwp/13000/lwp13058.elbll.gz'
-                >>> Observations.download_file(product)
-
+                >>> result = Observations.download_file(product)
                 Downloading URL https://mast.stsci.edu/api/v0.1/Download/file?uri=mast:IUE/url/pub/iue/data/lwp/13000/lwp13058.elbll.gz to ./lwp13058.elbll.gz ... [Done]
+                >>> print(result)
+                ('COMPLETE', None, None)
 
 Cloud Data Access
 ------------------

--- a/docs/mast/mast.rst
+++ b/docs/mast/mast.rst
@@ -23,45 +23,45 @@ The observation fields are documented
 .. code-block:: python
 
                 >>> from astroquery.mast import Observations
-                
+
                 >>> obs_table = Observations.query_region("322.49324 12.16683")
                 >>> print(obs_table[:10])
 
-                dataproduct_type obs_collection instrument_name ... distance 
-                ---------------- -------------- --------------- ... -------- 
-                            cube          SWIFT            UVOT ...      0.0 
-                            cube          SWIFT            UVOT ...      0.0 
-                            cube          SWIFT            UVOT ...      0.0 
-                            cube          SWIFT            UVOT ...      0.0 
-                            cube          SWIFT            UVOT ...      0.0 
-                            cube          SWIFT            UVOT ...      0.0 
-                            cube          SWIFT            UVOT ...      0.0 
-                            cube          SWIFT            UVOT ...      0.0 
-                            cube          SWIFT            UVOT ...      0.0 
-                            cube          SWIFT            UVOT ...      0.0 
+                dataproduct_type obs_collection instrument_name ... distance
+                ---------------- -------------- --------------- ... --------
+                            cube          SWIFT            UVOT ...      0.0
+                            cube          SWIFT            UVOT ...      0.0
+                            cube          SWIFT            UVOT ...      0.0
+                            cube          SWIFT            UVOT ...      0.0
+                            cube          SWIFT            UVOT ...      0.0
+                            cube          SWIFT            UVOT ...      0.0
+                            cube          SWIFT            UVOT ...      0.0
+                            cube          SWIFT            UVOT ...      0.0
+                            cube          SWIFT            UVOT ...      0.0
+                            cube          SWIFT            UVOT ...      0.0
 
 Radius is an optional parameter and the default is 0.2 degrees.
 
 .. code-block:: python
 
                 >>> from astroquery.mast import Observations
-                
+
                 >>> obs_table = Observations.query_object("M8",radius=".02 deg")
                 >>> print(obs_table[:10])
-                
-                dataproduct_type obs_collection instrument_name ...    distance   
-                ---------------- -------------- --------------- ... ------------- 
-                            cube             K2          Kepler ... 39.4914065162 
-                        spectrum            IUE             LWP ...           0.0 
-                        spectrum            IUE             LWP ...           0.0 
-                        spectrum            IUE             LWP ...           0.0 
-                        spectrum            IUE             LWR ...           0.0 
-                        spectrum            IUE             LWR ...           0.0 
-                        spectrum            IUE             LWR ...           0.0 
-                        spectrum            IUE             LWR ...           0.0 
-                        spectrum            IUE             LWR ...           0.0 
+
+                dataproduct_type obs_collection instrument_name ...    distance
+                ---------------- -------------- --------------- ... -------------
+                            cube             K2          Kepler ... 39.4914065162
+                        spectrum            IUE             LWP ...           0.0
+                        spectrum            IUE             LWP ...           0.0
+                        spectrum            IUE             LWP ...           0.0
                         spectrum            IUE             LWR ...           0.0
-                        
+                        spectrum            IUE             LWR ...           0.0
+                        spectrum            IUE             LWR ...           0.0
+                        spectrum            IUE             LWR ...           0.0
+                        spectrum            IUE             LWR ...           0.0
+                        spectrum            IUE             LWR ...           0.0
+
 
 
 Observation Criteria Queries
@@ -83,15 +83,15 @@ However, only one wildcarded value can be processed per criterion.
 RA and Dec must be given in decimal degrees, and datetimes in MJD.
 
 .. code-block:: python
-                
+
                 >>> from astroquery.mast import Observations
-                
+
                 >>> obs_table = Observations.query_criteria(dataproduct_type=["image"],
                 ...                                         proposal_pi="Osten*",
                 ...                                         s_dec=[43.5,45.5])
                 >>> print(obs_table)
 
-                dataproduct_type calib_level obs_collection ... dataURL   obsid      objID   
+                dataproduct_type calib_level obs_collection ... dataURL   obsid      objID
                 ---------------- ----------- -------------- ... ------- ---------- ----------
                            image           1            HST ...    None 2003520266 2011133418
                            image           1            HST ...    None 2003520267 2011133419
@@ -100,7 +100,7 @@ RA and Dec must be given in decimal degrees, and datetimes in MJD.
                 >>> obs_table = Observations.query_criteria(filters=["*UV","Kepler"],objectname="M101")
                 >>> print(obs_table)
 
-                dataproduct_type calib_level obs_collection ...   objID1      distance  
+                dataproduct_type calib_level obs_collection ...   objID1      distance
                 ---------------- ----------- -------------- ... ---------- -------------
                            image           2          GALEX ... 1000055044           0.0
                            image           2          GALEX ... 1000004937 3.83290685323
@@ -114,7 +114,7 @@ RA and Dec must be given in decimal degrees, and datetimes in MJD.
                            image           2          GALEX ... 1000004203           0.0
                            image           2          GALEX ... 1000016641           0.0
                            image           2          GALEX ... 1000048943 3.83290685323
-                           
+
 
 Getting Observation Counts
 --------------------------
@@ -123,12 +123,12 @@ To get the number of observations and not the observations themselves, query_cou
 This can be useful if trying to decide whether the available memory is sufficient for the number of observations.
 
 .. code-block:: python
-                
+
                 >>> from astroquery.mast import Observations
-                
+
                 >>> print(Observations.query_region_count("322.49324 12.16683"))
                 1804
-                
+
                 >>> print(Observations.query_object_count("M8",radius=".02 deg"))
                 196
 
@@ -136,7 +136,7 @@ This can be useful if trying to decide whether the available memory is sufficien
                 ...                                         filters=["NUV","FUV"],
                 ...                                         t_max=[52264.4586,54452.8914]))
                 59033
-                           
+
 
 
 Metadata Queries
@@ -145,9 +145,9 @@ Metadata Queries
 To list data missions archived by MAST and avaiable through `astroquery.mast`, use the `~astroquery.mast.ObservationsClass.list_missions` function.
 
 .. code-block:: python
-                
+
                 >>> from astroquery.mast import Observations
-                
+
                 >>> print(Observations.list_missions())
                 ['IUE', 'Kepler', 'K2FFI', 'EUVE', 'HLA', 'KeplerFFI','FUSE',
                 'K2', 'HST', 'WUPPE', 'BEFS', 'GALEX', 'TUES','HUT', 'SWIFT']
@@ -157,12 +157,12 @@ To get a table of metadata associated with observation or product lists use the
 `~astroquery.mast.ObservationsClass.get_metadata` function.
 
 .. code-block:: python
-                
+
                 >>> from astroquery.mast import Observations
-                
+
                 >>> meta_table = Observations.get_metadata("observations")
                 >>> print(meta_table[:5])
-                   Column Name    Column Label ...       Examples/Valid Values      
+                   Column Name    Column Label ...       Examples/Valid Values
                 ----------------- ------------ ... ---------------------------------
                    obs_collection      Mission ...         E.g. SWIFT, PS1, HST, IUE
                   instrument_name   Instrument ...    E.g. WFPC2/WFC, UVOT, STIS/CCD
@@ -173,14 +173,14 @@ To get a table of metadata associated with observation or product lists use the
                 >>> meta_table = Observations.get_metadata("products")
                 >>> print(meta_table[:3])
 
-                 Column Name     Column Label   ...         Examples/Valid Values        
+                 Column Name     Column Label   ...         Examples/Valid Values
                 -------------- ---------------- ... -------------------------------------
                         obs_id   Observation ID ...                  U24Z0101T, N4QF18030
                          obsID Product Group ID ...         Long integer, e.g. 2007590987
                 obs_collection          Mission ... HST, HLA, SWIFT, GALEX, Kepler, K2...
 
 
-                
+
 Downloading Data
 ================
 
@@ -194,14 +194,14 @@ a `~astropy.table.Table` containing the associated data products.
 The product fields are documented `here <https://mast.stsci.edu/api/v0/_productsfields.html>`__.
 
 .. code-block:: python
-                
+
                 >>> from astroquery.mast import Observations
-                
+
                 >>> obs_table = Observations.query_object("M8",radius=".02 deg")
                 >>> data_products_by_obs = Observations.get_product_list(obs_table[0:2])
                 >>> print(data_products_by_obs)
-                
-                  obsID    obs_collection ...          productFilename             size  
+
+                  obsID    obs_collection ...          productFilename             size
                 ---------- -------------- ... ---------------------------------- --------
                 3000007760            IUE ...                  lwp13058.elbll.gz   185727
                 3000007760            IUE ...                  lwp13058.elbls.gz   183350
@@ -219,12 +219,12 @@ The product fields are documented `here <https://mast.stsci.edu/api/v0/_products
                 9500243833             K2 ... ktwo200071160-c91_lpd-targ.fits.gz 39930404
                 9500243833             K2 ... ktwo200071160-c92_lpd-targ.fits.gz 62213068
                 9500243833             K2 ...    k2-tpf-only-target_bw_thumb.png     1301
-                
+
                 >>> obsids = obs_table[0:2]['obsid']
                 >>> data_products_by_id = Observations.get_product_list(obsids)
                 >>> print(data_products_by_id)
-                
-                  obsID    obs_collection ...          productFilename             size  
+
+                  obsID    obs_collection ...          productFilename             size
                 ---------- -------------- ... ---------------------------------- --------
                 3000007760            IUE ...                  lwp13058.elbll.gz   185727
                 3000007760            IUE ...                  lwp13058.elbls.gz   183350
@@ -242,11 +242,11 @@ The product fields are documented `here <https://mast.stsci.edu/api/v0/_products
                 9500243833             K2 ... ktwo200071160-c91_lpd-targ.fits.gz 39930404
                 9500243833             K2 ... ktwo200071160-c92_lpd-targ.fits.gz 62213068
                 9500243833             K2 ...    k2-tpf-only-target_bw_thumb.png     1301
-                
+
                 >>> print((data_products_by_obs == data_products_by_id).all())
                 True
 
-                
+
 
 
 
@@ -257,17 +257,17 @@ Products can be downloaded by using `~astroquery.mast.ObservationsClass.download
 with a `~astropy.table.Table` of data products, or a list (or single) obsid as the argument.
 
 .. code-block:: python
-                
+
                 >>> from astroquery.mast import Observations
-                
+
                 >>> obsid = '3000007760'
                 >>> data_products = Observations.get_product_list(obsid)
                 >>> manifest = Observations.download_products(data_products)
                 Downloading URL http://archive.stsci.edu/pub/iue/data/lwp/13000/lwp13058.mxlo.gz to ./mastDownload/IUE/lwp13058/lwp13058.mxlo.gz ... [Done]
                 Downloading URL http://archive.stsci.edu/pub/vospectra/iue2/lwp13058mxlo_vo.fits to ./mastDownload/IUE/lwp13058/lwp13058mxlo_vo.fits ... [Done]
                 >>> print(manifest)
-                
-                                   Local Path                     Status  Message URL 
+
+                                   Local Path                     Status  Message URL
                 ------------------------------------------------ -------- ------- ----
                     ./mastDownload/IUE/lwp13058/lwp13058.mxlo.gz COMPLETE    None None
                 ./mastDownload/IUE/lwp13058/lwp13058mxlo_vo.fits COMPLETE    None None
@@ -277,14 +277,14 @@ with a `~astropy.table.Table` of data products, or a list (or single) obsid as t
 .. code-block:: python
 
                 >>> from astroquery.mast import Observations
-                
+
                 >>> Observations.download_products('2003839997',
                 ...                                productType="SCIENCE",
                 ...                                curl_flag=True)
-                                                   
+
                 Downloading URL https://mast.stsci.edu/portal/Download/stage/anonymous/public/514cfaa9-fdc1-4799-b043-4488b811db4f/mastDownload_20170629162916.sh to ./mastDownload_20170629162916.sh ... [Done]
 
-                
+
 Filtering
 ---------
 
@@ -298,7 +298,7 @@ The below example illustrates downloading all product files with the extension "
 .. code-block:: python
 
                 >>> from astroquery.mast import Observations
-                
+
                 >>> Observations.download_products('2003839997',
                 ...                                productSubGroupDescription=["RAW", "UNCAL"],
                 ...                                extension="fits")
@@ -313,16 +313,32 @@ Product filtering can also be applied directly to a table of products without pr
 .. code-block:: python
 
                 >>> from astroquery.mast import Observations
-                
+
                 >>> products = Observations.get_product_list('2003839997')
                 >>> print(len(products))
                 31
-                
+
                 >>> products = Observations.filter_products(data_products,
                 ...                                         productSubGroupDescription=["RAW", "UNCAL"],
                 ...                                         extension="fits")
                 >>> print(len(products))
                 4
+
+Downloading a Single File
+-------------------------
+
+You can download a single data product file using the ``Observation.download_file`` method, and passing in
+a MAST dataURL.  The default is to download the file the current working directory, which can be changed with
+the `local_path` keyword argument.
+
+.. code-block: python
+
+                >>> from astroquery.mast import Observations
+
+                >>> product = 'mast:IUE/url/pub/iue/data/lwp/13000/lwp13058.elbll.gz'
+                >>> Observations.download_file(product)
+
+                Downloading URL https://mast.stsci.edu/api/v0.1/Download/file?uri=mast:IUE/url/pub/iue/data/lwp/13000/lwp13058.elbll.gz to ./lwp13058.elbll.gz ... [Done]
 
 Cloud Data Access
 ------------------
@@ -370,7 +386,7 @@ Getting a list of S3 URIs:
                 ...                                         filters='F606W',
                 ...                                         instrument_name='ACS/WFC',
                 ...                                         proposal_id=['12062'],
-                ...                                         dataRights='PUBLIC') 
+                ...                                         dataRights='PUBLIC')
                 >>> products = Observations.get_product_list(obs_table)
                 >>> filtered = Observations.filter_products(products,
                 ...                                         productSubGroupDescription='DRZ')
@@ -378,12 +394,12 @@ Getting a list of S3 URIs:
                 >>> print(s3_uris)
                 ['s3://stpubdata/hst/public/jbev/jbeveo010/jbeveo010_drz.fits',
                  's3://stpubdata/hst/public/jbev/jbevet010/jbevet010_drz.fits']
-                 
+
                 >>> Observations.disable_cloud_dataset()
 
-                 
+
 Downloading data products from S3:
-                 
+
 .. code-block:: python
 
                 >>> import os
@@ -398,7 +414,7 @@ Downloading data products from S3:
                 INFO: Using the S3 STScI public dataset [astroquery.mast.core]
                 INFO: See Request Pricing in https://aws.amazon.com/s3/pricing/ for details [astroquery.mast.core]
                 INFO: If you have not configured boto3, follow the instructions here: https://boto3.readthedocs.io/en/latest/guide/configuration.html [astroquery.mast.core]
-                
+
                 >>> # Downloading from the cloud
                 >>> obs_table = Observations.query_criteria(obs_collection=['Kepler'],
                 ...                                         objectname="Kepler 12b", radius=0)
@@ -421,7 +437,7 @@ Downloading data products from S3:
                 Downloading URL s3://stpubdata/kepler/public/lightcurves/0118/011804465/kplr011804465-2010009091648_llc.fits to ./mastDownload/Kepler/kplr011804465_lc_Q111111110111011101/kplr011804465-2010009091648_llc.fits ... [Done]
 
                 >>> print(manifest["Status"])
-                 Status 
+                 Status
                 --------
                  SKIPPED
                  SKIPPED
@@ -458,7 +474,7 @@ The returned fields vary by catalog, find the field documentation for specific c
 .. code-block:: python
 
                 >>> from astroquery.mast import Catalogs
-                
+
                 >>> catalog_data = Catalogs.query_object("158.47924 -7.30962", catalog="Galex")
                 >>> print(catalog_data[:10])
 
@@ -478,11 +494,11 @@ The returned fields vary by catalog, find the field documentation for specific c
 
 Some catalogs have a maximum number of results they will return.
 If a query results in this maximum number of results a warning will be displayed to alert the user that they might be getting a subset of the true result set.
-                  
+
 .. code-block:: python
 
                 >>> from astroquery.mast import Catalogs
-                
+
                 >>> catalog_data = Catalogs.query_region("322.49324 12.16683", catalog="HSC", magtype=2)
 
                 WARNING: MaxResultsWarning: Maximum catalog results returned, may not include all
@@ -509,11 +525,11 @@ Radius is an optional parameter and the default is 0.2 degrees.
 .. code-block:: python
 
                 >>> from astroquery.mast import Catalogs
-                
+
                 >>> catalog_data = Catalogs.query_object("M10", radius=.02, catalog="TIC")
                 >>> print(catalog_data[:10])
 
-                    ID          ra           dec       ... duplicate_id priority   dstArcSec  
+                    ID          ra           dec       ... duplicate_id priority   dstArcSec
                 --------- ------------- -------------- ... ------------ -------- -------------
                 189844423    254.287989      -4.099644 ...           --       -- 2.21043178558
                 189844434 254.286301884 -4.09872352783 ...           --       -- 4.69684511346
@@ -526,7 +542,7 @@ Radius is an optional parameter and the default is 0.2 degrees.
                 189844419    254.290767      -4.099757 ...           --       -- 11.9738216615
                 189844454 254.290349435 -4.09754191392 ...           --       -- 12.2100186781
 
-                
+
 The Hubble Source Catalog, the Gaia Catalog, and the PanSTARRS Catalog have multiple versions.
 An optional version parameter allows you to select which version you want, the default is the highest version.
 
@@ -538,7 +554,7 @@ An optional version parameter allows you to select which version you want, the d
                 >>> print(catalog_data[:4])
 
                 Number of results: 111
-                    solution_id             designation          ...      distance     
+                    solution_id             designation          ...      distance
                 ------------------- ---------------------------- ... ------------------
                 1635721458409799680 Gaia DR2 3774902350511581696 ... 0.6327882551927051
                 1635721458409799680 Gaia DR2 3774901427093274112 ... 0.8438875783827048
@@ -578,11 +594,11 @@ The TESS Input Catalog (TIC), Disk Detective Catalog, and PanSTARRS Catalog can 
 .. code-block:: python
 
                 >>> from astroquery.mast import Catalogs
-                
+
                 >>> catalog_data = Catalogs.query_criteria(catalog="Tic",Bmag=[30,50],objType="STAR")
                 >>> print(catalog_data)
 
-                    ID    version  HIP TYC ... disposition duplicate_id priority   objID  
+                    ID    version  HIP TYC ... disposition duplicate_id priority   objID
                 --------- -------- --- --- ... ----------- ------------ -------- ---------
                  81609218 20171221  --  -- ...          --           --       -- 217917514
                  23868624 20171221  --  -- ...          --           --       -- 296973171
@@ -592,11 +608,11 @@ The TESS Input Catalog (TIC), Disk Detective Catalog, and PanSTARRS Catalog can 
 .. code-block:: python
 
                 >>> from astroquery.mast import Catalogs
-                
+
                 >>> catalog_data = Catalogs.query_criteria(catalog="Ctl",
                 ...                                        objectname='M101', radius=1, Tmag=[10.75,11])
                 >>> print(catalog_data)
-                    ID    version  HIP     TYC      ... wdflag     ctlPriority        objID  
+                    ID    version  HIP     TYC      ... wdflag     ctlPriority        objID
                 --------- -------- --- ------------ ... ------ -------------------- ---------
                 441639577 20190415  -- 3852-00429-1 ...      0  0.00138923974233085 150848150
                 441662028 20190415  -- 3855-00941-1 ...      0  0.00100773800289492 151174508
@@ -607,16 +623,16 @@ The TESS Input Catalog (TIC), Disk Detective Catalog, and PanSTARRS Catalog can 
                 441659970 20190415  -- 3852-00505-1 ...      0 0.000894696498704202 151075682
                 441660006 20190415  -- 3852-00341-1 ...      0 0.000600037898043061 151075713
 
-     
+
 .. code-block:: python
 
                 >>> from astroquery.mast import Catalogs
-                
+
                 >>> catalog_data = Catalogs.query_criteria(catalog="DiskDetective",
                 ...                                        objectname="M10",radius=2,state="complete")
                 >>> print(catalog_data)
 
-                    designation     ...                    ZooniverseURL                    
+                    designation     ...                    ZooniverseURL
                 ------------------- ... ----------------------------------------------------
                 J165628.40-054630.8 ... https://talk.diskdetective.org/#/subjects/AWI0005cka
                 J165748.96-054915.4 ... https://talk.diskdetective.org/#/subjects/AWI0005ckd
@@ -672,7 +688,7 @@ Given an HSC Match ID, return all catalog results.
 .. code-block:: python
 
                 >>> from astroquery.mast import Catalogs
-                
+
                 >>> catalog_data = Catalogs.query_object("M10", radius=.02, catalog="HSC")
                 >>> matchid = catalog_data[0]["MatchID"]
                 >>> print(matchid)
@@ -682,7 +698,7 @@ Given an HSC Match ID, return all catalog results.
                 >>> matches = Catalogs.query_hsc_matchid(matchid)
                 >>> print(matches)
 
-                  CatID   MatchID  ...                       cd_matrix                       
+                  CatID   MatchID  ...                       cd_matrix
                 --------- -------- ... ------------------------------------------------------
                 303940283 17554326 ...   -1.10059e-005 6.90694e-010 6.90694e-010 1.10059e-005
                 303936256 17554326 ...   -1.10059e-005 6.90694e-010 6.90694e-010 1.10059e-005
@@ -694,12 +710,12 @@ Given an HSC Match ID, return all catalog results.
                 206507082 17554326 ... -1.38889e-005 -1.36001e-009 -1.36001e-009 1.38889e-005
 
 
-HSC spectra accessed through this class as well. `~astroquery.mast.CatalogsClass.get_hsc_spectra` does not take any arguments, and simply loads all HSC spectra. 
+HSC spectra accessed through this class as well. `~astroquery.mast.CatalogsClass.get_hsc_spectra` does not take any arguments, and simply loads all HSC spectra.
 
 .. code-block:: python
 
                 >>> from astroquery.mast import Catalogs
-                
+
                 >>> all_spectra = Catalogs.get_hsc_spectra()
                 >>> print(all_spectra[:10])
 
@@ -722,7 +738,7 @@ Individual or ranges of spectra can be downloaded using the `~astroquery.mast.Ca
 .. code-block:: python
 
                 >>> from astroquery.mast import Catalogs
-                
+
                 >>> all_spectra = Catalogs.get_hsc_spectra()
                 >>> manifest = Catalogs.download_hsc_spectra(all_spectra[100:104])
 
@@ -733,13 +749,13 @@ Individual or ranges of spectra can be downloaded using the `~astroquery.mast.Ca
 
                 >>> print(manifest)
 
-                                             Local Path                              ... URL 
+                                             Local Path                              ... URL
                 -------------------------------------------------------------------- ... ----
                 ./mastDownload/HSC/HAG_J072704.61+691530.3_J8HPAOZMQ_V01.SPEC1D.fits ... None
                 ./mastDownload/HSC/HAG_J072704.68+691535.9_J8HPAOZMQ_V01.SPEC1D.fits ... None
                 ./mastDownload/HSC/HAG_J072704.70+691530.2_J8HPAOZMQ_V01.SPEC1D.fits ... None
                 ./mastDownload/HSC/HAG_J072704.73+691808.0_J8HPAOZMQ_V01.SPEC1D.fits ... None
-                
+
 
 TESSCut
 =======
@@ -769,30 +785,30 @@ ccd a target pixel file will be produced for each one.
 
                 >>> from astroquery.mast import Tesscut
                 >>> from astropy.coordinates import SkyCoord
-                
+
                 >>> cutout_coord = SkyCoord(107.18696, -70.50919, unit="deg")
                 >>> hdulist = Tesscut.get_cutouts(coordinates=cutout_coord, size=5)
                 >>> hdulist[0].info()
                 Filename: <class '_io.BytesIO'>
                 No.    Name      Ver    Type      Cards   Dimensions   Format
-                  0  PRIMARY       1 PrimaryHDU      55   ()      
-                  1  PIXELS        1 BinTableHDU    279   1282R x 12C   [D, E, J, 25J, 25E, 25E, 25E, 25E, J, E, E, 38A]   
+                  0  PRIMARY       1 PrimaryHDU      55   ()
+                  1  PIXELS        1 BinTableHDU    279   1282R x 12C   [D, E, J, 25J, 25E, 25E, 25E, 25E, J, E, E, 38A]
                   2  APERTURE      1 ImageHDU        79   (5, 5)   int32
 
 
 .. code-block:: python
 
                 >>> from astroquery.mast import Tesscut
-                
+
                 >>> hdulist = Tesscut.get_cutouts(objectname="TIC 32449963", size=5)
                 >>> hdulist[0].info()
                 Filename: <class '_io.BytesIO'>
                 No.    Name      Ver    Type      Cards   Dimensions   Format
-                  0  PRIMARY       1 PrimaryHDU      56   ()      
-                  1  PIXELS        1 BinTableHDU    280   1211R x 12C   [D, E, J, 25J, 25E, 25E, 25E, 25E, J, E, E, 38A]   
-                  2  APERTURE      1 ImageHDU        80   (5, 5)   int32 
+                  0  PRIMARY       1 PrimaryHDU      56   ()
+                  1  PIXELS        1 BinTableHDU    280   1211R x 12C   [D, E, J, 25J, 25E, 25E, 25E, 25E, J, E, E, 38A]
+                  2  APERTURE      1 ImageHDU        80   (5, 5)   int32
 
-                
+
 The `~astroquery.mast.TesscutClass.download_cutouts` function takes a coordinate or object name
 (such as "M104" or "TIC 32449963") and cutout size (in pixels or an angular quantity) and
 downloads the cutout target pixel file(s).
@@ -806,14 +822,14 @@ a target pixel file will be produced for each one.
                 >>> from astroquery.mast import Tesscut
                 >>> from astropy.coordinates import SkyCoord
                 >>> import astropy.units as u
-                 
+
                 >>> cutout_coord = SkyCoord(107.18696, -70.50919, unit="deg")
                 >>> manifest = Tesscut.download_cutouts(coordinates=cutout_coord, size=[5, 7]*u.arcmin)
                 Downloading URL https://mast.stsci.edu/tesscut/api/v0.1/astrocut?ra=107.18696&dec=-70.50919&y=0.08333333333333333&x=0.11666666666666667&units=d&sector=1 to ./tesscut_20181102104719.zip ... [Done]
                 Inflating...
 
                 >>> print(manifest)
-                                      local_file                      
+                                      local_file
                 ------------------------------------------------------
                 ./tess-s0001-4-3_107.18696_-70.50919_14x21_astrocut.fits
 
@@ -826,7 +842,7 @@ To access sector information at a particular location there is  `~astroquery.mas
 
                 >>> from astroquery.mast import Tesscut
                 >>> from astropy.coordinates import SkyCoord
-                
+
                 >>> coord = SkyCoord(324.24368, -27.01029,unit="deg")
                 >>> sector_table = Tesscut.get_sectors(coordinates=coord)
                 >>> print(sector_table)
@@ -838,13 +854,13 @@ To access sector information at a particular location there is  `~astroquery.mas
 .. code-block:: python
 
                 >>> from astroquery.mast import Tesscut
-                
+
                 >>> sector_table = Tesscut.get_sectors(objectname="TIC 32449963")
                 >>> print(sector_table)
                   sectorName   sector camera ccd
                 -------------- ------ ------ ---
                 tess-s0010-1-4     10      1   4
-           
+
 
 Accessing Proprietary Data
 ==========================
@@ -861,7 +877,7 @@ To view tokens accessible through your account, visit https://auth.mast.stsci.ed
 .. code-block:: python
 
                 >>> from astroquery.mast import Observations
-                
+
                 >>> Observations.login(token="12348r9w0sa2392ff94as841")
 
                 INFO: MAST API token accepted, welcome User Name [astroquery.mast.core]
@@ -871,11 +887,11 @@ To view tokens accessible through your account, visit https://auth.mast.stsci.ed
                 eppn: user_name@stsci.edu
                 ezid: uname
                 ...
-              
+
 .. code-block:: python
 
                 >>> from astroquery.mast import Observations
-                
+
                 >>> my_session = Observations(token="12348r9w0sa2392ff94as841")
 
                 INFO: MAST API token accepted, welcome User Name [astroquery.mast.core]
@@ -898,7 +914,7 @@ This token can be overwritten using the ``reenter_token`` argument.
 To logout before a session expires, the `~astroquery.mast.MastClass.logout` method may be used.
 
 
-   
+
 Direct Mast Queries
 ===================
 
@@ -913,12 +929,12 @@ The basic MAST query function returns query results as an `~astropy.table.Table`
 .. code-block:: python
 
                 >>> from astroquery.mast import Mast
-                
+
                 >>> service = 'Mast.Caom.Cone'
                 >>> params = {'ra':184.3,
                 ...           'dec':54.5,
                 ...           'radius':0.2}
-        
+
                 >>> observations = Mast.service_request(service, params)
                 >>> print(observations)
 
@@ -939,12 +955,12 @@ In this case, the async method should be used to get the raw http response, whic
 .. code-block:: python
 
                 >>> from astroquery.mast import Mast
-                
+
                 >>> service = 'Mast.Name.Lookup'
                 >>> params ={'input':"M8",
                 ...          'format':'json'}
-        
-                >>> response = Mast.service_request_async(service,params)        
+
+                >>> response = Mast.service_request_async(service,params)
                 >>> result = response[0].json()
                 >>> print(result)
 
@@ -969,7 +985,7 @@ Additional Resources
 
 The Space Telescope Science Institute `Notebooks Repository <https://github.com/spacetelescope/notebooks>`_ includes many examples that use Astroquery.
 
-                 
+
 Reference/API
 =============
 


### PR DESCRIPTION
This PR adds the ability to download a single file using `Mast.Observations.download_file`, accepting a single MAST dataURI as input.  It essentially wraps the original content of `Mast.Observations._download_files` as I wanted to retain the potential cloud download option.  Rather than exposing `Mast.Observations._download_file` I decided to create a new method with simpler user inputs.