### PR TITLE
Rename Single Letter Internal Variables: modules a-e

### DIFF
--- a/astroquery/alfalfa/core.py
+++ b/astroquery/alfalfa/core.py
@@ -9,7 +9,7 @@ from __future__ import print_function
 import requests
 import numpy as np
 import numpy.ma as ma
-from astropy import units
+from astropy import units as u
 from astropy import coordinates as coord
 from ..utils import commons, prepend_docstr_nosections
 from ..query import BaseQuery
@@ -89,7 +89,7 @@ class AlfalfaClass(BaseQuery):
 
         return catalog
 
-    def query_region(self, coordinates, radius=3. * units.arcmin,
+    def query_region(self, coordinates, radius=3. * u.arcmin,
                      optical_counterpart=False):
         """
         Perform object cross-ID in ALFALFA.

--- a/astroquery/alfalfa/core.py
+++ b/astroquery/alfalfa/core.py
@@ -9,7 +9,7 @@ from __future__ import print_function
 import requests
 import numpy as np
 import numpy.ma as ma
-from astropy import units as u
+from astropy import units
 from astropy import coordinates as coord
 from ..utils import commons, prepend_docstr_nosections
 from ..query import BaseQuery
@@ -59,9 +59,9 @@ class AlfalfaClass(BaseQuery):
             # skip blank lines or trailing newlines
             if line == "":
                 continue
-            l = line.rstrip('\n').split(',')
+            col_values = line.rstrip('\n').split(',')
             for i, col in enumerate(cols):
-                item = l[i].strip()
+                item = col_values[i].strip()
                 if item == '\"\"':
                     catalog[col].append(self.PLACEHOLDER)
                 elif item.isdigit():
@@ -89,7 +89,7 @@ class AlfalfaClass(BaseQuery):
 
         return catalog
 
-    def query_region(self, coordinates, radius=3. * u.arcmin,
+    def query_region(self, coordinates, radius=3. * units.arcmin,
                      optical_counterpart=False):
         """
         Perform object cross-ID in ALFALFA.

--- a/astroquery/alfalfa/tests/test_alfalfa.py
+++ b/astroquery/alfalfa/tests/test_alfalfa.py
@@ -18,8 +18,8 @@ class MockResponseAlfalfa(MockResponse):
         super(MockResponseAlfalfa, self).__init__(content, **kwargs)
 
     def iter_lines(self):
-        for l in self.text.split("\n"):
-            yield l
+        for line in self.text.split("\n"):
+            yield line
 
     def close(self):
         pass

--- a/astroquery/alma/core.py
+++ b/astroquery/alma/core.py
@@ -347,20 +347,20 @@ class AlmaClass(QueryWithLogin):
             legacy_result = Table()
             # add 'Observation date' column
 
-            for ii in _OBSCORE_TO_ALMARESULT:
-                if ii in result.columns:
-                    if ii == 't_min':
+            for col_name in _OBSCORE_TO_ALMARESULT:
+                if col_name in result.columns:
+                    if col_name == 't_min':
                         legacy_result['Observation date'] = \
                             [Time(_['t_min'], format='mjd').strftime(
                                 ALMA_DATE_FORMAT) for _ in result]
                     else:
-                        legacy_result[_OBSCORE_TO_ALMARESULT[ii]] = \
-                            result[ii]
+                        legacy_result[_OBSCORE_TO_ALMARESULT[col_name]] = \
+                            result[col_name]
                 else:
                     log.error("Invalid column mapping in OBSCORE_TO_ALMARESULT: "
                               "{}:{}.  Please "
                               "report this as an Issue."
-                              .format(ii, _OBSCORE_TO_ALMARESULT[ii]))
+                              .format(col_name, _OBSCORE_TO_ALMARESULT[col_name]))
             return legacy_result
         return result
 
@@ -588,14 +588,14 @@ class AlmaClass(QueryWithLogin):
         totalsize = 0 * u.B
         data_sizes = {}
         pb = ProgressBar(len(files))
