### PR TITLE
Fail sphinx build on warnings

### DIFF
--- a/astroquery/alma/core.py
+++ b/astroquery/alma/core.py
@@ -12,7 +12,6 @@ from pkg_resources import resource_filename
 from bs4 import BeautifulSoup
 import pyvo
 
-
 from six.moves.urllib_parse import urljoin
 import six
 from astropy.table import Table, Column, vstack
@@ -545,18 +544,19 @@ class AlmaClass(QueryWithLogin):
 
         """
         Return information about the data associated with ALMA uid(s)
+
         Parameters
         ----------
-        uids: list or str
+        uids : list or str
             A list of valid UIDs or a single UID.
             UIDs should have the form: 'uid://A002/X391d0b/X7b'
-        expand_tarfiles: bool
+        expand_tarfiles : bool
             False to return information on the tarfiles packages containing
             the data or True to return information about individual files in
             these packages
-        with_auxiliary: bool
+        with_auxiliary : bool
             True to include the auxiliary packages, False otherwise
-        with_rawdata: bool
+        with_rawdata : bool
             True to include raw data, False otherwise
 
         Returns

--- a/astroquery/esa/xmm_newton/core.py
+++ b/astroquery/esa/xmm_newton/core.py
@@ -311,22 +311,13 @@ class XMMNewtonClass(BaseQuery):
                          instrument=[], path="", verbose=False):
         """Extracts in path (when set) the EPIC sources spectral products from a
         given TAR file.
-        For a given TAR file obtained with:
-            XMM.download_data(OBS_ID,level="PPS",extension="FTZ",filename=tarfile)
+
         This function extracts the EPIC sources spectral products in a given
         instrument (or instruments) from it
         The result is a dictionary containing the paths to the extracted EPIC
         sources spectral products with key being the instrument
         If the instrument is not specified this function will
         return all the available instruments
-
-        Examples:
-        Extracting all bands and instruments:
-            result = XMM.get_epic_spectra(tarfile,83,
-                                         instrument=['M1','M2','PN'])
-        If we want to retrieve the source spectrum of the instrument PN
-            fits_image = result['PN']
-        fits_image will be the full path to the extracted FTZ file
 
         Parameters
         ----------
