### PR TITLE
clarify astroquery is coordinated

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -3,7 +3,7 @@
 Astroquery
 ==========
 
-This is the documentation for the Astroquery affiliated package of `astropy
+This is the documentation for the Astroquery coordinated package of `astropy
 <http://www.astropy.org>`__.
 
 Code and issue tracker are on `GitHub <https://github.com/astropy/astroquery>`_.


### PR DESCRIPTION
A minor clarification in the docs that astroquery is a coordinated package. (This doc line seems to pre-date the very concept, so presumably just an oversight)