### PR TITLE
Add description for parameters set from config object

### DIFF
--- a/astroquery/vizier/core.py
+++ b/astroquery/vizier/core.py
@@ -62,6 +62,16 @@ class VizierClass(BaseQuery):
             column descriptions defined on the Vizier web pages.
             See http://vizier.u-strasbg.fr/vizier/vizHelp/1.htx#ucd and
             http://cds.u-strasbg.fr/w/doc/UCD/
+         vizier_server : string
+            Name of the VizieR mirror to use.
+            (This parameter's default is set from a configuration object.)
+        timeout : number
+            timeout for connecting to server
+            (This parameter's default is set from a configuration object.)
+        row_limit : int
+            Maximum number of rows that will be fetched from the result
+            (set to -1 for unlimited).
+            (This parameter's default is set from a configuration object.)
         """
 
         super(VizierClass, self).__init__()


### PR DESCRIPTION
By default, a vizier search returns only 50 rows. That's too little for me. So, I've tried to find out how to increase the limit. I looked for `myVizier.row_limit`, but that does not exist, then I read the docstring. The Jupyter notebook gives me this:
```
Signature:       vizier.Vizier(*args, **kwargs)
Type:            VizierClass
String form:     <astroquery.vizier.core.VizierClass object at 0x7fb103c2d790>
File:            ~/anaconda3/envs/ciao/lib/python3.7/site-packages/astroquery/vizier/core.py
Docstring:       <no docstring>
Class docstring:
This is the base class for all the query classes in astroquery. It
is implemented as an abstract class and must not be directly instantiated.
Init docstring: 
Parameters
----------
columns : list
    List of strings
column_filters : dict
catalog : str or None
keywords : str or None
ucd : string
    "Unified Content Description" column descriptions.  Specifying
    these will select only catalogs that have columns matching the
    column descriptions defined on the Vizier web pages.
    See http://vizier.u-strasbg.fr/vizier/vizHelp/1.htx#ucd and
    http://cds.u-strasbg.fr/w/doc/UCD/
Call docstring:  init a fresh copy of self 
```
No mention of any way to increase the row limit. I finally found it in the [Conf class](https://astroquery.readthedocs.io/en/latest/api/astroquery.vizier.Conf.html#astroquery.vizier.Conf) but it's still unclear to me how to make use of that conf class (Vizier does not take a conf argument). Then, I read the general docs (https://astroquery.readthedocs.io/en/latest/index.html) and the Vizier specific page. No mention of how to use a Conf object.
Finally, I decided to read the code instead of reading the docs and I saw that it's pretty easy: `myVizier = vizier.Vizier(row_limit=5000)`.

I feel that I'm probably overlooking something obvious and not using astroquery as intended. However, as a new user (I've used astroquery maybe a handful of times before this weekend), I feel it's important to let the developers know where I run into trouble; that's why I describe where I looked and where I expected to find the information in this much detail. It would have been far easier for me to just download the few searched I needed through the website, but I wanted to get to know astroquery. 

This PR adds the parameters that are set by the  conf object to the docstring, because the *can* be set by hand when initializing the Vizier object; if there is a better or more general way of fixing this, I'm happy to close this PR and copy by text above into an issue.

(I searched PRs and issues tagged "visier" and do not see any related issues.)
