### PR TITLE
Switch to https for IBE and SHA

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -54,6 +54,13 @@ irsa
 
 - Making optional kwargs keyword only. [#2092]
 
+ibe
+^^^
+
+- Doubling default timeout to 120 seconds. [#2108]
+
+- Change URL to https. [#2108]
+
 nasa_exoplanet_archive
 ^^^^^^^^^^^^^^^^^^^^^^
 
@@ -65,6 +72,11 @@ atomic
 ^^^^^^
 
  - Change URL to https [#2088]
+
+sha
+^^^
+
+- Change URL to https. [#2108]
 
 
 Infrastructure, Utility and Other Changes and Additions

--- a/astroquery/ibe/__init__.py
+++ b/astroquery/ibe/__init__.py
@@ -15,21 +15,21 @@ class Conf(_config.ConfigNamespace):
     """
 
     server = _config.ConfigItem(
-        'http://irsa.ipac.caltech.edu/ibe/',
+        'https://irsa.ipac.caltech.edu/ibe/',
         'Name of the IBE server to use.')
     mission = _config.ConfigItem(
         'ptf',
         ('Default mission. See, for example, '
-         'http://irsa.ipac.caltech.edu/ibe/search/ for options.'))
+         'https://irsa.ipac.caltech.edu/ibe/search/ for options.'))
 
     dataset = _config.ConfigItem(
         'images',
         ('Default data set. See, for example, '
-         'http://irsa.ipac.caltech.edu/ibe/search/ptf for options.'))
+         'https://irsa.ipac.caltech.edu/ibe/search/ptf for options.'))
     table = _config.ConfigItem(
         'level1',
         ('Default table. See, for example, '
-         'http://irsa.ipac.caltech.edu/ibe/search/ptf/images for options.'))
+         'https://irsa.ipac.caltech.edu/ibe/search/ptf/images for options.'))
     timeout = _config.ConfigItem(
         60,
         'Time limit for connecting to the IRSA server.')

--- a/astroquery/ibe/__init__.py
+++ b/astroquery/ibe/__init__.py
@@ -31,7 +31,7 @@ class Conf(_config.ConfigNamespace):
         ('Default table. See, for example, '
          'https://irsa.ipac.caltech.edu/ibe/search/ptf/images for options.'))
     timeout = _config.ConfigItem(
-        60,
+        120,
         'Time limit for connecting to the IRSA server.')
 
 

--- a/astroquery/ibe/core.py
+++ b/astroquery/ibe/core.py
@@ -5,7 +5,7 @@ IBE
 
 API from
 
- http://irsa.ipac.caltech.edu/ibe/
+ https://irsa.ipac.caltech.edu/ibe/
 """
 
 

--- a/astroquery/ibe/tests/test_ibe.py
+++ b/astroquery/ibe/tests/test_ibe.py
@@ -12,16 +12,16 @@ from ...utils.testing_tools import MockResponse
 from ...ibe import Ibe
 
 DATA_FILES = {
-    ('http://irsa.ipac.caltech.edu/ibe/search/', None): 'missions.html',
-    ('http://irsa.ipac.caltech.edu/ibe/search/ptf/', None): 'datasets.html',
-    ('http://irsa.ipac.caltech.edu/ibe/search/ptf/images/',
+    ('https://irsa.ipac.caltech.edu/ibe/search/', None): 'missions.html',
+    ('https://irsa.ipac.caltech.edu/ibe/search/ptf/', None): 'datasets.html',
+    ('https://irsa.ipac.caltech.edu/ibe/search/ptf/images/',
      None): 'tables.html',
-    ('http://irsa.ipac.caltech.edu/ibe/search/ptf/images/level1',
+    ('https://irsa.ipac.caltech.edu/ibe/search/ptf/images/level1',
      frozenset((('FORMAT', 'METADATA'),))): 'columns.txt',
-    ('http://irsa.ipac.caltech.edu/ibe/search/ptf/images/level1',
+    ('https://irsa.ipac.caltech.edu/ibe/search/ptf/images/level1',
      frozenset((('where', 'expid <= 43010'), ('POS', '148.969687,69.679383'),
                 ('INTERSECT', 'OVERLAPS')))): 'pos.txt',
-    ('http://irsa.ipac.caltech.edu/ibe/search/ptf/images/level1',
+    ('https://irsa.ipac.caltech.edu/ibe/search/ptf/images/level1',
      frozenset((('where', "ptffield = 4808 and filter='R'"),
                 ('INTERSECT', 'OVERLAPS')))): 'field_id.txt'}
 

--- a/astroquery/sha/__init__.py
+++ b/astroquery/sha/__init__.py
@@ -6,7 +6,7 @@ SHA Query Tool
 :Author: Brian Svoboda (svobodb@email.arizona.edu)
 
 This package is for querying the Spitzer Heritage Archive (SHA)
-found at: http://sha.ipac.caltech.edu/applications/Spitzer/SHA.
+found at: https://sha.ipac.caltech.edu/applications/Spitzer/SHA.
 """
 from .core import *
 

--- a/astroquery/sha/core.py
+++ b/astroquery/sha/core.py
@@ -14,7 +14,7 @@ id_parse = re.compile(r'ID\=(\d+)')
 # should skip only if remote_data = False
 __doctest_skip__ = ['query', 'save_file', 'get_file']
 
-uri = 'http://sha.ipac.caltech.edu/applications/Spitzer/SHA/servlet/DataService?'
+uri = 'https://sha.ipac.caltech.edu/applications/Spitzer/SHA/servlet/DataService?'
 
 
 def query(coord=None, ra=None, dec=None, size=None, naifid=None, pid=None,
@@ -102,7 +102,7 @@ def query(coord=None, ra=None, dec=None, size=None, naifid=None, pid=None,
     For column descriptions, metadata, and other information visit the SHA
     query API_ help page
 
-    .. _API: http://sha.ipac.caltech.edu/applications/Spitzer/SHA/help/doc/api.html
+    .. _API: https://sha.ipac.caltech.edu/applications/Spitzer/SHA/help/doc/api.html
     """
     # Use Coordinate instance if supplied
     if coord is not None:


### PR DESCRIPTION
Small changes for the IBE and SHA modules to use the https URLs. 

I've also changed the default timeout as I very often run into it with the remote-data tests.