### PR TITLE
Added case for catching empty observations product requests

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -41,6 +41,7 @@ mast
   ``Core.get_token()``, ``Core.enable_s3_hst_dataset()``, ``Core.disable_s3_hst_dataset()`` and 
   variables obstype and silent [#1884]
 - Added Zcut functionality to astroquery [#1911]
+- Added case for catching empty observations passed to ``Observations.get_product_list()`` [#1921]
 
 esa/hubble
 ^^^^^^^^^^

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -41,7 +41,8 @@ mast
   ``Core.get_token()``, ``Core.enable_s3_hst_dataset()``, ``Core.disable_s3_hst_dataset()`` and 
   variables obstype and silent [#1884]
 - Added Zcut functionality to astroquery [#1911]
-- Added case for catching empty observations passed to ``Observations.get_product_list()`` [#1921]
+- Fixed error causing empty products passed to ``Observations.get_product_list()`` to yeild a
+  non-empty result. [#1921]
 
 esa/hubble
 ^^^^^^^^^^

--- a/astroquery/mast/observations.py
+++ b/astroquery/mast/observations.py
@@ -427,6 +427,8 @@ class ObservationsClass(MastQueryWithLogin):
         -------
             response : list of `~requests.Response`
         """
+        if len(observations) == 0 or not observations["obsid"]:
+            raise InvalidQueryError("Observation list is empty.")
 
         # getting the obsid list
         if isinstance(observations, Row):

--- a/astroquery/mast/observations.py
+++ b/astroquery/mast/observations.py
@@ -428,7 +428,7 @@ class ObservationsClass(MastQueryWithLogin):
             response : list of `~requests.Response`
         """
         if len(observations) == 0 or not observations["obsid"]:
-            raise InvalidQueryError("Observation list is empty.")
+            raise InvalidQueryError("Observation list is empty, no associated products.")
 
         # getting the obsid list
         if isinstance(observations, Row):


### PR DESCRIPTION
Empty observation tables and strings passed to get_product_list() in Observations.py were yielding results because of the default case at the POST endpoint for the request.
Added a case to catch empty observations and pass an Invalid Query Error
This closes [#1917]