### PR TITLE
Remove non-buildtime dependencies from pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,8 +10,5 @@ filename = "CHANGES.rst"
 # dependency.
 
 [build-system]
-requires = ["setuptools",
-            "wheel",
-            "numpy",
-            "astropy"]
+requires = ["setuptools", "wheel"]
 build-backend = 'setuptools.build_meta'


### PR DESCRIPTION
As far as I can tell, numpy and astropy are not actually needed at build (wheel or sdist) time, so they should not be listed in the build system requirements.