### PR TITLE
Ned documentation cleanup

### DIFF
--- a/docs/ned/ned.rst
+++ b/docs/ned/ned.rst
@@ -1,5 +1,3 @@
-.. doctest-skip-all
-
 .. _astroquery.ned:
 
 ******************************
@@ -22,11 +20,11 @@ This may be used to query the object *by name* from the NED service. For
 instance if you want to query NGC 224
 
 .. code-block:: python
+.. doctest-remote-data::
 
     >>> from astroquery.ned import Ned
     >>> result_table = Ned.query_object("NGC 224")
     >>> print(result_table) # an astropy.table.Table
-
      No. Object Name  RA(deg)   ... Redshift Points Diameter Points Associations
     --- ----------- ---------- ... --------------- --------------- ------------
       1 MESSIER 031   10.68479 ...              26               7            2
@@ -44,12 +42,12 @@ arcmin. Another optional parameter is the equinox if coordinates are
 specified. By default this is J2000.0 but can also be set to B1950.0.
 
 .. code-block:: python
+.. doctest-remote-data::
 
     >>> from astroquery.ned import Ned
     >>> import astropy.units as u
     >>> result_table = Ned.query_region("3c 273", radius=0.05 * u.deg)
     >>> print(result_table)
-
     No.       Object Name        ... Diameter Points Associations
     --- ------------------------ ... --------------- ------------
       1    3C 273:[PWC2011] 3640 ...               0            0
@@ -75,6 +73,7 @@ coordinates. Any of the coordinate systems available in `astropy.coordinates`
 may be used (ICRS, Galactic, FK4, FK5). Note also the use of the equinox keyword argument:
 
 .. code-block:: python
+.. doctest-remote-data::
 
     >>> from astroquery.ned import Ned
     >>> import astropy.units as u
@@ -83,7 +82,6 @@ may be used (ICRS, Galactic, FK4, FK5). Note also the use of the equinox keyword
     ...                           unit=(u.deg, u.deg), frame='fk4')
     >>> result_table = Ned.query_region(co, radius=0.1 * u.deg, equinox='B1950.0')
     >>> print(result_table)
-
     No.       Object Name       ... Diameter Points Associations
     --- ----------------------- ... --------------- ------------
       1 2MASX J03514350+3841573 ...               2            0
@@ -105,11 +103,11 @@ that Ned report results by searching in a 15 arcmin radius around the specified
 target.
 
 .. code-block:: python
+.. doctest-remote-data::
 
     >>> from astroquery.ned import Ned
     >>> result_table = Ned.query_region_iau('1234-423', frame='SuperGalactic', equinox='J2000.0')
     >>> print(result_table)
-
         No.       Object Name        RA(deg)   ... Diameter Points Associations
     --- ----------------------- ---------- ... --------------- ------------
       1    SUMSS J123651-423554  189.21425 ...               0            0
@@ -126,11 +124,11 @@ These queries can be used to retrieve all objects that appear in the specified
 :meth:`~astroquery.simbad.SimbadClass.query_bibobj` queries.
 
 .. code-block:: python
+.. doctest-remote-data::
 
     >>> from astroquery.ned import Ned
     >>> result_table = Ned.query_refcode('1997A&A...323...31K')
     >>> print(result_table)
-
         No.       Object Name        RA(deg)   ... Diameter Points Associations
     --- ----------------------- ---------- ... --------------- ------------
       1                NGC 0262   12.19642 ...               8            0
@@ -157,10 +155,10 @@ The image queries return a list of `~astropy.io.fits.HDUList` objects for the
 specified name. For instance:
 
 .. code-block:: python
+.. doctest-remote-data::
 
     >>> from astroquery.ned import Ned
     >>> images = Ned.get_images("m1")
