### PR TITLE
hips2fits remove imshow calls from remote tests

### DIFF
--- a/astroquery/hips2fits/core.py
+++ b/astroquery/hips2fits/core.py
@@ -71,8 +71,7 @@ class hips2fitsClass(BaseQuery):
             See the list of valid HiPS ids hosted by the CDS `here <http://aladin.unistra.fr/hips/list>`_.
         wcs : `~astropy.wcs.WCS`
             An astropy WCS defining the astrometry you wish.
-            Alternatively, you can pass lon, lat, fov, coordsys keywords (if so, please use the
-            :meth:`~astroquery.hips2fits.hips2fitsClass.query_with_user_defined_wcs` method).
+            Alternatively, you can pass lon, lat, fov, coordsys keywords.
         format : str, optional
             Format of the output image.
             Allowed values are fits (default), jpg and png

--- a/astroquery/hips2fits/tests/test_hips2fits_remote.py
+++ b/astroquery/hips2fits/tests/test_hips2fits_remote.py
@@ -76,11 +76,11 @@ class TestHips2fitsRemote(object):
             cmap=Colormap('viridis'),
         )
 
-        import matplotlib.cm as cm
-        import matplotlib.pyplot as plt
+        # import matplotlib.cm as cm
+        # import matplotlib.pyplot as plt
 
-        im = plt.imshow(result)
-        plt.show(im)
+        # im = plt.imshow(result)
+        # plt.show(im)
 
         # We must get a numpy array with 3 dimensions, and the last one should be of size 3 (RGB)
         assert isinstance(result, np.ndarray) and result.shape[2] == 3

--- a/docs/hips2fits/hips2fits.rst
+++ b/docs/hips2fits/hips2fits.rst
@@ -13,7 +13,7 @@ Query the `CDS hips2fits service <http://alasky.u-strasbg.fr/hips-image-services
 
 The `CDS hips2fits service <http://alasky.u-strasbg.fr/hips-image-services/hips2fits>`_ offers a way
 to extract FITS images from HiPS sky maps. HiPS is an IVOA standard that combines individual images in
-order to produce a progressive hierarchical sky map describing the whole survey. Please refer to the 
+order to produce a progressive hierarchical sky map describing the whole survey. Please refer to the
 `IVOA paper <http://www.ivoa.net/documents/HiPS/20170519/REC-HIPS-1.0-20170519.pdf>`_ for more info.
 
 Given an astropy user-defined WCS with a HiPS name,
@@ -35,7 +35,7 @@ Examples
 ========
 
 With a user defined astropy WCS
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+-------------------------------
 
 .. code-block:: python
 
@@ -75,7 +75,7 @@ With a user defined astropy WCS
 .. image:: ./query_wcs.png
 
 Without WCS
-~~~~~~~~~~~
+-----------
 
     >>> from astroquery.hips2fits import hips2fits
     >>> import matplotlib.pyplot as plt
@@ -110,4 +110,3 @@ Reference/API
 
 
 .. _hips2fits: http://alasky.u-strasbg.fr/hips-image-services/hips2fits
-


### PR DESCRIPTION
This refers #1734 

@bsipocz @keflavich - I commented the call to matplotlib functions in the remote tests of hips2fits