### PR TITLE
class astroquery inherits from object, can be safely removed from bases in python3(useless object inheritence)

### DIFF
--- a/astroquery/query.py
+++ b/astroquery/query.py
@@ -34,7 +34,7 @@ def _replace_none_iterable(iterable):
     return tuple('' if i is None else i for i in iterable)
 
 
-class AstroQuery(object):
+class AstroQuery:
 
     def __init__(self, method, url,
                  params=None, data=None, headers=None,


### PR DESCRIPTION
Hello @bsipocz ,
I am an outreachy applicant. This is in reference to issue ::Cleanup python2 #1870. class astroquery inherits from object, can be safely removed from bases in python3(useless object inheritence). Looking forward to getting your feedback on this. Thank you