### PR TITLE
Remove python 2 __future__ syntax

### DIFF
--- a/astroquery/alfalfa/core.py
+++ b/astroquery/alfalfa/core.py
@@ -5,7 +5,7 @@ Affiliation: University of Colorado at Boulder
 Created on: Fri May  3 09:45:13 2013
 """
 
-from __future__ import print_function
+
 import requests
 import numpy as np
 import numpy.ma as ma

--- a/astroquery/alfalfa/tests/setup_package.py
+++ b/astroquery/alfalfa/tests/setup_package.py
@@ -1,5 +1,5 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
-from __future__ import absolute_import
+
 
 import os
 

--- a/astroquery/alma/core.py
+++ b/astroquery/alma/core.py
@@ -1,5 +1,5 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
-from __future__ import print_function
+
 import json
 import os.path
 import keyring

--- a/astroquery/alma/setup_package.py
+++ b/astroquery/alma/setup_package.py
@@ -1,5 +1,5 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
-from __future__ import absolute_import
+
 
 import os
 

--- a/astroquery/alma/tests/setup_package.py
+++ b/astroquery/alma/tests/setup_package.py
@@ -1,5 +1,5 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
-from __future__ import absolute_import
+
 
 import os
 

--- a/astroquery/astrometry_net/core.py
+++ b/astroquery/astrometry_net/core.py
@@ -1,5 +1,5 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
-from __future__ import print_function
+
 
 import json
 

--- a/astroquery/astrometry_net/tests/test_astrometry_net_remote.py
+++ b/astroquery/astrometry_net/tests/test_astrometry_net_remote.py
@@ -1,5 +1,5 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
-from __future__ import print_function
+
 
 import os
 

--- a/astroquery/atomic/setup_package.py
+++ b/astroquery/atomic/setup_package.py
@@ -1,4 +1,4 @@
-from __future__ import absolute_import
+
 
 import os.path
 

--- a/astroquery/besancon/core.py
+++ b/astroquery/besancon/core.py
@@ -1,5 +1,5 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
-from __future__ import print_function
+
 import socket
 import time
 import copy

--- a/astroquery/besancon/tests/setup_package.py
+++ b/astroquery/besancon/tests/setup_package.py
@@ -1,5 +1,5 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
-from __future__ import absolute_import
+
 
 import os
 

--- a/astroquery/cadc/tests/setup_package.py
+++ b/astroquery/cadc/tests/setup_package.py
@@ -1,5 +1,5 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
-from __future__ import absolute_import
+
 
 import os
 

--- a/astroquery/casda/tests/test_casda.py
+++ b/astroquery/casda/tests/test_casda.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*
 
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
-from __future__ import print_function
+
 
 import pytest
 import requests

--- a/astroquery/cosmosim/core.py
+++ b/astroquery/cosmosim/core.py
@@ -1,5 +1,5 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
-from __future__ import print_function
+
 
 import requests
 import warnings

--- a/astroquery/dace/core.py
+++ b/astroquery/dace/core.py
@@ -1,5 +1,5 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
-from __future__ import print_function
+
 from collections import defaultdict
 from json import JSONDecodeError
 from astropy.table import Table

--- a/astroquery/dace/tests/setup_package.py
+++ b/astroquery/dace/tests/setup_package.py
@@ -1,5 +1,5 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
-from __future__ import absolute_import
+
 
 import os
 

--- a/astroquery/esa/hubble/tests/setup_package.py
+++ b/astroquery/esa/hubble/tests/setup_package.py
@@ -1,5 +1,5 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
-from __future__ import absolute_import
+
 
 import os
 

--- a/astroquery/esa/xmm_newton/tests/setup_package.py
+++ b/astroquery/esa/xmm_newton/tests/setup_package.py
@@ -11,7 +11,6 @@ Created on 4 Sept. 2019
 """
 
 
-
 import os
 
 