@@ -354,6 +345,18 @@ class XMMNewtonClass(BaseQuery):
         The structure and the content of the extracted compressed FITS files
         are described in details in the Pipeline Products Description
         [XMM-SOC-GEN-ICD-0024](https://xmm-tools.cosmos.esa.int/external/xmm_obs_info/odf/data/docs/XMM-SOC-GEN-ICD-0024.pdf).
+
+        Examples
+        --------
+        Extracting all bands and instruments:
+
+        >>> result = XMM.get_epic_spectra(tarfile,83, instrument=['M1','M2','PN'])
+
+        To retrieve the source spectrum of the instrument PN.
+        (The full path of the extracted FTZ file is returned.)
+
+        >>> fits_image = result['PN']
+
         """
         _instrument = ["M1", "M2", "PN", "EP"]
         _product_type = ["SRSPEC", "BGSPEC", "SRCARF"]
@@ -445,9 +448,6 @@ class XMMNewtonClass(BaseQuery):
 
         """Extracts the EPIC images from a given TAR file
 
-        For a given TAR file obtained with:
-            XMM.download_data(OBS_ID,level="PPS",extension="FTZ",filename=tarfile)
-
         This function extracts the EPIC images in a given band (or bands) and
         instrument (or instruments) from it
 
@@ -460,30 +460,6 @@ class XMMNewtonClass(BaseQuery):
         Additionally, ``get_detmask`` and ``get_exposure_map`` can be set to True.
         If so, this function will also extract the exposure maps and detector
         masks within the specified bands and instruments
-
-        Examples
-        --------
-
-        Extract all bands and instruments::
-            result = XMM.get_epic_images(tarfile,band=[1,2,3,4,5,8],
-                                         instrument=['M1','M2','PN'],**kwargs)
-
-        If we want to retrieve the band 3 for the instrument PN (p-n junction)::
-            fits_image = result[3]['PN']
-
-        ``fits_image`` will be the full path to the extracted FTZ file
-
-        Extract the exposure and detector maps::
-            result = XMM.get_epic_images(tarfile,band=[1,2,3,4,5,8],
-                                         instrument=['M1','M2','PN'],
-                                         get_detmask=True,
-                                         get_exposure_map=True)
-
-        If we want to retrieve exposure map in the band 3 for the instrument PN::
-            fits_image = result[3]['PN_expo']
-
-        For retrieving the detector mask in the band 3 for the instrument PN::
-            fits_image = result[3]['PN_det']
 
         Parameters
         ----------
@@ -511,6 +487,33 @@ class XMMNewtonClass(BaseQuery):
         The structure and the content of the extracted compressed FITS files
         are described in details in the Pipeline Products Description
         [XMM-SOC-GEN-ICD-0024](https://xmm-tools.cosmos.esa.int/external/xmm_obs_info/odf/data/docs/XMM-SOC-GEN-ICD-0024.pdf).
+
+        Examples
+        --------
+
+        Extract all bands and instruments:
+
+        >>> result = XMM.get_epic_images(tarfile, band=[1,2,3,4,5,8], instrument=['M1','M2','PN'])
+
+        To retrieve the band 3 for the instrument PN (p-n junction):
+
+        >>> fits_image = result[3]['PN']
+
+        Extract the exposure and detector maps:
+
+        >>> result = XMM.get_epic_images(tarfile, band=[1, 2, 3, 4, 5, 8],
+                                         instrument=['M1', 'M2', 'PN'],
+                                         get_detmask=True,
+                                         get_exposure_map=True)
+
+        To retrieve exposure map in the band 3 for the instrument PN:
+
+        >>> fits_image = result[3]['PN_expo']
+
+        To retrieve the detector mask in the band 3 for the instrument PN:
+
+        >>> fits_image = result[3]['PN_det']
+
         """
 
         _product_type = ["IMAGE_"]
@@ -673,17 +676,6 @@ class XMMNewtonClass(BaseQuery):
         If the instrument is not specified, this function will
         return all available instruments
 
-        Examples:
-
-        Extracting all instruments:
-            result = XMM.get_epic_lightcurve(tarfile,146,
-                                             instrument=['M1','M2','PN'])
-
-        If we want to retrieve the light curve of the instrument PN
-            fits_image = result['PN']
-
-        fits_image will be the full path to the extracted FTZ file
-
         Parameters
         ----------
         filename : string, mandatory
@@ -708,6 +700,18 @@ class XMMNewtonClass(BaseQuery):
         The structure and the content of the extracted compressed FITS files
         are described in details in the Pipeline Products Description
         [XMM-SOC-GEN-ICD-0024](https://xmm-tools.cosmos.esa.int/external/xmm_obs_info/odf/data/docs/XMM-SOC-GEN-ICD-0024.pdf).
+
+        Examples
+        --------
+
+        Extracting all instruments:
+
+        >>> result = XMM.get_epic_lightcurve(tarfile, 146, instrument=['M1','M2', 'PN'])
+
+        To retrieve the light curve of the instrument PN:
+
+        >>> fits_image = result['PN']
+
         """
         _instrumnet = ["M1", "M2", "PN", "EP"]
         _band = [8]

--- a/astroquery/esa/xmm_newton/core.py
+++ b/astroquery/esa/xmm_newton/core.py
@@ -346,17 +346,6 @@ class XMMNewtonClass(BaseQuery):
         are described in details in the Pipeline Products Description
         [XMM-SOC-GEN-ICD-0024](https://xmm-tools.cosmos.esa.int/external/xmm_obs_info/odf/data/docs/XMM-SOC-GEN-ICD-0024.pdf).
 
-        Examples
-        --------
-        Extracting all bands and instruments:
-
-        >>> result = XMM.get_epic_spectra(tarfile,83, instrument=['M1','M2','PN'])
-
-        To retrieve the source spectrum of the instrument PN.
-        (The full path of the extracted FTZ file is returned.)
-
-        >>> fits_image = result['PN']
-
         """
         _instrument = ["M1", "M2", "PN", "EP"]
         _product_type = ["SRSPEC", "BGSPEC", "SRCARF"]
@@ -487,32 +476,6 @@ class XMMNewtonClass(BaseQuery):
         The structure and the content of the extracted compressed FITS files
         are described in details in the Pipeline Products Description
         [XMM-SOC-GEN-ICD-0024](https://xmm-tools.cosmos.esa.int/external/xmm_obs_info/odf/data/docs/XMM-SOC-GEN-ICD-0024.pdf).
-
-        Examples
-        --------
-
-        Extract all bands and instruments:
-
-        >>> result = XMM.get_epic_images(tarfile, band=[1,2,3,4,5,8], instrument=['M1','M2','PN'])
-
-        To retrieve the band 3 for the instrument PN (p-n junction):
-
-        >>> fits_image = result[3]['PN']
-
-        Extract the exposure and detector maps:
-
-        >>> result = XMM.get_epic_images(tarfile, band=[1, 2, 3, 4, 5, 8],
-                                         instrument=['M1', 'M2', 'PN'],
-                                         get_detmask=True,
-                                         get_exposure_map=True)
-
-        To retrieve exposure map in the band 3 for the instrument PN:
-
-        >>> fits_image = result[3]['PN_expo']
-
-        To retrieve the detector mask in the band 3 for the instrument PN:
-
-        >>> fits_image = result[3]['PN_det']
 
         """
 
@@ -664,8 +627,7 @@ class XMMNewtonClass(BaseQuery):
                             instrument=[], path=""):
         """Extracts the EPIC sources light curve products from a given TAR file
 
-        For a given TAR file obtained with:
-            XMM.download_data(OBS_ID,level="PPS",extension="FTZ",filename=tarfile)
+        For a given TAR file obtained with ``XMMNewton.download_data``.
 
         This function extracts the EPIC sources light curve products in a given
         instrument (or instruments) from said TAR file
@@ -700,17 +662,6 @@ class XMMNewtonClass(BaseQuery):
         The structure and the content of the extracted compressed FITS files
         are described in details in the Pipeline Products Description
         [XMM-SOC-GEN-ICD-0024](https://xmm-tools.cosmos.esa.int/external/xmm_obs_info/odf/data/docs/XMM-SOC-GEN-ICD-0024.pdf).
-
-        Examples
-        --------
-
-        Extracting all instruments:
-
-        >>> result = XMM.get_epic_lightcurve(tarfile, 146, instrument=['M1','M2', 'PN'])
-
-        To retrieve the light curve of the instrument PN:
-
-        >>> fits_image = result['PN']
 
         """
         _instrumnet = ["M1", "M2", "PN", "EP"]

--- a/astroquery/esasky/core.py
+++ b/astroquery/esasky/core.py
@@ -599,12 +599,9 @@ class ESASkyClass(BaseQuery):
 
         Examples
         --------
-        >>> query_ids_maps(observation_ids=['lbsk03vbq', 'ieag90010'], missions="HST-UV")
-
-        >>> query_ids_maps(observation_ids='lbsk03vbq')
-
-        >>> query_ids_maps(observation_ids=['lbsk03vbq', 'ieag90010', '1342221275', '1342221848'],
-        ...                   missions=["Herschel", "HST-UV"])
+        query_ids_maps(observation_ids=['lbsk03vbq', 'ieag90010'], missions="HST-UV")
+        query_ids_maps(observation_ids='lbsk03vbq')
+        query_ids_maps(observation_ids=['lbsk03vbq', '1342221848'], missions=["Herschel", "HST-UV"])
         """
         sanitized_observation_ids = self._sanitize_input_ids(observation_ids)
         sanitized_missions = self._sanitize_input_mission(missions)
@@ -655,12 +652,9 @@ class ESASkyClass(BaseQuery):
 
         Examples
         --------
-        >>> query_ids_catalogs(source_ids=['2CXO J090341.1-322609', '2CXO J090353.8-322642'], catalogs="CHANDRA-SC2")
-
-        >>> query_ids_catalogs(source_ids='2CXO J090341.1-322609')
-
-        >>> query_ids_catalogs(source_ids=['2CXO J090341.1-322609', '2CXO J090353.8-322642', '44899', '45057'],
-        ...                    catalogs=["CHANDRA-SC2", "Hipparcos-2"])
+        query_ids_catalogs(source_ids=['2CXO J090341.1-322609', '2CXO J090353.8-322642'], catalogs="CHANDRA-SC2")
+        query_ids_catalogs(source_ids='2CXO J090341.1-322609')
+        query_ids_catalogs(source_ids=['2CXO J090341.1-322609', '45057'], catalogs=["CHANDRA-SC2", "Hipparcos-2"])
         """
         sanitized_catalogs = self._sanitize_input_catalogs(catalogs)
         sanitized_row_limit = self._sanitize_input_row_limit(row_limit)
@@ -851,13 +845,11 @@ class ESASkyClass(BaseQuery):
 
         Examples
         --------
-        >>> get_images(position="m101", radius="14'", missions="all")
+        get_images(position="m101", radius="14'", missions="all")
 
-        >>> missions = ["SUZAKU", "ISO-IR", "Chandra", "XMM-OM-OPTICAL", "XMM", "XMM-OM-UV", "HST-IR", "Herschel",
-        ...             "Spitzer", "HST-UV", "HST-OPTICAL"]
-        >>> observation_ids = ["100001010", "01500403", "21171", "0852000101", "0851180201", "0851180201", "n3tr01c3q",
-        ...                    "1342247257", "30002561-25100", "hst_07553_3h_wfpc2_f160bw_pc", "ocli05leq"]
-        >>> get_images(observation_ids=observation_ids, missions=missions)
+        missions = ["SUZAKU", "ISO-IR", "Chandra", "XMM-OM-OPTICAL", "XMM", "XMM-OM-UV", "HST-IR", "Herschel", "Spitzer", "HST-UV", "HST-OPTICAL"]
+        observation_ids = ["100001010", "01500403", "21171", "0852000101", "0851180201", "0851180201", "n3tr01c3q", "1342247257", "30002561-25100", "hst_07553_3h_wfpc2_f160bw_pc", "ocli05leq"]
+        get_images(observation_ids=observation_ids, missions=missions)
         """
         if position is None and observation_ids is None:
             raise ValueError("An input is required for either position or observation_ids.")
@@ -948,12 +940,11 @@ class ESASkyClass(BaseQuery):
         Examples
         --------
 
-        >>> get_spectra(position="m101", radius="14'", missions=["HST-IR", "XMM-NEWTON", "HERSCHEL"])
+        get_spectra(position="m101", radius="14'", missions=["HST-IR", "XMM-NEWTON", "HERSCHEL"])
 
-        >>> missions = ["ISO-IR", "Chandra", "IUE", "XMM-NEWTON", "HST-IR", "Herschel", "HST-UV", "HST-OPTICAL"]
-        >>> observation_ids = ["02101201", "1005", "LWR13178", "0001730201", "ibh706cqq",
-        ...                    "1342253595", "z1ax0102t", "oeik2s020"]
-        >>> get_spectra(observation_ids=observation_ids, missions=missions)
+        missions = ["ISO-IR", "Chandra", "IUE", "XMM-NEWTON", "HST-IR", "Herschel", "HST-UV", "HST-OPTICAL"]
+        observation_ids = ["02101201", "1005", "LWR13178", "0001730201", "ibh706cqq", "1342253595", "z1ax0102t", "oeik2s020"]
+        get_spectra(observation_ids=observation_ids, missions=missions)
 
         """
         if position is None and observation_ids is None:

--- a/astroquery/esasky/core.py
+++ b/astroquery/esasky/core.py
@@ -599,10 +599,12 @@ class ESASkyClass(BaseQuery):
 
         Examples
         --------
-        query_ids_maps(observation_ids=['lbsk03vbq', 'ieag90010'], missions="HST-UV")
-        query_ids_maps(observation_ids='lbsk03vbq')
-        query_ids_maps(observation_ids=['lbsk03vbq', 'ieag90010', '1342221275', '1342221848'],
-                          missions=["Herschel", "HST-UV"])
+        >>> query_ids_maps(observation_ids=['lbsk03vbq', 'ieag90010'], missions="HST-UV")
+
+        >>> query_ids_maps(observation_ids='lbsk03vbq')
+
+        >>> query_ids_maps(observation_ids=['lbsk03vbq', 'ieag90010', '1342221275', '1342221848'],
+        ...                   missions=["Herschel", "HST-UV"])
         """
         sanitized_observation_ids = self._sanitize_input_ids(observation_ids)
         sanitized_missions = self._sanitize_input_mission(missions)
@@ -653,10 +655,12 @@ class ESASkyClass(BaseQuery):
 
         Examples
         --------
-        query_ids_catalogs(source_ids=['2CXO J090341.1-322609', '2CXO J090353.8-322642'], catalogs="CHANDRA-SC2")
-        query_ids_catalogs(source_ids='2CXO J090341.1-322609')
-        query_ids_catalogs(source_ids=['2CXO J090341.1-322609', '2CXO J090353.8-322642', '44899', '45057'],
-                           catalogs=["CHANDRA-SC2", "Hipparcos-2"])
+        >>> query_ids_catalogs(source_ids=['2CXO J090341.1-322609', '2CXO J090353.8-322642'], catalogs="CHANDRA-SC2")
+
+        >>> query_ids_catalogs(source_ids='2CXO J090341.1-322609')
+
+        >>> query_ids_catalogs(source_ids=['2CXO J090341.1-322609', '2CXO J090353.8-322642', '44899', '45057'],
+        ...                    catalogs=["CHANDRA-SC2", "Hipparcos-2"])
         """
         sanitized_catalogs = self._sanitize_input_catalogs(catalogs)
         sanitized_row_limit = self._sanitize_input_row_limit(row_limit)
@@ -847,13 +851,13 @@ class ESASkyClass(BaseQuery):
 
         Examples
         --------
-        get_images(position="m101", radius="14'", missions="all")
+        >>> get_images(position="m101", radius="14'", missions="all")
 
-        missions = ["SUZAKU", "ISO-IR", "Chandra", "XMM-OM-OPTICAL", "XMM", "XMM-OM-UV", "HST-IR", "Herschel",
-                    "Spitzer", "HST-UV", "HST-OPTICAL"]
-        observation_ids = ["100001010", "01500403", "21171", "0852000101", "0851180201", "0851180201", "n3tr01c3q",
-                           "1342247257", "30002561-25100", "hst_07553_3h_wfpc2_f160bw_pc", "ocli05leq"]
-        get_images(observation_ids=observation_ids, missions=missions)
+        >>> missions = ["SUZAKU", "ISO-IR", "Chandra", "XMM-OM-OPTICAL", "XMM", "XMM-OM-UV", "HST-IR", "Herschel",
+        ...             "Spitzer", "HST-UV", "HST-OPTICAL"]
+        >>> observation_ids = ["100001010", "01500403", "21171", "0852000101", "0851180201", "0851180201", "n3tr01c3q",
+        ...                    "1342247257", "30002561-25100", "hst_07553_3h_wfpc2_f160bw_pc", "ocli05leq"]
+        >>> get_images(observation_ids=observation_ids, missions=missions)
         """
         if position is None and observation_ids is None:
             raise ValueError("An input is required for either position or observation_ids.")
@@ -943,12 +947,13 @@ class ESASkyClass(BaseQuery):
 
         Examples
         --------
-        get_spectra(position="m101", radius="14'", missions=["HST-IR", "XMM-NEWTON", "HERSCHEL"])
 
-        missions = ["ISO-IR", "Chandra", "IUE", "XMM-NEWTON", "HST-IR", "Herschel", "HST-UV", "HST-OPTICAL"]
-        observation_ids = ["02101201", "1005", "LWR13178", "0001730201", "ibh706cqq", "1342253595", "z1ax0102t",
-                           "oeik2s020"]
-        get_spectra(observation_ids=observation_ids, missions=missions)
+        >>> get_spectra(position="m101", radius="14'", missions=["HST-IR", "XMM-NEWTON", "HERSCHEL"])
+
+        >>> missions = ["ISO-IR", "Chandra", "IUE", "XMM-NEWTON", "HST-IR", "Herschel", "HST-UV", "HST-OPTICAL"]
+        >>> observation_ids = ["02101201", "1005", "LWR13178", "0001730201", "ibh706cqq",
+        ...                    "1342253595", "z1ax0102t", "oeik2s020"]
+        >>> get_spectra(observation_ids=observation_ids, missions=missions)
 
         """
         if position is None and observation_ids is None:

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -29,18 +29,13 @@ import datetime
 import os
 import sys
 
-try:
-    import astropy_helpers
-except ImportError:
-    # Building from inside the docs/ directory?
-    if os.path.basename(os.getcwd()) == 'docs':
-        a_h_path = os.path.abspath(os.path.join('..', 'astropy_helpers'))
-        if os.path.isdir(a_h_path):
-            sys.path.insert(1, a_h_path)
-
 # Load all of the global Astropy configuration
-from astropy_helpers.sphinx.conf import *
-import urllib
+try:
+    from sphinx_astropy.conf.v1 import *  # noqa
+except ImportError:
+    print('ERROR: the documentation requires the sphinx-astropy package to '
+          'be installed')
+    sys.exit(1)
 
 from configparser import ConfigParser
 conf = ConfigParser()

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -65,10 +65,10 @@ rst_epilog += """
 del intersphinx_mapping['scipy']
 del intersphinx_mapping['h5py']
 intersphinx_mapping.update({
-    'astropy': ('http://docs.astropy.org/en/stable/', None),
+    'astropy': ('https://docs.astropy.org/en/stable/', None),
     'requests': ('https://requests.kennethreitz.org/en/stable/', None),
-    'pyregion': ('http://pyregion.readthedocs.io/en/stable/', None),
-    'regions': ('http://astropy-regions.readthedocs.io/en/stable/', None),
+    'pyregion': ('https://pyregion.readthedocs.io/en/stable/', None),
+    'regions': ('https://astropy-regions.readthedocs.io/en/stable/', None),
     'mocpy': ('https://cds-astro.github.io/mocpy/', None),
     'pyvo': ('https://pyvo.readthedocs.io/en/stable/', None),
 })

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -189,7 +189,7 @@ The following modules have been completed using a common API:
   hitran/hitran.rst
   ibe/ibe.rst
   irsa/irsa.rst
-  irsa/irsa_dust.rst
+  irsa_dust/irsa_dust.rst
   jplspec/jplspec.rst
   magpis/magpis.rst
   mast/mast.rst
@@ -260,7 +260,7 @@ for each source)
   gama/gama.rst
   ibe/ibe.rst
   irsa/irsa.rst
-  irsa/irsa_dust.rst
+  irsa_dust/irsa_dust.rst
   mast/mast.rst
   nasa_exoplanet_archive/nasa_exoplanet_archive.rst
   ned/ned.rst

--- a/docs/nasa_exoplanet_archive/nasa_exoplanet_archive.rst
+++ b/docs/nasa_exoplanet_archive/nasa_exoplanet_archive.rst
@@ -14,7 +14,7 @@ More information about the development of a more integrated NASA Exoplanet Archi
 fully TAP supported services can be found at [3]_.
 
 *NOTE*: the ``exoplanet`` and ``exomultpars`` tables are no longer available and have been replaced by the
-Planetary Systems table (``ps``). Likewise, the `compositepars` table has been replaced by the
+Planetary Systems table (``ps``). Likewise, the ``compositepars`` table has been replaced by the
 Planetary Systems Composite Parameters table (``pscomppars``). Both the ``ps`` and ``pscomppars`` tables are accessible
 through the Exoplanet Archive TAP service. Database column names have changed;
 `this document <https://exoplanetarchive.ipac.caltech.edu/docs/API_PS_columns.html>`_ contains the current definitions

--- a/readthedocs.yml
+++ b/readthedocs.yml
@@ -3,3 +3,6 @@ conda:
 
 python:
    setup_py_install: true
+
+sphinx:
+   fail_on_warning: true


### PR DESCRIPTION
A bunch of sphinx issues slipped through in the recent months. This PR adds back the failure on warnings for the docs build to ensure our docs builds without issues.

This PR contains the bare minimum fixes, on the other hand the examples may want to revisit the practice of including extensive remote reaching examples in docstrings in favour of directing users to the narrative docs.

