### PR TITLE
HEASARC: Add better error reporting for "no matches found"

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -29,6 +29,14 @@ Gemini
 - login() support for authenticated sessions to the GOA [#1778]
 - get_file() support for downloading files [#1778]
 
+
+heasarc
+^^^^^^^
+
+- A ``NoResultsWarning`` is now returned when there is no matching rows were
+  found in query. [#1829]
+
+
 SVO FPS
 ^^^^^^^
 

--- a/astroquery/heasarc/core.py
+++ b/astroquery/heasarc/core.py
@@ -1,5 +1,6 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 from __future__ import print_function
+import warnings
 from six import BytesIO
 from astropy.table import Table
 from astropy.io import fits
@@ -8,7 +9,7 @@ from astropy import units as u
 from ..query import BaseQuery
 from ..utils import commons
 from ..utils import async_to_sync
-from ..exceptions import InvalidQueryError
+from ..exceptions import InvalidQueryError, NoResultsWarning
 from . import conf
 
 __all__ = ['Heasarc', 'HeasarcClass']
@@ -219,7 +220,8 @@ class HeasarcClass(BaseQuery):
             raise InvalidQueryError("Unspecified error from HEASARC database. "
                                     "\nCheck error message: \n{!s}".format(response.text))
         elif "NO MATCHING ROWS" in response.text:
-            raise InvalidQueryError("No matching rows were found in the query.")
+            warnings.warn(NoResultsWarning("No matching rows were found in the query."))
+            return
 
         try:
             data = BytesIO(response.content)

--- a/astroquery/heasarc/core.py
+++ b/astroquery/heasarc/core.py
@@ -218,6 +218,8 @@ class HeasarcClass(BaseQuery):
         elif "Software error:" in response.text:
             raise InvalidQueryError("Unspecified error from HEASARC database. "
                                     "\nCheck error message: \n{!s}".format(response.text))
+        elif "NO MATCHING ROWS" in response.text:
+            raise InvalidQueryError("No matching rows were found in the query.")
 
         try:
             data = BytesIO(response.content)

--- a/astroquery/heasarc/core.py
+++ b/astroquery/heasarc/core.py
@@ -221,7 +221,7 @@ class HeasarcClass(BaseQuery):
                                     "\nCheck error message: \n{!s}".format(response.text))
         elif "NO MATCHING ROWS" in response.text:
             warnings.warn(NoResultsWarning("No matching rows were found in the query."))
-            return
+            return Table()
 
         try:
             data = BytesIO(response.content)


### PR DESCRIPTION
Partial fix for #1637.

The FIRST catalog seems to work if there are results in the table.

The ROSAT catalogs appear to be malformatted and are therefore not parsing as FITS tables.