### PR TITLE
Updates to alma/core.py to fix Issues #1737, #1740

### DIFF
--- a/astroquery/alma/core.py
+++ b/astroquery/alma/core.py
@@ -450,7 +450,7 @@ class AlmaClass(QueryWithLogin):
                 response.raise_for_status()
                 # Jan 2017: we have to force https because the archive doesn't
                 # tell us it needs https.
-                self.dataarchive_url = response.url.replace("http://", "https://")
+                self.dataarchive_url = response.url.replace("/asax/","").replace("/aq/","").replace("http://", "https://")
             else:
                 self.dataarchive_url = self.archive_url
         elif self.dataarchive_url in ('http://almascience.org',
@@ -531,7 +531,7 @@ class AlmaClass(QueryWithLogin):
                 else:
                     table = uid_json_to_table(jdata,
                                               productlist=['ASDM',
-                                                           'PIPELINE_PRODUCT'
+                                                           'PIPELINE_PRODUCT',
                                                            'PIPELINE_PRODUCT_TARFILE',
                                                            'PIPELINE_AUXILIARY_TARFILE'])
                 table['sizeInBytes'].unit = u.B


### PR DESCRIPTION
A missing comma in AlmaClass.stage_data() prevented products files from being added to the results table when expand_tarfiles=False. This fixes Issue #1740. 

AlmaClass._get_dataarchive_url() returns an unusable url due to a trailing "/asax/" added on to the url in the _request() call. This needs to be removed. In the future, the trailing characters will likely change to "/aq/" as that is the ALMA standard. This change fixes that issue (Issue #1737).