--- a/astroquery/esa/xmm_newton/tests/setup_package.py
+++ b/astroquery/esa/xmm_newton/tests/setup_package.py
@@ -10,7 +10,7 @@ European Space Agency (ESA)
 Created on 4 Sept. 2019
 """
 
-from __future__ import absolute_import
+
 
 import os
 

--- a/astroquery/esasky/core.py
+++ b/astroquery/esasky/core.py
@@ -1,5 +1,5 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
-from __future__ import print_function
+
 import json
 import os
 import tempfile

--- a/astroquery/esasky/tests/setup_package.py
+++ b/astroquery/esasky/tests/setup_package.py
@@ -1,5 +1,5 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
-from __future__ import absolute_import
+
 
 import os
 

--- a/astroquery/esasky/tests/test_esasky.py
+++ b/astroquery/esasky/tests/test_esasky.py
@@ -1,5 +1,5 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
-from __future__ import print_function
+
 
 import pytest
 

--- a/astroquery/esasky/tests/test_esasky_remote.py
+++ b/astroquery/esasky/tests/test_esasky_remote.py
@@ -1,5 +1,5 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
-from __future__ import print_function
+
 import os
 import shutil
 import pytest

--- a/astroquery/eso/core.py
+++ b/astroquery/eso/core.py
@@ -1,5 +1,5 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
-from __future__ import print_function
+
 import time
 import sys
 import os.path

--- a/astroquery/eso/tests/setup_package.py
+++ b/astroquery/eso/tests/setup_package.py
@@ -1,5 +1,5 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
-from __future__ import absolute_import
+
 
 import os
 

--- a/astroquery/exoplanet_orbit_database/setup_package.py
+++ b/astroquery/exoplanet_orbit_database/setup_package.py
@@ -1,5 +1,5 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
-from __future__ import absolute_import
+
 
 import os
 

--- a/astroquery/fermi/core.py
+++ b/astroquery/fermi/core.py
@@ -1,6 +1,6 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 """Download of Fermi LAT (Large Area Telescope) data"""
-from __future__ import print_function
+
 import re
 import requests
 import time

--- a/astroquery/fermi/setup_package.py
+++ b/astroquery/fermi/setup_package.py
@@ -1,5 +1,5 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
-from __future__ import absolute_import
+
 
 import os
 

--- a/astroquery/fermi/tests/test_fermi.py
+++ b/astroquery/fermi/tests/test_fermi.py
@@ -1,5 +1,5 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
-from __future__ import print_function
+
 import os
 import requests
 import pytest

--- a/astroquery/fermi/tests/test_fermi_remote.py
+++ b/astroquery/fermi/tests/test_fermi_remote.py
@@ -1,5 +1,5 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
-from __future__ import print_function
+
 
 import pytest
 import astropy.coordinates as coord

--- a/astroquery/gaia/tests/setup_package.py
+++ b/astroquery/gaia/tests/setup_package.py
@@ -1,5 +1,5 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
-from __future__ import absolute_import
+
 
 import os
 

--- a/astroquery/gama/tests/setup_package.py
+++ b/astroquery/gama/tests/setup_package.py
@@ -1,5 +1,5 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
-from __future__ import absolute_import
+
 
 import os
 

--- a/astroquery/heasarc/core.py
+++ b/astroquery/heasarc/core.py
@@ -1,5 +1,5 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
-from __future__ import print_function
+
 import warnings
 from six import BytesIO
 from astropy.table import Table

--- a/astroquery/heasarc/tests/setup_package.py
+++ b/astroquery/heasarc/tests/setup_package.py
@@ -1,5 +1,5 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
-from __future__ import absolute_import
+
 
 import os
 

--- a/astroquery/heasarc/tests/test_heasarc.py
+++ b/astroquery/heasarc/tests/test_heasarc.py
@@ -1,2 +1,1 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
-

--- a/astroquery/heasarc/tests/test_heasarc.py
+++ b/astroquery/heasarc/tests/test_heasarc.py
@@ -1,2 +1,2 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
-from __future__ import print_function
+

--- a/astroquery/heasarc/tests/test_heasarc_remote.py
+++ b/astroquery/heasarc/tests/test_heasarc_remote.py
@@ -1,5 +1,5 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
-from __future__ import print_function
+
 
 import pytest
 import requests

--- a/astroquery/hitran/setup_package.py
+++ b/astroquery/hitran/setup_package.py
@@ -1,5 +1,5 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
-from __future__ import absolute_import
+
 
 import os
 

--- a/astroquery/ibe/core.py
+++ b/astroquery/ibe/core.py
@@ -7,7 +7,7 @@ API from
 
  http://irsa.ipac.caltech.edu/ibe/
 """
