### PR TITLE
Added HTTP logging capability

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -128,6 +128,15 @@ esa.xmm_newton
 
 - Added new function to download EPIC sources metadate. [#1814]
 
+
+Infrastructure, Utility and Other Changes and Additions
+-------------------------------------------------------
+
+- HTTP requests and responses can now be logged when the astropy
+  logger is set to level "DEBUG" and "TRACE" respectively. [#1992]
+- Astroquery now uses a logger similar to Astropy's. [#1992]
+
+
 0.4.1 (2020-06-19)
 ==================
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -134,7 +134,7 @@ Infrastructure, Utility and Other Changes and Additions
 
 - HTTP requests and responses can now be logged when the astropy
   logger is set to level "DEBUG" and "TRACE" respectively. [#1992]
-- Astroquery now uses a logger similar to Astropy's. [#1992]
+- Astroquery and all its modules now uses a logger similar to Astropy's. [#1992]
 
 
 0.4.1 (2020-06-19)

--- a/astroquery/__init__.py
+++ b/astroquery/__init__.py
@@ -13,6 +13,9 @@ from ._astropy_init import *
 # ----------------------------------------------------------------------------
 
 import os
+import logging
+
+from .logger import _init_log
 
 
 # Set the bibtex entry to the article referenced in CITATION.
@@ -39,3 +42,9 @@ try:
 except ImportError:
     # TODO: Issue a warning using the logging framework
     __githash__ = ''
+
+
+# Setup logging for astroquery
+logging.addLevelName(5, "TRACE")
+log = logging.getLogger()
+log = _init_log()

--- a/astroquery/alma/core.py
+++ b/astroquery/alma/core.py
@@ -16,7 +16,7 @@ import pyvo
 from six.moves.urllib_parse import urljoin
 import six
 from astropy.table import Table, Column, vstack
-from astropy import log
+from astroquery import log
 from astropy.utils import deprecated
 from astropy.utils.console import ProgressBar
 from astropy.utils.exceptions import AstropyDeprecationWarning

--- a/astroquery/alma/utils.py
+++ b/astroquery/alma/utils.py
@@ -7,7 +7,7 @@ import os
 import numpy as np
 
 from astropy import wcs
-from astropy import log
+from astroquery import log
 from astropy import units as u
 from astropy.io import fits
 from astroquery.utils.commons import ASTROPY_LT_4_1

--- a/astroquery/astrometry_net/core.py
+++ b/astroquery/astrometry_net/core.py
@@ -6,7 +6,7 @@ import json
 import six
 from six import string_types
 from astropy.io import fits
-from astropy import log
+from astroquery import log
 from astropy.stats import sigma_clipped_stats
 from astropy.coordinates import SkyCoord
 

--- a/astroquery/cadc/core.py
+++ b/astroquery/cadc/core.py
@@ -7,7 +7,7 @@ CADC
 Module to query the Canadian Astronomy Data Centre (CADC).
 """
 
-from astroquery import log as logger
+from astroquery import log
 import warnings
 import requests
 from numpy import ma
@@ -190,7 +190,7 @@ class CadcClass(BaseQuery):
             try:
                 response.raise_for_status()
             except Exception as e:
-                logger.error('Logging error: {}'.format(e))
+                log.error('Logging error: {}'.format(e))
                 raise e
             # extract cookie
             cookie = '"{}"'.format(response.text)
@@ -355,7 +355,7 @@ class CadcClass(BaseQuery):
                 images.append(fn.get_fits())
             except requests.exceptions.HTTPError as err:
                 # Catch HTTPError if user is unauthorized to access file
-                logger.debug(
+                log.debug(
                     "{} - Problem retrieving the file: {}".
                     format(str(err), str(err.url)))
                 pass
@@ -809,7 +809,7 @@ def get_access_url(service, capability=None):
                 response = requests.get(conf.CADC_REGISTRY_URL)
                 response.raise_for_status()
             except requests.exceptions.HTTPError as err:
-                logger.debug(
+                log.debug(
                     "ERROR getting the CADC registry: {}".format(str(err)))
                 raise err
             for line in response.text.splitlines():
@@ -833,7 +833,7 @@ def get_access_url(service, capability=None):
         response2 = requests.get(caps_url)
         response2.raise_for_status()
     except Exception as e:
-        logger.debug(
+        log.debug(
             "ERROR getting the service capabilities: {}".format(str(e)))
         raise e
 

--- a/astroquery/cadc/core.py
+++ b/astroquery/cadc/core.py
@@ -38,7 +38,7 @@ __all__ = ['Cadc', 'CadcClass']
 
 CADC_COOKIE_PREFIX = 'CADC_SSO'
 
-logger = logging.getLogger(__name__)
+logger = logging.getLogger('cadc')
 
 # TODO figure out what to do if anything about them. Some might require
 # fixes on the CADC servers

--- a/astroquery/cadc/core.py
+++ b/astroquery/cadc/core.py
@@ -7,7 +7,7 @@ CADC
 Module to query the Canadian Astronomy Data Centre (CADC).
 """
 
-import logging
+from astroquery import log as logger
 import warnings
 import requests
 from numpy import ma
@@ -37,8 +37,6 @@ except AstropyDeprecationWarning as e:
 __all__ = ['Cadc', 'CadcClass']
 
 CADC_COOKIE_PREFIX = 'CADC_SSO'
-
-logger = logging.getLogger('cadc')
 
 # TODO figure out what to do if anything about them. Some might require
 # fixes on the CADC servers

--- a/astroquery/casda/core.py
+++ b/astroquery/casda/core.py
@@ -12,7 +12,7 @@ import astropy.units as u
 import astropy.coordinates as coord
 from astropy.table import Table
 from astropy.io.votable import parse
-from astropy import log
+from astroquery import log
 
 # 3. local imports - use relative imports
 # commonly required local imports shown below as example

--- a/astroquery/casda/tests/test_casda.py
+++ b/astroquery/casda/tests/test_casda.py
@@ -11,7 +11,7 @@ from astropy.coordinates import SkyCoord
 import astropy.units as u
 from astropy.table import Table, Column
 from astropy.io.votable import parse
-from astropy import log
+from astroquery import log
 
 from astroquery.casda import Casda
 

--- a/astroquery/cosmosim/core.py
+++ b/astroquery/cosmosim/core.py
@@ -19,7 +19,7 @@ from six.moves.email_mime_text import MIMEText
 # Astropy imports
 from astropy.table import Table
 import astropy.io.votable as votable
-from astroquery import log as logging
+from astroquery import log
 
 # Astroquery imports
 from ..query import QueryWithLogin
@@ -72,8 +72,8 @@ class CosmoSimClass(QueryWithLogin):
 
         # login after login (interactive)
         if hasattr(self, 'username'):
-            logging.warning("Attempting to login while another user ({0}) "
-                            "is already logged in.".format(self.username))
+            log.warning("Attempting to login while another user ({0}) "
+                        "is already logged in.".format(self.username))
             self.check_login_status()
             return
 
@@ -144,7 +144,7 @@ class CosmoSimClass(QueryWithLogin):
             del self.username
             del self.password
         else:
-            logging.error("You must log in before attempting to logout.")
+            log.error("You must log in before attempting to logout.")
 
     def check_login_status(self):
         """
@@ -220,8 +220,8 @@ class CosmoSimClass(QueryWithLogin):
                 gen_tablename = "{0}".format(phase)
             else:
                 gen_tablename = str(soup.find(id="table").string)
-            logging.warning("Table name {0} is already taken."
-                            .format(tablename))
+            log.warning("Table name {0} is already taken."
+                        .format(tablename))
             warnings.warn("Generated table name: {0}".format(gen_tablename))
         elif tablename is None:
             result = self._request('POST', CosmoSim.QUERY_URL,
@@ -293,7 +293,7 @@ class CosmoSimClass(QueryWithLogin):
             auth=(self.username, self.password), data={'print': 'b'},
             cache=False)
 
-        logging.info("Job {}: {}".format(jobid, response.content))
+        log.info("Job {}: {}".format(jobid, response.content))
         return response.content
 
     def check_all_jobs(self, phase=None, regex=None, sortby=None):
@@ -586,7 +586,7 @@ class CosmoSimClass(QueryWithLogin):
             elif len(dictkeys) == 1:
                 print(self.response_dict_current[dictkeys[0]]['content'])
             else:
-                logging.error('No completed jobs found.')
+                log.error('No completed jobs found.')
             return
         else:
             return
@@ -680,7 +680,7 @@ class CosmoSimClass(QueryWithLogin):
                 auth=(self.username, self.password), cache=False)]
 
             if response_list[0].ok is False:
-                logging.error('Must provide a valid jobid.')
+                log.error('Must provide a valid jobid.')
                 return
             else:
                 self.response_dict_current = {}
@@ -940,7 +940,7 @@ class CosmoSimClass(QueryWithLogin):
                          for key in self.db_dict[db].keys()]
                 size2 = len(max(slist, key=np.size))
             except (KeyError, NameError):
-                logging.error("Must first specify a valid database.")
+                log.error("Must first specify a valid database.")
                 return
             # if col is specified, table must be specified, and I need to
             # check the max size of any given column in the structure
@@ -954,13 +954,13 @@ class CosmoSimClass(QueryWithLogin):
                                                    [table]['columns']
                                                    [col].keys())))
                         except(KeyError, NameError):
-                            logging.error("Must first specify a valid column "
-                                          "of the `{0}` table within the `{1}`"
-                                          " db".format(table, db))
+                            log.error("Must first specify a valid column "
+                                      "of the `{0}` table within the `{1}`"
+                                      " db".format(table, db))
                             return
                 except (KeyError, NameError):
-                    logging.error("Must first specify a valid table within "
-                                  "the `{0}` db.".format(db))
+                    log.error("Must first specify a valid table within "
+                              "the `{0}` db.".format(db))
                     return
 
             t['Projects'] = (['--> @ {}:'.format(db)] +
@@ -1202,7 +1202,7 @@ class CosmoSimClass(QueryWithLogin):
         time.sleep(1)
 
         if jobid not in self.job_dict.keys():
-            logging.error("Job not present in job dictionary.")
+            log.error("Job not present in job dictionary.")
             return
 
         else:
@@ -1291,7 +1291,7 @@ class CosmoSimClass(QueryWithLogin):
             self._smspw = password_from_keyring
 
         if not password_from_keyring:
-            logging.warning("CosmoSim SMS alerting has not been initialized.")
+            log.warning("CosmoSim SMS alerting has not been initialized.")
             warnings.warn("Initializing SMS alerting.")
             keyring.set_password("astroquery:cosmosim.SMSAlert",
                                  self._smsaddress, "LambdaCDM")

--- a/astroquery/cosmosim/core.py
+++ b/astroquery/cosmosim/core.py
@@ -19,7 +19,7 @@ from six.moves.email_mime_text import MIMEText
 # Astropy imports
 from astropy.table import Table
 import astropy.io.votable as votable
-from astropy import log as logging
+from astroquery import log as logging
 
 # Astroquery imports
 from ..query import QueryWithLogin

--- a/astroquery/esa/hubble/core.py
+++ b/astroquery/esa/hubble/core.py
@@ -28,7 +28,7 @@ import shutil
 import os
 
 from . import conf
-from astropy import log
+from astroquery import log
 
 __all__ = ['ESAHubble', 'ESAHubbleClass']
 

--- a/astroquery/esa/iso/core.py
+++ b/astroquery/esa/iso/core.py
@@ -21,7 +21,7 @@ import requests
 from pathlib import Path
 
 from . import conf
-from astropy import log
+from astroquery import log
 
 
 __all__ = ['ISO', 'ISOClass']

--- a/astroquery/esa/xmm_newton/core.py
+++ b/astroquery/esa/xmm_newton/core.py
@@ -21,7 +21,7 @@ import tarfile
 import os
 
 from . import conf
-from astropy import log
+from astroquery import log
 from astropy.coordinates import SkyCoord
 
 

--- a/astroquery/esasky/core.py
+++ b/astroquery/esasky/core.py
@@ -10,7 +10,7 @@ from io import BytesIO
 
 import six
 from astropy.io import fits
-from astropy import log
+from astroquery import log
 import astropy.units
 import astropy.io.votable as votable
 from requests import HTTPError

--- a/astroquery/eso/core.py
+++ b/astroquery/eso/core.py
@@ -14,7 +14,7 @@ from bs4 import BeautifulSoup
 from six import BytesIO
 import six
 from astropy.table import Table, Column
-from astropy import log
+from astroquery import log
 
 from ..exceptions import LoginError, RemoteServiceError, NoResultsWarning
 from ..utils import schema, system_tools

--- a/astroquery/gaia/core.py
+++ b/astroquery/gaia/core.py
@@ -284,7 +284,7 @@ class GaiaClass(TapPlus):
 
         if verbose:
             if output_file_specified:
-                logger.info("output_file =", output_file)
+                logger.info("output_file = %s" % output_file)
 
         logger.debug("List of products available:")
         # for key, value in files.items():

--- a/astroquery/gaia/core.py
+++ b/astroquery/gaia/core.py
@@ -18,6 +18,7 @@ from requests import HTTPError
 
 from astroquery.utils.tap import TapPlus
 from astroquery.utils import commons
+from astroquery import log
 from astropy import units
 from astropy.units import Quantity
 import six
@@ -32,8 +33,6 @@ from astropy.io import votable
 from astropy.io import fits
 from astropy.table import Table
 from astropy import units as u
-
-from ..cadc.core import logger
 
 
 class GaiaClass(TapPlus):
@@ -93,22 +92,22 @@ class GaiaClass(TapPlus):
             flag to display information about the process
         """
         try:
-            logger.info("Login to gaia TAP server")
+            log.info("Login to gaia TAP server")
             TapPlus.login(self, user=user, password=password,
                           credentials_file=credentials_file,
                           verbose=verbose)
         except HTTPError as err:
-            logger.error("Error logging in TAP server")
+            log.error("Error logging in TAP server")
             return
         u = self._TapPlus__user
         p = self._TapPlus__pwd
         try:
-            logger.info("Login to gaia data server")
+            log.info("Login to gaia data server")
             TapPlus.login(self.__gaiadata, user=u, password=p,
                           verbose=verbose)
         except HTTPError as err:
-            logger.error("Error logging in data server")
-            logger.error("Logging out from TAP server")
+            log.error("Error logging in data server")
+            log.error("Logging out from TAP server")
             TapPlus.logout(self, verbose=verbose)
 
     def login_gui(self, verbose=False):
@@ -120,20 +119,20 @@ class GaiaClass(TapPlus):
             flag to display information about the process
         """
         try:
-            logger.info("Login to gaia TAP server")
+            log.info("Login to gaia TAP server")
             TapPlus.login_gui(self, verbose=verbose)
         except HTTPError as err:
-            logger.error("Error logging in TAP server")
+            log.error("Error logging in TAP server")
             return
         u = self._TapPlus__user
         p = self._TapPlus__pwd
         try:
-            logger.info("Login to gaia data server")
+            log.info("Login to gaia data server")
             TapPlus.login(self.__gaiadata, user=u, password=p,
                           verbose=verbose)
         except HTTPError as err:
-            logger.error("Error logging in data server")
-            logger.error("Logging out from TAP server")
+            log.error("Error logging in data server")
+            log.error("Logging out from TAP server")
             TapPlus.logout(self, verbose=verbose)
 
     def logout(self, verbose=False):
@@ -147,14 +146,14 @@ class GaiaClass(TapPlus):
         try:
             TapPlus.logout(self, verbose=verbose)
         except HTTPError as err:
-            logger.error("Error logging out TAP server")
+            log.error("Error logging out TAP server")
             return
-        logger.info("Gaia TAP server logout OK")
+        log.info("Gaia TAP server logout OK")
         try:
             TapPlus.logout(self.__gaiadata, verbose=verbose)
-            logger.info("Gaia data server logout OK")
+            log.info("Gaia data server logout OK")
         except HTTPError as err:
-            logger.error("Error logging out data server")
+            log.error("Error logging out data server")
 
     def load_data(self, ids, data_release=None, data_structure='INDIVIDUAL', retrieval_type="ALL", valid_data=True,
                   band=None, avoid_datatype_check=False, format="votable", output_file=None,
@@ -267,9 +266,9 @@ class GaiaClass(TapPlus):
             try:
                 os.mkdir(path)
             except FileExistsError:
-                logger.error("Path %s already exist" % path)
+                log.error("Path %s already exist" % path)
             except OSError:
-                logger.error("Creation of the directory %s failed" % path)
+                log.error("Creation of the directory %s failed" % path)
 
         try:
             self.__gaiadata.load_data(params_dict=params_dict,
@@ -284,9 +283,9 @@ class GaiaClass(TapPlus):
 
         if verbose:
             if output_file_specified:
-                logger.info("output_file = %s" % output_file)
+                log.info("output_file = %s" % output_file)
 
-        logger.debug("List of products available:")
+        log.debug("List of products available:")
         # for key, value in files.items():
         # print("Product =", key)
 
@@ -295,7 +294,7 @@ class GaiaClass(TapPlus):
         for item in items:
             # print(f'* {item}')
             if verbose:
-                logger.debug("Product = " + item)
+                log.debug("Product = " + item)
 
         return files
 

--- a/astroquery/gemini/core.py
+++ b/astroquery/gemini/core.py
@@ -8,22 +8,17 @@ import os
 
 from datetime import date
 
-from astropy import log
+from astroquery import log as logger
 from astropy import units
 from astropy.table import Table, MaskedColumn
 
 from astroquery.gemini.urlhelper import URLHelper
 import numpy as np
 
-import logging
-
 from ..query import BaseQuery, QueryWithLogin
 from ..utils.class_or_instance import class_or_instance
 from . import conf
 from ..exceptions import AuthenticationWarning
-
-
-logger = logging.getLogger(__name__)
 
 
 __all__ = ['Observations', 'ObservationsClass']  # specifies what to import

--- a/astroquery/gemini/core.py
+++ b/astroquery/gemini/core.py
@@ -8,7 +8,7 @@ import os
 
 from datetime import date
 
-from astroquery import log as logger
+from astroquery import log
 from astropy import units
 from astropy.table import Table, MaskedColumn
 
@@ -128,7 +128,7 @@ class ObservationsClass(QueryWithLogin):
         params = dict(username=username, password=password)
         r = self._session.request('POST', 'https://archive.gemini.edu/login/', params=params)
         if b'<P>Welcome, you are sucessfully logged in' not in r.content:
-            logger.error('Unable to login, please check your credentials')
+            log.error('Unable to login, please check your credentials')
             return False
         return True
 

--- a/astroquery/lamda/core.py
+++ b/astroquery/lamda/core.py
@@ -2,7 +2,7 @@
 import os
 import json
 from astropy import table
-from astropy import log
+from astroquery import log
 from astropy.utils.console import ProgressBar
 from bs4 import BeautifulSoup
 from six.moves import urllib_parse as urlparse

--- a/astroquery/lcogt/core.py
+++ b/astroquery/lcogt/core.py
@@ -73,7 +73,7 @@ constraint  Optional    User defined query constraint(s)
 
 
 import warnings
-from astropy.logger import log
+from astroquery import log
 
 import six
 import astropy.units as u

--- a/astroquery/logger.py
+++ b/astroquery/logger.py
@@ -5,10 +5,7 @@ from astropy.logger import AstropyLogger
 
 def _init_log(config=None):
     """
-    Initializes the SunPy log.
-    In most circumstances this is called automatically when importing
-    SunPy. This code is based on that provided by Astropy see
-    "licenses/ASTROPY.rst".
+    Initializes the logger, using the AstropyLogger class.
     """
     orig_logger_cls = logging.getLoggerClass()
     logging.setLoggerClass(AstropyLogger)
@@ -25,7 +22,7 @@ def _init_log(config=None):
 
 def _config_to_loggerConf(config):
     """
-    Translates a user-provided config to ~`astropy.logger.LoggerConf`.
+    Translates a user-provided config to `~astropy.logger.LoggerConf`.
     """
 
     if config.has_section('logger'):

--- a/astroquery/logger.py
+++ b/astroquery/logger.py
@@ -1,0 +1,39 @@
+import logging
+
+from astropy.logger import AstropyLogger
+
+
+def _init_log(config=None):
+    """
+    Initializes the SunPy log.
+    In most circumstances this is called automatically when importing
+    SunPy. This code is based on that provided by Astropy see
+    "licenses/ASTROPY.rst".
+    """
+    orig_logger_cls = logging.getLoggerClass()
+    logging.setLoggerClass(AstropyLogger)
+    try:
+        log = logging.getLogger('astroquery')
+        if config is not None:
+            _config_to_loggerConf(config)
+        log._set_defaults()
+    finally:
+        logging.setLoggerClass(orig_logger_cls)
+
+    return log
+
+
+def _config_to_loggerConf(config):
+    """
+    Translates a user-provided config to ~`astropy.logger.LoggerConf`.
+    """
+
+    if config.has_section('logger'):
+        from astropy.logger import Conf as LoggerConf
+        conf = LoggerConf()
+        loggerconf_option_list = ['log_level', 'use_color', 'log_warnings', 'log_exceptions', 'log_to_file',
+                                  'log_file_path', 'log_file_level', 'log_file_format']
+        for this_option in loggerconf_option_list:
+            if config.has_option('logger', this_option):
+                setattr(conf, this_option, config.get('logger', this_option))
+    return conf

--- a/astroquery/mast/auth.py
+++ b/astroquery/mast/auth.py
@@ -13,7 +13,7 @@ import warnings
 
 from getpass import getpass
 
-from astropy.logger import log
+from astroquery import log
 
 from ..exceptions import AuthenticationWarning
 

--- a/astroquery/mast/cloud.py
+++ b/astroquery/mast/cloud.py
@@ -11,7 +11,7 @@ import warnings
 import threading
 import requests
 
-from astropy.logger import log
+from astroquery import log
 from astropy.utils.console import ProgressBarOrSpinner
 from astropy.utils.exceptions import AstropyDeprecationWarning
 

--- a/astroquery/mast/observations.py
+++ b/astroquery/mast/observations.py
@@ -21,7 +21,7 @@ import astropy.units as u
 import astropy.coordinates as coord
 
 from astropy.table import Table, Row, vstack, MaskedColumn
-from astropy.logger import log
+from astroquery import log
 
 from astropy.utils import deprecated
 from astropy.utils.console import ProgressBarOrSpinner

--- a/astroquery/nrao/core.py
+++ b/astroquery/nrao/core.py
@@ -13,7 +13,7 @@ import astropy.io.votable as votable
 from astropy import coordinates
 import six
 from astropy.table import Table
-from astropy import log
+from astroquery import log
 from bs4 import BeautifulSoup
 
 from ..query import QueryWithLogin

--- a/astroquery/oac/core.py
+++ b/astroquery/oac/core.py
@@ -15,7 +15,7 @@ import csv
 
 import astropy.units as u
 from astropy.table import Column, Table
-from astropy.logger import log
+from astroquery import log
 
 from . import conf
 from ..query import BaseQuery

--- a/astroquery/query.py
+++ b/astroquery/query.py
@@ -14,7 +14,7 @@ import textwrap
 
 import six
 from astropy.config import paths
-from astropy.logger import log
+from astroquery import log
 import astropy.units as u
 from astropy.utils.console import ProgressBarOrSpinner
 import astropy.utils.data

--- a/astroquery/query.py
+++ b/astroquery/query.py
@@ -10,6 +10,7 @@ import keyring
 import io
 import os
 import requests
+import textwrap
 
 import six
 from astropy.config import paths
@@ -152,7 +153,8 @@ class BaseQuery:
     """
 
     def __init__(self):
-        S = self._session = requests.session()
+        S = self._session = requests.Session()
+        self._session.hooks['response'].append(self._response_hook)
         S.headers['User-Agent'] = (
             'astroquery/{vers} {olduseragent}'
             .format(vers=version.version,
@@ -168,6 +170,28 @@ class BaseQuery:
     def __call__(self, *args, **kwargs):
         """ init a fresh copy of self """
         return self.__class__(*args, **kwargs)
+
+    def _response_hook(self, response, *args, **kwargs):
+        # Log request at INFO severity
+        request_hdrs = '\n'.join(f'{k}: {v}' for k, v in response.request.headers.items())
+        request_log = textwrap.indent(
+            f"-----------------------------------------\n"
+            f"{response.request.method} {response.request.url}\n"
+            f"{request_hdrs}\n"
+            f"\n"
+            f"{response.request.body}\n"
+            f"-----------------------------------------", '\t')
+        log.debug(f"HTTP request\n{request_log}")
+        # Log response at DEBUG severity
+        response_hdrs = '\n'.join(f'{k}: {v}' for k, v in response.headers.items())
+        response_log = textwrap.indent(
+            f"-----------------------------------------\n"
+            f"{response.status_code} {response.reason} {response.url}\n"
+            f"{response_hdrs}\n"
+            f"\n"
+            f"{response.text}\n"
+            f"-----------------------------------------", '\t')
+        log.log(5, f"HTTP response\n{response_log}")
 
     def _request(self, method, url,
                  params=None, data=None, headers=None,

--- a/astroquery/splatalogue/core.py
+++ b/astroquery/splatalogue/core.py
@@ -10,7 +10,7 @@ import warnings
 import sys
 from astropy.io import ascii
 from astropy import units as u
-from astropy import log
+from astroquery import log
 from ..query import BaseQuery
 from ..utils import async_to_sync, prepend_docstr_nosections
 from . import conf

--- a/astroquery/utils/tap/core.py
+++ b/astroquery/utils/tap/core.py
@@ -27,7 +27,7 @@ from astroquery.utils.tap.xmlparser import utils
 from astroquery.utils.tap.model.filter import Filter
 import six
 import requests
-from astropy.logger import log
+from astroquery import log
 import getpass
 import os
 from astropy.table.table import Table

--- a/astroquery/utils/timer.py
+++ b/astroquery/utils/timer.py
@@ -13,7 +13,7 @@ import numpy as np
 
 # LOCAL
 from astropy import units as u
-from astropy import log
+from astroquery import log
 from astropy import modeling
 from astropy.utils.exceptions import AstropyUserWarning
 

--- a/astroquery/vamdc/load_species_table.py
+++ b/astroquery/vamdc/load_species_table.py
@@ -1,5 +1,5 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
-from astropy import log
+from astroquery import log
 import os
 import json
 from ..splatalogue.load_species_table import SpeciesLookuptable

--- a/astroquery/vo_conesearch/validator/validate.py
+++ b/astroquery/vo_conesearch/validator/validate.py
@@ -11,7 +11,7 @@ from collections import OrderedDict
 from astropy.io import votable
 from astropy.io.votable.exceptions import E19
 from astropy.io.votable.validator import html, result
-from astropy.logger import log
+from astroquery import log
 from astropy.utils import data
 from astropy.utils.exceptions import AstropyUserWarning
 from astropy.utils.xml.unescaper import unescape_all

--- a/docs/gallery-examples/example7_alma.py
+++ b/docs/gallery-examples/example7_alma.py
@@ -9,7 +9,7 @@ import string
 from astropy import units as u
 from astropy.io import fits
 from astropy import wcs
-from astropy import log
+from astroquery import log
 import pylab as pl
 import aplpy
 import pyregion

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -384,6 +384,16 @@ services in Astroquery, you can use them for your scripts, but we don't guarante
   query.rst
   utils/tap.rst
 
+To debug astroquery, logging level can be configured with the following:
+
+.. code-block:: python
+
+    >>> from astroquery import log
+    >>> log.setLevel(level)
+
+If ``level`` is set to ``"DEBUG"``, then HTTP requests are logged.
+If ``level`` is set to ``"TRACE"``, then HTTP requests and responses are logged.
+
 License
 -------
 


### PR DESCRIPTION
This is a pull request to add HTTP logging capability. I am using it at the moment to debug Vizier. Could be useful to other maintainers. As it is based on the standard logging python module, all you have to do is:

To log HTTP requests: `logging.getLogger('astroquery.query').setLevel(logging.INFO)`

To log HTTP requests and responses: `logging.getLogger('astroquery.query').setLevel(logging.DEBUG)`

Should work for all modules.