### PR TITLE
Revert temporary doctest remote-data removal, and fix code blocks

### DIFF
--- a/docs/irsa/irsa.rst
+++ b/docs/irsa/irsa.rst
@@ -23,7 +23,6 @@ All region queries require a ``catalog`` keyword argument, which is the name of
 the catalog in the IRSA database, on which the query must be performed. To take
 a look at all the available catalogs:
 
-.. code-block:: python
 .. doctest-remote-data::
 
     >>> from astroquery.irsa import Irsa
@@ -41,7 +40,6 @@ a look at all the available catalogs:
 This returns a dictionary of catalog names with their description. If you would
 rather just print out this information:
 
-.. code-block:: python
 .. doctest-remote-data::
 
     >>> from astroquery.irsa import Irsa
@@ -64,7 +62,6 @@ missing, it defaults to a value of 10 arcsec. The radius may be specified in
 any appropriate unit using a `~astropy.units.Quantity` object. It may also be
 entered as a string that is parsable by `~astropy.coordinates.Angle`.
 
-.. code-block:: python
 .. doctest-remote-data::
 
     >>> from astroquery.irsa import Irsa
@@ -89,7 +86,6 @@ name. The coordinates can be specified using the appropriate
 `astropy.coordinates` object. ICRS coordinates may also be entered directly as
 a string, as specified by `astropy.coordinates`:
 
-.. code-block:: python
 .. doctest-remote-data::
 
     >>> from astroquery.irsa import Irsa
@@ -120,7 +116,6 @@ region is required. The width may be specified in the same way as the radius
 for cone search queries, above - so it may be set using the appropriate
 `~astropy.units.Quantity` object or a string parsable by `~astropy.coordinates.Angle`.
 
-.. code-block:: python
 .. doctest-remote-data::
 
     >>> from astroquery.irsa import Irsa
@@ -152,7 +147,6 @@ the coordinates is also available - Coordinates may also be entered as a list of
 tuples, each tuple containing the ra and dec values in degrees. Each of these
 options is illustrated below:
 
-.. code-block:: python
 .. doctest-remote-data::
 
     >>> from astroquery.irsa import Irsa
@@ -177,7 +171,6 @@ options is illustrated below:
 Another way to specify the polygon is directly as a list of tuples - each tuple
 is an ra, dec pair expressed in degrees:
 
-.. code-block:: python
 .. doctest-remote-data::
 
     >>> from astroquery.irsa import Irsa
@@ -209,7 +202,6 @@ An example where the AllWISE Source Catalog needs to be queried around the
 star HIP 12 with just the ra, dec and w1mpro columns would be:
 
 
-.. code-block:: python
 .. doctest-remote-data::
 
     >>> from astroquery.irsa import Irsa
@@ -235,7 +227,6 @@ not only the display of columns, but also the precision that is output when the 
 is written in ``ascii.ipac`` or ``ascii.csv`` formats. The ``.format`` attribute of
 individual columns may be set to increase the precision.
 
-.. code-block:: python
 .. doctest-remote-data::
 
     >>> from astroquery.irsa import Irsa
@@ -256,7 +247,6 @@ By default the maximum number of rows that is fetched is set to 500. However,
 this option may be changed by changing the astroquery configuration file. To
 change the setting only for the ongoing python session, you could also do:
 
-.. code-block:: python
 
     >>> from astroquery.irsa import Irsa
     >>> Irsa.ROW_LIMIT = 1000   # 1000 is the new value for row limit here.

--- a/docs/irsa_dust/irsa_dust.rst
+++ b/docs/irsa_dust/irsa_dust.rst
@@ -20,7 +20,6 @@ specified. If missing the radius defaults to 5 degrees. Note that radius may be
 specified in any appropriate unit, however it must fall in the range of 2 to
 37.5 degrees.
 
-.. code-block:: python
 .. doctest-remote-data::
 
     >>> from astroquery.irsa_dust import IrsaDust
@@ -43,7 +42,6 @@ to the :meth:`~astroquery.irsa_dust.IrsaDustClass.get_images` method. It can tak
 ``ebv``, ``100um`` and ``temperature``, corresponding to each of the 3 kinds of
 images:
 
-.. code-block:: python
 .. doctest-remote-data::
 
     >>> from astroquery.irsa_dust import IrsaDust
@@ -56,7 +54,6 @@ images:
 
 The image types that are available can also be listed out any time:
 
-.. code-block:: python
 .. doctest-remote-data::
 
     >>> from astroquery.irsa_dust import IrsaDust
@@ -66,7 +63,6 @@ The image types that are available can also be listed out any time:
 The target may also be specified via coordinates passed as strings. Examples of acceptable coordinate
 strings can be found on this `IRSA DUST coordinates description page`_.
 
-.. code-block:: python
 .. doctest-remote-data::
 
     >>> from astroquery.irsa_dust import IrsaDust
