### PR TITLE
TST: Add dependabot YAML

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,7 @@
+version: 2
+updates:
+- package-ecosystem: pip
+  directory: "/"
+  schedule:
+    interval: monthly
+  open-pull-requests-limit: 10

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,5 +3,5 @@ updates:
 - package-ecosystem: pip
   directory: "/"
   schedule:
-    interval: monthly
+    interval: weekly
   open-pull-requests-limit: 10


### PR DESCRIPTION
I see the Dependabot is active but there is no YAML to control its behavior. If you go into Insights -> Dependency graph -> Dependabot (Beta) -> Create config file , this is what you get.

```yaml
# To get started with Dependabot version updates, you'll need to specify which
# package ecosystems to update and where the package manifests are located.
# Please see the documentation for all configuration options:
# https://help.github.com/github/administering-a-repository/configuration-options-for-dependency-updates

version: 2
updates:
  - package-ecosystem: "" # See documentation for possible values
    directory: "/" # Location of package manifests
    schedule:
      interval: "daily"
```

But I copied over a working copy from another project instead, which has some missing stuff filled in. I'll let you set the milestone.

Ref: https://help.github.com/github/administering-a-repository/configuration-options-for-dependency-updates