### PR TITLE
Usage statistics for ESASky module

### DIFF
--- a/astroquery/esasky/core.py
+++ b/astroquery/esasky/core.py
@@ -142,12 +142,15 @@ class ESASkyClass(BaseQuery):
         query_object_maps("265.05, 69.0", "Herschel")
         query_object_maps("265.05, 69.0", ["Herschel", "HST-OPTICAL"])
         """
-        return self.query_region_maps(position=position,
+        sanitized_missions = [m.lower() for m in self._sanitize_input_mission(missions)]
+
+        self._send_stats("Query Object Maps", self._comma_separate_upper_list(sanitized_missions))
+        return self._query_region_maps(position=position,
                                       radius=self.__ZERO_ARCMIN_STRING,
-                                      missions=missions,
+                                      missions=sanitized_missions,
                                       get_query_payload=get_query_payload,
                                       cache=cache,
-                                      row_limit=row_limit)
+                                      row_limit=row_limit, send_stats=False)
 
     def query_object_catalogs(self, position, catalogs=__ALL_STRING,
                               row_limit=DEFAULT_ROW_LIMIT,
@@ -195,12 +198,15 @@ class ESASkyClass(BaseQuery):
         query_object_catalogs("202.469, 47.195", "HSC")
         query_object_catalogs("202.469, 47.195", ["HSC", "XMM-OM"])
         """
