### PR TITLE
Removed old deprecation warnings

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -24,6 +24,9 @@ mast
 - Added ``Observations.download_file`` method to download a single file from MAST given an input
   data URI. [#1825]
 - Added case for passing a row to ``Observations.download_file` [#1881]
+- Removed deprecated ``Observations.get_hst_s3_uris()``, ``Observations.get_hst_s3_uri()``, 
+  ``Core.get_token()``, ``Core.enable_s3_hst_dataset()``, ``Core.disable_s3_hst_dataset()`` and 
+  variables obstype and silent [#1884]
 
 esa/hubble
 ^^^^^^^^^^

--- a/astroquery/mast/core.py
+++ b/astroquery/mast/core.py
@@ -9,7 +9,6 @@ This the base class for MAST queries.
 import warnings
 
 from astropy.utils import deprecated
-from astropy.utils.exceptions import AstropyDeprecationWarning
 
 from ..query import QueryWithLogin
 
@@ -66,19 +65,12 @@ class MastQueryWithLogin(QueryWithLogin):
 
         return self._auth_obj.login(token, store_token, reenter_token)
 
-    @deprecated(since="v0.3.9", message=("The get_token function is deprecated, "
-                                         "session token is now the token used for login."))
-    def get_token(self):
-        return None
-
-    def session_info(self, silent=None, verbose=None):
+    def session_info(self, verbose=True):
         """
         Displays information about current MAST user, and returns user info dictionary.
 
         Parameters
         ----------
-        silent :
-            Deprecated. Use verbose instead.
         verbose : bool, optional
             Default True. Set to False to suppress output to stdout.
 
@@ -86,18 +78,6 @@ class MastQueryWithLogin(QueryWithLogin):
         -------
         response : dict
         """
-
-        # Dealing with deprecated argument
-        if (silent is not None) and (verbose is not None):
-            warnings.warn(("Argument 'silent' has been deprecated, "
-                           "will be ignored in favor of 'verbose'"), AstropyDeprecationWarning)
-        elif silent is not None:
-            warnings.warn(("Argument 'silent' has been deprecated, "
-                           "and will be removed in the future. "
-                           " Use 'verbose' instead."), AstropyDeprecationWarning)
-            verbose = not silent
-        elif (silent is None) and (verbose is None):
-            verbose = True
 
         return self._auth_obj.session_info(verbose)
 
@@ -107,10 +87,6 @@ class MastQueryWithLogin(QueryWithLogin):
         """
         self._auth_obj.logout()
         self._authenticated = False
-
-    @deprecated(since="v0.3.9", alternative="enable_cloud_dataset")
-    def enable_s3_hst_dataset(self):
-        return self.enable_cloud_dataset()
 
     def enable_cloud_dataset(self, provider="AWS", profile=None, verbose=True):
         """
@@ -130,10 +106,6 @@ class MastQueryWithLogin(QueryWithLogin):
         """
 
         self._cloud_connection = CloudAccess(provider, profile, verbose)
-
-    @deprecated(since="v0.3.9", alternative="disable_cloud_dataset")
-    def disable_s3_hst_dataset(self):
-        return self.disable_cloud_dataset()
 
     def disable_cloud_dataset(self):
         """

--- a/astroquery/mast/observations.py
+++ b/astroquery/mast/observations.py
@@ -429,11 +429,11 @@ class ObservationsClass(MastQueryWithLogin):
         """
 
         # getting the obsid list
-        if type(observations) == Row:
+        if isinstance(observations, Row):
             observations = observations["obsid"]
         if np.isscalar(observations):
             observations = [observations]
-        if type(observations) == Table:
+        if isinstance(observations, Table):
             observations = observations['obsid']
 
         service = 'Mast.Caom.Products'
@@ -473,7 +473,7 @@ class ObservationsClass(MastQueryWithLogin):
             filter_mask &= (products['productGroupDescription'] == "Minimum Recommended Products")
 
         if extension:
-            if type(extension) == str:
+            if isinstance(extension, str):
                 extension = [extension]
 
             mask = np.full(len(products), False, dtype=bool)
@@ -485,7 +485,7 @@ class ObservationsClass(MastQueryWithLogin):
         # Applying the rest of the filters
         for colname, vals in filters.items():
 
-            if type(vals) == str:
+            if isinstance(vals, str):
                 vals = [vals]
 
             mask = np.full(len(products), False, dtype=bool)
@@ -688,14 +688,14 @@ class ObservationsClass(MastQueryWithLogin):
             The manifest of files downloaded, or status of files on disk if curl option chosen.
         """
         # If the products list is a row we need to cast it as a table
-        if type(products) == Row:
+        if isinstance(products, Row):
             products = Table(products, masked=True)
 
         # If the products list is not already a table of products we need to
         # get the products and filter them appropriately
-        if type(products) != Table:
+        if not isinstance(products, Table):
 
-            if type(products) == str:
+            if isinstance(products, str):
                 products = [products]
 
             # collect list of products

--- a/astroquery/mast/observations.py
+++ b/astroquery/mast/observations.py
@@ -25,7 +25,6 @@ from astropy.logger import log
 
 from astropy.utils import deprecated
 from astropy.utils.console import ProgressBarOrSpinner
-from astropy.utils.exceptions import AstropyDeprecationWarning
 
 from six.moves.urllib.parse import quote as urlencode
 
@@ -150,28 +149,6 @@ class ObservationsClass(MastQueryWithLogin):
         coordinates = criteria.pop('coordinates', None)
         objectname = criteria.pop('objectname', None)
         radius = criteria.pop('radius', 0.2*u.deg)
-
-        # Dealing with observation type (science vs calibration)
-        if ('obstype' in criteria) and ('intentType' in criteria):
-            warn_string = ("Cannot specify both obstype and intentType, "
-                           "obstype is the deprecated version of intentType and will be ignored.")
-            warnings.warn(warn_string, InputWarning)
-            criteria.pop('obstype', None)
-
-        # Temporarily issuing warning about change in behavior
-        # continuing old behavior
-        # grabbing the observation type (science vs calibration)
-        obstype = criteria.pop('obstype', None)
-        if obstype:
-            warn_string = ("Criteria obstype argument disappeared in May 2019. "
-                          "Criteria 'obstype' is now 'intentType', options are 'science' or 'calibration', "
-                          "if intentType is not supplied all observations (science and calibration) are returned.")
-            warnings.warn(warn_string, AstropyDeprecationWarning)
-
-            if obstype == "science":
-                criteria["intentType"] = "science"
-            elif obstype == "cal":
-                criteria["intentType"] = "calibration"
 
         # Build the mashup filter object and store it in the correct service_name entry
         if coordinates or objectname:
@@ -748,10 +725,6 @@ class ObservationsClass(MastQueryWithLogin):
 
         return manifest
 
-    @deprecated(since="v0.3.9", alternative="get_cloud_uris")
-    def get_hst_s3_uris(self, data_products, include_bucket=True, full_url=False):
-        return self.get_cloud_uris(data_products, include_bucket, full_url)
-
     def get_cloud_uris(self, data_products, include_bucket=True, full_url=False):
         """
         Takes an `~astropy.table.Table` of data products and returns the associated cloud data uris.
@@ -779,10 +752,6 @@ class ObservationsClass(MastQueryWithLogin):
             raise AttributeError("Must enable s3 dataset before attempting to query the s3 information")
 
         return self._cloud_connection.get_cloud_uri_list(data_products, include_bucket, full_url)
-
-    @deprecated(since="v0.3.9", alternative="get_cloud_uri")
-    def get_hst_s3_uri(self, data_product, include_bucket=True, full_url=False):
-        return self.get_cloud_uri(data_product, include_bucket, full_url)
 
     def get_cloud_uri(self, data_product, include_bucket=True, full_url=False):
         """

--- a/astroquery/mast/tests/test_mast.py
+++ b/astroquery/mast/tests/test_mast.py
@@ -270,16 +270,6 @@ def test_observations_query_criteria(patch_post):
                                               objectname="M101")
     assert isinstance(result, Table)
 
-    # TEMPORARY test the obstype deprecation
-    with catch_warnings(AstropyDeprecationWarning) as warning_lines:
-        result = mast.Observations.query_criteria(objectname="M101",
-                                                  dataproduct_type="IMAGE", obstype="science")
-        assert isinstance(result, Table)
-
-    with pytest.warns(InputWarning) as i_w:
-        mast.Observations.query_criteria(obstype="science", intentType="science")
-    assert "obstype and intentType" in str(i_w[0].message)
-
     with pytest.raises(InvalidQueryError) as invalid_query:
         mast.Observations.query_criteria(objectname="M101")
     assert "least one non-positional criterion" in str(invalid_query.value)

--- a/astroquery/mast/tests/test_mast_remote.py
+++ b/astroquery/mast/tests/test_mast_remote.py
@@ -175,16 +175,6 @@ class TestMast:
         assert (result['obs_collection'] == 'GALEX').all()
         assert sum(result['filters'] == 'NUV') == 6
 
-        # TEMPORARY test the obstype deprecation
-        with catch_warnings(AstropyDeprecationWarning) as warning_lines:
-            result = mast.Observations.query_criteria(objectname="M101",
-                                                      dataproduct_type="IMAGE", obstype="science")
-            assert (result["intentType"] == "science").all()
-
-            result = mast.Observations.query_criteria(objectname="M101",
-                                                      dataproduct_type="IMAGE", obstype="cal")
-            assert (result["intentType"] == "calibration").all()
-
         result = mast.Observations.query_criteria(objectname="M101",
                                                   dataproduct_type="IMAGE", intentType="calibration")
         assert (result["intentType"] == "calibration").all()


### PR DESCRIPTION
This closes issue #1708 
Got rid of outdated deprecation warnings and cases handling deprecated variables
Removed tests for the deleted warnings and cases
The testing errors are fixed in [#1881 ], I will rebase once that one is merged
