### PR TITLE
Fix for CI issues

### DIFF
--- a/astroquery/gaia/tests/test_gaiatap.py
+++ b/astroquery/gaia/tests/test_gaiatap.py
@@ -86,7 +86,7 @@ class TestTap(unittest.TestCase):
                                     'source_id',
                                     'source_id',
                                     None,
-                                    np.object)
+                                    object)
         self.__check_results_column(table,
                                     'table1_oid',
                                     'table1_oid',
@@ -112,7 +112,7 @@ class TestTap(unittest.TestCase):
                                     'source_id',
                                     'source_id',
                                     None,
-                                    np.object)
+                                    object)
         self.__check_results_column(table,
                                     'table1_oid',
                                     'table1_oid',
@@ -181,7 +181,7 @@ class TestTap(unittest.TestCase):
                                     'source_id',
                                     'source_id',
                                     None,
-                                    np.object)
+                                    object)
         self.__check_results_column(table,
                                     'table1_oid',
                                     'table1_oid',
@@ -207,7 +207,7 @@ class TestTap(unittest.TestCase):
                                     'source_id',
                                     'source_id',
                                     None,
-                                    np.object)
+                                    object)
         self.__check_results_column(table,
                                     'table1_oid',
                                     'table1_oid',
@@ -260,7 +260,7 @@ class TestTap(unittest.TestCase):
                                     'source_id',
                                     'source_id',
                                     None,
-                                    np.object)
+                                    object)
         self.__check_results_column(results,
                                     'table1_oid',
                                     'table1_oid',
@@ -337,7 +337,7 @@ class TestTap(unittest.TestCase):
                                     'source_id',
                                     'source_id',
                                     None,
-                                    np.object)
+                                    object)
         self.__check_results_column(results,
                                     'table1_oid',
                                     'table1_oid',

--- a/astroquery/nasa_exoplanet_archive/core.py
+++ b/astroquery/nasa_exoplanet_archive/core.py
@@ -430,7 +430,7 @@ class NasaExoplanetArchiveClass(BaseQuery):
                 data[col].mask[:] = False
 
             # Deal with strings consistently
-            if data[col].dtype == np.object:
+            if data[col].dtype == object:
                 data[col] = data[col].astype(str)
 
             data[col].unit = unit

--- a/astroquery/utils/tap/tests/test_tap.py
+++ b/astroquery/utils/tap/tests/test_tap.py
@@ -220,7 +220,7 @@ def test_launch_sync_job():
                            'source_id',
                            'source_id',
                            None,
-                           np.object)
+                           object)
     __check_results_column(results,
                            'table1_oid',
                            'table1_oid',
@@ -323,7 +323,7 @@ def test_launch_sync_job_redirect():
                            'source_id',
                            'source_id',
                            None,
-                           np.object)
+                           object)
     __check_results_column(results,
                            'table1_oid',
                            'table1_oid',
@@ -419,7 +419,7 @@ def test_launch_async_job():
                            'source_id',
                            'source_id',
                            None,
-                           np.object)
+                           object)
     __check_results_column(results,
                            'table1_oid',
                            'table1_oid',


### PR DESCRIPTION
This PR addresses the deprecation of the np.object alias to builtin object in numpy 1.20.0.
See: https://numpy.org/doc/stable/release/1.20.0-notes.html#using-the-aliases-of-builtin-types-like-np-int-is-deprecated