### PR TITLE
Delete range from session request header after use

### DIFF
--- a/astroquery/query.py
+++ b/astroquery/query.py
@@ -369,6 +369,7 @@ class BaseQuery:
                                                  timeout=timeout, stream=True,
                                                  auth=auth, **kwargs)
                 response.raise_for_status()
+                del self._session.headers['Range']
 
         elif cache and os.path.exists(local_filepath):
             if length is not None:

--- a/astroquery/query.py
+++ b/astroquery/query.py
@@ -250,7 +250,7 @@ class BaseQuery:
             See `_download_file`.
         stream : bool
         return_response_on_save : bool
-            If ``save==True``, also return the server response. The default is to only
+            If ``save``, also return the server response. The default is to only
             return the local file path.
 
         Returns

--- a/astroquery/tests/test_resume.py
+++ b/astroquery/tests/test_resume.py
@@ -9,10 +9,8 @@ ACTIVE_HTTPBIN = os.getenv('ACTIVE_HTTPBIN') is not None
 
 
 @pytest.mark.skipif('not ACTIVE_HTTPBIN')
-def test_resume():
+def test_resume(length=2048, partial_length=1024, qu=None):
     # Test that a resumed query will finish
-
-    length = 2048
 
     # 'range' will return abcd...xyz repeating
     target_url = 'http://127.0.0.1:5000/range/{0}'.format(length)
@@ -20,7 +18,8 @@ def test_resume():
     # simple check: make sure the server does what's expected
     assert len(requests.get(target_url).content) == length
 
-    qu = query.BaseQuery()
+    if qu is None:
+        qu = query.BaseQuery()
 
     result_1 = qu._request('GET', target_url, save=True)
     # now the full file is written, so we have to delete parts of it
@@ -29,17 +28,29 @@ def test_resume():
         data = fh.read()
     with open(result_1, 'wb') as fh:
         # overwrite with a partial file
-        fh.write(data[:1024])
+        fh.write(data[:partial_length])
     with open(result_1, 'rb') as fh:
         data = fh.read()
-        assert len(data) == 1024
+        assert len(data) == partial_length
 
-    result_2 = qu._request('GET', target_url, save=True, continuation=True)
+    result_2, response = qu._request('GET', target_url, save=True, continuation=True,
+                                     return_response_on_save=True)
 
-    assert 'range' in qu._session.headers
-    assert qu._session.headers['range'] == 'bytes={0}-{1}'.format(1024, length-1)
+    assert 'content-range' in response.headers
+    assert response.headers['content-range'] == 'bytes {0}-{1}/{2}'.format(
+        partial_length, length-1, length
+    )
 
     with open(result_2, 'rb') as fh:
         data = fh.read()
     assert len(data) == length
-    assert data == (string.ascii_lowercase*80)[:length].encode('ascii')
+    assert data == (string.ascii_lowercase*(length//26+1))[:length].encode('ascii')
+
+
+@pytest.mark.skipif('not ACTIVE_HTTPBIN')
+def test_resume_consecutive():
+    # Test that consecutive resumed queries request the correct content range and finish
+    qu = query.BaseQuery()
+
+    test_resume(length=2048, partial_length=1024, qu=qu)
+    test_resume(length=2048, partial_length=512, qu=qu)


### PR DESCRIPTION
I encountered a problem when downloading multiple files from CASDA which I think is unrelated to the CASDA module. When a partially downloaded file is resumed, the session header is set with the range of bytes required to complete the file. However, setting the range in this way makes it persist for subsequent requests that use the same session. This can be quite nasty as it will happen transparently if the subsequent files are of the same size or larger as the first encountered incomplete file. I only noticed it when one of the subsequent files was smaller than the first incomplete file and so a HTTP 416 error was thrown.

This PR is a simple fix to delete the range header once the request completed successfully.