### PR TITLE
MNT: Fix Travis CI badge link

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -4,8 +4,8 @@
    :target: https://img.shields.io/pypi/v/astroquery.svg
    :alt: Latest PyPI version
 
-.. image:: https://travis-ci.org/astropy/astroquery.svg?branch=master
-   :target: https://travis-ci.org/astropy/astroquery
+.. image:: https://travis-ci.com/astropy/astroquery.svg?branch=master
+   :target: https://travis-ci.com/astropy/astroquery
    :alt: Travis CI Status
 
 .. image:: https://coveralls.io/repos/astropy/astroquery/badge.png


### PR DESCRIPTION
`.org` -> `.com`

Not sure what is the proper milestone for this, so I'll let you set it. Thanks!