### PR TITLE
Cleanup Irsa module

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -36,6 +36,12 @@ heasarc
 - Add alternative instance of HEASARC Server, maintained by
   INTEGRAL Science Data Center. [#1988]
 
+irsa
+^^^^
+
+- Adding ``cache`` kwarg to the class methods to be able to control the use
+  of local cache. [#2092]
+
 nasa_exoplanet_archive
 ^^^^^^^^^^^^^^^^^^^^^^
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -42,6 +42,8 @@ irsa
 - Adding ``cache`` kwarg to the class methods to be able to control the use
   of local cache. [#2092]
 
+- Making optional kwargs keyword only. [#2092]
+
 nasa_exoplanet_archive
 ^^^^^^^^^^^^^^^^^^^^^^
 

--- a/astroquery/irsa/core.py
+++ b/astroquery/irsa/core.py
@@ -130,7 +130,7 @@ class IrsaClass(BaseQuery):
     def query_region_async(self, coordinates=None, *, catalog=None,
                            spatial='Cone', radius=10 * u.arcsec, width=None,
                            polygon=None, get_query_payload=False,
-                           selcols=None, cache=True):
+                           selcols=None, verbose=False, cache=True):
         """
         This function serves the same purpose as
         :meth:`~astroquery.irsa.IrsaClass.query_region`, but returns the raw
@@ -170,6 +170,9 @@ class IrsaClass(BaseQuery):
             Defaults to `False`.
         selcols : str, optional
             Target column list with value separated by a comma(,)
+        verbose : bool, optional.
+            If `True` then displays warnings when the returned VOTable does not
+            conform to the standard. Defaults to `False`.
         cache : bool, optional
             Use local cache when set to `True`.
 

--- a/astroquery/irsa/core.py
+++ b/astroquery/irsa/core.py
@@ -99,7 +99,6 @@ If onlist=0, the following parameters are required:
                         constraints.
 """
 
-
 import warnings
 from io import BytesIO
 import xml.etree.ElementTree as tree
@@ -107,8 +106,6 @@ import xml.etree.ElementTree as tree
 import astropy.units as u
 import astropy.coordinates as coord
 import astropy.io.votable as votable
-from astropy.table import Table
-
 
 from astroquery.query import BaseQuery
 from astroquery.utils import commons, async_to_sync
@@ -125,7 +122,6 @@ class IrsaClass(BaseQuery):
     GATOR_LIST_URL = conf.gator_list_catalogs
     TIMEOUT = conf.timeout
     ROW_LIMIT = conf.row_limit
-
 
     def query_region_async(self, coordinates=None, *, catalog=None,
                            spatial='Cone', radius=10 * u.arcsec, width=None,
@@ -357,7 +353,6 @@ class IrsaClass(BaseQuery):
                           "be empty", NoResultsWarning)
 
         return table
-
 
     def list_catalogs(self, cache=False):
         """

--- a/astroquery/irsa/tests/test_irsa.py
+++ b/astroquery/irsa/tests/test_irsa.py
@@ -39,7 +39,7 @@ def patch_get(request):
     return mp
 
 
-def get_mockreturn(method, url, params=None, timeout=10, **kwargs):
+def get_mockreturn(method, url, params=None, timeout=10, cache=False, **kwargs):
     filename = data_path(DATA_FILES[params['spatial']])
     content = open(filename, 'rb').read()
     return MockResponse(content, **kwargs)

--- a/astroquery/irsa/tests/test_irsa.py
+++ b/astroquery/irsa/tests/test_irsa.py
@@ -10,10 +10,10 @@ from astropy.table import Table
 import astropy.coordinates as coord
 import astropy.units as u
 
-from ...utils.testing_tools import MockResponse
-from ...utils import commons
-from ... import irsa
-from ...irsa import conf
+from astroquery.utils.testing_tools import MockResponse
+from astroquery.utils import commons
+from astroquery.irsa import Irsa, conf
+from astroquery import irsa
 
 DATA_FILES = {'Cone': 'Cone.xml',
               'Box': 'Box.xml',
@@ -35,7 +35,7 @@ def patch_get(request):
         mp = request.getfixturevalue("monkeypatch")
     except AttributeError:  # pytest < 3
         mp = request.getfuncargvalue("monkeypatch")
-    mp.setattr(irsa.Irsa, '_request', get_mockreturn)
+    mp.setattr(Irsa, '_request', get_mockreturn)
     return mp
 
 
@@ -78,26 +78,26 @@ def test_parse_coordinates(coordinates, expected):
 
 
 def test_args_to_payload():
-    out = irsa.core.Irsa._args_to_payload("fp_psc")
+    out = Irsa._args_to_payload("fp_psc")
     assert out == dict(catalog='fp_psc', outfmt=3, outrows=conf.row_limit,
                        selcols='')
 
 
 @pytest.mark.parametrize(("coordinates"), OBJ_LIST)
 def test_query_region_cone_async(coordinates, patch_get):
-    response = irsa.core.Irsa.query_region_async(
+    response = Irsa.query_region_async(
         coordinates, catalog='fp_psc', spatial='Cone',
         radius=2 * u.arcmin, get_query_payload=True)
     assert response['radius'] == 2
     assert response['radunits'] == 'arcmin'
-    response = irsa.core.Irsa.query_region_async(
+    response = Irsa.query_region_async(
         coordinates, catalog='fp_psc', spatial='Cone', radius=2 * u.arcmin)
     assert response is not None
 
 
 @pytest.mark.parametrize(("coordinates"), OBJ_LIST)
 def test_query_region_cone(coordinates, patch_get):
-    result = irsa.core.Irsa.query_region(
+    result = Irsa.query_region(
         coordinates, catalog='fp_psc', spatial='Cone', radius=2 * u.arcmin)
 
     assert isinstance(result, Table)
@@ -105,18 +105,18 @@ def test_query_region_cone(coordinates, patch_get):
 
 @pytest.mark.parametrize(("coordinates"), OBJ_LIST)
 def test_query_region_box_async(coordinates, patch_get):
-    response = irsa.core.Irsa.query_region_async(
+    response = Irsa.query_region_async(
         coordinates, catalog='fp_psc', spatial='Box',
         width=2 * u.arcmin, get_query_payload=True)
     assert response['size'] == 120
-    response = irsa.core.Irsa.query_region_async(
+    response = Irsa.query_region_async(
         coordinates, catalog='fp_psc', spatial='Box', width=2 * u.arcmin)
     assert response is not None
 
 
 @pytest.mark.parametrize(("coordinates"), OBJ_LIST)
 def test_query_region_box(coordinates, patch_get):
-    result = irsa.core.Irsa.query_region(
+    result = Irsa.query_region(
         coordinates, catalog='fp_psc', spatial='Box', width=2 * u.arcmin)
 
     assert isinstance(result, Table)
@@ -129,12 +129,9 @@ poly2 = [(10.1 * u.deg, 10.1 * u.deg), (10.0 * u.deg, 10.1 * u.deg),
          (10.0 * u.deg, 10.0 * u.deg)]
 
 
-@pytest.mark.parametrize(("polygon"),
-                         [poly1,
-                          poly2
-                          ])
+@pytest.mark.parametrize(("polygon"), [poly1, poly2])
 def test_query_region_async_polygon(polygon, patch_get):
-    response = irsa.core.Irsa.query_region_async(
+    response = Irsa.query_region_async(
         "m31", catalog="fp_psc", spatial="Polygon",
         polygon=polygon, get_query_payload=True)
 
@@ -145,7 +142,7 @@ def test_query_region_async_polygon(polygon, patch_get):
             b1 = float(b1)
             np.testing.assert_almost_equal(a1, b1)
 
-    response = irsa.core.Irsa.query_region_async(
+    response = Irsa.query_region_async(
         "m31", catalog="fp_psc", spatial="Polygon", polygon=polygon)
 
     assert response is not None
@@ -156,7 +153,7 @@ def test_query_region_async_polygon(polygon, patch_get):
                           poly2,
                           ])
 def test_query_region_polygon(polygon, patch_get):
-    result = irsa.core.Irsa.query_region(
+    result = Irsa.query_region(
         "m31", catalog="fp_psc", spatial="Polygon", polygon=polygon)
 
     assert isinstance(result, Table)
@@ -166,7 +163,7 @@ def test_query_region_polygon(polygon, patch_get):
                          zip(('Cone', 'Box', 'Polygon', 'All-Sky'),
                              ('Cone', 'Box', 'Polygon', 'NONE')))
 def test_spatial_valdi(spatial, result):
-    out = irsa.core.Irsa._parse_spatial(
+    out = Irsa._parse_spatial(
         spatial, coordinates='m31', radius=5 * u.deg, width=5 * u.deg,
         polygon=[(5 * u.hour, 5 * u.deg)] * 3)
     assert out['spatial'] == result
@@ -176,4 +173,4 @@ def test_spatial_valdi(spatial, result):
                                         'All-sky', 'invalid', 'blah')])
 def test_spatial_invalid(spatial):
     with pytest.raises(ValueError):
-        irsa.core.Irsa._parse_spatial(spatial, coordinates='m31')
+        Irsa._parse_spatial(spatial, coordinates='m31')

--- a/astroquery/irsa/tests/test_irsa_remote.py
+++ b/astroquery/irsa/tests/test_irsa_remote.py
@@ -6,7 +6,7 @@ import astropy.units as u
 from astropy.table import Table
 from astropy.coordinates import SkyCoord
 
-from ... import irsa
+from astroquery.irsa import Irsa
 
 
 OBJ_LIST = ["m31", "00h42m44.330s +41d16m07.50s",
@@ -16,41 +16,46 @@ OBJ_LIST = ["m31", "00h42m44.330s +41d16m07.50s",
 
 @pytest.mark.remote_data
 class TestIrsa:
-
     def test_query_region_cone_async(self):
-        response = irsa.core.Irsa.query_region_async(
-            'm31', catalog='fp_psc', spatial='Cone', radius=2 * u.arcmin)
+        response = Irsa.query_region_async(
+            'm31', catalog='fp_psc', spatial='Cone', radius=2 * u.arcmin, cache=False)
         assert response is not None
 
     def test_query_region_cone(self):
-        result = irsa.core.Irsa.query_region(
-            'm31', catalog='fp_psc', spatial='Cone', radius=2 * u.arcmin)
+        result = Irsa.query_region(
+            'm31', catalog='fp_psc', spatial='Cone', radius=2 * u.arcmin, cache=False)
         assert isinstance(result, Table)
 
     def test_query_region_box_async(self):
-        response = irsa.core.Irsa.query_region_async(
+        response = Irsa.query_region_async(
             "00h42m44.330s +41d16m07.50s", catalog='fp_psc', spatial='Box',
-            width=2 * u.arcmin)
+            width=2 * u.arcmin, cache=False)
         assert response is not None
 
     def test_query_region_box(self):
-        result = irsa.core.Irsa.query_region(
+        result = Irsa.query_region(
             "00h42m44.330s +41d16m07.50s", catalog='fp_psc', spatial='Box',
-            width=2 * u.arcmin)
+            width=2 * u.arcmin, cache=False)
         assert isinstance(result, Table)
 
     def test_query_region_async_polygon(self):
         polygon = [SkyCoord(ra=10.1, dec=10.1, unit=(u.deg, u.deg)),
                    SkyCoord(ra=10.0, dec=10.1, unit=(u.deg, u.deg)),
                    SkyCoord(ra=10.0, dec=10.0, unit=(u.deg, u.deg))]
-        response = irsa.core.Irsa.query_region_async(
-            "m31", catalog="fp_psc", spatial="Polygon", polygon=polygon)
+        response = Irsa.query_region_async(
+            "m31", catalog="fp_psc", spatial="Polygon", polygon=polygon, cache=False)
 
         assert response is not None
 
     def test_query_region_polygon(self):
         polygon = [(10.1, 10.1), (10.0, 10.1), (10.0, 10.0)]
-        result = irsa.core.Irsa.query_region(
-            "m31", catalog="fp_psc", spatial="Polygon", polygon=polygon)
+        result = Irsa.query_region(
+            "m31", catalog="fp_psc", spatial="Polygon", polygon=polygon, cache=False)
 
         assert isinstance(result, Table)
+
+    def test_list_catalogs(self):
+        catalogs = Irsa.list_catalogs(cache=False)
+        # Number of available catalogs may change over time, test only for significant drop.
+        # (at the time of writing there are 587 catalogs in the list).
+        assert len(catalogs) > 500


### PR DESCRIPTION
- adding `cache` as kwarg
- using async_to_sync to be able to remove code duplication
- minor code cleanup of python2

closes #2049 as an alternative cleanup.