-        for ii, fileLink in enumerate(files):
+        for index, fileLink in enumerate(files):
             response = self._request('HEAD', fileLink, stream=False,
                                      cache=False, timeout=self.TIMEOUT)
             filesize = (int(response.headers['content-length']) * u.B).to(u.GB)
             totalsize += filesize
             data_sizes[fileLink] = filesize
             log.debug("File {0}: size {1}".format(fileLink, filesize))
-            pb.update(ii + 1)
+            pb.update(index + 1)
             response.raise_for_status()
 
         return data_sizes, totalsize.to(u.GB)
@@ -1191,15 +1191,15 @@ def uid_json_to_table(jdata,
 
     def flatten_jdata(this_jdata, mousID=None):
         if isinstance(this_jdata, list):
-            for kk in this_jdata:
-                if kk['type'] in productlist:
-                    kk['mous_uid'] = mousID
-                    rows.append(kk)
-                elif len(kk['children']) > 0:
-                    if len(kk['allMousUids']) == 1:
-                        flatten_jdata(kk['children'], kk['allMousUids'][0])
+            for item in this_jdata:
+                if item['type'] in productlist:
+                    item['mous_uid'] = mousID
+                    rows.append(item)
+                elif len(item['children']) > 0:
+                    if len(item['allMousUids']) == 1:
+                        flatten_jdata(item['children'], item['allMousUids'][0])
                     else:
-                        flatten_jdata(kk['children'])
+                        flatten_jdata(item['children'])
 
     flatten_jdata(jdata['children'])
 

--- a/astroquery/alma/utils.py
+++ b/astroquery/alma/utils.py
@@ -137,7 +137,7 @@ def footprint_to_reg(footprint):
         reglist.append(reg)
 
     else:
-        polygons = [ii for ii, xx in enumerate(entries) if xx == 'Polygon']
+        polygons = [index for index, entry in enumerate(entries) if entry == 'Polygon']
 
         for start, stop in zip(polygons, polygons[1:]+[None]):
             reg = Shape('polygon', [float(x) for x in entries[start+1:stop] if x != 'ICRS'])

--- a/astroquery/besancon/core.py
+++ b/astroquery/besancon/core.py
@@ -247,11 +247,11 @@ class BesanconClass(BaseQuery):
         kwd['oo'][0] = absmag_limits[0]
         kwd['ff'][0] = absmag_limits[1]
 
-        for ii, (key, val) in enumerate(colors_limits.items()):
+        for index, (key, val) in enumerate(colors_limits.items()):
             if key[0] in mag_order and key[1] == '-' and key[2] in mag_order:
-                kwd['colind'][ii] = key
-                kwd['oo'][ii + 9] = val[0]
-                kwd['ff'][ii + 9] = val[1]
+                kwd['colind'][index] = key
+                kwd['oo'][index + 9] = val[0]
+                kwd['ff'][index + 9] = val[1]
             else:
                 raise ValueError('Invalid color %s' % key)
 
@@ -263,9 +263,9 @@ class BesanconClass(BaseQuery):
                 raise ValueError('Invalid band %s' % key)
 
         if clouds is not None:
-            for ii, (AV, di) in enumerate(clouds):
-                kwd['AV'][ii] = AV
-                kwd['di'][ii] = di
+            for index, (AV, di) in enumerate(clouds):
+                kwd['AV'][index] = AV
+                kwd['di'][index] = di
 
         # parse the default dictionary
         # request_data = parse_besancon_dict(keyword_defaults)
@@ -278,8 +278,8 @@ class BesanconClass(BaseQuery):
                         (isinstance(v, tuple) and len(v) > 1)):
                     if k in request_data:
                         del request_data[k]
-                    for ii, x in enumerate(v):
-                        request_data['%s[%i]' % (k, ii)] = x
+                    for index, val in enumerate(v):
+                        request_data['%s[%i]' % (k, index)] = val
 
         # an e-mail address is required
         request_data['email'] = email
@@ -326,12 +326,12 @@ def parse_besancon_dict(bd):
                 for listval in val:
                     http_dict.append((key, listval))
             else:
-                for ii, listval in enumerate(val):
+                for index, listval in enumerate(val):
                     if isinstance(listval, list):
-                        for jj, lv in enumerate(listval):
-                            http_dict.append((key + "[%i][%i]" % (ii, jj), lv))
+                        for inner_index, inner_listval in enumerate(listval):
+                            http_dict.append((key + "[%i][%i]" % (index, inner_index), inner_listval))
                     else:
-                        http_dict.append((key + "[%i]" % (ii), listval))
+                        http_dict.append((key + "[%i]" % (index), listval))
         else:
             http_dict.append((key, val))
 
@@ -379,7 +379,7 @@ def parse_besancon_model_string(bms,):
     # locate index of data start
     lines = bms.split('\n')
     nblanks1 = 0
-    for ii, line in enumerate(lines):
+    for index, line in enumerate(lines):
         if line.strip() == '':
             nblanks1 += 1
         if all([h in line for h in header_start]):
@@ -387,7 +387,7 @@ def parse_besancon_model_string(bms,):
 
     names = line.split()
     ncols = len(names)
-    header_line = ii
+    header_line = index
     # data starts 1 line after header
     first_data_line = lines[header_line + 1]
     # apparently ascii wants you to start 1 early though
@@ -397,7 +397,7 @@ def parse_besancon_model_string(bms,):
 
     # locate index of data end
     nblanks2 = 0
-    for jj, line in enumerate(lines[::-1]):
+    for data_index, line in enumerate(lines[::-1]):
         if "TOTAL NUMBER OF STARS :" in line:
             nstars = int(line.split()[-1])
         if line.strip() == '':
@@ -405,7 +405,7 @@ def parse_besancon_model_string(bms,):
         if all([h in line for h in header_start]):
             break
     # most likely = -7
-    data_end = -(jj - nblanks2 + 1)
+    data_end = -(data_index - nblanks2 + 1)
 
     # note: old col_starts/col_ends were:
     # (0,7,13,16,21,27,33,36,41,49,56,62,69,76,82,92,102,109)

--- a/astroquery/cadc/tests/test_cadctap.py
+++ b/astroquery/cadc/tests/test_cadctap.py
@@ -53,8 +53,8 @@ def test_get_tables():
     table_set = PropertyMock()
     table_set.keys.return_value = ['table1', 'table2']
     table_set.values.return_value = ['tab1val', 'tab2val', 'tab3val']
-    with patch('astroquery.cadc.core.pyvo.dal.TAPService', autospec=True) as m:
-        m.return_value.tables = table_set
+    with patch('astroquery.cadc.core.pyvo.dal.TAPService', autospec=True) as tapservice_mock:
+        tapservice_mock.return_value.tables = table_set
         cadc = Cadc()
         assert len(cadc.get_tables(only_names=True)) == 2
         assert len(cadc.get_tables()) == 3
@@ -71,8 +71,8 @@ def test_get_table():
     tables_result[2].name = 'tab3'
     table_set.values.return_value = tables_result
 
-    with patch('astroquery.cadc.core.pyvo.dal.TAPService', autospec=True) as m:
-        m.return_value.tables = table_set
+    with patch('astroquery.cadc.core.pyvo.dal.TAPService', autospec=True) as tapservice_mock:
+        tapservice_mock.return_value.tables = table_set
         cadc = Cadc()
         assert cadc.get_table('tab2').name == 'tab2'
         assert cadc.get_table('foo') is None
@@ -108,13 +108,13 @@ def test_get_collections():
        Mock(side_effect=lambda x: 'https://some.url'))
 @pytest.mark.skipif(not pyvo_OK, reason='not pyvo_OK')
 def test_load_async_job():
-    with patch('astroquery.cadc.core.pyvo.dal.TAPService', autospec=True) as t:
+    with patch('astroquery.cadc.core.pyvo.dal.TAPService', autospec=True) as tapservice_mock:
         with patch('astroquery.cadc.core.pyvo.dal.AsyncTAPJob',
-                   autospec=True) as j:
-            t.return_value.baseurl.return_value = 'https://www.example.com/tap'
+                   autospec=True) as tapjob_mock:
+            tapservice_mock.return_value.baseurl.return_value = 'https://www.example.com/tap'
             mock_job = Mock()
             mock_job.job_id = '123'