-
     Downloading http://ned.ipac.caltech.edu/dss1B2/Bb/MESSIER_001:I:103aE:dss1.fits.gz
     |===========================================|  32k/ 32k (100.00%)        00s
     Downloading http://ned.ipac.caltech.edu/img5/1995RXCD3.T...0000C/p083n22a:I:0.1-2.4keV:cop1995.fits.gz
@@ -171,9 +169,7 @@ specified name. For instance:
     |===========================================|  52k/ 52k (100.00%)        01s
     Downloading http://ned.ipac.caltech.edu/img5/1998RXCD8.T...0000C/h083n22a:I:0.1-2.4keV:cps1998.fits.gz
     |===========================================|  35k/ 35k (100.00%)        00s
-
-    >>> images # may be used to do further processing on individual cutouts
-
+    >>> images # may be used to do further processing on individual cutouts doctest: +IGNORE_OUTPUT
     [[<astropy.io.fits.hdu.image.PrimaryHDU at 0x4311890>],
     [<astropy.io.fits.hdu.image.PrimaryHDU at 0x432b350>],
     [<astropy.io.fits.hdu.image.PrimaryHDU at 0x3e9c5d0>],
@@ -183,11 +179,11 @@ specified name. For instance:
 To get the URLs of the downloadable FITS images:
 
 .. code-block:: python
+.. doctest-remote-data::
 
     >>> from astroquery.ned import Ned
     >>> image_list = Ned.get_image_list("m1")
     >>> image_list
-
     ['http://ned.ipac.caltech.edu/dss1B2/Bb/MESSIER_001:I:103aE:dss1.fits.gz',
      'http://ned.ipac.caltech.edu/img5/1995RXCD3.T...0000C/p083n22a:I:0.1-2.4keV:cop1995.fits.gz',
      'http://ned.ipac.caltech.edu/img5/1996RXCD6.T...0000C/p083n22a:I:0.1-2.4keV:cps1996.fits.gz',
@@ -197,19 +193,17 @@ To get the URLs of the downloadable FITS images:
 Spectra can also be fetched in the same way:
 
 .. code-block:: python
+.. doctest-remote-data::
 
     >>> from astroquery.ned import Ned
     >>> spectra = Ned.get_spectra('3c 273')
-
     Downloading http://ned.ipac.caltech.edu/spc1/2009A+A...495.1033B/3C_273:S:B:bcc2009.fits.gz
     |===========================================| 7.8k/7.8k (100.00%)        00s
     Downloading http://ned.ipac.caltech.edu/spc1/1992ApJS...80..109B/PG_1226+023:S:B_V:bg1992.fits.gz
     |===========================================| 5.0k/5.0k (100.00%)        00s
     Downloading http://ned.ipac.caltech.edu/spc1/2009A+A...495.1033B/3C_273:S:RI:bcc2009.fits.gz
     |===========================================| 9.4k/9.4k (100.00%)        00s
-
-    >>> spectra
-
+    >>> spectra       # doctest: +IGNORE_OUTPUT
     [[<astropy.io.fits.hdu.image.PrimaryHDU at 0x41b4190>],
     [<astropy.io.fits.hdu.image.PrimaryHDU at 0x41b0990>],
     [<astropy.io.fits.hdu.image.PrimaryHDU at 0x430a450>]]
@@ -217,11 +211,11 @@ Spectra can also be fetched in the same way:
 Similarly the list of URLs for spectra of a particular object may be fetched:
 
 .. code-block:: python
+.. doctest-remote-data::
 
     >>> from astroquery.ned import Ned
     >>> image_list = Ned.get_image_list("3c 273", item='spectra')
     >>> image_list
-
     ['http://ned.ipac.caltech.edu/spc1/2009A+A...495.1033B/3C_273:S:B:bcc2009.fits.gz',
     'http://ned.ipac.caltech.edu/spc1/1992ApJS...80..109B/PG_1226+023:S:B_V:bg1992.fits.gz',
     'http://ned.ipac.caltech.edu/spc1/2009A+A...495.1033B/3C_273:S:RI:bcc2009.fits.gz']
@@ -236,11 +230,11 @@ instance the ``table=photometry`` will fetch all the relevant photometric data
 for the specified object. We look at a simple example:
 
 .. code-block:: python
+.. doctest-remote-data::
 
     >>> from astroquery.ned import Ned
     >>> result_table = Ned.get_table("3C 273", table='positions')
     >>> print(result_table)
-
       No.       RA            DEC       ... Published Frame  Published Frequence Mode                           Qualifiers
     --- -------------- -------------- ... --------------- ------------------------- --------------------------------------------------------------
       0 12h29m06.6997s +02d03m08.598s ...

--- a/docs/ned/ned.rst
+++ b/docs/ned/ned.rst
@@ -13,21 +13,23 @@ and spectra queries on the other hand return the results as a list of
 `~astropy.io.fits.HDUList` objects. Below are some working examples that
 illustrate common use cases.
 
+
 Query an object
 ---------------
 
 This may be used to query the object *by name* from the NED service. For
 instance if you want to query NGC 224
 
-.. code-block:: python
 .. doctest-remote-data::
 
     >>> from astroquery.ned import Ned
     >>> result_table = Ned.query_object("NGC 224")
     >>> print(result_table) # an astropy.table.Table
-     No. Object Name  RA(deg)   ... Redshift Points Diameter Points Associations
+    No. Object Name     RA     ... Redshift Points Diameter Points Associations
+                     degrees   ...
     --- ----------- ---------- ... --------------- --------------- ------------
-      1 MESSIER 031   10.68479 ...              26               7            2
+      1 MESSIER 031   10.68479 ...              37               7            2
+
 
 Query a region
 --------------
@@ -41,38 +43,31 @@ be specified as a string in which case it will be parsed using
 arcmin. Another optional parameter is the equinox if coordinates are
 specified. By default this is J2000.0 but can also be set to B1950.0.
 
-.. code-block:: python
 .. doctest-remote-data::
 
     >>> from astroquery.ned import Ned
     >>> import astropy.units as u
     >>> result_table = Ned.query_region("3c 273", radius=0.05 * u.deg)
     >>> print(result_table)
-    No.       Object Name        ... Diameter Points Associations
-    --- ------------------------ ... --------------- ------------
-      1    3C 273:[PWC2011] 3640 ...               0            0
-      2    3C 273:[PWC2011] 3592 ...               0            0
-      3    3C 273:[PWC2011] 3593 ...               0            0
-      4    3C 273:[PWC2011] 3577 ...               0            0
-      5 SDSS J122856.35+020325.3 ...               3            0
-      6    3C 273:[PWC2011] 3553 ...               0            0
-      7    3C 273:[PWC2011] 3544 ...               0            0
-      8    3C 273:[PWC2011] 3521 ...               0            0
-    ...                      ... ...             ...          ...
-    346    3C 273:[PWC2011] 2370 ...               0            0
-    347 SDSS J122917.00+020436.3 ...               4            0
-    348    3C 273:[PWC2011] 2338 ...               0            0
-    349    3C 273:[PWC2011] 2349 ...               0            0
-    350 SDSS J122917.52+020301.5 ...               4            0
-    351    3C 273:[PWC2011] 2326 ...               0            0
-    352 SDSS J122917.72+020356.8 ...               3            0
-    353 SDSS J122918.38+020323.4 ...               4            0
+    No.        Object Name             RA     ... Diameter Points Associations
+                                    degrees   ...
+    --- -------------------------- ---------- ... --------------- ------------
+      1  WISEA J122855.03+020309.1  187.22917 ...               0            0
+      2 SSTSL2 J122855.02+020313.7  187.22925 ...               0            0
+      3 SSTSL2 J122855.23+020341.5  187.23013 ...               0            0
+      4 SSTSL2 J122855.36+020346.9  187.23068 ...               0            0
+    ...                        ...        ... ...             ...          ...
+    863 SSTSL2 J122918.24+020330.7    187.326 ...               0            0
+    864   SDSS J122918.38+020323.4   187.3266 ...               4            0
+    865 SSTSL2 J122918.52+020338.9  187.32718 ...               0            0
+    866 SSTSL2 J122918.64+020326.7  187.32767 ...               0            0
+    Length = 866 rows
+
 
 Instead of using the name, the target may also be specified via
 coordinates. Any of the coordinate systems available in `astropy.coordinates`
 may be used (ICRS, Galactic, FK4, FK5). Note also the use of the equinox keyword argument:
 
-.. code-block:: python
 .. doctest-remote-data::
 
     >>> from astroquery.ned import Ned
@@ -82,13 +77,20 @@ may be used (ICRS, Galactic, FK4, FK5). Note also the use of the equinox keyword
     ...                           unit=(u.deg, u.deg), frame='fk4')
     >>> result_table = Ned.query_region(co, radius=0.1 * u.deg, equinox='B1950.0')
     >>> print(result_table)
-    No.       Object Name       ... Diameter Points Associations
-    --- ----------------------- ... --------------- ------------
-      1 2MASX J03514350+3841573 ...               2            0
-      2 2MASX J03514563+3839573 ...               2            0
-      3     NVSS J035158+384747 ...               0            0
-      4 2MASX J03521115+3849288 ...               2            0
-      5 2MASX J03521844+3840179 ...               2            0
+    No.        Object Name            RA     ... Diameter Points Associations
+                                   degrees   ...
+    --- ------------------------- ---------- ... --------------- ------------
+      1 WISEA J035137.90+384313.7   57.90793 ...               0            0
+      2 WISEA J035138.59+384305.6   57.91062 ...               0            0
+      3 WISEA J035139.28+384324.4   57.91371 ...               0            0
+      4 WISEA J035139.77+384507.4   57.91572 ...               0            0
+    ...                       ...        ... ...             ...          ...
+    631 WISEA J035237.78+384519.3   58.15743 ...               0            0
+    632 WISEA J035238.62+384431.9   58.16083 ...               0            0
+    633 WISEA J035238.74+384352.1   58.16145 ...               0            0
+    634 WISEA J035238.84+384437.0   58.16177 ...               0            0
+    Length = 634 rows
+
 
 Query in the IAU format
 ^^^^^^^^^^^^^^^^^^^^^^^
@@ -102,19 +104,25 @@ queries). It defaults to ``B1950`` but again it may be set to ``J2000.0``. Note
 that Ned report results by searching in a 15 arcmin radius around the specified
 target.
 