-from __future__ import print_function, division
+
 
 import os
 import webbrowser

--- a/astroquery/ibe/tests/setup_package.py
+++ b/astroquery/ibe/tests/setup_package.py
@@ -1,5 +1,5 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
-from __future__ import absolute_import
+
 
 import os
 

--- a/astroquery/ibe/tests/test_ibe.py
+++ b/astroquery/ibe/tests/test_ibe.py
@@ -1,5 +1,5 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
-from __future__ import print_function
+
 import os
 import requests
 

--- a/astroquery/imcce/core.py
+++ b/astroquery/imcce/core.py
@@ -1,5 +1,5 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
-from __future__ import print_function
+
 
 from collections import OrderedDict
 import warnings

--- a/astroquery/imcce/tests/setup_package.py
+++ b/astroquery/imcce/tests/setup_package.py
@@ -1,5 +1,5 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
-from __future__ import absolute_import
+
 
 import os
 

--- a/astroquery/imcce/tests/test_miriade.py
+++ b/astroquery/imcce/tests/test_miriade.py
@@ -1,5 +1,5 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
-from __future__ import print_function
+
 
 import pytest
 import os

--- a/astroquery/imcce/tests/test_miriade_remote.py
+++ b/astroquery/imcce/tests/test_miriade_remote.py
@@ -1,5 +1,5 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
-from __future__ import print_function
+
 
 import numpy.testing as npt
 import pytest

--- a/astroquery/irsa/core.py
+++ b/astroquery/irsa/core.py
@@ -98,7 +98,7 @@ If onlist=0, the following parameters are required:
                         equal to available to be retrieved rows under the same
                         constraints.
 """
-from __future__ import print_function, division
+
 
 import warnings
 import xml.etree.ElementTree as tree

--- a/astroquery/irsa/tests/setup_package.py
+++ b/astroquery/irsa/tests/setup_package.py
@@ -1,5 +1,5 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
-from __future__ import absolute_import
+
 
 import os
 

--- a/astroquery/irsa/tests/test_irsa.py
+++ b/astroquery/irsa/tests/test_irsa.py
@@ -1,5 +1,5 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
-from __future__ import print_function
+
 import os
 import re
 import requests

--- a/astroquery/irsa/tests/test_irsa_remote.py
+++ b/astroquery/irsa/tests/test_irsa_remote.py
@@ -1,5 +1,5 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
-from __future__ import print_function
+
 
 import pytest
 import astropy.units as u

--- a/astroquery/irsa_dust/tests/setup_package.py
+++ b/astroquery/irsa_dust/tests/setup_package.py
@@ -1,5 +1,5 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
-from __future__ import absolute_import
+
 
 import os
 

--- a/astroquery/jplhorizons/core.py
+++ b/astroquery/jplhorizons/core.py
@@ -1,5 +1,5 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
-from __future__ import print_function
+
 
 # 1. standard library imports
 from numpy import nan

--- a/astroquery/jplhorizons/tests/setup_package.py
+++ b/astroquery/jplhorizons/tests/setup_package.py
@@ -1,5 +1,5 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
-from __future__ import absolute_import
+
 
 import os
 

--- a/astroquery/jplhorizons/tests/test_jplhorizons.py
+++ b/astroquery/jplhorizons/tests/test_jplhorizons.py
@@ -1,5 +1,5 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
-from __future__ import print_function
+
 
 import pytest
 import os

--- a/astroquery/jplhorizons/tests/test_jplhorizons_remote.py
+++ b/astroquery/jplhorizons/tests/test_jplhorizons_remote.py
@@ -1,5 +1,5 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
-from __future__ import print_function
+
 
 import pytest
 from astropy.tests.helper import assert_quantity_allclose

--- a/astroquery/jplsbdb/tests/setup_package.py
+++ b/astroquery/jplsbdb/tests/setup_package.py
@@ -1,5 +1,5 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
-from __future__ import absolute_import
+
 
 import os
 

--- a/astroquery/jplspec/setup_package.py
+++ b/astroquery/jplspec/setup_package.py
@@ -1,5 +1,5 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
-from __future__ import absolute_import
+
 
 import os
 

--- a/astroquery/lamda/tests/setup_package.py
+++ b/astroquery/lamda/tests/setup_package.py
@@ -1,5 +1,5 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
-from __future__ import absolute_import
+
 
 import os
 

--- a/astroquery/lcogt/core.py
+++ b/astroquery/lcogt/core.py
@@ -70,7 +70,7 @@ constraint  Optional    User defined query constraint(s)
                         Note: The constraint should follow SQL syntax.
 
 """
