### PR TITLE
Drop python3.6

### DIFF
--- a/.github/workflows/ci_tests.yml
+++ b/.github/workflows/ci_tests.yml
@@ -35,8 +35,8 @@ jobs:
 
           - name: oldest dependencies
             os: ubuntu-latest
-            python: 3.6
-            toxenv: py36-test-oldestdeps
+            python: 3.7
+            toxenv: py37-test-oldestdeps
             toxargs: -v
 
           - name: astropy dev with all dependencies with coverage

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -65,6 +65,7 @@ Infrastructure, Utility and Other Changes and Additions
 
 - Fixed progressbar download to report the correct downloaded amount. [#2091]
 
+- Dropping Python 3.6 support. [#2102]
 
 
 0.4.2 (2021-05-14)

--- a/README.rst
+++ b/README.rst
@@ -42,7 +42,7 @@ website <http://simbad.u-strasbg.fr/simbad/>`_, use the ``simbad`` sub-package:
 Installation and Requirements
 -----------------------------
 
-Astroquery works with Python 3.6 or later.
+Astroquery works with Python 3.7 or later.
 As an `astropy`_ affiliate, astroquery requires `astropy`_ version 3.1.2 or later.
 
 astroquery uses the `requests <http://docs.python-requests.org/en/latest/>`_

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -68,11 +68,11 @@ The development version can be obtained and installed from github:
 Requirements
 ------------
 
-Astroquery works with Python 3.6 or later.
+Astroquery works with Python 3.7 or later.
 
 The following packages are required for astroquery installation & use:
 
-* `numpy <http://www.numpy.org>`_ >= 1.14
+* `numpy <http://www.numpy.org>`_ >= 1.15
 * `astropy <http://www.astropy.org>`__ (>=3.1.2)
 * `pyVO`_ (>=1.1)
 * `requests <http://docs.python-requests.org/en/latest/>`_

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 envlist =
-    py{36,37,38,39}-test{,-alldeps,-oldestdeps}{,-devastropy}{,-cov}
+    py{37,38,39}-test{,-alldeps,-oldestdeps}{,-devastropy}{,-cov}
     codestyle
     build_docs
 requires =

--- a/tox.ini
+++ b/tox.ini
@@ -31,10 +31,12 @@ deps =
 
 # TODO: Add more versions to oldestdeps. numpy<1.15 could not be installed
 # in CI, a much newer version was pulled in instead, thus setting
-# minimum numpy to 1.15.
+# minimum numpy to 1.15. mpl while not a dependency, it's required for the
+# tests, and would pull up a newer numpy version if not pinned.
 
     oldestdeps: astropy==3.1.2
     oldestdeps: numpy==1.15
+    oldestdeps: matplotlib==3.3.*
     cov: codecov
 
 extras =


### PR DESCRIPTION
@keflavich and @ceb8 - We need to drop testing with python3.6 as doctestplus made the 3.7 the minimum version and we require that latest doctestplus version to be able to test the remote data in documentation (errors are raised with earlier version when we use the new directive).

Dropping support is in accordance with the timelines in APE18, and NEP29 and the new SPEC, but we have not opted in officially in any of those with astroquery or in generally with the coordinated packages. I would be in favour of such a policy, so the question was raised both in the infra team (for writing a formal document), and project wide. It was released in 2016, and EOL is in Dec2021. 

Currently this PR drops the testing only, but if you're on board, I could drop its support from packaging in this PR, too.