### PR TITLE
Refactor xmm_newton download to use astroquery tools

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -15,8 +15,6 @@ esa.xmm_newton
 
 - Adding the extraction epic light curves. [#2017]
 - Adding the extraction of epic spectra. [#2017]
-- Use astroquery downloader tool to get progressbar, caching, and prevent
-  memory leaks [#2087]
 
 Service fixes and enhancements
 ------------------------------
@@ -25,6 +23,8 @@ esa.xmm_newton
 ^^^^^^^^^^^^^^
 
 - Bug fixes. Fixed the generation of files with wrong extension. [#2017]
+- Use astroquery downloader tool to get progressbar, caching, and prevent
+  memory leaks [#2087]
 
 gaia
 ^^^^
@@ -49,7 +49,6 @@ atomic
 ^^^^^^
 
  - Change URL to https [#2088]
-
 
 
 0.4.2 (2021-05-14)

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -15,6 +15,8 @@ esa.xmm_newton
 
 - Adding the extraction epic light curves. [#2017]
 - Adding the extraction of epic spectra. [#2017]
+- Use astroquery downloader tool to get progressbar, caching, and prevent
+  memory leaks [#2087]
 
 Service fixes and enhancements
 ------------------------------

--- a/astroquery/esa/xmm_newton/core.py
+++ b/astroquery/esa/xmm_newton/core.py
@@ -47,7 +47,7 @@ class XMMNewtonClass(BaseQuery):
         self._rmf_ftp = str("http://sasdev-xmm.esac.esa.int/pub/ccf/constituents/extras/responses/")
 
     def download_data(self, observation_id, *, filename=None, verbose=False,
-                      **kwargs):
+                      cache=True, **kwargs):
         """
         Download data from XMM-Newton
 
@@ -110,7 +110,9 @@ class XMMNewtonClass(BaseQuery):
         if verbose:
             log.info(link)
 
-        response = self._request('HEAD', link, save=False, cache=False)
+        # we can cache this HEAD request - the _download_file one will check
+        # the file size and will never cache
+        response = self._request('HEAD', link, save=False, cache=cache)
 
         # Get original extension
         _, params = cgi.parse_header(response.headers['Content-Disposition'])
@@ -122,7 +124,7 @@ class XMMNewtonClass(BaseQuery):
 
         filename += "".join(suffixes)
 
-        self._download_file(link, filename, head_safe=True)
+        self._download_file(link, filename, head_safe=True, cache=cache)
 
         if verbose:
             log.info("Wrote {0} to {1}".format(link, filename))

--- a/astroquery/esa/xmm_newton/core.py
+++ b/astroquery/esa/xmm_newton/core.py
@@ -110,7 +110,7 @@ class XMMNewtonClass(BaseQuery):
         if verbose:
             log.info(link)
 
-        response = self._request('GET', link, save=False, cache=True)
+        response = self._request('HEAD', link, save=False, cache=False)
 
         # Get original extension
         _, params = cgi.parse_header(response.headers['Content-Disposition'])
@@ -122,9 +122,7 @@ class XMMNewtonClass(BaseQuery):
 
         filename += "".join(suffixes)
 
-        log.info("Copying file to {0}...".format(filename))
-        with open(filename, 'wb') as f:
-            f.write(response.content)
+        self._download_file(link, filename)
 
         if verbose:
             log.info("Wrote {0} to {1}".format(link, filename))

--- a/astroquery/esa/xmm_newton/core.py
+++ b/astroquery/esa/xmm_newton/core.py
@@ -116,11 +116,10 @@ class XMMNewtonClass(BaseQuery):
         response = self._request('HEAD', link, save=False, cache=cache)
 
         # Get original extension
-        if 'Content-Type' in response.headers.keys() and 'text' not in response.headers['Content-Type']:
+        if 'Content-Type' in response.headers and 'text' not in response.headers['Content-Type']:
             _, params = cgi.parse_header(response.headers['Content-Disposition'])
         else:
             error = "Data protected by proprietary rights. Please check your credentials"
-            log.error(error)
             raise LoginError(error)
 
         r_filename = params["filename"]

--- a/astroquery/esa/xmm_newton/core.py
+++ b/astroquery/esa/xmm_newton/core.py
@@ -122,7 +122,7 @@ class XMMNewtonClass(BaseQuery):
 
         filename += "".join(suffixes)
 
-        self._download_file(link, filename)
+        self._download_file(link, filename, head_safe=True)
 
         if verbose:
             log.info("Wrote {0} to {1}".format(link, filename))


### PR DESCRIPTION
XMM Newton was not using the `_download_file` tool, and was therefore loading the entire file into memory before writing to disk rather than streaming to disk.

fixes: #2075 