### PR TITLE
MAST user survey banner

### DIFF
--- a/docs/mast/mast.rst
+++ b/docs/mast/mast.rst
@@ -6,6 +6,11 @@
 MAST Queries (`astroquery.mast`)
 ********************************
 
+.. raw:: html
+
+         <div class="service-status mast-survey" id="survey-banner" style="background-color: #C75109; border-color: #C75109; color: white; padding-top: 1rem; padding-bottom: 1rem; line-height: 30px; font-size: x-large; display: flex; margin-left: 0rem; margin-right: 0rem; margin-bottom: 1rem; margin-top: 1rem;"><span class="status-message" style="margin-left: 2rem; margin-right: 2rem;">The MAST team wants your feedback on the <a href="https://www.surveymonkey.com/r/mastportal" target="_blank" style="color: white; text-decoration: underline;">MAST Portal</a> and <a href="https://www.surveymonkey.com/r/mastcatalogs" target="_blank" style="color: white; text-decoration: underline;">MAST catalogs</a>. If you use either of these, please take five to ten minutes to fill out the linked survey(s). Thank you!</span></div>
+
+
 Getting Started
 ===============
 


### PR DESCRIPTION
The MAST archive is running some user surveys and would like to get feedback from API users, not just web interface users. The PR adds a banner to the top of the MAST documentation page leading users to the relevant user surveys. The banner will be taken down when the survey is done.