### PR TITLE
Magpis, Xmatch documentation cleanup

### DIFF
--- a/docs/magpis/magpis.rst
+++ b/docs/magpis/magpis.rst
@@ -1,5 +1,3 @@
-.. doctest-skip-all
-
 .. _astroquery.magpis:
 
 *****************************************
@@ -17,13 +15,13 @@ functions or as coordinates using any of the coordinate systems available in
 `~astropy.io.fits.HDUList` object. Here is a sample query:
 
 .. code-block:: python
-
+.. doctest-remote-data::
     >>> from astroquery.magpis import Magpis
     >>> from astropy import coordinates
     >>> from astropy import units as u
     >>> image = Magpis.get_images(coordinates.SkyCoord(10.5*u.deg, 0.0*u.deg,
     ...                                                frame='galactic'))
-    >>> image
+    >>> image   # doctest: +IGNORE_OUTPUT
     
     [<astropy.io.fits.hdu.image.PrimaryHDU at 0x4008650>]
 
@@ -36,11 +34,13 @@ You may also specify the MAGPIS survey from which to fetch the cutout via the
 keyword ``survey``. To know the list of valid surveys:
 
 .. code-block:: python
-
+.. doctest-remote-data::
     >>> from astroquery.magpis import Magpis
-    >>> Magpis.list_surveys()
-
-       ['gps6epoch3',
+    >>> Magpis.list_surveys()   # doctest: +IGNORE_OUTPUT
+       [
+        'gps6'
+        'gps6epoch2',
+        'gps6epoch3',
         'gps6epoch4',
         'gps20',
         'gps20new',
@@ -52,13 +52,14 @@ keyword ``survey``. To know the list of valid surveys:
         'gpsglimpse58',
         'gpsglimpse80',
         'mipsgal',
+        'atlasgal',
         'bolocam']
 
 The default survey used is 'bolocam'. Here is a query setting these optional
 parameters as well.
 
 .. code-block:: python
-
+.. doctest-remote-data::
     >>> from astroquery.magpis import Magpis
     >>> import astropy.units as u
     >>> import astropy.coordinates as coord
@@ -66,7 +67,7 @@ parameters as well.
     ...                                                frame='galactic'),
     ...                                                image_size=10*u.arcmin,
     ...                                                survey='gps20new')
-    >>> image
+    >>> image  # doctest: +IGNORE_OUTPUT
 
     [<astropy.io.fits.hdu.image.PrimaryHDU at 0x4013e10>]
 

--- a/docs/magpis/magpis.rst
+++ b/docs/magpis/magpis.rst
@@ -14,15 +14,15 @@ functions or as coordinates using any of the coordinate systems available in
 `astropy.coordinates`. The FITS image is returned as an
 `~astropy.io.fits.HDUList` object. Here is a sample query:
 
-.. code-block:: python
 .. doctest-remote-data::
+
     >>> from astroquery.magpis import Magpis
     >>> from astropy import coordinates
     >>> from astropy import units as u
     >>> image = Magpis.get_images(coordinates.SkyCoord(10.5*u.deg, 0.0*u.deg,
     ...                                                frame='galactic'))
     >>> image   # doctest: +IGNORE_OUTPUT
-    
+
     [<astropy.io.fits.hdu.image.PrimaryHDU at 0x4008650>]
 
 There are some other optional parameters that you may additionally specify.
@@ -33,33 +33,32 @@ appropriate `~astropy.units.Quantity` object.
 You may also specify the MAGPIS survey from which to fetch the cutout via the
 keyword ``survey``. To know the list of valid surveys:
 
-.. code-block:: python
 .. doctest-remote-data::
+
     >>> from astroquery.magpis import Magpis
-    >>> Magpis.list_surveys()   # doctest: +IGNORE_OUTPUT
-       [
-        'gps6'
-        'gps6epoch2',
-        'gps6epoch3',
-        'gps6epoch4',
-        'gps20',
-        'gps20new',
-        'gps90',
-        'gpsmsx',
-        'gpsmsx2',
-        'gpsglimpse36',
-        'gpsglimpse45',
-        'gpsglimpse58',
-        'gpsglimpse80',
-        'mipsgal',
-        'atlasgal',
-        'bolocam']
+    >>> Magpis.list_surveys()
+    ['gps6',
+     'gps6epoch2',
+     'gps6epoch3',
+     'gps6epoch4',
+     'gps20',
+     'gps20new',
+     'gps90',
+     'gpsmsx',
+     'gpsmsx2',
+     'gpsglimpse36',
+     'gpsglimpse45',
+     'gpsglimpse58',
+     'gpsglimpse80',
+     'mipsgal',
+     'atlasgal',
+     'bolocam']
 
 The default survey used is 'bolocam'. Here is a query setting these optional
 parameters as well.
 