-.. code-block:: python
 .. doctest-remote-data::
 
     >>> from astroquery.ned import Ned
     >>> result_table = Ned.query_region_iau('1234-423', frame='SuperGalactic', equinox='J2000.0')
     >>> print(result_table)
-        No.       Object Name        RA(deg)   ... Diameter Points Associations
-    --- ----------------------- ---------- ... --------------- ------------
-      1    SUMSS J123651-423554  189.21425 ...               0            0
-      2    SUMSS J123658-423457    189.245 ...               0            0
-      3    SUMSS J123711-424119  189.29663 ...               0            0
-      4 2MASX J12373141-4239342  189.38083 ...               2            0
-      5 2MASX J12373567-4239122  189.39908 ...               2            0
+    No.        Object Name            RA     ... Diameter Points Associations
+                                   degrees   ...
+    --- ------------------------- ---------- ... --------------- ------------
+      1 WISEA J123639.37-423822.9  189.16406 ...               0            0
+      2 WISEA J123639.47-423656.3  189.16458 ...               0            0
+      3 WISEA J123639.61-423637.9  189.16506 ...               0            0
+      4 WISEA J123639.91-423709.9   189.1663 ...               0            0
+    ...                       ...        ... ...             ...          ...
+    760   2MASS J12374631-4236174  189.44299 ...               0            0
+    761 WISEA J123746.44-423727.9  189.44359 ...               0            0
+    762 WISEA J123746.48-423838.1   189.4437 ...               0            0
+    763 WISEA J123747.07-423742.9  189.44616 ...               0            0
+    Length = 763 rows
+
 
 Query a reference code for objects
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -123,30 +131,25 @@ These queries can be used to retrieve all objects that appear in the specified
 19 digit reference code. These are similar to the
 :meth:`~astroquery.simbad.SimbadClass.query_bibobj` queries.
 
