### PR TITLE
Bug: ALMA queries with lon, lat instead of RA, dec

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -92,6 +92,9 @@ alma
 - The archive query interface has been deprecated in favour of
   VirtualObservatory (VO) services such as TAP, ObsCore etc. The alma
   library has been updated accordingly. [#1689]
+- ALMA queries using string representations will now convert to appropriate
+  coordinates before being sent to the server; previously they were treated as
+  whatever unit they were presented in.  [#1867]
 
 gaia
 ^^^^

--- a/astroquery/alma/core.py
+++ b/astroquery/alma/core.py
@@ -267,7 +267,7 @@ class AlmaClass(QueryWithLogin):
         rad = radius
         if not isinstance(radius, u.Quantity):
             rad = radius*u.deg
-        obj_coord = commons.parse_coordinates(coordinate)
+        obj_coord = commons.parse_coordinates(coordinate).fk5
         ra_dec = '{}, {}'.format(obj_coord.to_string(), rad.to(u.deg).value)
         if payload is None:
             payload = {}

--- a/astroquery/alma/core.py
+++ b/astroquery/alma/core.py
@@ -309,8 +309,7 @@ class AlmaClass(QueryWithLogin):
 
         for arg in local_args:
             # check if the deprecated attributes have been used
-            for deprecated in ['cache', 'max_retries', 'get_html_version',
-                               'get_query_payload']:
+            for deprecated in ['cache', 'max_retries', 'get_html_version']:
                 if arg[0] == deprecated and arg[1] is not None:
                     warnings.warn(
                         ("Argument '{}' has been deprecated "
@@ -337,6 +336,10 @@ class AlmaClass(QueryWithLogin):
                 payload['public_data'] = True
             else:
                 payload['public_data'] = False
+
+        if get_query_payload:
+            return payload
+
         query = _gen_sql(payload)
         result = self.query_tap(query, **kwargs)
         if result:

--- a/astroquery/alma/core.py
+++ b/astroquery/alma/core.py
@@ -267,7 +267,7 @@ class AlmaClass(QueryWithLogin):
         rad = radius
         if not isinstance(radius, u.Quantity):
             rad = radius*u.deg
-        obj_coord = commons.parse_coordinates(coordinate).fk5
+        obj_coord = commons.parse_coordinates(coordinate).icrs
         ra_dec = '{}, {}'.format(obj_coord.to_string(), rad.to(u.deg).value)
         if payload is None:
             payload = {}

--- a/astroquery/alma/tests/test_alma.py
+++ b/astroquery/alma/tests/test_alma.py
@@ -373,3 +373,21 @@ def test_tap():
 
     tap_mock.search.assert_called_once_with('select * from ivoa.ObsCore',
                                             language='ADQL')
+
+def test_galactic_query():
+    """
+    regression test for 1867
+    """
+    tap_mock = Mock()
+    empty_result = Table.read(os.path.join(DATA_DIR, 'alma-empty.txt'),
+                              format='ascii')
+    mock_result = Mock()
+    mock_result.to_table.return_value = empty_result
+    tap_mock.search.return_value = mock_result
+    alma = Alma()
+    alma._get_dataarchive_url = Mock()
+    alma._tap = tap_mock
+    result = alma.query_region(SkyCoord(0*u.deg, 0*u.deg, frame='galactic'),
+                               radius=1*u.deg, get_query_payload=True)
+
+    assert result['ra_dec'] == SkyCoord(0*u.deg, 0*u.deg, frame='galactic').icrs.to_string() + ", 1.0"

--- a/astroquery/alma/tests/test_alma.py
+++ b/astroquery/alma/tests/test_alma.py
@@ -243,7 +243,8 @@ def test_query():
     alma = Alma()
     alma._get_dataarchive_url = Mock()
     alma._tap = tap_mock
-    result = alma.query_region('1 2', radius=1*u.deg)
+    result = alma.query_region(SkyCoord(1*u.deg, 2*u.deg, frame='fk5'),
+                               radius=1*u.deg)
     assert len(result) == 0
     assert 'proposal_id' in result.columns
     tap_mock.search.assert_called_once_with(

--- a/astroquery/alma/tests/test_alma.py
+++ b/astroquery/alma/tests/test_alma.py
@@ -374,6 +374,7 @@ def test_tap():
     tap_mock.search.assert_called_once_with('select * from ivoa.ObsCore',
                                             language='ADQL')
 
+
 def test_galactic_query():
     """
     regression test for 1867

--- a/astroquery/alma/tests/test_alma.py
+++ b/astroquery/alma/tests/test_alma.py
@@ -243,7 +243,7 @@ def test_query():
     alma = Alma()
     alma._get_dataarchive_url = Mock()
     alma._tap = tap_mock
-    result = alma.query_region(SkyCoord(1*u.deg, 2*u.deg, frame='fk5'),
+    result = alma.query_region(SkyCoord(1*u.deg, 2*u.deg, frame='icrs'),
                                radius=1*u.deg)
     assert len(result) == 0
     assert 'proposal_id' in result.columns


### PR DESCRIPTION
ALMA queries were using SkyCoord's string representation without converting to RA/Dec first.  This is a simple bugfix.