### PR TITLE
Fix downloaded amount for progressbar

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -16,6 +16,7 @@ esa.xmm_newton
 - Adding the extraction epic light curves. [#2017]
 - Adding the extraction of epic spectra. [#2017]
 
+
 Service fixes and enhancements
 ------------------------------
 
@@ -49,6 +50,13 @@ atomic
 ^^^^^^
 
  - Change URL to https [#2088]
+
+
+Infrastructure, Utility and Other Changes and Additions
+-------------------------------------------------------
+
+- Fixed progressbar download to report the correct downloaded amount. [#2091]
+
 
 
 0.4.2 (2021-05-14)

--- a/astroquery/query.py
+++ b/astroquery/query.py
@@ -423,7 +423,7 @@ class BaseQuery:
             with open(local_filepath, open_mode) as f:
                 for block in response.iter_content(blocksize):
                     f.write(block)
-                    bytes_read += blocksize
+                    bytes_read += len(block)
                     if length is not None:
                         pb.update(bytes_read if bytes_read <= length else length)
                     else:

--- a/astroquery/query.py
+++ b/astroquery/query.py
@@ -385,11 +385,8 @@ class BaseQuery:
             if length is not None:
                 statinfo = os.stat(local_filepath)
                 if statinfo.st_size != length:
-                    log.warning("Found cached file {0} with size {1} that is "
-                                "different from expected size {2}"
-                                .format(local_filepath,
-                                        statinfo.st_size,
-                                        length))
+                    log.warning(f"Found cached file {local_filepath} with size {statinfo.st_size} "
+                                f"that is different from expected size {length}")
                     open_mode = 'wb'
                 else:
                     log.info("Found cached file {0} with expected size {1}."
@@ -421,20 +418,16 @@ class BaseQuery:
         else:
             progress_stream = io.StringIO()
 
-        with ProgressBarOrSpinner(
-                length, ('Downloading URL {0} to {1} ...'
-                         .format(url, local_filepath)),
-                file=progress_stream) as pb:
+        with ProgressBarOrSpinner(length, f'Downloading URL {url} to {local_filepath} ...',
+                                  file=progress_stream) as pb:
             with open(local_filepath, open_mode) as f:
                 for block in response.iter_content(blocksize):
                     f.write(block)
                     bytes_read += blocksize
                     if length is not None:
-                        pb.update(bytes_read if bytes_read <= length else
-                                  length)
+                        pb.update(bytes_read if bytes_read <= length else length)
                     else:
                         pb.update(bytes_read)
-
         response.close()
         return response
 


### PR DESCRIPTION
This should fix the progressbar bug that it reports 100% download an order of magnitude prematurely. Apparently, we had this bug since forever.

This is good reminder to switch to use something more standard, e.g. `tqdm` rather than maintaining our homegrown solution at two places. https://github.com/astropy/astropy/issues/4738