-.. code-block:: python
 .. doctest-remote-data::
 
     >>> from astroquery.ned import Ned
     >>> result_table = Ned.query_refcode('1997A&A...323...31K')
     >>> print(result_table)
-        No.       Object Name        RA(deg)   ... Diameter Points Associations
-    --- ----------------------- ---------- ... --------------- ------------
-      1                NGC 0262   12.19642 ...               8            0
-      2                NGC 0449    19.0302 ...               7            0
-      3                NGC 0591   23.38028 ...               7            0
-      4               UGC 01214   25.99084 ...               7            0
-      5 2MASX J01500266-0725482   27.51124 ...               2            0
-      6             MESSIER 077   40.66963 ...               8            0
-      7                MRK 0599   41.94759 ...               6            0
-      8                MRK 1058   42.46596 ...               4            0
-    ...                     ...        ... ...             ...          ...
-     30                NGC 5643  218.16977 ...              18            0
-     31            SBS 1439+537   220.1672 ...               2            3
-     32                MRK 1388  222.65772 ...               6            0
-     33 2MASX J20232535+1131352  305.85577 ...               2            0
-     34               UGC 12149  340.28163 ...               8            0
-     35                MRK 0522  345.07954 ...               4            0
-     36                NGC 7674  351.98635 ...               8            0
+    No.        Object Name            RA     ... Diameter Points Associations
+                                   degrees   ...
+    --- ------------------------- ---------- ... --------------- ------------
+      1                  NGC 0262   12.19642 ...               8            0
+      2                  NGC 0449    19.0302 ...               7            0
+      3                  NGC 0591   23.38028 ...               7            0
+      4                 UGC 01214   25.99084 ...               7            0
+    ...                       ...        ... ...             ...          ...
+     33 WISEA J202325.39+113134.6  305.85577 ...               2            0
+     34                 UGC 12149  340.28163 ...               8            0
+     35                  MRK 0522  345.07954 ...               4            0
+     36                  NGC 7674  351.98635 ...               8            0
+    Length = 36 rows
+
 
 Image and Spectra Queries
 ^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -154,11 +157,10 @@ Image and Spectra Queries
 The image queries return a list of `~astropy.io.fits.HDUList` objects for the
 specified name. For instance:
 
