### PR TITLE
Comment api_key in the default config file

### DIFF
--- a/astroquery/astroquery.cfg
+++ b/astroquery/astroquery.cfg
@@ -207,4 +207,4 @@
 [astrometry_net]
 
 # The Astrometry.net API key
-api_key =
+#api_key =


### PR DESCRIPTION
Having this key defined breaks the detection of unmodified config file.

Related to (proposed) changes to `astropy.config` (https://github.com/astropy/astropy/pull/10877, https://github.com/astropy/astropy/pull/10893). If this key is not commented, the detection of unmodified config file does not work, unless the config file is strictly the same as the default one.