-from __future__ import print_function, division
+
 
 import warnings
 from astropy.logger import log

--- a/astroquery/lcogt/tests/setup_package.py
+++ b/astroquery/lcogt/tests/setup_package.py
@@ -1,5 +1,5 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
-from __future__ import absolute_import
+
 
 import os
 

--- a/astroquery/lcogt/tests/test_lcogt.py
+++ b/astroquery/lcogt/tests/test_lcogt.py
@@ -1,5 +1,5 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
-from __future__ import print_function
+
 import os
 import re
 import numpy as np

--- a/astroquery/lcogt/tests/test_lcogt_remote.py
+++ b/astroquery/lcogt/tests/test_lcogt_remote.py
@@ -1,5 +1,5 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
-from __future__ import print_function
+
 
 import pytest
 

--- a/astroquery/magpis/core.py
+++ b/astroquery/magpis/core.py
@@ -1,5 +1,5 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
-from __future__ import print_function
+
 from io import BytesIO
 import astropy.units as u
 import astropy.coordinates as coord

--- a/astroquery/magpis/tests/setup_package.py
+++ b/astroquery/magpis/tests/setup_package.py
@@ -1,5 +1,5 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
-from __future__ import absolute_import
+
 
 import os
 

--- a/astroquery/magpis/tests/test_magpis.py
+++ b/astroquery/magpis/tests/test_magpis.py
@@ -1,5 +1,5 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
-from __future__ import print_function
+
 
 import os
 

--- a/astroquery/magpis/tests/test_magpis_remote.py
+++ b/astroquery/magpis/tests/test_magpis_remote.py
@@ -1,5 +1,5 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
-from __future__ import print_function
+
 
 import pytest
 import astropy.units as u

--- a/astroquery/mast/cutouts.py
+++ b/astroquery/mast/cutouts.py
@@ -8,7 +8,7 @@ Cutout queries on TESS FFIs.
 
 """
 
-from __future__ import print_function, division
+
 
 import warnings
 import time

--- a/astroquery/mast/cutouts.py
+++ b/astroquery/mast/cutouts.py
@@ -9,7 +9,6 @@ Cutout queries on TESS FFIs.
 """
 
 
-
 import warnings
 import time
 import json

--- a/astroquery/mast/tests/test_mast.py
+++ b/astroquery/mast/tests/test_mast.py
@@ -1,5 +1,5 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
-from __future__ import print_function
+
 
 import os
 import re

