### PR TITLE
Make radius defaut smarter in criteria query

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -41,8 +41,8 @@ mast
 - Added ``Observations.download_file`` method to download a single file from MAST given an input
   data URI. [#1825]
 - Added case for passing a row to ``Observations.download_file` [#1881]
-- Removed deprecated ``Observations.get_hst_s3_uris()``, ``Observations.get_hst_s3_uri()``, 
-  ``Core.get_token()``, ``Core.enable_s3_hst_dataset()``, ``Core.disable_s3_hst_dataset()`` and 
+- Removed deprecated ``Observations.get_hst_s3_uris()``, ``Observations.get_hst_s3_uri()``,
+  ``Core.get_token()``, ``Core.enable_s3_hst_dataset()``, ``Core.disable_s3_hst_dataset()`` and
   variables obstype and silent [#1884]
 - Added Zcut functionality to astroquery [#1911]
 - Fixed error causing empty products passed to ``Observations.get_product_list()`` to yeild a
@@ -55,6 +55,7 @@ esa/hubble
 
 - Module added to query eHST TAP based on a set of specific criteria and
   asynchronous jobs are now supported. [#1723]
+
 
 esa/xmm_newton
 ^^^^^^^^^^^^^^
@@ -75,14 +76,14 @@ Gemini
 - get_file() support for downloading files [#1778]
 - fix syntax error in query_criteria() [#1823]
 - If QA and/or engineering parameters are explicitly passed, remove the add defaults of `notengineering` and/or
-  `NotFail` [#1996]
+- Smarter defaulting of radius to None unless coordinates are specified, in
+  which case defaults to 0.3 degrees. [#1995]
 
 heasarc
 ^^^^^^^
 
 - A ``NoResultsWarning`` is now returned when there is no matching rows were
   found in query. [#1829]
-
 
 SVO FPS
 ^^^^^^^

--- a/astroquery/gemini/core.py
+++ b/astroquery/gemini/core.py
@@ -182,7 +182,7 @@ class ObservationsClass(QueryWithLogin):
         return self.query_criteria(objectname=objectname, radius=radius)
 
     @class_or_instance
-    def query_criteria(self, *rawqueryargs, coordinates=None, radius=0.3*units.deg, pi_name=None, program_id=None, utc_date=None,
+    def query_criteria(self, *rawqueryargs, coordinates=None, radius=None, pi_name=None, program_id=None, utc_date=None,
                        instrument=None, observation_class=None, observation_type=None, mode=None,
                        adaptive_optics=None, program_text=None, objectname=None, raw_reduced=None,
                        orderby=None, **rawquerykwargs):
@@ -199,7 +199,7 @@ class ObservationsClass(QueryWithLogin):
             The target around which to search. It may be specified as a
             string or as the appropriate `~astropy.coordinates` object.
         radius : str or `~astropy.units.Quantity` object, optional
-            Default 0.3 degrees.
+            Default 0.3 degrees if coordinates are set, else None
             The string must be parsable by `~astropy.coordinates.Angle`. The
             appropriate `~astropy.units.Quantity` object from
             `~astropy.units` may also be used. Defaults to 0.3 deg.
@@ -319,6 +319,9 @@ class ObservationsClass(QueryWithLogin):
             for (k, v) in rawquerykwargs.items():
                 kwargs[k] = v
 
+        # If coordinates is set but we have no radius, set a default
+        if (coordinates or objectname) and radius is None:
+            radius = 0.3 * units.deg
         # Now consider the canned criteria
         if radius is not None:
             kwargs["radius"] = radius

--- a/astroquery/gemini/tests/test_gemini.py
+++ b/astroquery/gemini/tests/test_gemini.py
@@ -40,8 +40,14 @@ def patch_get(request):
     return mp
 
 
+# to inspect behavior, updated when the mock get call is made
+saved_request = None
+
+
 def get_mockreturn(url, *args, **kwargs):
     """ generate the actual mock textual data from our included datafile with json results """
+    global saved_request
+    saved_request = {'url': url, 'args': args, 'kwargs': kwargs}
     filename = data_path(DATA_FILES['m101'])
     f = open(filename, 'r')
     text = f.read()
@@ -74,6 +80,26 @@ def test_observations_query_criteria(patch_get):
                                                 utc_date=(date(2019, 10, 1), date(2019, 11, 25)))
     assert isinstance(result, Table)
     assert len(result) > 0
+
+
+def test_observations_query_criteria_radius_defaults(patch_get):
+    """ test query against an instrument/program via criteria """
+    result = gemini.Observations.query_criteria(instrument='GMOS-N', program_id='GN-CAL20191122',
+                                                observation_type='BIAS')
+    global saved_request
+    assert(saved_request is not None and 'args' in saved_request and len(saved_request['args']) >= 2)
+    assert('/sr=' not in saved_request['args'][1])
+    saved_request = None
+    result = gemini.Observations.query_criteria(instrument='GMOS-N', program_id='GN-2016A-Q-9',
+                                                observation_type='BIAS', coordinates=coords)
+    assert(saved_request is not None and 'args' in saved_request and len(saved_request['args']) >= 2)
+    assert('/sr=0.300000d' in saved_request['args'][1])
+    saved_request = None
+    result = gemini.Observations.query_criteria(instrument='GMOS-N', program_id='GN-2016A-Q-9',
+                                                observation_type='BIAS', objectname='m101')
+    assert(saved_request is not None and 'args' in saved_request and len(saved_request['args']) >= 2)
+    assert('/sr=0.300000d' in saved_request['args'][1])
+
 
 
 def test_observations_query_raw(patch_get):

--- a/astroquery/gemini/tests/test_gemini.py
+++ b/astroquery/gemini/tests/test_gemini.py
@@ -101,7 +101,6 @@ def test_observations_query_criteria_radius_defaults(patch_get):
     assert('/sr=0.300000d' in saved_request['args'][1])
 
 
-
 def test_observations_query_raw(patch_get):
     """ test querying raw """
     result = gemini.Observations.query_raw('GMOS-N', 'BIAS', progid='GN-CAL20191122')

--- a/docs/gemini/gemini.rst
+++ b/docs/gemini/gemini.rst
@@ -60,7 +60,9 @@ Observation Criteria Queries
 ----------------------------
 
 Additional search terms are available as optional arguments to the `~astroquery.gemini.ObservationsClass.query_criteria`
-call.  These all have default values of None, in which case they will not be considered during the search.
+call.  These all have default values of None, in which case they will not be considered during the search.  The one
+exception is `radius`, which will be set to 0.3 degrees by default if either `coordinates` or `objectname` are
+specified.
 
 Some examples of available search fields are the instrument used, such as GMOS-N, the observation_type, such as BIAS,
 and the program ID.  For a complete list of available search fields, see

--- a/docs/gemini/gemini.rst
+++ b/docs/gemini/gemini.rst
@@ -25,7 +25,7 @@ Positional queries can be based on a sky position.  Radius is an optional parame
                 >>> coord = coordinates.SkyCoord(210.80242917, 54.34875, unit="deg")
                 >>> data = Observations.query_region(coordinates=coord, radius=0.3*units.deg)
                 >>> print(data[0:5])
-                
+
                 exposure_time detector_roi_setting detector_welldepth_setting  telescope   ...
                 ------------- -------------------- -------------------------- ------------ ...
                      119.9986           Full Frame                         -- Gemini-North ...
@@ -61,7 +61,7 @@ Observation Criteria Queries
 
 Additional search terms are available as optional arguments to the `~astroquery.gemini.ObservationsClass.query_criteria`
 call.  These all have default values of None, in which case they will not be considered during the search.  The one
-exception is `radius`, which will be set to 0.3 degrees by default if either `coordinates` or `objectname` are
+exception is ``radius``, which will be set to 0.3 degrees by default if either ``coordinates`` or ``objectname`` are
 specified.
 
 Some examples of available search fields are the instrument used, such as GMOS-N, the observation_type, such as BIAS,
@@ -69,7 +69,7 @@ and the program ID.  For a complete list of available search fields, see
 `~astroquery.gemini.ObservationsClass.query_criteria`
 
 .. code-block:: python
-                
+
                 >>> from astroquery.gemini import Observations
 
                 >>> data = Observations.query_criteria(instrument='GMOS-N',
@@ -85,7 +85,7 @@ and the program ID.  For a complete list of available search fields, see
                           0.0           Full Frame                         -- Gemini-North    True ...
                           0.0           Full Frame                         -- Gemini-North    True ...
 
-In addition, the criteria query can accept additional parameters via the ``*rawqueryargs`` and ``**rawquerykwargs`` 
+In addition, the criteria query can accept additional parameters via the ``*rawqueryargs`` and ``**rawquerykwargs``
 optional parameters.
 
 The ``orderby`` parameter can be used to pass the desired sort order.
@@ -113,14 +113,15 @@ Regular *args* search terms are sent down as part of the URL path.  Any *kwargs*
 key=value also in the URL path.  You can infer what to pass the function by inspecting the URL after a search in the
 Gemini website.  This call also supports the ``orderby`` kwarg for requesting the sort order.
 
-This example is equivalent to doing a web search with 
+This example is equivalent to doing a web search with
 `this example search <https://archive.gemini.edu/searchform/RAW/cols=CTOWEQ/notengineering/GMOS-N/PIname=Hirst/NotFail>`_ .
-Note that *NotFail*, *notengineering*, *RAW*, and *cols* are all sent automatically.  Only the additional 
+
+Note that *NotFail*, *notengineering*, *RAW*, and *cols* are all sent automatically.  Only the additional
 terms need be passed into the method.  If QA or engineering search terms are passed, those will replace
 the *NotFail* or *notengineering* terms respectively.
 
 .. code-block:: python
-                
+
                 >>> from astroquery.gemini import Observations
 
                 >>> data = Observations.query_raw('GMOS-N', 'BIAS', progid='GN-CAL20191122')
@@ -139,7 +140,7 @@ Authenticated Sessions
 ----------------------
 
 The Gemini module allows for authenticated sessions using your GOA account.  This is the same account you login
-with on the GOA homepage at `<https://archive.gemini.edu/>`__.  The `astroquery.gemini.ObservationsClass.login` 
+with on the GOA homepage at `<https://archive.gemini.edu/>`__.  The `astroquery.gemini.ObservationsClass.login`
 method returns `True` if successful.
 
 .. code-block:: python
@@ -169,4 +170,3 @@ Reference/API
 
 .. automodapi:: astroquery.gemini
     :no-inheritance-diagram:
-


### PR DESCRIPTION
Closes #1995 using 0.3 degrees only when coordinates or objectname are passed, and None otherwise
