### PR TITLE
Enabling rst docs testing

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -137,7 +137,9 @@ install_requires=
    keyring>=4.0
    pyvo>=1.1
    six
-tests_require = pytest-astropy
+tests_require =
+   pytest-doctestplus>=0.9
+   pytest-astropy
 
 [options.extras_require]
 test=

--- a/setup.cfg
+++ b/setup.cfg
@@ -16,9 +16,11 @@ show-response = 1
 minversion = 6.0
 norecursedirs = build docs/_build docs/gallery-examples
 doctest_plus = enabled
+astropy_header = true
 text_file_format = rst
 xfail_strict = true
 remote_data_strict = true
+addopts = --doctest-rst
 filterwarnings =
     error
     ignore: Experimental:UserWarning:

--- a/tox.ini
+++ b/tox.ini
@@ -44,10 +44,9 @@ extras =
 
 commands =
     pip freeze
-# FIXME: there are too many failures from the docs example gallery ignore docs for now
-# !cov: pytest {toxinidir}/astroquery {toxinidir}/docs {posargs}
-    !cov: pytest --pyargs astroquery {posargs}
-    cov:  pytest --pyargs astroquery --cov astroquery {posargs}
+    # FIXME: there are too many failures in the docs example gallery, ignore it for now
+    !cov: pytest --pyargs astroquery {toxinidir}/docs --ignore={toxinidir}/docs/gallery* {posargs}
+    cov:  pytest --pyargs astroquery {toxinidir}/docs --ignore={toxinidir}/docs/gallery* --cov astroquery {posargs}
     cov: coverage xml -o {toxinidir}/coverage.xml
 
 [testenv:codestyle]


### PR DESCRIPTION
After this PR is merged we can start rebasing @tinumide's PRs and once they pass locally with ``--remote-data``, can merge those, too.