--- a/astroquery/mast/tests/test_mast_remote.py
+++ b/astroquery/mast/tests/test_mast_remote.py
@@ -1,5 +1,5 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
-from __future__ import print_function
+
 
 import numpy as np
 import os

--- a/astroquery/nasa_exoplanet_archive/core.py
+++ b/astroquery/nasa_exoplanet_archive/core.py
@@ -1,5 +1,5 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
-from __future__ import print_function
+
 
 import copy
 import io

--- a/astroquery/nasa_exoplanet_archive/tests/setup_package.py
+++ b/astroquery/nasa_exoplanet_archive/tests/setup_package.py
@@ -1,5 +1,5 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
-from __future__ import absolute_import
+
 
 import os
 

--- a/astroquery/nasa_exoplanet_archive/tests/test_nasa_exoplanet_archive.py
+++ b/astroquery/nasa_exoplanet_archive/tests/test_nasa_exoplanet_archive.py
@@ -1,5 +1,5 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
-from __future__ import print_function
+
 
 import json
 import os

--- a/astroquery/nasa_exoplanet_archive/tests/test_nasa_exoplanet_archive_remote.py
+++ b/astroquery/nasa_exoplanet_archive/tests/test_nasa_exoplanet_archive_remote.py
@@ -1,5 +1,5 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
-from __future__ import print_function
+
 
 import pytest
 

--- a/astroquery/ned/core.py
+++ b/astroquery/ned/core.py
@@ -1,5 +1,5 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
-from __future__ import print_function
+
 
 import re
 from collections import namedtuple

--- a/astroquery/ned/setup_package.py
+++ b/astroquery/ned/setup_package.py
@@ -1,5 +1,5 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
-from __future__ import absolute_import
+
 
 import os
 

--- a/astroquery/ned/tests/test_ned.py
+++ b/astroquery/ned/tests/test_ned.py
@@ -1,5 +1,5 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
-from __future__ import print_function
+
 
 import os
 

--- a/astroquery/ned/tests/test_ned_remote.py
+++ b/astroquery/ned/tests/test_ned_remote.py
@@ -1,5 +1,5 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
-from __future__ import print_function
+
 
 import pytest
 from astropy.table import Table

--- a/astroquery/nist/core.py
+++ b/astroquery/nist/core.py
@@ -1,5 +1,5 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
-from __future__ import print_function
+
 
 import re
 

--- a/astroquery/nist/tests/setup_package.py
+++ b/astroquery/nist/tests/setup_package.py
@@ -1,5 +1,5 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
-from __future__ import absolute_import
+
 
 import os
 

--- a/astroquery/nist/tests/test_nist_remote.py
+++ b/astroquery/nist/tests/test_nist_remote.py
@@ -1,5 +1,5 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
-from __future__ import print_function
+
 
 import numpy as np
 

--- a/astroquery/noirlab/tests/test_noirlab_remote.py
+++ b/astroquery/noirlab/tests/test_noirlab_remote.py
@@ -1,6 +1,6 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 # Python library
-from __future__ import print_function
+
 # External packages
 from astropy import units as u
 from astropy.coordinates import SkyCoord

--- a/astroquery/nrao/core.py
+++ b/astroquery/nrao/core.py
@@ -1,5 +1,5 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
-from __future__ import print_function
+
 
 import re
 import os

--- a/astroquery/nrao/tests/setup_package.py
+++ b/astroquery/nrao/tests/setup_package.py
@@ -1,5 +1,5 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
-from __future__ import absolute_import
+
 
 import os
 

--- a/astroquery/nrao/tests/test_nrao.py
+++ b/astroquery/nrao/tests/test_nrao.py
@@ -1,5 +1,5 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
-from __future__ import print_function
+
 import os
 import requests
 

