### PR TITLE
MNT: Remove pytest.ini

### DIFF
--- a/astroquery/conftest.py
+++ b/astroquery/conftest.py
@@ -32,7 +32,7 @@ except (NameError, KeyError):
 
 # ignoring pyvo can be removed once we require >0.9.3
 enable_deprecations_as_exceptions(include_astropy_deprecations=False,
-                                  warnings_to_ignore_entire_module=['pyregion', 'html5lib'],)
+                                  warnings_to_ignore_entire_module=['regions', 'pyregion', 'html5lib'],)
 
 # add '_testrun' to the version name so that the user-agent indicates that
 # it's being run in a test

--- a/astroquery/nasa_exoplanet_archive/core.py
+++ b/astroquery/nasa_exoplanet_archive/core.py
@@ -61,7 +61,7 @@ UNIT_MAPPER = {
     "seconds": u.s,
     "solarradius": u.R_sun,
 }
-CONVERTERS = dict(koi_quarters=[ascii.convert_numpy(np.str)])
+CONVERTERS = dict(koi_quarters=[ascii.convert_numpy(str)])
 OBJECT_TABLES = {"exoplanets": "pl_", "compositepars": "fpl_", "exomultpars": "mpl_"}
 
 

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,2 +1,0 @@
-[pytest]
-addopts = --doctest-plus

--- a/setup.cfg
+++ b/setup.cfg
@@ -13,7 +13,7 @@ upload-dir = docs/_build/html
 show-response = 1
 
 [tool:pytest]
-minversion = 3.0
+minversion = 6.0
 norecursedirs = build docs/_build docs/gallery-examples
 doctest_plus = enabled
 text_file_format = rst


### PR DESCRIPTION
`pytest.ini` is overwriting the `addopts` in `setup.cfg`. I was so confused why the warnings won't go away no matter how much I want to ignore it until I realized that `pytest.ini` exists and is taking precedence over `setup.cfg`. I think the `setup.cfg` setting is more correct, but you can also argue that `pytest` config can all move from `setup.cfg` to `pytest.ini`. I'll leave it to your good judgement.