-.. code-block:: python
 .. doctest-remote-data::
 
     >>> from astroquery.ned import Ned
-    >>> images = Ned.get_images("m1")
+    >>> images = Ned.get_images("m1")  # doctest: +IGNORE_OUTPUT
     Downloading http://ned.ipac.caltech.edu/dss1B2/Bb/MESSIER_001:I:103aE:dss1.fits.gz
     |===========================================|  32k/ 32k (100.00%)        00s
     Downloading http://ned.ipac.caltech.edu/img5/1995RXCD3.T...0000C/p083n22a:I:0.1-2.4keV:cop1995.fits.gz
@@ -169,7 +171,7 @@ specified name. For instance:
     |===========================================|  52k/ 52k (100.00%)        01s
     Downloading http://ned.ipac.caltech.edu/img5/1998RXCD8.T...0000C/h083n22a:I:0.1-2.4keV:cps1998.fits.gz
     |===========================================|  35k/ 35k (100.00%)        00s
-    >>> images # may be used to do further processing on individual cutouts doctest: +IGNORE_OUTPUT
+    >>> images  # doctest: +IGNORE_OUTPUT
     [[<astropy.io.fits.hdu.image.PrimaryHDU at 0x4311890>],
     [<astropy.io.fits.hdu.image.PrimaryHDU at 0x432b350>],
     [<astropy.io.fits.hdu.image.PrimaryHDU at 0x3e9c5d0>],
@@ -178,47 +180,47 @@ specified name. For instance:
 
 To get the URLs of the downloadable FITS images:
 
-.. code-block:: python
 .. doctest-remote-data::
 
     >>> from astroquery.ned import Ned
     >>> image_list = Ned.get_image_list("m1")
-    >>> image_list
+    >>> image_list  # doctest: +NORMALIZE_WHITESPACE
     ['http://ned.ipac.caltech.edu/dss1B2/Bb/MESSIER_001:I:103aE:dss1.fits.gz',
-     'http://ned.ipac.caltech.edu/img5/1995RXCD3.T...0000C/p083n22a:I:0.1-2.4keV:cop1995.fits.gz',
-     'http://ned.ipac.caltech.edu/img5/1996RXCD6.T...0000C/p083n22a:I:0.1-2.4keV:cps1996.fits.gz',
-     'http://ned.ipac.caltech.edu/img5/1995RXCD3.T...0000C/p084n22a:I:0.1-2.4keV:cop1995.fits.gz',
-     'http://ned.ipac.caltech.edu/img5/1998RXCD8.T...0000C/h083n22a:I:0.1-2.4keV:cps1998.fits.gz']
+     'http://ned.ipac.caltech.edu/img/1995RXCD3.T...0000C/p084n22a:I:0.1-2.4keV:cop1995.fits.gz',
+     'http://ned.ipac.caltech.edu/img/1996RXCD6.T...0000C/p083n22a:I:0.1-2.4keV:cps1996.fits.gz',
+     'http://ned.ipac.caltech.edu/img/1998RXCD8.T...0000C/h083n22a:I:0.1-2.4keV:cps1998.fits.gz',
+     'http://ned.ipac.caltech.edu/img/1995RXCD3.T...0000C/p083n22a:I:0.1-2.4keV:cop1995.fits.gz']
+
 
 Spectra can also be fetched in the same way:
 