-.. code-block:: python
 .. doctest-remote-data::
+
     >>> from astroquery.magpis import Magpis
     >>> import astropy.units as u
     >>> import astropy.coordinates as coord

--- a/docs/xmatch/xmatch.rst
+++ b/docs/xmatch/xmatch.rst
@@ -21,21 +21,33 @@ has the following content::
     306.01575,33.86756
     322.493,12.16703
 
+.. testsetup::
+
+   >>> with open('pos_list.csv', 'w') as f:    # doctest: +IGNORE_OUTPUT
+   ...    f.write("""ra,dec
+   ... 267.22029,-20.35869
+   ... 274.83971,-25.42714
+   ... 275.92229,-30.36572
+   ... 283.26621,-8.70756
+   ... 306.01575,33.86756
+   ... 322.493,12.16703""")
+
 Next, the xMatch service will be used to find cross matches between the
 uploaded file and a VizieR catalogue.  The parameters ``cat1`` and ``cat2``
 define the catalogues where one of them may point to a local file (in this
 example, the CSV file is stored in
-``'/tmp/pos_list.csv'``). ``max_distance`` denotes the maximum distance in
+``'pos_list.csv'``). ``max_distance`` denotes the maximum distance in
 arcsec to look for counterparts; it is used here to limit the number of rows
 in the resulting table for demonstration purposes.  Finally, ``colRa1`` and
 ``colDec1`` are used to denote the column names in the input file.
 
-.. code-block:: python
 .. doctest-remote-data::
 
     >>> from astropy import units as u
-    >>> from astroquery.xmatch import XMatch   # doctest: +IGNORE_OUTPUT
-    >>> table = XMatch.query(cat1=open('/tmp/pos_list.csv'),
+    >>> from astroquery.xmatch import XMatch
+    >>> from astropy.table import Table
+    >>> input_table = Table.read('pos_list.csv')
+    >>> table = XMatch.query(cat1=input_table,
     ...                      cat2='vizier:II/246/out',
     ...                      max_distance=5 * u.arcsec, colRA1='ra',
     ...                      colDec1='dec')
@@ -55,6 +67,13 @@ in the resulting table for demonstration purposes.  Finally, ``colRa1`` and
     1.178542 306.01575  33.86756 20240382+3352021 ... AAA 222   0 2450948.9708
     0.853178   322.493  12.16703 21295836+1210007 ... EEA 222   0 2451080.6935
      4.50395   322.493  12.16703 21295861+1210023 ... EEE 222   0 2451080.6935
+
+
+.. testcleanup::
+
+    >>> from astroquery.utils import cleanup_saved_downloads
+    >>> cleanup_saved_downloads(['pos_list.csv'])
+
 
 Reference/API
 =============

--- a/docs/xmatch/xmatch.rst
+++ b/docs/xmatch/xmatch.rst
@@ -1,5 +1,3 @@
-.. doctest-skip-all
-
 .. _astroquery_xmatch:
 
 ************************************
@@ -33,9 +31,10 @@ in the resulting table for demonstration purposes.  Finally, ``colRa1`` and
 ``colDec1`` are used to denote the column names in the input file.
 
 .. code-block:: python
+.. doctest-remote-data::
 
     >>> from astropy import units as u
-    >>> from astroquery.xmatch import XMatch
+    >>> from astroquery.xmatch import XMatch   # doctest: +IGNORE_OUTPUT
     >>> table = XMatch.query(cat1=open('/tmp/pos_list.csv'),
     ...                      cat2='vizier:II/246/out',
     ...                      max_distance=5 * u.arcsec, colRA1='ra',


### PR DESCRIPTION
- Noirlab raises this exception `The astroquery.noirlab module module is expecting an older version of the https://astroarchive.noao.edu API services` the API is of version 5.0 but the module checks for version 2.0 as the latest version. Would open an issue to correct that.
- The svo server `http://svo2.cab.inta-csic.es/` times out 
