### PR TITLE
MNT: workaround astropy unit parsing changes

### DIFF
--- a/astroquery/imcce/tests/test_miriade.py
+++ b/astroquery/imcce/tests/test_miriade.py
@@ -93,10 +93,10 @@ def test_observation_coordinates(patch_request):
     eph = Miriade.get_ephemerides('3552', coordtype=5)
     cols = ('target', 'epoch', 'siderealtime', 'RAJ2000', 'DECJ2000',
             'hourangle', 'DEC', 'AZ', 'EL', 'refraction',
-            'airmass', 'V', 'delta', 'heldist', 'alpha', 'elong', 'posunc',
+            'V', 'delta', 'heldist', 'alpha', 'elong', 'posunc',
             'RAcosD_rate', 'DEC_rate', 'delta_rate')
     units = (None, u.d, u.h, u.deg, u.deg, u.deg, u.deg, u.deg, u.deg,
-             u.arcsec, '-', u.mag, u.au, u.au, u.deg, u.deg, u.arcsec,
+             u.arcsec, u.mag, u.au, u.au, u.deg, u.deg, u.arcsec,
              u.arcsec / u.minute, u.arcsec / u.minute, u.km / u.s)
     for i in range(len(cols)):
         assert cols[i] in eph.columns
@@ -106,9 +106,9 @@ def test_observation_coordinates(patch_request):
 def test_aoobservation_coordinates(patch_request):
     eph = Miriade.get_ephemerides('3552', coordtype=6)
     cols = ('target', 'epoch', 'siderealtime', 'RAJ2000', 'DECJ2000',
-            'refraction', 'airmass', 'V', 'delta', 'heldist', 'alpha',
+            'refraction', 'V', 'delta', 'heldist', 'alpha',
             'elong', 'posunc', 'RAcosD_rate', 'DEC_rate', 'delta_rate')
-    units = (None, u.d, u.h, u.deg, u.deg, u.arcsec, '-', u.mag,
+    units = (None, u.d, u.h, u.deg, u.deg, u.arcsec, u.mag,
              u.au, u.au, u.deg, u.deg, u.arcsec, u.arcsec / u.minute,
              u.arcsec / u.minute, u.km / u.s)
     for i in range(len(cols)):


### PR DESCRIPTION
I think it's fine not to test for the airmass unit parsing, which has changed recently for astropy 4.3

xref: https://github.com/astropy/astropy/pull/11250

this should fix the failing CI