-.. code-block:: python
 .. doctest-remote-data::
 
     >>> from astroquery.ned import Ned
-    >>> spectra = Ned.get_spectra('3c 273')
+    >>> spectra = Ned.get_spectra('3c 273')  # doctest: +IGNORE_OUTPUT
     Downloading http://ned.ipac.caltech.edu/spc1/2009A+A...495.1033B/3C_273:S:B:bcc2009.fits.gz
     |===========================================| 7.8k/7.8k (100.00%)        00s
     Downloading http://ned.ipac.caltech.edu/spc1/1992ApJS...80..109B/PG_1226+023:S:B_V:bg1992.fits.gz
     |===========================================| 5.0k/5.0k (100.00%)        00s
     Downloading http://ned.ipac.caltech.edu/spc1/2009A+A...495.1033B/3C_273:S:RI:bcc2009.fits.gz
     |===========================================| 9.4k/9.4k (100.00%)        00s
-    >>> spectra       # doctest: +IGNORE_OUTPUT
+    >>> spectra  # doctest: +IGNORE_OUTPUT
     [[<astropy.io.fits.hdu.image.PrimaryHDU at 0x41b4190>],
     [<astropy.io.fits.hdu.image.PrimaryHDU at 0x41b0990>],
     [<astropy.io.fits.hdu.image.PrimaryHDU at 0x430a450>]]
 
+
 Similarly the list of URLs for spectra of a particular object may be fetched:
 
-.. code-block:: python
 .. doctest-remote-data::
 
     >>> from astroquery.ned import Ned
