### PR TITLE
Allow engineering/qa search terms

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -69,7 +69,8 @@ Gemini
 - login() support for authenticated sessions to the GOA [#1778]
 - get_file() support for downloading files [#1778]
 - fix syntax error in query_criteria() [#1823]
-
+- If QA and/or engineering parameters are explicitly passed, remove the add defaults of `notengineering` and/or
+  `NotFail` [#1996]
 
 heasarc
 ^^^^^^^

--- a/astroquery/gemini/tests/test_gemini.py
+++ b/astroquery/gemini/tests/test_gemini.py
@@ -147,4 +147,3 @@ def test_url_helper_eng_fail(test_arg):
     urlsplit = url.split('/')
     assert(('notengineering' in urlsplit) == should_have_noteng)
     assert(('NotFail' in urlsplit) == should_have_notfail)
-

--- a/astroquery/gemini/tests/test_gemini.py
+++ b/astroquery/gemini/tests/test_gemini.py
@@ -117,3 +117,34 @@ def test_url_helper_coordinates():
     kwargs = {"coordinates": "210.80242917 54.348753"}
     url = urlh.build_url(*args, **kwargs)
     assert url == "https://archive.gemini.edu/jsonsummary/notengineering/NotFail/ra=210.802429/dec=54.348753"
+
+
+# send arg, should it have notengineering?, should it have NotFail?
+eng_fail_tests = [
+    ('notengineering', True, True),
+    ('engineering', False, True),
+    ('includeengineering', False, True),
+    ('NotFail', True, True),
+    ('AnyQA', True, False),
+    ('Pass', True, False),
+    ('Lucky', True, False),
+    ('Win', True, False),
+    ('Usable', True, False),
+    ('Undefind', True, False),
+    ('Fail', True, False),
+    ]
+
+
+@pytest.mark.parametrize("test_arg", eng_fail_tests)
+def test_url_helper_eng_fail(test_arg):
+    """ test the urlhelper logic around engineering/fail requests/defaults """
+    urlh = URLHelper()
+    args = [test_arg[0]]
+    should_have_noteng = test_arg[1]
+    should_have_notfail = test_arg[2]
+    kwargs = {}
+    url = urlh.build_url(*args, **kwargs)
+    urlsplit = url.split('/')
+    assert(('notengineering' in urlsplit) == should_have_noteng)
+    assert(('NotFail' in urlsplit) == should_have_notfail)
+

--- a/astroquery/gemini/urlhelper.py
+++ b/astroquery/gemini/urlhelper.py
@@ -73,8 +73,34 @@ class URLHelper:
         -------
         response : `string` url to execute the query
         """
+        qa_parm = ''
+        eng_parm = ''
 
-        url = "%s/jsonsummary/notengineering/NotFail" % self.server
+        # List of args that specify a QA state
+        qa_parameters = (
+            'NotFail',
+            'AnyQA',
+            'Pass',
+            'Lucky',
+            'Win',
+            'Usable',
+            'Undefind',
+            'Fail'
+        )
+
+        # List of args that specify engineering data (or not)
+        engineering_parameters = (
+            'notengineering',
+            'engineering',
+            'includeengineering'
+        )
+
+        if not any(eng_parm in args for eng_parm in engineering_parameters):
+            eng_parm = 'notengineering/'
+        if not any(qa_parm in args for qa_parm in qa_parameters):
+            qa_parm = 'NotFail/'
+        url = "%s/jsonsummary/%s%s" % (self.server, eng_parm, qa_parm)
+        url = url[:-1]  # strip trailing /
 
         for arg in args:
             url = "%s/%s" % (url, arg)

--- a/docs/gemini/gemini.rst
+++ b/docs/gemini/gemini.rst
@@ -114,7 +114,8 @@ Gemini website.  This call also supports the ``orderby`` kwarg for requesting th
 This example is equivalent to doing a web search with 
 `this example search <https://archive.gemini.edu/searchform/RAW/cols=CTOWEQ/notengineering/GMOS-N/PIname=Hirst/NotFail>`_ .
 Note that *NotFail*, *notengineering*, *RAW*, and *cols* are all sent automatically.  Only the additional 
-terms need be passed into the method.
+terms need be passed into the method.  If QA or engineering search terms are passed, those will replace
+the *NotFail* or *notengineering* terms respectively.
 
 .. code-block:: python
                 


### PR DESCRIPTION
closes #1996

If the user passes QA or engineering search terms, the constructed URL should not add the defaults of notengineering and/or NotFail.