-            j.return_value = mock_job
+            tapjob_mock.return_value = mock_job
             cadc = Cadc()
             jobid = '123'
             job = cadc.load_async_job(jobid)
@@ -126,8 +126,8 @@ def test_load_async_job():
        Mock(side_effect=lambda x: 'https://some.url'))
 @pytest.mark.skipif(not pyvo_OK, reason='not pyvo_OK')
 def test_list_async_jobs():
-    with patch('astroquery.cadc.core.pyvo.dal.TAPService', autospec=True) as t:
-        t.return_value.baseurl.return_value = 'https://www.example.com/tap'
+    with patch('astroquery.cadc.core.pyvo.dal.TAPService', autospec=True) as tapservice_mock:
+        tapservice_mock.return_value.baseurl.return_value = 'https://www.example.com/tap'
         cadc = Cadc()
         cadc.list_async_jobs()
 
@@ -233,8 +233,8 @@ def test_get_data_urls():
     package_file = Mock()
     package_file.semantics = 'http://www.openadc.org/caom2#pkg'
     result = [file1, file2, file3, package_file]
-    with patch('pyvo.dal.adhoc.DatalinkResults.from_result_url') as m:
-        m.return_value = result
+    with patch('pyvo.dal.adhoc.DatalinkResults.from_result_url') as dl_results_mock:
+        dl_results_mock.return_value = result
         cadc = Cadc()
         cadc._request = get  # mock the request
         assert [file1.access_url] == \
@@ -322,8 +322,8 @@ def test_get_image_list():
     service_def_list = [service_def1, service_def2]
     result.bysemantics.return_value = service_def_list
 
-    with patch('pyvo.dal.adhoc.DatalinkResults.from_result_url') as m:
-        m.return_value = result
+    with patch('pyvo.dal.adhoc.DatalinkResults.from_result_url') as dl_results_mock:
+        dl_results_mock.return_value = result
         cadc = Cadc()
         cadc._request = get  # Mock the request
         url_list = cadc.get_image_list(
@@ -391,8 +391,8 @@ def test_exec_sync():
        Mock(side_effect=lambda x, y, z: ['https://some.url']))
 @pytest.mark.skipif(not pyvo_OK, reason='not pyvo_OK')
 def test_get_images():
-    with patch('astroquery.utils.commons.get_readable_fileobj', autospec=True) as t:
-        t.return_value = open(data_path('query_images.fits'), 'rb')
+    with patch('astroquery.utils.commons.get_readable_fileobj', autospec=True) as readable_fobj_mock:
+        readable_fobj_mock.return_value = open(data_path('query_images.fits'), 'rb')
 
         cadc = Cadc()
         fits_images = cadc.get_images('08h45m07.5s +54d18m00s', 0.01*u.deg,
@@ -409,8 +409,8 @@ def test_get_images():
        Mock(side_effect=lambda x, y, z: ['https://some.url']))
 @pytest.mark.skipif(not pyvo_OK, reason='not pyvo_OK')
 def test_get_images_async():