-    >>> image_list = Ned.get_image_list("3c 273", item='spectra')
-    >>> image_list
-    ['http://ned.ipac.caltech.edu/spc1/2009A+A...495.1033B/3C_273:S:B:bcc2009.fits.gz',
-    'http://ned.ipac.caltech.edu/spc1/1992ApJS...80..109B/PG_1226+023:S:B_V:bg1992.fits.gz',
-    'http://ned.ipac.caltech.edu/spc1/2009A+A...495.1033B/3C_273:S:RI:bcc2009.fits.gz']
+    >>> spectra_list = Ned.get_image_list("3c 273", item='spectra')
+    >>> spectra_list
+    ['http://ned.ipac.caltech.edu/spc1/1992/1992ApJS...80..109B/PG_1226+023:S:B_V:bg1992.fits.gz',
+     'http://ned.ipac.caltech.edu/spc1/2009/2009A+A...495.1033B/3C_273:S:B:bcc2009.fits.gz',
+     'http://ned.ipac.caltech.edu/spc1/2009/2009A+A...495.1033B/3C_273:S:RI:bcc2009.fits.gz']
+
 
 Fetching other data tables for an object
 ----------------------------------------
@@ -229,26 +231,25 @@ queries. These take a keyword argument ``table``, which may be set to one of
 instance the ``table=photometry`` will fetch all the relevant photometric data
 for the specified object. We look at a simple example:
 
-.. code-block:: python
 .. doctest-remote-data::
 
     >>> from astroquery.ned import Ned
     >>> result_table = Ned.get_table("3C 273", table='positions')
     >>> print(result_table)
-      No.       RA            DEC       ... Published Frame  Published Frequence Mode                           Qualifiers
-    --- -------------- -------------- ... --------------- ------------------------- --------------------------------------------------------------
-      0 12h29m06.6997s +02d03m08.598s ...
-      1 12h29m06.6997s +02d03m08.598s ...             ICR Multiple line measurement                                             From new, raw data
-      2  12h29m06.699s  +02d03m08.59s ...             ICR    Broad-band measurement                                             From new, raw data
-      3   12h29m06.64s   +02d03m09.0s ...             FK4    Broad-band measurement From reprocessed raw data; Corrected for contaminating sources
-      4   12h29m06.79s   +02d03m08.0s ...             FK5    Broad-band measurement  From new, raw data; Systematic errors in RA and Dec corrected
-      5   12h29m06.05s   +02d02m57.1s ...             FK4    Broad-band measurement                                             From new, raw data
-      6   12h29m05.60s   +02d03m09.0s ...             FK5    Broad-band measurement                                             From new, raw data
-      7    12h29m04.5s     +02d03m03s ...                    Broad-band measurement                                             From new, raw data
-      8   12h29m07.55s   +02d03m02.3s ...             FK4    Broad-band measurement                                      From reprocessed raw data
-      9   12h29m06.05s   +02d03m11.3s ...             FK4    Broad-band measurement                                             From new, raw data
-     10    12h29m06.5s     +02d02m53s ...             FK4    Broad-band measurement                                             From new, raw data
-     11    12h29m06.5s     +02d02m52s ...             FK4    Broad-band measurement                                      From reprocessed raw data
+    No.       RA       ... Published Frequence Mode         Qualifiers
+                       ...
+    --- -------------- ... ------------------------ -------------------------
+      0 12h29m06.6997s ...
+      1 12h29m06.7000s ...                                   Uncertain origin
+      2 12h29m06.7000s ...                                   Uncertain origin
+      3 12h29m06.7000s ...                                   Uncertain origin
+    ...            ... ...                      ...                       ...
+    113    12h29m07.9s ...                                   Uncertain origin
+    114      12h29m04s ...                                   Uncertain origin
+    115      12h29m06s ...                                   Uncertain origin
+    116      12h29m08s ...                                   Uncertain origin
+    Length = 117 rows
+
 
 Reference/API
 =============


### PR DESCRIPTION
ned.ipac.caltech.edu down

Edit (bsipocz): This PR enables the doctesting of examples in the narrative docs of the ned module. 