### PR TITLE
BUGFIX: Logger will try to download too-large files

### DIFF
--- a/astroquery/alma/tests/test_alma_remote.py
+++ b/astroquery/alma/tests/test_alma_remote.py
@@ -677,3 +677,23 @@ def test_staging_stacking(dataarchive_url):
 
     alma.stage_data(['uid://A001/X13d5/X1d', 'uid://A002/X3216af/X31',
                      'uid://A001/X12a3/X240'])
+
+
+@pytest.mark.remote_data
+@pytest.mark.skipif("SKIP_SLOW", "Huge data file download")
+@pytest.mark.parametrize('dataarchive_url', _test_url_list)
+def test_big_download_regression(dataarchive_url):
+    """
+    Regression test for #2020/#2021 - this download fails if logging tries to
+    load the whole data file into memory.
+    """
+    result = Alma.query({'project_code':'2013.1.01365.S'})
+    uids = np.unique(result['member_ous_uid'])
+    files = Alma.get_data_info(uids)
+
+    #we may need to change the cache dir for this to work on testing machines?
+    # savedir='/big/data/path/'
+    # Alma.cache_dir=savedir
+
+    # this is a big one that fails
+    Alma.download_files([files['access_url'][3]])

--- a/astroquery/alma/tests/test_alma_remote.py
+++ b/astroquery/alma/tests/test_alma_remote.py
@@ -687,11 +687,11 @@ def test_big_download_regression(dataarchive_url):
     Regression test for #2020/#2021 - this download fails if logging tries to
     load the whole data file into memory.
     """
-    result = Alma.query({'project_code':'2013.1.01365.S'})
+    result = Alma.query({'project_code': '2013.1.01365.S'})
     uids = np.unique(result['member_ous_uid'])
     files = Alma.get_data_info(uids)
 
-    #we may need to change the cache dir for this to work on testing machines?
+    # we may need to change the cache dir for this to work on testing machines?
     # savedir='/big/data/path/'
     # Alma.cache_dir=savedir
 


### PR DESCRIPTION
In #1992, an error was introduced in which streamed files (large files intended for download) would be downloaded and sent to the logger.  They could be printed if the appropriate log level was set.

This fix avoids printing out any content from an HTTP request if the request is made with `stream=True`.

cc @jwoillez 

(this replaces part of #2020)