### PR TITLE
MAST: making AWS clous access anonymous

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -43,6 +43,7 @@ mast
 - Added Zcut functionality to astroquery [#1911]
 - Fixed error causing empty products passed to ``Observations.get_product_list()`` to yeild a
   non-empty result. [#1921]
+- Changed AWS cloud access from RequesterPays to anonymous acces [#1980]
 
 esa/hubble
 ^^^^^^^^^^

--- a/astroquery/mast/cloud.py
+++ b/astroquery/mast/cloud.py
@@ -47,7 +47,7 @@ class CloudAccess:  # pragma:no-cover
 
         # Dealing with deprecated argument
         if profile is not None:
-            warnings.warn(("MAST cloud data is now free to access and does "
+            warnings.warn(("MAST Open Data on AWS is now free to access and does "
                            "not require an AWS account"), AstropyDeprecationWarning)
 
         import boto3

--- a/astroquery/mast/cloud.py
+++ b/astroquery/mast/cloud.py
@@ -49,7 +49,7 @@ class CloudAccess:  # pragma:no-cover
         if profile is not None:
             warnings.warn(("MAST cloud data is now free to access and does "
                            "not require an AWS account"), AstropyDeprecationWarning)
-        
+
         import boto3
         import botocore
 
@@ -110,7 +110,6 @@ class CloudAccess:  # pragma:no-cover
             found in the cloud, None is returned.
         """
 
-        
         s3_client = self.boto3.client('s3', config=self.config)
 
         path = utils.mast_relative_path(data_product["dataURI"])

--- a/astroquery/mast/observations.py
+++ b/astroquery/mast/observations.py
@@ -539,7 +539,7 @@ class ObservationsClass(MastQueryWithLogin):
             local_path = os.path.join(os.path.abspath('.'), filename)
 
         # recreate the data_product key for cloud connection check
-        data_product = {'dataURI': data_url}
+        data_product = {'dataURI': uri}
 
         status = "COMPLETE"
         msg = None


### PR DESCRIPTION
MAST data on AWS is now free to the world, so this PR changes MAST cloud access from "RequesterPays" to anonymous access.