-    with patch('astroquery.utils.commons.get_readable_fileobj', autospec=True) as t:
-        t.return_value = open(data_path('query_images.fits'), 'rb')
+    with patch('astroquery.utils.commons.get_readable_fileobj', autospec=True) as readable_fobj_mock:
+        readable_fobj_mock.return_value = open(data_path('query_images.fits'), 'rb')
 
     cadc = Cadc()
     readable_objs = cadc.get_images_async('08h45m07.5s +54d18m00s',

--- a/astroquery/casda/core.py
+++ b/astroquery/casda/core.py
@@ -101,18 +101,18 @@ class CasdaClass(BaseQuery):
 
         # Convert the coordinates to FK5
         coordinates = kwargs.get('coordinates')
-        c = commons.parse_coordinates(coordinates).transform_to(coord.FK5)
+        fk5_coords = commons.parse_coordinates(coordinates).transform_to(coord.FK5)
 
         if kwargs['radius'] is not None:
             radius = u.Quantity(kwargs['radius']).to(u.deg)
-            pos = 'CIRCLE {} {} {}'.format(c.ra.degree, c.dec.degree, radius.value)
+            pos = 'CIRCLE {} {} {}'.format(fk5_coords.ra.degree, fk5_coords.dec.degree, radius.value)
         elif kwargs['width'] is not None and kwargs['height'] is not None:
             width = u.Quantity(kwargs['width']).to(u.deg).value
             height = u.Quantity(kwargs['height']).to(u.deg).value
-            top = c.dec.degree - (height/2)
-            bottom = c.dec.degree + (height/2)
-            left = c.ra.degree - (width/2)
-            right = c.ra.degree + (width/2)
+            top = fk5_coords.dec.degree - (height/2)
+            bottom = fk5_coords.dec.degree + (height/2)
+            left = fk5_coords.ra.degree - (width/2)
+            right = fk5_coords.ra.degree + (width/2)
             pos = 'RANGE {} {} {} {}'.format(left, right, top, bottom)
         else:
             raise ValueError("Either 'radius' or both 'height' and 'width' must be supplied.")
@@ -264,22 +264,22 @@ class CasdaClass(BaseQuery):
         authenticated_id_token = None
 
         # Find the authenticated id token for accessing the image cube
-        for x in results_array:
-            service_def = x['service_def']
+        for result in results_array:
+            service_def = result['service_def']
             if isinstance(service_def, bytes):
                 service_def = service_def.decode("utf8")
             if service_def == service_name:
-                authenticated_id_token = x['authenticated_id_token']
+                authenticated_id_token = result['authenticated_id_token']
                 if isinstance(service_def, bytes):
                     authenticated_id_token = authenticated_id_token.decode("utf8")
 
         # Find the async url
-        for x in votable.resources:
-            if x.type == "meta":
-                if x.ID == service_name:
-                    for p in x.params:
-                        if p.name == "accessURL":
-                            async_url = p.value
+        for resource in votable.resources:
+            if resource.type == "meta":
+                if resource.ID == service_name:
+                    for param in resource.params:
+                        if param.name == "accessURL":
+                            async_url = param.value
                             if isinstance(async_url, bytes):
                                 async_url = async_url.decode()
 

--- a/astroquery/cosmosim/core.py
+++ b/astroquery/cosmosim/core.py
@@ -259,10 +259,10 @@ class CosmoSimClass(QueryWithLogin):
         soup = BeautifulSoup(checkalljobs.content, "lxml")
         self.table_dict = {}
 
-        for i in soup.find_all({"uws:jobref"}):
-            jobid = i.get('xlink:href').split('/')[-1]
+        for tag in soup.find_all({"uws:jobref"}):
+            jobid = tag.get('xlink:href').split('/')[-1]
             if jobid in completed_jobs:
-                self.table_dict[jobid] = str(i.get('id'))
+                self.table_dict[jobid] = str(tag.get('id'))
 
     def check_job_status(self, jobid=None):
         """
@@ -329,13 +329,13 @@ class CosmoSimClass(QueryWithLogin):
         self.job_dict = {}
         soup = BeautifulSoup(checkalljobs.content, "lxml")
 
-        for i in soup.find_all({"uws:jobref"}):
-            i_phase = str(i.find('uws:phase').string)
-            if i_phase in ['COMPLETED', 'EXECUTING', 'ABORTED', 'ERROR']:
-                self.job_dict['{0}'.format(i.get('xlink:href')
-                                           .split('/')[-1])] = i_phase
+        for tag in soup.find_all({"uws:jobref"}):
+            tag_phase = str(tag.find('uws:phase').string)
+            if tag_phase in ['COMPLETED', 'EXECUTING', 'ABORTED', 'ERROR']:
+                self.job_dict['{0}'.format(tag.get('xlink:href')
+                                           .split('/')[-1])] = tag_phase
             else:
-                self.job_dict[str(i.get('id'))] = i_phase
+                self.job_dict[str(tag.get('id'))] = tag_phase
 
         if phase:
             phase = [phase[i].upper() for i in range(len(phase))]

--- a/astroquery/esa/hubble/core.py
+++ b/astroquery/esa/hubble/core.py
@@ -503,8 +503,8 @@ class ESAHubbleClass(BaseQuery):
             raise ValueError(str(msg) + ""
                              " must be either a string or astropy.coordinates")
         if isinstance(value, str):
-            c = commons.parse_coordinates(value)
-            return c
+            coords = commons.parse_coordinates(value)
+            return coords
         else:
             return value
 

--- a/astroquery/esa/hubble/tests/test_esa_hubble.py
+++ b/astroquery/esa/hubble/tests/test_esa_hubble.py
@@ -84,7 +84,7 @@ class TestESAHubble():
 
     @pytest.mark.remote_data
     def test_cone_search(self):
-        c = coordinates.SkyCoord("00h42m44.51s +41d16m08.45s", frame='icrs')
+        coords = coordinates.SkyCoord("00h42m44.51s +41d16m08.45s", frame='icrs')
 
         parameterst = {'query': "select top 10 * from hsc_v2.hubble_sc2",
                        'output_file': "test2.vot",
@@ -92,7 +92,7 @@ class TestESAHubble():
                        'verbose': False}
         dummyTapHandler = DummyHubbleTapHandler("launch_job", parameterst)
 
-        parameters = {'coordinates': c,
+        parameters = {'coordinates': coords,
                       'radius': 0.0,
                       'file_name': 'file_cone',
                       'output_format': 'votable',
@@ -113,7 +113,7 @@ class TestESAHubble():
 
     @pytest.mark.remote_data
     def test_cone_search_coords(self):
-        c = "00h42m44.51s +41d16m08.45s"
+        coords = "00h42m44.51s +41d16m08.45s"
 
         parameterst = {'query': "select top 10 * from hsc_v2.hubble_sc2",
                        'output_file': "test2.vot",
@@ -121,7 +121,7 @@ class TestESAHubble():
                        'verbose': False}
         dummyTapHandler = DummyHubbleTapHandler("launch_job", parameterst)
 
-        parameters = {'coordinates': c,
+        parameters = {'coordinates': coords,
                       'radius': 0.0,
                       'file_name': 'file_cone',
                       'output_format': 'votable',

--- a/astroquery/esa/xmm_newton/core.py
+++ b/astroquery/esa/xmm_newton/core.py
@@ -396,8 +396,8 @@ class XMMNewtonClass(BaseQuery):
                     log.warning("Invalid instrument %s" % i)
                     instrument.remove(i)
         with tarfile.open(filename, "r") as tar:
-            for i in tar.getmembers():
-                paths = os.path.split(i.name)
+            for member in tar.getmembers():
+                paths = os.path.split(member.name)
                 fname = paths[1]
                 paths = os.path.split(paths[0])
                 if paths[1] != "pps":
@@ -411,12 +411,12 @@ class XMMNewtonClass(BaseQuery):
                     continue
                 if not fname_info["T"] in _product_type:
                     continue
-                tar.extract(i, _path)
+                tar.extract(member, _path)
                 if not ret.get(int(fname_info["S"])):
                     ret[int(fname_info["S"])] = {}
                 b = int(fname_info["S"])
                 ins = fname_info["I"]
-                value = os.path.abspath(os.path.join(_path, i.name))
+                value = os.path.abspath(os.path.join(_path, member.name))
                 if fname_info["T"] == "DETMSK":
                     ins = fname_info["I"] + "_det"
                 elif fname_info["T"] == "EXPMAP":


### PR DESCRIPTION
This PR renames single letter internal variables as per issue #1572.

__Modules covered so far:__
- [x] alfalfa
- [x] alma
- [x] astrometry_net
- [x] atomic
- [x] besancon
- [x] cadc
- [x] casda
- [x] cds
- [x] cosmosim
- [x] dace
- [x] esa
- [x] esasky
- [x] eso
- [x] exoplanet_orbit_database