### PR TITLE
Read/write TableList

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -23,7 +23,7 @@ mast
 
 - Added ``Observations.download_file`` method to download a single file from MAST given an input
   data URI. [#1825]
-- Added case for passing a row to ``Observations.download_file` [#1881]
+- Added case for passing a row to ``Observations.download_file`` [#1881]
 - Removed deprecated ``Observations.get_hst_s3_uris()``, ``Observations.get_hst_s3_uri()``, 
   ``Core.get_token()``, ``Core.enable_s3_hst_dataset()``, ``Core.disable_s3_hst_dataset()`` and 
   variables obstype and silent [#1884]
@@ -99,6 +99,11 @@ gaia
 - Changed file names handling when downloading data. [#1784]
 - Improved code to handle bit data type. [#1784]
 - Prepared code to handle new datalink products. [#1784]
+  
+utils
+^^^^^
+
+- Read/write TableList [#1902]
 
 
 0.4.1 (2020-06-19)

--- a/astroquery/utils/tests/test_common.py
+++ b/astroquery/utils/tests/test_common.py
@@ -1,0 +1,88 @@
+# -*- coding: utf-8 -*-
+
+"""Tests for :class:`~astroquery.utils.commons`."""
+
+__all__ = [
+    "Test_TableList",
+]
+
+
+##############################################################################
+# IMPORTS
+
+# BUILT-IN
+import tempfile
+from collections import OrderedDict
+
+# THIRD PARTY
+import astropy.units as u
+import numpy as np
+import pytest
+
+try:
+    import asdf
+except ImportError:
+    HAS_ASDF = False
+else:
+    HAS_ASDF = True
+
+# PROJECT-SPECIFIC
+from astropy.table import QTable, Table
+from astroquery.utils.commons import TableList
+
+##############################################################################
+# PARAMETERS
+
+# Quantity Tables
+qt1 = QTable(data={"a": [1, 2, 3] * u.m, "b": [4, 5, 6] * u.s})
+qt2 = Table(data={"c": [7, 8, 9], "d": [10, 11, 12]})
+
+##############################################################################
+# TESTS
+##############################################################################
+
+
+class Test_TableList(object):
+    """Tests for `~asatronat.utils.table.core.TablesList`."""
+
+    klass = TableList
+
+    @classmethod
+    def setup_class(cls):
+        """Setup any state specific to the execution."""
+        # tables
+        cls.qt1 = qt1
+        cls.qt2 = qt2
+
+        # tables
+        cls.inp = {"table1": cls.qt1, "table2": cls.qt2}
+
+        # ordered tables
+        cls.ordered_inp = OrderedDict(cls.inp)
+
+        # the list of tables
+        cls.QT = cls.klass(
+            inp=cls.ordered_inp,
+            name="Name",
+            reference="Reference",
+            extra="Extra",
+        )
+
+        cls.tempdir = tempfile.TemporaryDirectory(dir="./")
+
+    @classmethod
+    def teardown_class(cls):
+        """Teardown any state specific to the execution."""
+        cls.tempdir.cleanup()
+
+    # ----------------------
+
+    @pytest.mark.skipif(not HAS_ASDF, reason="`asdf` not installed.")
+    def test_IO(self):
+        """Test read/write."""
+        self.QT.write(drct=self.tempdir.name + "/saved")
+
+        QT = self.klass.read(self.tempdir.name + "/saved")
+
+        for q1, q2 in zip(self.QT, QT):
+            assert np.all(q1 == q2)


### PR DESCRIPTION
Allow TableList I/O, using ASDF. Tables may be written one of two ways: as a single ASDF object or as separate files (anything supported by Table) with a coordinating container.