### PR TITLE
TST: Remove custom CI skip

### DIFF
--- a/.github/workflows/ci_tests.yml
+++ b/.github/workflows/ci_tests.yml
@@ -17,19 +17,10 @@ jobs:
   cancel_ci:
     name: Mandatory checks before CI
     runs-on: ubuntu-latest
-    outputs:
-      run_next: ${{ steps.skip_ci_step.outputs.run_next }}
     steps:
-    - name: Check skip CI
-      uses: OpenAstronomy/action-skip-ci@main
-      id: skip_ci_step
-      with:
-        NO_FAIL: true
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-    # This should only run if we did not skip CI
+    # TODO: Fix this for PRs
     - name: Cancel Previous Runs
       uses: styfle/cancel-workflow-action@ce177499ccf9fd2aded3b0426c97e5434c2e8a73
-      if: steps.skip_ci_step.outputs.run_next == 'true'
       with:
         access_token: ${{ secrets.GITHUB_TOKEN }}
 
@@ -39,7 +30,6 @@ jobs:
     name: ${{ matrix.name }}
     runs-on: ${{ matrix.os }}
     needs: cancel_ci
-    if: needs.cancel_ci.outputs.run_next == 'true'
     strategy:
       fail-fast: true
       matrix:
@@ -124,7 +114,6 @@ jobs:
     name: egg_info with Python 3.7
     runs-on: ubuntu-latest
     needs: cancel_ci
-    if: needs.cancel_ci.outputs.run_next == 'true'
     steps:
     - name: Checkout code
       uses: actions/checkout@v2

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -22,20 +22,9 @@ jobs:
   cancel_ci:
     name: Mandatory checks before CI
     runs-on: ubuntu-latest
-    outputs:
-      run_next: ${{ steps.skip_ci_step.outputs.run_next }}
-    steps:
-    - name: Check skip CI
-      uses: OpenAstronomy/action-skip-ci@main
-      id: skip_ci_step
-      with:
-        NO_FAIL: true
-        SKIP_DIRECTIVES: '[skip ci],[ci skip],[skip codeql],[codeql skip]'
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-    # This should only run if we did not skip CI
+    # TODO: Fix this for PRs
     - name: Cancel Previous Runs
       uses: styfle/cancel-workflow-action@ce177499ccf9fd2aded3b0426c97e5434c2e8a73
-      if: steps.skip_ci_step.outputs.run_next == 'true'
       with:
         access_token: ${{ secrets.GITHUB_TOKEN }}
 
@@ -45,7 +34,6 @@ jobs:
     name: Analyze
     runs-on: ubuntu-latest
     needs: cancel_ci
-    if: needs.cancel_ci.outputs.run_next == 'true'
 
     strategy:
       fail-fast: false


### PR DESCRIPTION
Follow up of #1940 as a result of https://github.blog/changelog/2021-02-08-github-actions-skip-pull-request-and-push-workflows-with-skip-ci/ .

Also see astropy/astropy#11316