--- a/astroquery/nrao/tests/test_nrao_remote.py
+++ b/astroquery/nrao/tests/test_nrao_remote.py
@@ -1,5 +1,5 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
-from __future__ import print_function
+
 
 import pytest
 import astropy.coordinates as coord

--- a/astroquery/nvas/core.py
+++ b/astroquery/nvas/core.py
@@ -1,5 +1,5 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
-from __future__ import print_function
+
 
 import re
 

--- a/astroquery/nvas/tests/setup_package.py
+++ b/astroquery/nvas/tests/setup_package.py
@@ -1,5 +1,5 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
-from __future__ import absolute_import
+
 
 import os
 

--- a/astroquery/nvas/tests/test_nvas.py
+++ b/astroquery/nvas/tests/test_nvas.py
@@ -1,5 +1,5 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
-from __future__ import print_function
+
 
 import os
 import re

--- a/astroquery/nvas/tests/test_nvas_remote.py
+++ b/astroquery/nvas/tests/test_nvas_remote.py
@@ -1,5 +1,5 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
-from __future__ import print_function
+
 
 import pytest
 import astropy.units as u

--- a/astroquery/oac/core.py
+++ b/astroquery/oac/core.py
@@ -8,7 +8,7 @@ see: https://api.astrocats.space.
 :authors: Philip S. Cowperthwaite (pcowpert@cfa.harvard.edu)
 and James Guillochon (jguillochon@cfa.harvard.edu)
 """
-from __future__ import print_function
+
 
 import json
 import csv

--- a/astroquery/oac/tests/setup_package.py
+++ b/astroquery/oac/tests/setup_package.py
@@ -1,5 +1,5 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
-from __future__ import absolute_import
+
 
 import os
 

--- a/astroquery/oac/tests/test_oac_remote.py
+++ b/astroquery/oac/tests/test_oac_remote.py
@@ -1,5 +1,5 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
-from __future__ import print_function
+
 
 import pytest
 

--- a/astroquery/ogle/core.py
+++ b/astroquery/ogle/core.py
@@ -1,5 +1,5 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
-from __future__ import print_function
+
 
 import warnings
 import functools

--- a/astroquery/ogle/tests/setup_package.py
+++ b/astroquery/ogle/tests/setup_package.py
@@ -1,5 +1,5 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
-from __future__ import absolute_import
+
 
 import os
 

--- a/astroquery/open_exoplanet_catalogue/tests/setup_package.py
+++ b/astroquery/open_exoplanet_catalogue/tests/setup_package.py
@@ -1,5 +1,5 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
-from __future__ import absolute_import
+
 
 import os
 

--- a/astroquery/sdss/tests/setup_package.py
+++ b/astroquery/sdss/tests/setup_package.py
@@ -1,5 +1,5 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
-from __future__ import absolute_import
+
 
 import os
 

--- a/astroquery/setup_package.py
+++ b/astroquery/setup_package.py
@@ -1,6 +1,5 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 
 
-
 def get_package_data():
     return {'astroquery': ['astroquery.cfg', 'CITATION']}

--- a/astroquery/setup_package.py
+++ b/astroquery/setup_package.py
@@ -1,5 +1,5 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
-from __future__ import absolute_import
+
 
 
 def get_package_data():

--- a/astroquery/sha/tests/setup_package.py
+++ b/astroquery/sha/tests/setup_package.py
@@ -1,5 +1,5 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
-from __future__ import absolute_import
+
 
 import os
 

--- a/astroquery/simbad/core.py
+++ b/astroquery/simbad/core.py
@@ -2,7 +2,7 @@
 """
 Simbad query class for accessing the Simbad Service
 """
-from __future__ import print_function
+
 import copy
 import re
 import requests

--- a/astroquery/simbad/get_votable_fields.py
+++ b/astroquery/simbad/get_votable_fields.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
-from __future__ import print_function
+
 import re
 import json
 import astropy.utils.data as aud

--- a/astroquery/simbad/setup_package.py
+++ b/astroquery/simbad/setup_package.py
@@ -1,5 +1,5 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
-from __future__ import absolute_import
+
 
 import os
 

--- a/astroquery/skyview/setup_package.py
+++ b/astroquery/skyview/setup_package.py
@@ -1,5 +1,5 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
-from __future__ import absolute_import
+
 
 import os
 

--- a/astroquery/splatalogue/setup_package.py
+++ b/astroquery/splatalogue/setup_package.py
@@ -1,5 +1,5 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
-from __future__ import absolute_import
+
 
 import os
 

--- a/astroquery/svo_fps/tests/setup_package.py
+++ b/astroquery/svo_fps/tests/setup_package.py
@@ -1,5 +1,5 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
-from __future__ import absolute_import
+
 
 import os
 

--- a/astroquery/template_module/core.py
+++ b/astroquery/template_module/core.py
@@ -1,5 +1,5 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
-from __future__ import print_function
+
 
 # put all imports organized as shown below
 # 1. standard library imports

--- a/astroquery/template_module/tests/setup_package.py
+++ b/astroquery/template_module/tests/setup_package.py
@@ -1,5 +1,5 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
-from __future__ import absolute_import
+
 
 import os
 

--- a/astroquery/template_module/tests/test_module.py
+++ b/astroquery/template_module/tests/test_module.py
@@ -1,5 +1,5 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
-from __future__ import print_function
+
 
 # astroquery uses the pytest framework for testing
 # this is already available in astropy and does

--- a/astroquery/template_module/tests/test_module_remote.py
+++ b/astroquery/template_module/tests/test_module_remote.py
@@ -1,5 +1,5 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
-from __future__ import print_function
+
 
 # performs similar tests as test_module.py, but performs
 # the actual HTTP request rather than monkeypatching them.

--- a/astroquery/tests/setup_package.py
+++ b/astroquery/tests/setup_package.py
@@ -1,7 +1,6 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 
 
-
 def get_package_data():
     return {
         _ASTROPY_PACKAGE_NAME_ + '.tests': ['coveragerc']}

--- a/astroquery/tests/setup_package.py
+++ b/astroquery/tests/setup_package.py
@@ -1,5 +1,5 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
-from __future__ import absolute_import
+
 
 
 def get_package_data():

--- a/astroquery/ukidss/core.py
+++ b/astroquery/ukidss/core.py
@@ -1,5 +1,5 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
-from __future__ import print_function
+
 
 from . import conf
 

--- a/astroquery/ukidss/tests/setup_package.py
+++ b/astroquery/ukidss/tests/setup_package.py
@@ -1,5 +1,5 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
-from __future__ import absolute_import
+
 
 import os
 

--- a/astroquery/ukidss/tests/test_ukidss_remote.py
+++ b/astroquery/ukidss/tests/test_ukidss_remote.py
@@ -1,5 +1,5 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
-from __future__ import print_function
+
 
 import pytest
 import astropy.units as u

--- a/astroquery/utils/decorators.py
+++ b/astroquery/utils/decorators.py
@@ -1,4 +1,4 @@
-from __future__ import print_function
+
 
 import warnings
 import functools

--- a/astroquery/utils/system_tools.py
+++ b/astroquery/utils/system_tools.py
@@ -1,5 +1,5 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
-from __future__ import print_function
+
 import os
 
 # Import DEVNULL for py3 or py3

--- a/astroquery/utils/tap/conn/tests/setup_package.py
+++ b/astroquery/utils/tap/conn/tests/setup_package.py
@@ -14,7 +14,7 @@ Created on 30 jun. 2016
 
 
 """
