### PR TITLE
TMP: revert remote doctest for nasa_exoplanet_archive

### DIFF
--- a/docs/nasa_exoplanet_archive/nasa_exoplanet_archive.rst
+++ b/docs/nasa_exoplanet_archive/nasa_exoplanet_archive.rst
@@ -1,3 +1,5 @@
+.. doctest-skip-all
+
 .. _astroquery.nasa_exoplanet_archive:
 
 ************************************************************
@@ -25,7 +27,7 @@ The `~astroquery.nasa_exoplanet_archive.NasaExoplanetArchiveClass.query_object` 
 For example, the following query searches the ``ps`` table of confirmed exoplanets for information about the planet K2-18 b.
 
 .. code-block:: python
-.. doctest-remote-data::
+
     >>> from astroquery.nasa_exoplanet_archive import NasaExoplanetArchive
     >>> NasaExoplanetArchive.query_object("K2-18 b")
     <QTable masked=True length=11>
@@ -49,7 +51,6 @@ For example, the following query searches the ``ps`` table of confirmed exoplane
 Similarly, cone searches can be executed using the `~astroquery.nasa_exoplanet_archive.NasaExoplanetArchiveClass.query_region` method:
 
 .. code-block:: python
-.. doctest-remote-data::
 
     >>> import astropy.units as u
     >>> from astropy.coordinates import SkyCoord
@@ -70,7 +71,6 @@ The most general queries can be performed using the `~astroquery.nasa_exoplanet_
 For example, a full table can be queried as follows:
 
 .. code-block:: python
-.. doctest-remote-data::
 
     >>> from astroquery.nasa_exoplanet_archive import NasaExoplanetArchive
     >>> NasaExoplanetArchive.query_criteria(table="cumulative", select="*")
@@ -98,7 +98,6 @@ In this section, we demonstrate
 1. The number of confirmed planets discovered by TESS:
 
 .. code-block:: python
-.. doctest-remote-data::
 
     >>> from astroquery.nasa_exoplanet_archive import NasaExoplanetArchive
     >>> NasaExoplanetArchive.query_criteria(table="pscomppars", select="count(*)",
@@ -113,7 +112,6 @@ In this section, we demonstrate
 2. The list of confirmed planets discovered by TESS and their host star coordinates:
 
 .. code-block:: python
-.. doctest-remote-data::
 
     >>> from astroquery.nasa_exoplanet_archive import NasaExoplanetArchive
     >>> NasaExoplanetArchive.query_criteria(table="pscomppars", select="pl_name,ra,dec",
@@ -135,7 +133,6 @@ In this section, we demonstrate
 3. The list of confirmed planets discovered using microlensing that have data available in the archive:
 
 .. code-block:: python
-.. doctest-remote-data::
 
     >>> from astroquery.nasa_exoplanet_archive import NasaExoplanetArchive
     >>> NasaExoplanetArchive.query_criteria(
@@ -159,7 +156,6 @@ In this section, we demonstrate
 4. The list of confirmed planets where the host star name starts with "Kepler" using a *wildcard search*:
 
 .. code-block:: python
-.. doctest-remote-data::
 
     >>> from astroquery.nasa_exoplanet_archive import NasaExoplanetArchive
     >>> NasaExoplanetArchive.query_criteria(
@@ -186,7 +182,6 @@ In this section, we demonstrate
 5. The Kepler Objects of Interest that were vetted more recently than January 24, 2015 using a *date search*:
 
 .. code-block:: python
-.. doctest-remote-data::
 
     >>> from astroquery.nasa_exoplanet_archive import NasaExoplanetArchive
     >>> NasaExoplanetArchive.query_criteria(


### PR DESCRIPTION
This is a temporary revert workaround for #2111 to be able to advertise the new release of 0.4.3 including the refactoring of the nasa_exoplanet_archive module.

(Somehow I have sphinx issues locally, will merge this if the RTD build looks good).