### PR TITLE
MAST: Fixing Spitzer download bug

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -44,6 +44,7 @@ mast
 - Fixed error causing empty products passed to ``Observations.get_product_list()`` to yeild a
   non-empty result. [#1921]
 - Changed AWS cloud access from RequesterPays to anonymous acces [#1980]
+- Fixed error with download of Spitzer data [#1994]
 
 esa/hubble
 ^^^^^^^^^^

--- a/astroquery/mast/observations.py
+++ b/astroquery/mast/observations.py
@@ -535,7 +535,7 @@ class ObservationsClass(MastQueryWithLogin):
 
         # create a local file path if none is input.  Use current directory as default.
         if not local_path:
-            filename = uri.rsplit('/', 1)[-1]
+            filename = os.path.basename(uri)
             local_path = os.path.join(os.path.abspath('.'), filename)
 
         # recreate the data_product key for cloud connection check
@@ -606,7 +606,7 @@ class ObservationsClass(MastQueryWithLogin):
             local_path = os.path.join(base_dir, data_product['obs_collection'], data_product['obs_id'])
             if not os.path.exists(local_path):
                 os.makedirs(local_path)
-            local_path = os.path.join(local_path, data_product['productFilename'])
+            local_path = os.path.join(local_path, os.path.basename(data_product['productFilename']))
 
             # download the files
             status, msg, url = self.download_file(data_product["dataURI"], local_path=local_path,

--- a/docs/mast/mast.rst
+++ b/docs/mast/mast.rst
@@ -6,11 +6,6 @@
 MAST Queries (`astroquery.mast`)
 ********************************
 
-.. raw:: html
-
-         <div class="service-status mast-survey" id="survey-banner" style="background-color: #C75109; border-color: #C75109; color: white; padding-top: 1rem; padding-bottom: 1rem; line-height: 30px; font-size: x-large; display: flex; margin-left: 0rem; margin-right: 0rem; margin-bottom: 1rem; margin-top: 1rem;"><span class="status-message" style="margin-left: 2rem; margin-right: 2rem;">The MAST team wants your feedback on the <a href="https://www.surveymonkey.com/r/mastportal" target="_blank" style="color: white; text-decoration: underline;">MAST Portal</a> and <a href="https://www.surveymonkey.com/r/mastcatalogs" target="_blank" style="color: white; text-decoration: underline;">MAST catalogs</a>. If you use either of these, please take five to ten minutes to fill out the linked survey(s). Thank you!</span></div>
-
-
 Getting Started
 ===============
 


### PR DESCRIPTION
Closes https://github.com/astropy/astroquery/issues/1979, by handling the case when filenames in the CAOM DB are really paths. This currently appears with Spitzer data.

Also, I removed the MAST survey banner from the docs, because the survey period is over.