-        return self.query_region_catalogs(position=position,
+        sanitized_catalogs = [m.lower() for m in self._sanitize_input_catalogs(catalogs)]
+
+        self._send_stats("Query Object Catalogs", self._comma_separate_upper_list(sanitized_catalogs))
+        return self._query_region_catalogs(position=position,
                                           radius=self.__ZERO_ARCMIN_STRING,
-                                          catalogs=catalogs,
+                                          catalogs=sanitized_catalogs,
                                           row_limit=row_limit,
                                           get_query_payload=get_query_payload,
-                                          cache=cache)
+                                          cache=cache, send_stats=False)
 
     def query_object_spectra(self, position, missions=__ALL_STRING,
                              get_query_payload=False, cache=True,
@@ -248,12 +254,15 @@ class ESASkyClass(BaseQuery):
         query_object_spectra("202.469, 47.195", "Herschel")
         query_object_spectra("202.469, 47.195", ["Herschel", "HST-OPTICAL"])
         """
-        return self.query_region_spectra(position=position,
+        sanitized_missions = [m.lower() for m in self._sanitize_input_spectra(missions)]
+
+        self._send_stats("Query Object Spectra", self._comma_separate_upper_list(sanitized_missions))
+        return self._query_region_spectra(position=position,
                                       radius=self.__ZERO_ARCMIN_STRING,
-                                      missions=missions,
+                                      missions=sanitized_missions,
                                       get_query_payload=get_query_payload,
                                       cache=cache,
-                                      row_limit=row_limit)
+                                      row_limit=row_limit, send_stats=False)
 
     def query_region_maps(self, position, radius, missions=__ALL_STRING,
                           get_query_payload=False, cache=True,
@@ -303,24 +312,9 @@ class ESASkyClass(BaseQuery):
         query_region_maps("265.05, 69.0", 14*u.arcmin, "Herschel")
         query_region_maps("265.05, 69.0", 14*u.arcmin, ["Herschel", "HST-OPTICAL"])
         """
-        sanitized_position = self._sanitize_input_position(position)
-        sanitized_radius = self._sanitize_input_radius(radius)
-        sanitized_missions = self._sanitize_input_mission(missions)
-        sanitized_row_limit = self._sanitize_input_row_limit(row_limit)
-
-        query_result = {}
-
-        sesame_database.set('simbad')
-        coordinates = commons.parse_coordinates(sanitized_position)
-
-        self._store_query_result(query_result, sanitized_missions,
-                                    coordinates, sanitized_radius, sanitized_row_limit,
-                                    get_query_payload, cache, self._get_observation_json())
-
-        if (get_query_payload):
-            return query_result
-
-        return commons.TableList(query_result)
+        return self._query_region_maps(position, radius, missions=missions,
+                          get_query_payload=get_query_payload, cache=cache,
+                          row_limit=row_limit)
 
     def query_region_catalogs(self, position, radius, catalogs=__ALL_STRING,
                               row_limit=DEFAULT_ROW_LIMIT,
@@ -370,25 +364,9 @@ class ESASkyClass(BaseQuery):
         query_region_catalogs("265.05, 69.0", 14*u.arcmin, "Hipparcos-2")
         query_region_catalogs("265.05, 69.0", 14*u.arcmin, ["Hipparcos-2", "HSC"])
         """
-        sanitized_position = self._sanitize_input_position(position)
-        sanitized_radius = self._sanitize_input_radius(radius)
-        sanitized_catalogs = self._sanitize_input_catalogs(catalogs)
-        sanitized_row_limit = self._sanitize_input_row_limit(row_limit)
-
-        sesame_database.set('simbad')
-        coordinates = commons.parse_coordinates(sanitized_position)
-
-        query_result = {}
-
-        self._store_query_result(query_result, sanitized_catalogs,
-                                          coordinates, sanitized_radius,
-                                          sanitized_row_limit,
-                                          get_query_payload, cache, self._get_catalogs_json())
-
-        if (get_query_payload):
-            return query_result
-
-        return commons.TableList(query_result)
+        return self._query_region_catalogs(position, radius, catalogs=catalogs,
+                              row_limit=row_limit,
+                              get_query_payload=get_query_payload, cache=cache)
 
     def query_region_spectra(self, position, radius, missions=__ALL_STRING,
                              row_limit=DEFAULT_ROW_LIMIT,
@@ -438,24 +416,9 @@ class ESASkyClass(BaseQuery):
         query_region_spectra("265.05, 69.0", 30*u.arcmin, "Herschel")
         query_region_spectra("265.05, 69.0", 30*u.arcmin, ["Herschel", "IUE"])
         """
-        sanitized_position = self._sanitize_input_position(position)
-        sanitized_radius = self._sanitize_input_radius(radius)
-        sanitized_missions = self._sanitize_input_spectra(missions)
-        sanitized_row_limit = self._sanitize_input_row_limit(row_limit)
-
-        query_result = {}
-
-        sesame_database.set('simbad')
-        coordinates = commons.parse_coordinates(sanitized_position)
-
-        self._store_query_result(query_result, sanitized_missions,
-                                    coordinates, sanitized_radius, sanitized_row_limit,
-                                    get_query_payload, cache, self._get_spectra_json())
-
-        if (get_query_payload):
-            return query_result
-
-        return commons.TableList(query_result)
+        return self._query_region_spectra(position, radius, missions=missions,
+                             row_limit=row_limit,
+                             get_query_payload=get_query_payload, cache=cache)
 
     def get_maps(self, query_table_list, missions=__ALL_STRING,
                  download_dir=_MAPS_DOWNLOAD_DIR, cache=True):
@@ -505,6 +468,12 @@ class ESASkyClass(BaseQuery):
         """
         sanitized_query_table_list = self._sanitize_input_table_list(query_table_list)
         sanitized_missions = [m.lower() for m in self._sanitize_input_mission(missions)]
+
+        matching_missions = [input_mission for input_mission in sanitized_missions if input_mission.lower()
+                             in (query_table_mission.lower() for query_table_mission
+                                 in sanitized_query_table_list.keys())]
+
+        self._send_stats("Get maps", self._comma_separate_upper_list(matching_missions))
 
         maps = dict()
         json = self._get_observation_json()
@@ -582,11 +551,13 @@ class ESASkyClass(BaseQuery):
 
         maps = dict()
 
-        map_query_result = self.query_region_maps(sanitized_position,
+        self._send_stats("Get Images", self._comma_separate_upper_list(sanitized_missions))
+
+        map_query_result = self._query_region_maps(sanitized_position,
                                                   sanitized_radius,
                                                   sanitized_missions,
                                                   get_query_payload=False,
-                                                  cache=cache)
+                                                  cache=cache, send_stats=False)
 
         json = self._get_observation_json()
         for query_mission in map_query_result.keys():
@@ -657,15 +628,17 @@ class ESASkyClass(BaseQuery):
         """
         sanitized_position = self._sanitize_input_position(position)
         sanitized_radius = self._sanitize_input_radius(radius)
-        sanitized_missions = self._sanitize_input_spectra(missions)
+        sanitized_missions = [m.lower() for m in self._sanitize_input_spectra(missions)]
+
+        self._send_stats("Get Spectra", self._comma_separate_upper_list(sanitized_missions))
 
         spectra = dict()
 
-        spectra_query_result = self.query_region_spectra(sanitized_position,
+        spectra_query_result = self._query_region_spectra(sanitized_position,
                                                   sanitized_radius,
                                                   sanitized_missions,
                                                   get_query_payload=False,
-                                                  cache=cache)
+                                                  cache=cache, send_stats=False)
         json = self._get_spectra_json()
         for query_mission in spectra_query_result.keys():
             spectra[query_mission] = (
@@ -731,6 +704,11 @@ class ESASkyClass(BaseQuery):
         sanitized_query_table_list = self._sanitize_input_table_list(query_table_list)
         sanitized_missions = [m.lower() for m in self._sanitize_input_spectra(missions)]
 
+        matching_missions = [input_mission for input_mission in sanitized_missions if input_mission.lower()
+                             in (query_table_mission.lower()
+                                 for query_table_mission in sanitized_query_table_list.keys())]
+        self._send_stats("Get Spectra From Table", self._comma_separate_upper_list(matching_missions))
+
         spectra = dict()
         json = self._get_spectra_json()
 
@@ -749,6 +727,83 @@ class ESASkyClass(BaseQuery):
         else:
             log.info("No spectra found.")
         return spectra
+
+
+    def _query_region_maps(self, position, radius, missions=__ALL_STRING,
+                          get_query_payload=False, cache=True,
+                          row_limit=DEFAULT_ROW_LIMIT, send_stats=True):
+        sanitized_position = self._sanitize_input_position(position)
+        sanitized_radius = self._sanitize_input_radius(radius)
+        sanitized_missions = [m.lower() for m in self._sanitize_input_mission(missions)]
+        sanitized_row_limit = self._sanitize_input_row_limit(row_limit)
+
+        query_result = {}
+
+        sesame_database.set('simbad')
+        coordinates = commons.parse_coordinates(sanitized_position)
+
+        if send_stats:
+            self._send_stats("Query Region Maps", self._comma_separate_upper_list(sanitized_missions))
+
+        self._store_query_result(query_result, sanitized_missions,
+                                    coordinates, sanitized_radius, sanitized_row_limit,
+                                    get_query_payload, cache, self._get_observation_json())
+
+        if (get_query_payload):
+            return query_result
+
+        return commons.TableList(query_result)
+
+    def _query_region_catalogs(self, position, radius, catalogs=__ALL_STRING,
+                              row_limit=DEFAULT_ROW_LIMIT,
+                              get_query_payload=False, cache=True, send_stats=True):
+        sanitized_position = self._sanitize_input_position(position)
+        sanitized_radius = self._sanitize_input_radius(radius)
+        sanitized_catalogs = [cat.lower() for cat in self._sanitize_input_catalogs(catalogs)]
+        sanitized_row_limit = self._sanitize_input_row_limit(row_limit)
+
+        sesame_database.set('simbad')
+        coordinates = commons.parse_coordinates(sanitized_position)
+
+        if send_stats:
+            self._send_stats("Query Region Catalogs", self._comma_separate_upper_list(sanitized_catalogs))
+
+        query_result = {}
+
+        self._store_query_result(query_result, sanitized_catalogs,
+                                          coordinates, sanitized_radius,
+                                          sanitized_row_limit,
+                                          get_query_payload, cache, self._get_catalogs_json())
+
+        if (get_query_payload):
+            return query_result
+
+        return commons.TableList(query_result)
+
+    def _query_region_spectra(self, position, radius, missions=__ALL_STRING,
+                             row_limit=DEFAULT_ROW_LIMIT,
+                             get_query_payload=False, cache=True, send_stats=True):
+        sanitized_position = self._sanitize_input_position(position)
+        sanitized_radius = self._sanitize_input_radius(radius)
+        sanitized_missions = [m.lower() for m in self._sanitize_input_spectra(missions)]
+        sanitized_row_limit = self._sanitize_input_row_limit(row_limit)
+
+        query_result = {}
+
+        sesame_database.set('simbad')
+        coordinates = commons.parse_coordinates(sanitized_position)
+
+        if send_stats:
+            self._send_stats("Query Region Spectra", self._comma_separate_upper_list(sanitized_missions))
+
+        self._store_query_result(query_result, sanitized_missions,
+                                    coordinates, sanitized_radius, sanitized_row_limit,
+                                    get_query_payload, cache, self._get_spectra_json())
+
+        if (get_query_payload):
+            return query_result
+
+        return commons.TableList(query_result)
 
     def _sanitize_input_position(self, position):
         if (isinstance(position, str) or isinstance(position,
@@ -886,7 +941,9 @@ class ESASkyClass(BaseQuery):
                             headers=self._get_header())
 
                         response.raise_for_status()
-
+                        type = "Spectra" if is_spectra else "Observation"
+                        self._send_stats("Download product - {type}".format(type=type), mission,
+                                         "Total size (KB) {size}".format(size=sys.getsizeof(response.content) / 1024))
                         file_name = self._extract_file_name_from_response_header(response.headers)
                         if (file_name == ""):
                             file_name = self._extract_file_name_from_url(product_url)
@@ -920,6 +977,8 @@ class ESASkyClass(BaseQuery):
                                  stream=True, headers=self._get_header())
         response.raise_for_status()
 
+        self._send_stats("Download product - Observation", "HERSCHEL",
+                         "Total size (KB) {size}".format(size=sys.getsizeof(response.content) / 1024))
         with tarfile.open(fileobj=BytesIO(response.content)) as tar:
             for member in tar.getmembers():
                 member_name = member.name.lower()
@@ -938,6 +997,8 @@ class ESASkyClass(BaseQuery):
 
         response.raise_for_status()
 
+        self._send_stats("Download product - Spectra", "HERSCHEL",
+                         "Total size (KB) {size}".format(size=sys.getsizeof(response.content) / 1024))
         with tarfile.open(fileobj=BytesIO(response.content)) as tar:
             for member in tar.getmembers():
                 member_name = member.name.lower()
@@ -1185,6 +1246,26 @@ class ESASkyClass(BaseQuery):
             vers=version.version,
             isTest=self._isTest)
         return {'User-Agent': user_agent}
+
+    def _send_stats(self, category, action, names=""):
+        if self._isTest:
+            return
+        url = ('https://esdcwebanalytics.esac.esa.int/matomo/matomo.php?ca=1'
+               '&e_c={category}&e_a={action}&e_n={names}&idsite=3&rec=1'
+               ).format(category=category, action=str(action), names=names)
+        try:
+            response = self._request(
+                'GET',
+                url,
+                cache=False,
+                stream=True,
+                headers=self._get_header())
+
+        except (HTTPError, ConnectionError) as err:
+            None
+
+    def _comma_separate_upper_list(self, list):
+        return ', '.join(str(item).upper() for item in list)
 
 
 ESASky = ESASkyClass()

--- a/astroquery/esasky/core.py
+++ b/astroquery/esasky/core.py
@@ -372,7 +372,7 @@ class ESASkyClass(BaseQuery):
         """
         sanitized_position = self._sanitize_input_position(position)
         sanitized_radius = self._sanitize_input_radius(radius)
-        sanitized_catalogs = [cat.lower() for cat in self._sanitize_input_catalogs(catalogs)]
+        sanitized_catalogs = self._sanitize_input_catalogs(catalogs)
         sanitized_row_limit = self._sanitize_input_row_limit(row_limit)
 
         sesame_database.set('simbad')
@@ -440,7 +440,7 @@ class ESASkyClass(BaseQuery):
         """
         sanitized_position = self._sanitize_input_position(position)
         sanitized_radius = self._sanitize_input_radius(radius)
-        sanitized_missions = [m.lower() for m in self._sanitize_input_spectra(missions)]
+        sanitized_missions = self._sanitize_input_spectra(missions)
         sanitized_row_limit = self._sanitize_input_row_limit(row_limit)
 
         query_result = {}
@@ -657,7 +657,7 @@ class ESASkyClass(BaseQuery):
         """
         sanitized_position = self._sanitize_input_position(position)
         sanitized_radius = self._sanitize_input_radius(radius)
-        sanitized_missions = [m.lower() for m in self._sanitize_input_spectra(missions)]
+        sanitized_missions = self._sanitize_input_spectra(missions)
 
         spectra = dict()
 
@@ -1197,7 +1197,7 @@ class ESASkyClass(BaseQuery):
             return
         url = ('https://esdcwebanalytics.esac.esa.int/matomo/matomo.php?ca=1'
                '&e_c={category}&e_a={action}&e_n={names}&idsite=3&rec=1'
-               ).format(category=category, action=str(action), names=names)
+               ).format(category=category, action=action, names=names)
         try:
             response = self._request(
                 'GET',


### PR DESCRIPTION
We would like to know more about how our users use this module, especially for users downloading data. Since the download requests go directly to each archive, and never touch to the ESASky servers we have no idea how much data and which missions are being downloaded. 

This is my proposal on how to solve this issue. I've tried to only collect high level information (which mission, data volume, and which methods are used), which I hope no user would protest against. What do you think about this @keflavich, @bsipocz?