### PR TITLE
Added case for passing row to download_products()

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -23,6 +23,7 @@ mast
 
 - Added ``Observations.download_file`` method to download a single file from MAST given an input
   data URI. [#1825]
+- Added case for passing a row to ``Observations.download_file` [#1881]
 
 esa/hubble
 ^^^^^^^^^^

--- a/astroquery/mast/observations.py
+++ b/astroquery/mast/observations.py
@@ -718,7 +718,7 @@ class ObservationsClass(MastQueryWithLogin):
 
             if type(products) == str:
                 products = [products]
-                
+
             # collect list of products
             product_lists = []
             for oid in products:

--- a/astroquery/mast/observations.py
+++ b/astroquery/mast/observations.py
@@ -714,7 +714,7 @@ class ObservationsClass(MastQueryWithLogin):
 
         # If the products list is not already a table of products we need to
         # get the products and filter them appropriately
-        if type(products) != Table: 
+        if type(products) != Table:
 
             if type(products) == str:
                 products = [products]

--- a/astroquery/mast/observations.py
+++ b/astroquery/mast/observations.py
@@ -438,12 +438,14 @@ class ObservationsClass(MastQueryWithLogin):
         """
         Given a "Product Group Id" (column name obsid) returns a list of associated data products.
         See column documentation `here <https://masttest.stsci.edu/api/v0/_productsfields.html>`__.
+
         Parameters
         ----------
         observations : str or `~astropy.table.Row` or list/Table of same
             Row/Table of MAST query results (e.g. output from `query_object`)
             or single/list of MAST Product Group Id(s) (obsid).
             See description `here <https://masttest.stsci.edu/api/v0/_c_a_o_mfields.html>`__.
+
         Returns
         -------
             response : list of `~requests.Response`
@@ -722,7 +724,6 @@ class ObservationsClass(MastQueryWithLogin):
             # collect list of products
             product_lists = []
             for oid in products:
-                print(oid)
                 product_lists.append(self.get_product_list(oid))
 
             products = vstack(product_lists)

--- a/astroquery/mast/observations.py
+++ b/astroquery/mast/observations.py
@@ -438,14 +438,12 @@ class ObservationsClass(MastQueryWithLogin):
         """
         Given a "Product Group Id" (column name obsid) returns a list of associated data products.
         See column documentation `here <https://masttest.stsci.edu/api/v0/_productsfields.html>`__.
-
         Parameters
         ----------
         observations : str or `~astropy.table.Row` or list/Table of same
             Row/Table of MAST query results (e.g. output from `query_object`)
             or single/list of MAST Product Group Id(s) (obsid).
             See description `here <https://masttest.stsci.edu/api/v0/_c_a_o_mfields.html>`__.
-
         Returns
         -------
             response : list of `~requests.Response`
@@ -710,17 +708,21 @@ class ObservationsClass(MastQueryWithLogin):
         response : `~astropy.table.Table`
             The manifest of files downloaded, or status of files on disk if curl option chosen.
         """
+        # If the products list is a row we need to cast it as a table
+        if type(products) == Row:
+            products = Table(products, masked=True)
 
         # If the products list is not already a table of products we need to
         # get the products and filter them appropriately
-        if type(products) != Table:
+        if type(products) != Table: 
 
             if type(products) == str:
                 products = [products]
-
+                
             # collect list of products
             product_lists = []
             for oid in products:
+                print(oid)
                 product_lists.append(self.get_product_list(oid))
 
             products = vstack(product_lists)

--- a/astroquery/mast/tests/test_mast.py
+++ b/astroquery/mast/tests/test_mast.py
@@ -372,6 +372,11 @@ def test_observations_download_products(patch_post, tmpdir):
                                                  mrp_only=False)
     assert isinstance(result, Table)
 
+    # passing row product
+    products = mast.Observations.get_product_list('2003738726')
+    result1 = mast.Observations.download_products(products[0])
+    assert isinstance(result1, Table)
+
 
 def test_observations_download_file(patch_post, tmpdir):
     # pull a single data product

--- a/astroquery/mast/tests/test_mast_remote.py
+++ b/astroquery/mast/tests/test_mast_remote.py
@@ -249,12 +249,12 @@ class TestMast(object):
         obsLoc = np.where(observations["obs_id"] == 'ktwo200071160-c92_lc')
         result = mast.Observations.get_product_list(observations[obsLoc])
         assert isinstance(result, Table)
-        assert len(result) == 3
+        assert len(result) == 1
 
         obsLocs = np.where((observations['target_name'] == 'NGC6523') & (observations['obs_collection'] == "IUE"))
         result = mast.Observations.get_product_list(observations[obsLocs])
         assert isinstance(result, Table)
-        assert len(result) == 27
+        assert len(result) == 30
 
     def test_observations_filter_products(self):
         observations = mast.Observations.query_object("M8", radius=".04 deg")
@@ -285,6 +285,14 @@ class TestMast(object):
                                                      mrp_only=False)
         assert isinstance(result, Table)
         assert os.path.isfile(result['Local Path'][0])
+
+        # check for row input
+        result1 = mast.Observations.get_product_list(test_obs_id)
+        result2 = mast.Observations.download_products(result1[0])
+        assert isinstance(result2, Table)
+        assert os.path.isfile(result2['Local Path'][0])
+        assert len(result2) == 1
+
 
     def test_observations_download_file(self, tmpdir):
         test_obs_id = '2003600312'

--- a/astroquery/mast/tests/test_mast_remote.py
+++ b/astroquery/mast/tests/test_mast_remote.py
@@ -293,7 +293,6 @@ class TestMast(object):
         assert os.path.isfile(result2['Local Path'][0])
         assert len(result2) == 1
 
-
     def test_observations_download_file(self, tmpdir):
         test_obs_id = '2003600312'
 


### PR DESCRIPTION
This closes issue #1535 
Added case to check if product passed is a row, casts to Table if needed
Added test cases for row input for download_products() in both test_mast.py and test_mast_remote.py
Fixed two failing test cases in TestMast.test_observations_get_product_list