@@ -86,7 +82,6 @@ than the actual images, via the :meth:`~astroquery.irsa_dust.IrsaDustClass.get_i
 supports the ``image_type`` argument, in the same way as described for
 :meth:`~astroquery.irsa_dust.IrsaDustClass.get_images`.
 
-.. code-block:: python
 .. doctest-remote-data::
 
     >>> from astroquery.irsa_dust import IrsaDust
@@ -107,7 +102,6 @@ This fetches the extinction table as a `~astropy.table.Table`. The input paramet
 the queries discussed above, namely the target string and optionally a radius
 value:
 
-.. code-block:: python
 .. doctest-remote-data::
 
     >>> from astroquery.irsa_dust import IrsaDust
@@ -155,7 +149,6 @@ additional section ``location`` may be fetched using the ``section`` keyword
 argument. If on the other hand, ``section`` is missing then the complete table
 with all the four sections will be returned.
 
-.. code-block:: python
 .. doctest-remote-data::
 
     >>> from astroquery.irsa_dust import IrsaDust

--- a/docs/nasa_exoplanet_archive/nasa_exoplanet_archive.rst
+++ b/docs/nasa_exoplanet_archive/nasa_exoplanet_archive.rst
@@ -1,5 +1,3 @@
-.. doctest-skip-all
-
 .. _astroquery.nasa_exoplanet_archive:
 
 ************************************************************
@@ -26,7 +24,7 @@ Query methods
 The `~astroquery.nasa_exoplanet_archive.NasaExoplanetArchiveClass.query_object` method can be used to query for a specific planet or planet host.
 For example, the following query searches the ``ps`` table of confirmed exoplanets for information about the planet K2-18 b.
 
-.. code-block:: python
+.. doctest-remote-data::
 
     >>> from astroquery.nasa_exoplanet_archive import NasaExoplanetArchive
     >>> NasaExoplanetArchive.query_object("K2-18 b")
@@ -50,7 +48,7 @@ For example, the following query searches the ``ps`` table of confirmed exoplane
 
 Similarly, cone searches can be executed using the `~astroquery.nasa_exoplanet_archive.NasaExoplanetArchiveClass.query_region` method:
 
-.. code-block:: python
+.. doctest-remote-data::
 
     >>> import astropy.units as u
     >>> from astropy.coordinates import SkyCoord
@@ -70,7 +68,7 @@ Similarly, cone searches can be executed using the `~astroquery.nasa_exoplanet_a
 The most general queries can be performed using the `~astroquery.nasa_exoplanet_archive.NasaExoplanetArchiveClass.query_criteria` method.
 For example, a full table can be queried as follows:
 
-.. code-block:: python
+.. doctest-remote-data::
 
     >>> from astroquery.nasa_exoplanet_archive import NasaExoplanetArchive
     >>> NasaExoplanetArchive.query_criteria(table="cumulative", select="*")
@@ -97,7 +95,7 @@ In this section, we demonstrate
 
 1. The number of confirmed planets discovered by TESS:
 
-.. code-block:: python
+.. doctest-remote-data::
 
     >>> from astroquery.nasa_exoplanet_archive import NasaExoplanetArchive
     >>> NasaExoplanetArchive.query_criteria(table="pscomppars", select="count(*)",
@@ -111,7 +109,7 @@ In this section, we demonstrate
 
 2. The list of confirmed planets discovered by TESS and their host star coordinates:
 
-.. code-block:: python
+.. doctest-remote-data::
 
     >>> from astroquery.nasa_exoplanet_archive import NasaExoplanetArchive
     >>> NasaExoplanetArchive.query_criteria(table="pscomppars", select="pl_name,ra,dec",
@@ -132,7 +130,7 @@ In this section, we demonstrate
 
 3. The list of confirmed planets discovered using microlensing that have data available in the archive:
 
-.. code-block:: python
+.. doctest-remote-data::
 
     >>> from astroquery.nasa_exoplanet_archive import NasaExoplanetArchive
     >>> NasaExoplanetArchive.query_criteria(
@@ -155,7 +153,7 @@ In this section, we demonstrate
 
 4. The list of confirmed planets where the host star name starts with "Kepler" using a *wildcard search*:
 
-.. code-block:: python
+.. doctest-remote-data::
 
     >>> from astroquery.nasa_exoplanet_archive import NasaExoplanetArchive
     >>> NasaExoplanetArchive.query_criteria(
@@ -181,7 +179,7 @@ In this section, we demonstrate
 
 5. The Kepler Objects of Interest that were vetted more recently than January 24, 2015 using a *date search*:
 
-.. code-block:: python
+.. doctest-remote-data::
 
     >>> from astroquery.nasa_exoplanet_archive import NasaExoplanetArchive
     >>> NasaExoplanetArchive.query_criteria(

--- a/setup.cfg
+++ b/setup.cfg
@@ -138,7 +138,7 @@ install_requires=
    pyvo>=1.1
    six
 tests_require =
-   pytest-doctestplus>=0.9
+   pytest-doctestplus>=0.10.1
    pytest-astropy
 
 [options.extras_require]
@@ -149,7 +149,7 @@ test=
    flask
    pytest-dependency
 docs=
-   sphinx-astropy
+   sphinx-astropy>=1.5
 all=
    mocpy>=0.5.2
    astropy-healpix


### PR DESCRIPTION
~DO NOT MERGE yet:  This PR requires the new `sphinx-astropy` release.~ Releases are done, this is ready for merge.

This is to revert #2117. Also, note the removal of `code-block` directives, it is to clean up the empty cell renderings (see screenshot below).

This PR requires the new `sphinx-astropy` release.
<img width="742" alt="Screen Shot 2021-07-15 at 00 05 27" src="https://user-images.githubusercontent.com/6788290/125745053-751d4841-c83f-4f24-8878-f360aaa3f573.png">
