### PR TITLE
Preparing for release v0.4.2

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,22 +1,62 @@
 0.4.2 (unreleased)
 ==================
 
-Service fixes and enhancements
-------------------------------
+New Tools and Services
+----------------------
 
 cds.hips2fits
 ^^^^^^^^^^^^^
 
-- HIPS2fits is a service providing nice fits/jpg/png image cutouts from a HiPS + a WCS. It can now be queried from python [#1734]
+- New module HIPS2fits to provide access to fits/jpg/png image cutouts from a
+  HiPS + a WCS. [#1734]
 
-
-esa/iso
+esa.iso
 ^^^^^^^
 
-- New module to access ESA ISO mission [#1914]
+- New module to access ESA ISO mission. [#1914]
 
-ESASky
+esa.xmm_newton
+^^^^^^^^^^^^^^
+
+- New method ``get_epic_images`` is added to extract EPIC images from
+  tarballs. [#1759]
+
+- New method ``get_epic_metadata`` is added to download EPIC sources
+  metadata. [#1814]
+
+mast
 ^^^^
+
+- Added Zcut functionality to astroquery [#1911]
+
+svo_fps
+^^^^^^^
+
+- New module to access the Spanish Virtual Observatory Filter Profile List. [#1498]
+
+
+Service fixes and enhancements
+------------------------------
+
+alma
+^^^^
+
+- The archive query interface has been deprecated in favour of
+  VirtualObservatory (VO) services such as TAP, ObsCore etc. The alma
+  library has been updated accordingly. [#1689]
+
+- ALMA queries using string representations will now convert to appropriate
+  coordinates before being sent to the server; previously they were treated as
+  whatever unit they were presented in.  [#1867]
+
+- Download mechanism uses the ALMA Datalink service that allows exploring and
+  downloading entire tarball package files or just part of their
+  content. [#1820]
+
+- Fixed bug in ``get_data_info`` to ensure relevant fields are strings. [#2022]
+
+esa.esasky
+^^^^^^^^^^
 
 - All ESASky spectra now accessible. [#1909]
 
@@ -24,6 +64,42 @@ ESASky
 
 - Added row limit parameter for map queries. [#1858]
 
+esa.hubble
+^^^^^^^^^^
+
+- Module added to query eHST TAP based on a set of specific criteria and
+  asynchronous jobs are now supported. [#1723]
+
+gaia
+^^^^
+- Fixed RA/dec table edit capability. [#1784]
+
+- Changed file names handling when downloading data. [#1784]
+
+- Improved code to handle bit data type. [#1784]
+
+- Prepared code to handle new datalink products. [#1784]
+
+gemini
+^^^^^^
+
+- ``login()`` method to support authenticated sessions to the GOA. [#1780]
+
+- ``get_file()`` to support downloading files. [#1780]
+
+- fix syntax error in ``query_criteria()`` [#1823]
+
+- If QA and/or engineering parameters are explicitly passed, remove the
+  defaults of ``notengineering`` and/or ``NotFail``. [#2000]
+
+- Smarter defaulting of radius to None unless coordinates are specified, in
+  which case defaults to 0.3 degrees. [#1995]
+
+heasarc
+^^^^^^^
+
+- A ``NoResultsWarning`` is now returned when there is no matching rows were
+  found in query. [#1829]
 
 irsa
 ^^^^
@@ -38,101 +114,48 @@ jplsbdb
 mast
 ^^^^
 
-- Added ``Observations.download_file`` method to download a single file from MAST given an input
-  data URI. [#1825]
-- Added case for passing a row to ``Observations.download_file` [#1881]
-- Removed deprecated ``Observations.get_hst_s3_uris()``, ``Observations.get_hst_s3_uri()``,
-  ``Core.get_token()``, ``Core.enable_s3_hst_dataset()``, ``Core.disable_s3_hst_dataset()`` and
-  variables obstype and silent [#1884]
-- Added Zcut functionality to astroquery [#1911]
-- Fixed error causing empty products passed to ``Observations.get_product_list()`` to yeild a
-  non-empty result. [#1921]
-- Changed AWS cloud access from RequesterPays to anonymous acces [#1980]
-- Fixed error with download of Spitzer data [#1994]
+- Added ``Observations.download_file`` method to download a single file from
+  MAST given an input data URI. [#1825]
 
-esa/hubble
-^^^^^^^^^^
+- Added case for passing a row to ``Observations.download_file``. [#1881]
 
-- Module added to query eHST TAP based on a set of specific criteria and
-  asynchronous jobs are now supported. [#1723]
+- Removed deprecated methods: ``Observations.get_hst_s3_uris()``,
+  ``Observations.get_hst_s3_uri()``, ``Core.get_token()``,
+  ``Core.enable_s3_hst_dataset()``, ``Core.disable_s3_hst_dataset()``; and
+  parameters: ``obstype`` and ``silent``. [#1884]
 
+- Fixed error causing empty products passed to ``Observations.get_product_list()``
+  to yeild a non-empty result. [#1921]
 
-esa/xmm_newton
-^^^^^^^^^^^^^^
+- Changed AWS cloud access from RequesterPays to anonymous acces. [#1980]
 
-- new method ``get_epic_images`` is added to extract EPIC images from
-  tarballs. [#1759]
+- Fixed error with download of Spitzer data. [#1994]
 
-esasky
-^^^^^^
+sdss
+^^^^
 
-- Converted unittest styled tests to pytest. [#1862]
+- Fix validation of field names. [#1790]
 
-
-Gemini
-^^^^^^
-
-- login() support for authenticated sessions to the GOA [#1778]
-- get_file() support for downloading files [#1778]
-- fix syntax error in query_criteria() [#1823]
-- If QA and/or engineering parameters are explicitly passed, remove the add defaults of `notengineering` and/or
-- Smarter defaulting of radius to None unless coordinates are specified, in
-  which case defaults to 0.3 degrees. [#1995]
-
-heasarc
-^^^^^^^
-
-- A ``NoResultsWarning`` is now returned when there is no matching rows were
-  found in query. [#1829]
-
-SVO FPS
-^^^^^^^
-
-- Module added to access the Spanish Virtual Observatory Filter Profile List [#1498]
-
-Splatalogue
+splatalogue
 ^^^^^^^^^^^
 
-- The Splatalogue ID querying is now properly cached in the `astropy` cache
-  directory (Issue [#423]) The scraping function has also been updated to reflect
+- The Splatalogue ID querying is now properly cached in the astropy cache
+  directory. The scraping function has also been updated to reflect
   the Splatalogue webpage. [#1772]
 
 - The splatalogue URL has changed to https://splatalogue.online, as the old site
   stopped functioning in September 2020 [#1817]
 
-UKIDSS
+ukidss
 ^^^^^^
 
-- Updated to ``UKIDSSDR11PLUS`` as the default version [#1767]
+- Updated to ``UKIDSSDR11PLUS`` as the default data release. [#1767]
 
-utils/tap
+vizier
 ^^^^^^
 
-- Converted unittest styled tests to pytest. [#1862]
-
-alma
-^^^^
-
-- The archive query interface has been deprecated in favour of
-  VirtualObservatory (VO) services such as TAP, ObsCore etc. The alma
-  library has been updated accordingly. [#1689]
-- ALMA queries using string representations will now convert to appropriate
-  coordinates before being sent to the server; previously they were treated as
-  whatever unit they were presented in.  [#1867]
-- Download mechanism uses the ALMA Datalink service that allows exploring and
-  downloading entire tarball package files or just part of their content. [#1820]
-
-gaia
-^^^^
-- Fixed RA/dec table edit capability. [#1784]
-- Changed file names handling when downloading data. [#1784]
-- Improved code to handle bit data type. [#1784]
-- Prepared code to handle new datalink products. [#1784]
-
-esa.xmm_newton
-^^^^^^^^^^^^^^
-
-- Added new function to download EPIC sources metadate. [#1814]
+- Refactor module to support list of coordinates as well as several fixes to
+  follow changes in upstream API. [#2012]
 
 
 Infrastructure, Utility and Other Changes and Additions
@@ -140,6 +163,7 @@ Infrastructure, Utility and Other Changes and Additions
 
 - HTTP requests and responses can now be logged when the astropy
   logger is set to level "DEBUG" and "TRACE" respectively. [#1992]
+
 - Astroquery and all its modules now uses a logger similar to Astropy's. [#1992]
 
 

--- a/astroquery/alma/tests/setup_package.py
+++ b/astroquery/alma/tests/setup_package.py
@@ -5,5 +5,5 @@ import os
 
 
 def get_package_data():
-    paths = [os.path.join('data', '*.txt')]
+    paths = [os.path.join('data', '*.txt'), os.path.join('data', '*.xml')]
     return {'astroquery.alma.tests': paths}

--- a/astroquery/cds/tests/test_mocserver.py
+++ b/astroquery/cds/tests/test_mocserver.py
@@ -11,13 +11,15 @@ from astropy.table import Table
 
 try:
     from mocpy import MOC
+    HAS_MOCPY = True
 except ImportError:
-    pass
+    HAS_MOCPY = False
 
 try:
     from regions import CircleSkyRegion, PolygonSkyRegion
+    HAS_REGIONS = True
 except ImportError:
-    pass
+    HAS_REGIONS = False
 
 from ..core import cds
 from ...utils.testing_tools import MockResponse
@@ -72,8 +74,8 @@ with regards to the true results stored in a file located in the data directory
 """
 
 
-@pytest.mark.skipif('regions' not in sys.modules,
-                    reason="requires astropy-regions")
+@pytest.mark.skipif('not HAS_REGIONS')
+@pytest.mark.skipif('not HAS_MOCPY')
 @pytest.mark.parametrize('datafile',
                          ['PROPERTIES_SEARCH', 'HIPS_FROM_SAADA_AND_ALASKY'])
 def test_request_results(patch_get, datafile):
@@ -97,8 +99,8 @@ request param 'intersect' is correct
 """
 
 
-@pytest.mark.skipif('regions' not in sys.modules,
-                    reason="requires astropy-regions")
+@pytest.mark.skipif('not HAS_REGIONS')
+@pytest.mark.skipif('not HAS_MOCPY')
 @pytest.mark.parametrize('RA, DEC, RADIUS',
                          [(10.8, 6.5, 0.5),
                           (25.6, -23.2, 1.1),
@@ -117,8 +119,8 @@ def test_cone_search_spatial_request(RA, DEC, RADIUS):
            (request_payload['SR'] == str(RADIUS))
 
 
-@pytest.mark.skipif('regions' not in sys.modules,
-                    reason="requires astropy-regions")
+@pytest.mark.skipif('not HAS_REGIONS')
+@pytest.mark.skipif('not HAS_MOCPY')
 @pytest.mark.parametrize('poly, poly_payload',
                          [(polygon1, 'Polygon 57.376 24.053 56.391 24.622 56.025 24.049 56.616 24.291'),
                           (polygon2, 'Polygon 58.376 24.053 53.391 25.622 56.025 22.049 54.616 27.291')])
@@ -132,8 +134,8 @@ def test_polygon_spatial_request(poly, poly_payload):
     assert request_payload['stc'] == poly_payload
 
 
-@pytest.mark.skipif('regions' not in sys.modules,
-                    reason="requires astropy-regions")
+@pytest.mark.skipif('not HAS_REGIONS')
+@pytest.mark.skipif('not HAS_MOCPY')
 @pytest.mark.parametrize('intersect',
                          ['encloses', 'overlaps', 'covers'])
 def test_intersect_param(intersect):

--- a/astroquery/conftest.py
+++ b/astroquery/conftest.py
@@ -21,7 +21,12 @@ try:
     PYTEST_HEADER_MODULES['Astropy'] = 'astropy'
     PYTEST_HEADER_MODULES['APLpy'] = 'aplpy'
     PYTEST_HEADER_MODULES['pyregion'] = 'pyregion'
+    PYTEST_HEADER_MODULES['regions'] = 'regions'
     PYTEST_HEADER_MODULES['pyVO'] = 'pyvo'
+    PYTEST_HEADER_MODULES['mocpy'] = 'mocpy'
+    PYTEST_HEADER_MODULES['astropy-healpix'] = 'astropy_healpix'
+    PYTEST_HEADER_MODULES['vamdclib'] = 'vamdclib'
+
     # keyring doesn't provide __version__ any more
     # PYTEST_HEADER_MODULES['keyring'] = 'keyring'
     del PYTEST_HEADER_MODULES['h5py']

--- a/astroquery/conftest.py
+++ b/astroquery/conftest.py
@@ -7,8 +7,6 @@ import os
 from pytest_astropy_header.display import (PYTEST_HEADER_MODULES,
                                            TESTED_VERSIONS)
 
-from astropy.tests.helper import enable_deprecations_as_exceptions
-
 
 def pytest_configure(config):
     config.option.astropy_header = True
@@ -34,10 +32,6 @@ try:
     del PYTEST_HEADER_MODULES['Pandas']
 except (NameError, KeyError):
     pass
-
-# ignoring pyvo can be removed once we require >0.9.3
-enable_deprecations_as_exceptions(include_astropy_deprecations=False,
-                                  warnings_to_ignore_entire_module=['regions', 'pyregion', 'html5lib'],)
 
 # add '_testrun' to the version name so that the user-agent indicates that
 # it's being run in a test

--- a/astroquery/imcce/tests/test_skybot.py
+++ b/astroquery/imcce/tests/test_skybot.py
@@ -2,7 +2,6 @@
 
 import pytest
 import os
-import warnings
 
 from astroquery.utils.testing_tools import MockResponse
 import astropy.units as u
@@ -61,11 +60,10 @@ def test_input():
                                 2451200, get_query_payload=True)
     assert(a['-rd'] == b['-rd'])
 
-    with warnings.catch_warnings(record=True) as w:
+    with pytest.warns(UserWarning, match='search cone radius'):
         a = core.Skybot.cone_search((100, 20), 100, 2451200,
                                     get_query_payload=True)
         assert(a['-rd'] == 10)
-        assert('search cone radius' in str(w[-1].message))
 
     # test epoch input
     a = core.Skybot.cone_search((100, 20), 1, 2451200, get_query_payload=True)
@@ -84,11 +82,10 @@ def test_input():
                                 get_query_payload=True)
     assert(a['-filter'] == b['-filter'])
 
-    with warnings.catch_warnings(record=True) as w:
+    with pytest.warns(UserWarning, match='positional error'):
         a = core.Skybot.cone_search((100, 20), 1, 2451200, position_error=1000,
                                     get_query_payload=True)
         assert(a['-filter'] == 120)
-        assert('positional error' in str(w[-1].message))
 
     # test target filters
     a = core.Skybot.cone_search((100, 20), 1, 2451200, get_query_payload=True)

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -98,6 +98,8 @@ full functionality of the `~astroquery.cds` module:
 * `astropy-healpix <http://astropy-healpix.readthedocs.io/en/latest/>`_
 * `regions <https://astropy-regions.readthedocs.io/en/latest/>`_
 * `mocpy <https://cds-astro.github.io/mocpy/>`_ >= 0.5.2
+* `vamdclib <https://github.com/VAMDC/vamdclib/>`_  install version from
+  personal fork: ``pip install git+https://github.com/keflavich/vamdclib-1.git``
 
 The following packages are optional dependencies and are required for the
 full functionality of the `~astroquery.mast` module:

--- a/docs/vamdc/vamdc.rst
+++ b/docs/vamdc/vamdc.rst
@@ -12,7 +12,7 @@ Getting Started
 The astroquery vamdc interface requires vamdclib_.  The documentation is sparse
 to nonexistent, but installation is straightforward::
 
-    pip install https://github.com/keflavich/vamdclib/archive/master.zip
+    pip install git+https://github.com/keflavich/vamdclib-1.git
 
 This is the personal fork of the astroquery maintainer that includes astropy's
 setup helpers on top of the vamdclib infrastructure.  If the infrastructure is
@@ -41,4 +41,4 @@ Reference/API
 .. automodapi:: astroquery.vamdc
     :no-inheritance-diagram:
 
-.. _vamdclib: http://vamdclib.readthedocs.io/en/latest/ 
+.. _vamdclib: http://vamdclib.readthedocs.io/en/latest/

--- a/setup.cfg
+++ b/setup.cfg
@@ -146,6 +146,7 @@ all=
    astropy-healpix
    boto3
    regions
+   vamdclib @ git+https://github.com/keflavich/vamdclib-1.git
 # aplpy is not py39 compatible (it requires shapely that doesn't compile
 # pyregion is not py39 compatible
 all_lt_39=
@@ -155,3 +156,4 @@ all_lt_39=
    astropy-healpix
    aplpy
    boto3
+   vamdclib @ git+https://github.com/keflavich/vamdclib-1.git

--- a/setup.cfg
+++ b/setup.cfg
@@ -17,9 +17,26 @@ minversion = 6.0
 norecursedirs = build docs/_build docs/gallery-examples
 doctest_plus = enabled
 text_file_format = rst
-addopts = -p no:warnings
 xfail_strict = true
 remote_data_strict = true
+filterwarnings =
+    error
+    ignore: Experimental:UserWarning:
+    ignore: The LCOGT archive:UserWarning:
+# This is a temporary measure, all of these should be fixed:
+    ignore::pytest.PytestUnraisableExceptionWarning
+    ignore::numpy.VisibleDeprecationWarning
+    ignore: unclosed file:ResourceWarning
+    ignore::UserWarning
+    ignore::astroquery.exceptions.InputWarning
+    ignore::astropy.utils.exceptions.AstropyDeprecationWarning
+    ignore::astropy.io.votable.exceptions.W50
+    ignore::astropy.io.votable.exceptions.W06
+    ignore::astropy.io.votable.exceptions.W03
+    ignore::astropy.io.votable.exceptions.W21
+    ignore::astropy.io.votable.exceptions.W42
+markers =
+    bigdata: marks tests that are expected to trigger a large download (deselect with '-m "not bigdata"')
 
 [ah_bootstrap]
 auto_use = True

--- a/setup.cfg
+++ b/setup.cfg
@@ -33,8 +33,15 @@ filterwarnings =
     ignore::astropy.io.votable.exceptions.W50
     ignore::astropy.io.votable.exceptions.W06
     ignore::astropy.io.votable.exceptions.W03
+    ignore::astropy.io.votable.exceptions.W15
+    ignore::astropy.io.votable.exceptions.W49
     ignore::astropy.io.votable.exceptions.W21
     ignore::astropy.io.votable.exceptions.W42
+    ignore:numpy.ndarray size changed:RuntimeWarning
+    ignore:OverflowError converting::astropy
+# Upstream, remove when fixed, PRs have been opened
+    ignore::DeprecationWarning:pyvo
+    ignore::DeprecationWarning:regions
 markers =
     bigdata: marks tests that are expected to trigger a large download (deselect with '-m "not bigdata"')
 
@@ -121,7 +128,7 @@ exclude = _astropy_init.py,version.py
 
 [options]
 install_requires=
-   numpy
+   numpy>=1.15.0
    astropy>=3.1.2
    requests>=2.4.3
    beautifulsoup4>=4.3.2

--- a/tox.ini
+++ b/tox.ini
@@ -43,8 +43,8 @@ commands =
     pip freeze
 # FIXME: there are too many failures from the docs example gallery ignore docs for now
 # !cov: pytest {toxinidir}/astroquery {toxinidir}/docs {posargs}
-    !cov: pytest {toxinidir}/astroquery {posargs}
-    cov:  pytest {toxinidir}/astroquery --cov {toxinidir}/astroquery {posargs}
+    !cov: pytest --pyargs astroquery {posargs}
+    cov:  pytest --pyargs astroquery --cov astroquery {posargs}
     cov: coverage xml -o {toxinidir}/coverage.xml
 
 [testenv:codestyle]

--- a/tox.ini
+++ b/tox.ini
@@ -29,9 +29,12 @@ description = run tests
 deps =
     devastropy: git+https://github.com/astropy/astropy.git#egg=astropy
 
-# TODO: Add more versions to oldestdeps
-    oldestdeps: astropy==3.1
+# TODO: Add more versions to oldestdeps. numpy<1.15 could not be installed
+# in CI, a much newer version was pulled in instead, thus setting
+# minimum numpy to 1.15.
 
+    oldestdeps: astropy==3.1.2
+    oldestdeps: numpy==1.15
     cov: codecov
 
 extras =


### PR DESCRIPTION
I run into some inconsistencies between the CI test suite and what I saw locally, and went ahead fixing the infrastructure so deprecations are in fact raised.

I also went a bit overboard with raising warnings as errors, I firmly believe it is the right direction (and e.g. in astropy it's already the case), but cleaning up everything is not a blocker for the release, so see the newly opened issues instead. 

Keep this PR as there are more things that needs to go in to `main` before the release can be tagged.

fixes: #2052

fixes #2062 

closes #1745