-from __future__ import absolute_import
+
 
 import os
 

--- a/astroquery/utils/tap/model/tests/setup_package.py
+++ b/astroquery/utils/tap/model/tests/setup_package.py
@@ -14,7 +14,7 @@ Created on 30 jun. 2016
 
 
 """
-from __future__ import absolute_import
+
 
 import os
 

--- a/astroquery/utils/tap/tests/setup_package.py
+++ b/astroquery/utils/tap/tests/setup_package.py
@@ -14,7 +14,7 @@ Created on 30 jun. 2016
 
 
 """
-from __future__ import absolute_import
+
 
 import os
 

--- a/astroquery/utils/tap/xmlparser/tests/setup_package.py
+++ b/astroquery/utils/tap/xmlparser/tests/setup_package.py
@@ -14,7 +14,7 @@ Created on 30 jun. 2016
 
 
 """
-from __future__ import absolute_import
+
 
 import os
 

--- a/astroquery/utils/testing_tools.py
+++ b/astroquery/utils/testing_tools.py
@@ -1,5 +1,5 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
-from __future__ import print_function
+
 import socket
 
 import pytest

--- a/astroquery/vamdc/core.py
+++ b/astroquery/vamdc/core.py
@@ -1,5 +1,5 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
-from __future__ import print_function
+
 
 import os.path
 import warnings

--- a/astroquery/vamdc/tests/setup_package.py
+++ b/astroquery/vamdc/tests/setup_package.py
@@ -1,5 +1,5 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
-from __future__ import absolute_import
+
 
 import os
 

--- a/astroquery/vamdc/tests/test_vamdc.py
+++ b/astroquery/vamdc/tests/test_vamdc.py
@@ -1,5 +1,5 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
-from __future__ import print_function
+
 
 import os
 

--- a/astroquery/vamdc/tests/test_vamdc_remote.py
+++ b/astroquery/vamdc/tests/test_vamdc_remote.py
@@ -1,5 +1,5 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
-from __future__ import print_function
+
 
 # performs similar tests as test_module.py, but performs
 # the actual HTTP request rather than monkeypatching them.

--- a/astroquery/vizier/core.py
+++ b/astroquery/vizier/core.py
@@ -1,5 +1,5 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
-from __future__ import print_function
+
 
 import os
 import warnings

--- a/astroquery/vizier/setup_package.py
+++ b/astroquery/vizier/setup_package.py
@@ -1,5 +1,5 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
-from __future__ import absolute_import
+
 
 import os
 

--- a/astroquery/vsa/core.py
+++ b/astroquery/vsa/core.py
@@ -1,5 +1,5 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
-from __future__ import print_function
+
 
 from . import conf
 from ..wfau import BaseWFAUClass, clean_catalog

--- a/astroquery/vsa/tests/test_vista_remote.py
+++ b/astroquery/vsa/tests/test_vista_remote.py
@@ -1,5 +1,5 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
-from __future__ import print_function
+
 
 import pytest
 

--- a/astroquery/wfau/core.py
+++ b/astroquery/wfau/core.py
@@ -1,5 +1,5 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
-from __future__ import print_function
+
 
 import warnings
 import re

--- a/astroquery/xmatch/setup_package.py
+++ b/astroquery/xmatch/setup_package.py
@@ -1,5 +1,5 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
-from __future__ import absolute_import
+
 
 import os
 


### PR DESCRIPTION
This PR removes the use of `from __future__ ` usages in the codebase. I'm using the `2to3` translator which comes with the python interpreter as a script. By default it uses a lot of fixers which made changes I wasn't sure is what we want. For example this line 

```python
print('Some text', someobject.name)
```

was replaced with

```python
print(('Some text', someobject.name))
```

And also calls to the `items()` method of dictionaries were wrapped arounded the `list()` function. While all these are valid code, I just don't see the point and felt like these will just increase code review time. What are your thoughts on these modifications and is there another approach to removing all python2 code in a sensible way?

I'm not adding the closes section of this PR because I don't want the issue to be closed when this PR gets merged as it doesn't resolve the ticket completely.