### PR TITLE
MAST: Moving target TESScut

### DIFF
--- a/astroquery/mast/cutouts.py
+++ b/astroquery/mast/cutouts.py
@@ -121,8 +121,7 @@ class TesscutClass(MastQueryWithLogin):
             The target around which to search. It may be specified as a
             string or as the appropriate `astropy.coordinates` object.
 
-            NOTE: If moving_targets or objectname is supplied, this argument cannot be used.
-
+            NOTE: If moving_target or objectname is supplied, this argument cannot be used.
         radius : str, float, or `~astropy.units.Quantity` object, optional
             Default 0 degrees.
             If supplied as a float degrees is the assumed unit.
@@ -131,7 +130,6 @@ class TesscutClass(MastQueryWithLogin):
             `astropy.units` may also be used.
 
             NOTE: If moving_target is supplied, this argument is ignored.
-
         objectname : str, optional
             The target around which to search, by name (objectname="M104")
             or TIC ID (objectname="TIC 141914082"). If moving_target is True, input must be the name or ID (as understood by the
@@ -139,12 +137,10 @@ class TesscutClass(MastQueryWithLogin):
             of a moving target such as an asteroid or comet.
 
             NOTE: If coordinates is supplied, this argument cannot be used.
-
         moving_target : bool, optional
             Indicate whether the object is a moving target or not. Default is set to False, in other words, not a moving target.
 
             NOTE: If coordinates is supplied, this argument cannot be used.
-
         mt_type : str, optional
             The moving target type, valid inputs are majorbody and smallbody. If not supplied
             first majorbody is tried and then smallbody if a matching majorbody is not found.
@@ -208,7 +204,7 @@ class TesscutClass(MastQueryWithLogin):
         return Table(sector_dict)
 
     def download_cutouts(self, coordinates=None, size=5, sector=None, path=".", inflate=True,
-                         objectname=None, moving_target=None, mt_type=None):
+                         objectname=None, moving_target=False, mt_type=None):
         """
         Download cutout target pixel file(s) around the given coordinates with indicated size.
 
@@ -217,7 +213,8 @@ class TesscutClass(MastQueryWithLogin):
         coordinates : str or `astropy.coordinates` object, optional
             The target around which to search. It may be specified as a
             string or as the appropriate `astropy.coordinates` object.
-            One and only one of coordinates, objectname, and moving_target must be supplied.
+
+            NOTE: If moving_target or objectname is supplied, this argument cannot be used.
         size : int, array-like, `~astropy.units.Quantity`
             Optional, default 5 pixels.
             The size of the cutout array. If ``size`` is a scalar number or
@@ -241,17 +238,20 @@ class TesscutClass(MastQueryWithLogin):
             Set inflate to false to stop before the inflate step.
         objectname : str, optional
             The target around which to search, by name (objectname="M104")
-            or TIC ID (objectname="TIC 141914082").
-            One and only one of coordinates, objectname, and moving_target must be supplied.
-        moving_target : str, optional
-            The name or ID (as understood by the
+            or TIC ID (objectname="TIC 141914082"). If moving_target is True, input must be the name or ID (as understood by the
             `JPL ephemerides service <https://ssd.jpl.nasa.gov/horizons.cgi>`__)
             of a moving target such as an asteroid or comet.
-            One and only one of coordinates, objectname, and moving_target must be supplied.
+
+            NOTE: If coordinates is supplied, this argument cannot be used.
+        moving_target : str, optional
+            Indicate whether the object is a moving target or not. Default is set to False, in other words, not a moving target.
+
+            NOTE: If coordinates is supplied, this argument cannot be used.
         mt_type : str, optional
             The moving target type, valid inputs are majorbody and smallbody. If not supplied
             first majorbody is tried and then smallbody if a matching majorbody is not found.
-            This argument is ignored unless moving_target is supplied.
+
+            NOTE: If moving_target is supplied, this argument is ignored.
 
         Returns
         -------
@@ -309,7 +309,7 @@ class TesscutClass(MastQueryWithLogin):
         return localpath_table
 
     def get_cutouts(self, coordinates=None, size=5, sector=None,
-                    objectname=None, moving_target=None, mt_type=None):
+                    objectname=None, moving_target=False, mt_type=None):
         """
         Get cutout target pixel file(s) around the given coordinates with indicated size,
         and return them as a list of  `~astropy.io.fits.HDUList` objects.
@@ -319,7 +319,8 @@ class TesscutClass(MastQueryWithLogin):
         coordinates : str or `astropy.coordinates` object, optional
             The target around which to search. It may be specified as a
             string or as the appropriate `astropy.coordinates` object.
-            One and only one of coordinates, objectname, and moving_target must be supplied.
+
+            NOTE: If moving_target or objectname is supplied, this argument cannot be used.
         size : int, array-like, `~astropy.units.Quantity`
             Optional, default 5 pixels.
             The size of the cutout array. If ``size`` is a scalar number or
@@ -334,17 +335,20 @@ class TesscutClass(MastQueryWithLogin):
             from all available sectors on which the coordinate appears will be returned.
         objectname : str, optional
             The target around which to search, by name (objectname="M104")
-            or TIC ID (objectname="TIC 141914082").
-            One and only one of coordinates, objectname, and moving_target must be supplied.
-        moving_target : str, optional
-            The name or ID (as understood by the
+            or TIC ID (objectname="TIC 141914082"). If moving_target is True, input must be the name or ID (as understood by the
             `JPL ephemerides service <https://ssd.jpl.nasa.gov/horizons.cgi>`__)
             of a moving target such as an asteroid or comet.
-            One and only one of coordinates, objectname, and moving_target must be supplied.
+
+            NOTE: If coordinates is supplied, this argument cannot be used.
+        moving_target : str, optional
+            Indicate whether the object is a moving target or not. Default is set to False, in other words, not a moving target.
+
+            NOTE: If coordinates is supplied, this argument cannot be used.
         mt_type : str, optional
             The moving target type, valid inputs are majorbody and smallbody. If not supplied
             first majorbody is tried and then smallbody if a matching majorbody is not found.
-            This argument is ignored unless moving_target is supplied.
+
+            NOTE: If moving_target is supplied, this argument is ignored.
 
         Returns
         -------

--- a/astroquery/mast/cutouts.py
+++ b/astroquery/mast/cutouts.py
@@ -155,9 +155,10 @@ class TesscutClass(MastQueryWithLogin):
 
         if moving_target:
 
-            # Check that objectname has been passed in
+            # Check that objectname has been passed in and coordinates
+            # is not
             if coordinates:
-                raise InvalidQueryError("Only one of moving_target and coordinates may be specified.")
+                raise InvalidQueryError("Only one of moving_target and coordinates may be specified. Please remove coordinates if using moving_target and objectname.")
 
             if not objectname:
                 raise InvalidQueryError("Please specify the object name or ID (as understood by the `JPL ephemerides service <https://ssd.jpl.nasa.gov/horizons.cgi>`__) of a moving target such as an asteroid or comet.")
@@ -259,14 +260,21 @@ class TesscutClass(MastQueryWithLogin):
         """
 
         if moving_target:
-            # Check only ony object designator has been passed in
-            if objectname or coordinates:
-                raise InvalidQueryError("Only one of objectname, coordinates, and moving_target may be specified.")
 
-            astrocut_request = f"moving_target/astrocut?obj_id={moving_target}"
+            # Check that objectname has been passed in and coordinates
+            # is not
+            if coordinates:
+                raise InvalidQueryError("Only one of moving_target and coordinates may be specified. Please remove coordinates if using moving_target and objectname.")
+
+            if not objectname:
+                raise InvalidQueryError("Please specify the object name or ID (as understood by the `JPL ephemerides service <https://ssd.jpl.nasa.gov/horizons.cgi>`__) of a moving target such as an asteroid or comet.")
+
+            astrocut_request = f"moving_target/astrocut?obj_id={objectname}"
             if mt_type:
                 astrocut_request += f"&obj_type={mt_type}"
+
         else:
+
             # Get Skycoord object for coordinates/object
             coordinates = parse_input_location(coordinates, objectname)
 
@@ -364,11 +372,15 @@ class TesscutClass(MastQueryWithLogin):
 
         if moving_target:
 
-            # Check only on object designator has been passed in
-            if objectname or coordinates:
-                raise InvalidQueryError("Only one of objectname, coordinates, and moving_target may be specified.")
+            # Check that objectname has been passed in and coordinates
+            # is not
+            if coordinates:
+                raise InvalidQueryError("Only one of moving_target and coordinates may be specified. Please remove coordinates if using moving_target and objectname.")
 
-            param_dict["obj_id"] = moving_target
+            if not objectname:
+                raise InvalidQueryError("Please specify the object name or ID (as understood by the `JPL ephemerides service <https://ssd.jpl.nasa.gov/horizons.cgi>`__) of a moving target such as an asteroid or comet.")
+
+            param_dict["obj_id"] = objectname
 
             # Add optional parameter if present
             if mt_type:

--- a/astroquery/mast/cutouts.py
+++ b/astroquery/mast/cutouts.py
@@ -133,8 +133,8 @@ class TesscutClass(MastQueryWithLogin):
             or TIC ID (objectname="TIC 141914082").
             One and only one of coordinates, objectname, moving_target must be supplied.
         moving_target : str, optional
-            The name or ID (as understood by the 
-            `JPL ephemerides service <https://ssd.jpl.nasa.gov/horizons.cgi>`__) 
+            The name or ID (as understood by the
+            `JPL ephemerides service <https://ssd.jpl.nasa.gov/horizons.cgi>`__)
             of a moving target such as an asteroid or comet.
             One and only one of coordinates, objectname, and moving_target must be supplied.
         mt_type : str, optional
@@ -150,7 +150,7 @@ class TesscutClass(MastQueryWithLogin):
 
         if moving_target:
 
-            # Check only ony object designator has been passed in 
+            # Check only ony object designator has been passed in
             if objectname or coordinates:
                 raise InvalidQueryError("Only one of objectname, coordinates, and moving_target may be specified.")
 
@@ -163,7 +163,7 @@ class TesscutClass(MastQueryWithLogin):
             response = self._service_api_connection.service_request_async("mt_sector", params)
 
         else:
-            
+
             # Get Skycoord object for coordinates/object
             coordinates = parse_input_location(coordinates, objectname)
 
@@ -176,8 +176,8 @@ class TesscutClass(MastQueryWithLogin):
 
             response = self._service_api_connection.service_request_async("sector", params)
 
-        # Raise any errors 
-        response.raise_for_status()  
+        # Raise any errors
+        response.raise_for_status()
 
         sector_json = response.json()['results']
         sector_dict = {'sectorName': [],
@@ -232,8 +232,8 @@ class TesscutClass(MastQueryWithLogin):
             or TIC ID (objectname="TIC 141914082").
             One and only one of coordinates, objectname, and moving_target must be supplied.
         moving_target : str, optional
-            The name or ID (as understood by the 
-            `JPL ephemerides service <https://ssd.jpl.nasa.gov/horizons.cgi>`__) 
+            The name or ID (as understood by the
+            `JPL ephemerides service <https://ssd.jpl.nasa.gov/horizons.cgi>`__)
             of a moving target such as an asteroid or comet.
             One and only one of coordinates, objectname, and moving_target must be supplied.
         mt_type : str, optional
@@ -247,23 +247,23 @@ class TesscutClass(MastQueryWithLogin):
         """
 
         if moving_target:
-            # Check only ony object designator has been passed in 
+            # Check only ony object designator has been passed in
             if objectname or coordinates:
                 raise InvalidQueryError("Only one of objectname, coordinates, and moving_target may be specified.")
-            
+
             astrocut_request = f"moving_target/astrocut?obj_id={moving_target}"
             if mt_type:
                 astrocut_request += f"&obj_type={mt_type}"
         else:
             # Get Skycoord object for coordinates/object
             coordinates = parse_input_location(coordinates, objectname)
-            
+
             astrocut_request = f"astrocut?ra={coordinates.ra.deg}&dec={coordinates.dec.deg}"
 
         # Adding the arguments that are common between moving/still astrocut requests
         size_dict = _parse_cutout_size(size)
         astrocut_request += f"&y={size_dict['y']}&x={size_dict['x']}&units={size_dict['units']}"
-        
+
         if sector:
             astrocut_request += "&sector={}".format(sector)
 
@@ -325,8 +325,8 @@ class TesscutClass(MastQueryWithLogin):
             or TIC ID (objectname="TIC 141914082").
             One and only one of coordinates, objectname, and moving_target must be supplied.
         moving_target : str, optional
-            The name or ID (as understood by the 
-            `JPL ephemerides service <https://ssd.jpl.nasa.gov/horizons.cgi>`__) 
+            The name or ID (as understood by the
+            `JPL ephemerides service <https://ssd.jpl.nasa.gov/horizons.cgi>`__)
             of a moving target such as an asteroid or comet.
             One and only one of coordinates, objectname, and moving_target must be supplied.
         mt_type : str, optional
@@ -345,10 +345,10 @@ class TesscutClass(MastQueryWithLogin):
         # Add sector if present
         if sector:
             param_dict["sector"] = sector
-        
+
         if moving_target:
 
-            # Check only on object designator has been passed in 
+            # Check only on object designator has been passed in
             if objectname or coordinates:
                 raise InvalidQueryError("Only one of objectname, coordinates, and moving_target may be specified.")
 
@@ -361,13 +361,13 @@ class TesscutClass(MastQueryWithLogin):
             response = self._service_api_connection.service_request_async("mt_astrocut", param_dict)
 
         else:
-        
+
             # Get Skycoord object for coordinates/object
             coordinates = parse_input_location(coordinates, objectname)
- 
+
             param_dict["ra"] = coordinates.ra.deg
             param_dict["dec"] = coordinates.dec.deg
-            
+
             response = self._service_api_connection.service_request_async("astrocut", param_dict)
 
         response.raise_for_status()  # Raise any errors

--- a/astroquery/mast/cutouts.py
+++ b/astroquery/mast/cutouts.py
@@ -110,7 +110,7 @@ class TesscutClass(MastQueryWithLogin):
                     }
         self._service_api_connection.set_service_params(services, "tesscut")
 
-    def get_sectors(self, coordinates=None, radius=0*u.deg, objectname=None, moving_target=None, mt_type=None):
+    def get_sectors(self, coordinates=None, radius=0*u.deg, objectname=None, moving_target=False, mt_type=None):
         """
         Get a list of the TESS data sectors whose footprints intersect
         with the given search area.
@@ -120,27 +120,36 @@ class TesscutClass(MastQueryWithLogin):
         coordinates : str or `astropy.coordinates` object, optional
             The target around which to search. It may be specified as a
             string or as the appropriate `astropy.coordinates` object.
-            One and only one of coordinates, objectname, and moving_target must be supplied.
+
+            NOTE: If moving_targets or objectname is supplied, this argument cannot be used.
+
         radius : str, float, or `~astropy.units.Quantity` object, optional
             Default 0 degrees.
             If supplied as a float degrees is the assumed unit.
             The string must be parsable by `~astropy.coordinates.Angle`. The
             appropriate `~astropy.units.Quantity` object from
             `astropy.units` may also be used.
-            This argument is ignored if moving_target is supplied.
+
+            NOTE: If moving_target is supplied, this argument is ignored.
+
         objectname : str, optional
             The target around which to search, by name (objectname="M104")
-            or TIC ID (objectname="TIC 141914082").
-            One and only one of coordinates, objectname, moving_target must be supplied.
-        moving_target : str, optional
-            The name or ID (as understood by the
+            or TIC ID (objectname="TIC 141914082"). If moving_target is True, input must be the name or ID (as understood by the
             `JPL ephemerides service <https://ssd.jpl.nasa.gov/horizons.cgi>`__)
             of a moving target such as an asteroid or comet.
-            One and only one of coordinates, objectname, and moving_target must be supplied.
+
+            NOTE: If coordinates is supplied, this argument cannot be used.
+
+        moving_target : bool, optional
+            Indicate whether the object is a moving target or not. Default is set to False, in other words, not a moving target.
+
+            NOTE: If coordinates is supplied, this argument cannot be used.
+
         mt_type : str, optional
             The moving target type, valid inputs are majorbody and smallbody. If not supplied
             first majorbody is tried and then smallbody if a matching majorbody is not found.
-            This argument is ignored unless moving_target is supplied.
+
+            NOTE: If moving_target is supplied, this argument is ignored.
 
         Returns
         -------
@@ -150,11 +159,14 @@ class TesscutClass(MastQueryWithLogin):
 
         if moving_target:
 
-            # Check only ony object designator has been passed in
-            if objectname or coordinates:
-                raise InvalidQueryError("Only one of objectname, coordinates, and moving_target may be specified.")
+            # Check that objectname has been passed in
+            if coordinates:
+                raise InvalidQueryError("Only one of moving_target and coordinates may be specified.")
 
-            params = {"obj_id": moving_target}
+            if not objectname:
+                raise InvalidQueryError("Please specify the object name or ID (as understood by the `JPL ephemerides service <https://ssd.jpl.nasa.gov/horizons.cgi>`__) of a moving target such as an asteroid or comet.")
+
+            params = {"obj_id": objectname}
 
             # Add optional parameter is present
             if mt_type:

--- a/astroquery/mast/observations.py
+++ b/astroquery/mast/observations.py
@@ -551,11 +551,18 @@ class ObservationsClass(MastQueryWithLogin):
         url = None
 
         try:
-            if self._cloud_connection is not None and self._cloud_connection.is_supported(data_product):
-                try:
-                    self._cloud_connection.download_file(data_product, local_path, cache)
-                except Exception as ex:
-                    log.exception("Error pulling from S3 bucket: {}".format(ex))
+            if self._cloud_connection is not None:
+                fall_back = False
+                if not self._cloud_connection.is_supported(data_product):
+                    log.warn("Data product not in S3.")
+                    fall_back = True
+                else:
+                    try:
+                        self._cloud_connection.download_file(data_product, local_path, cache)
+                    except Exception as ex:
+                        log.exception("Error pulling from S3 bucket: {}".format(ex))
+                        fall_back = True
+                if fall_back:
                     if cloud_only:
                         log.warn("Skipping file...")
                         local_path = ""
@@ -565,6 +572,7 @@ class ObservationsClass(MastQueryWithLogin):
                         self._download_file(data_url, local_path,
                                             cache=cache, head_safe=True, continuation=False)
             else:
+                
                 self._download_file(data_url, local_path,
                                     cache=cache, head_safe=True, continuation=False)
 

--- a/astroquery/mast/observations.py
+++ b/astroquery/mast/observations.py
@@ -572,7 +572,7 @@ class ObservationsClass(MastQueryWithLogin):
                         self._download_file(data_url, local_path,
                                             cache=cache, head_safe=True, continuation=False)
             else:
-                
+
                 self._download_file(data_url, local_path,
                                     cache=cache, head_safe=True, continuation=False)
 

--- a/astroquery/mast/observations.py
+++ b/astroquery/mast/observations.py
@@ -551,18 +551,11 @@ class ObservationsClass(MastQueryWithLogin):
         url = None
 
         try:
-            if self._cloud_connection is not None:
-                fall_back = False
-                if not self._cloud_connection.is_supported(data_product):
-                    log.warn("Data product not in S3.")
-                    fall_back = True
-                else:
-                    try:
-                        self._cloud_connection.download_file(data_product, local_path, cache)
-                    except Exception as ex:
-                        log.exception("Error pulling from S3 bucket: {}".format(ex))
-                        fall_back = True
-                if fall_back:
+            if self._cloud_connection is not None and self._cloud_connection.is_supported(data_product):
+                try:
+                    self._cloud_connection.download_file(data_product, local_path, cache)
+                except Exception as ex:
+                    log.exception("Error pulling from S3 bucket: {}".format(ex))
                     if cloud_only:
                         log.warn("Skipping file...")
                         local_path = ""
@@ -572,7 +565,6 @@ class ObservationsClass(MastQueryWithLogin):
                         self._download_file(data_url, local_path,
                                             cache=cache, head_safe=True, continuation=False)
             else:
-
                 self._download_file(data_url, local_path,
                                     cache=cache, head_safe=True, continuation=False)
 

--- a/astroquery/mast/tests/test_mast.py
+++ b/astroquery/mast/tests/test_mast.py
@@ -589,6 +589,15 @@ def test_tesscut_get_sector(patch_post):
     assert sector_table['camera'][0] == 1
     assert sector_table['ccd'][0] == 3
 
+    # Exercising the search by moving target
+    sector_table = mast.Tesscut.get_sectors(moving_target="Ceres")
+    assert isinstance(sector_table, Table)
+    assert len(sector_table) == 1
+    assert sector_table['sectorName'][0] == "tess-s0001-1-3"
+    assert sector_table['sector'][0] == 1
+    assert sector_table['camera'][0] == 1
+    assert sector_table['ccd'][0] == 3
+
 
 def test_tesscut_download_cutouts(patch_post, tmpdir):
 
@@ -616,6 +625,13 @@ def test_tesscut_download_cutouts(patch_post, tmpdir):
     assert manifest["Local Path"][0][-4:] == "fits"
     assert os.path.isfile(manifest[0]['Local Path'])
 
+    # Exercising the search by moving target
+    manifest = mast.Tesscut.download_cutouts(moving_target="Eleonora", size=5, path=str(tmpdir))
+    assert isinstance(manifest, Table)
+    assert len(manifest) == 1
+    assert manifest["Local Path"][0][-4:] == "fits"
+    assert os.path.isfile(manifest[0]['Local Path'])
+
 
 def test_tesscut_get_cutouts(patch_post, tmpdir):
 
@@ -630,6 +646,13 @@ def test_tesscut_get_cutouts(patch_post, tmpdir):
     assert isinstance(cutout_hdus_list, list)
     assert len(cutout_hdus_list) == 1
     assert isinstance(cutout_hdus_list[0], fits.HDUList)
+
+    # Exercising the search by object name
+    cutout_hdus_list = mast.Tesscut.get_cutouts(moving_target="Eleonora", size=5)
+    assert isinstance(cutout_hdus_list, list)
+    assert len(cutout_hdus_list) == 1
+    assert isinstance(cutout_hdus_list[0], fits.HDUList)
+
 
 ######################
 # ZcutClass tests #

--- a/astroquery/mast/tests/test_mast.py
+++ b/astroquery/mast/tests/test_mast.py
@@ -590,7 +590,8 @@ def test_tesscut_get_sector(patch_post):
     assert sector_table['ccd'][0] == 3
 
     # Exercising the search by moving target
-    sector_table = mast.Tesscut.get_sectors(moving_target="Ceres")
+    sector_table = mast.Tesscut.get_sectors(objectname="Ceres",
+                                            moving_target=True)
     assert isinstance(sector_table, Table)
     assert len(sector_table) == 1
     assert sector_table['sectorName'][0] == "tess-s0001-1-3"
@@ -599,14 +600,10 @@ def test_tesscut_get_sector(patch_post):
     assert sector_table['ccd'][0] == 3
 
     # Testing catch for multiple designators'
-    error_str = "Only one of objectname, coordinates, and moving_target may be specified."
+    error_str = "Only one of moving_target and coordinates may be specified. Please remove coordinates if using moving_target and objectname."
 
     with pytest.raises(InvalidQueryError) as invalid_query:
-        mast.Tesscut.get_sectors(moving_target="Ceres", coordinates=coord)
-    assert error_str in str(invalid_query.value)
-
-    with pytest.raises(InvalidQueryError) as invalid_query:
-        mast.Tesscut.get_sectors(moving_target="Ceres", objectname="M103")
+        mast.Tesscut.get_sectors(objectname='Ceres', moving_target=True, coordinates=coord)
     assert error_str in str(invalid_query.value)
 
 
@@ -637,21 +634,24 @@ def test_tesscut_download_cutouts(patch_post, tmpdir):
     assert os.path.isfile(manifest[0]['Local Path'])
 
     # Exercising the search by moving target
-    manifest = mast.Tesscut.download_cutouts(moving_target="Eleonora", size=5, path=str(tmpdir))
+    manifest = mast.Tesscut.download_cutouts(objectname="Eleonora",
+                                             moving_target=True,
+                                             size=5,
+                                             path=str(tmpdir))
     assert isinstance(manifest, Table)
     assert len(manifest) == 1
     assert manifest["Local Path"][0][-4:] == "fits"
     assert os.path.isfile(manifest[0]['Local Path'])
 
     # Testing catch for multiple designators'
-    error_str = "Only one of objectname, coordinates, and moving_target may be specified."
+    error_str = "Only one of moving_target and coordinates may be specified. Please remove coordinates if using moving_target and objectname."
 
     with pytest.raises(InvalidQueryError) as invalid_query:
-        mast.Tesscut.download_cutouts(moving_target="Eleonora", coordinates=coord, size=5, path=str(tmpdir))
-    assert error_str in str(invalid_query.value)
-
-    with pytest.raises(InvalidQueryError) as invalid_query:
-        mast.Tesscut.download_cutouts(moving_target="Eleonora", objectname="M103", size=5, path=str(tmpdir))
+        mast.Tesscut.download_cutouts(objectname="Eleonora",
+                                      moving_target=True,
+                                      coordinates=coord,
+                                      size=5,
+                                      path=str(tmpdir))
     assert error_str in str(invalid_query.value)
 
 
@@ -670,20 +670,21 @@ def test_tesscut_get_cutouts(patch_post, tmpdir):
     assert isinstance(cutout_hdus_list[0], fits.HDUList)
 
     # Exercising the search by object name
-    cutout_hdus_list = mast.Tesscut.get_cutouts(moving_target="Eleonora", size=5)
+    cutout_hdus_list = mast.Tesscut.get_cutouts(objectname='Eleonora',
+                                                moving_target=True,
+                                                size=5)
     assert isinstance(cutout_hdus_list, list)
     assert len(cutout_hdus_list) == 1
     assert isinstance(cutout_hdus_list[0], fits.HDUList)
 
     # Testing catch for multiple designators'
-    error_str = "Only one of objectname, coordinates, and moving_target may be specified."
+    error_str = "Only one of moving_target and coordinates may be specified. Please remove coordinates if using moving_target and objectname."
 
     with pytest.raises(InvalidQueryError) as invalid_query:
-        mast.Tesscut.get_cutouts(moving_target="Eleonora", coordinates=coord, size=5)
-    assert error_str in str(invalid_query.value)
-
-    with pytest.raises(InvalidQueryError) as invalid_query:
-        mast.Tesscut.get_cutouts(moving_target="Eleonora", objectname="M103", size=5)
+        mast.Tesscut.get_cutouts(objectname="Eleonora",
+                                 moving_target=True,
+                                 coordinates=coord,
+                                 size=5)
     assert error_str in str(invalid_query.value)
 
 

--- a/astroquery/mast/tests/test_mast.py
+++ b/astroquery/mast/tests/test_mast.py
@@ -13,7 +13,7 @@ from astropy.io import fits
 import astropy.units as u
 
 from ...utils.testing_tools import MockResponse
-from ...exceptions import (InvalidQueryError, InputWarning)
+from ...exceptions import InvalidQueryError, InputWarning
 
 from ... import mast
 
@@ -598,6 +598,17 @@ def test_tesscut_get_sector(patch_post):
     assert sector_table['camera'][0] == 1
     assert sector_table['ccd'][0] == 3
 
+    # Testing catch for multiple designators'
+    error_str = "Only one of objectname, coordinates, and moving_target may be specified."
+
+    with pytest.raises(InvalidQueryError) as invalid_query:
+        mast.Tesscut.get_sectors(moving_target="Ceres", coordinates=coord)
+    assert error_str in str(invalid_query.value)
+
+    with pytest.raises(InvalidQueryError) as invalid_query:
+        mast.Tesscut.get_sectors(moving_target="Ceres", objectname="M103")
+    assert error_str in str(invalid_query.value)
+
 
 def test_tesscut_download_cutouts(patch_post, tmpdir):
 
@@ -632,6 +643,17 @@ def test_tesscut_download_cutouts(patch_post, tmpdir):
     assert manifest["Local Path"][0][-4:] == "fits"
     assert os.path.isfile(manifest[0]['Local Path'])
 
+    # Testing catch for multiple designators'
+    error_str = "Only one of objectname, coordinates, and moving_target may be specified."
+
+    with pytest.raises(InvalidQueryError) as invalid_query:
+        mast.Tesscut.download_cutouts(moving_target="Eleonora", coordinates=coord, size=5, path=str(tmpdir))
+    assert error_str in str(invalid_query.value)
+
+    with pytest.raises(InvalidQueryError) as invalid_query:
+        mast.Tesscut.download_cutouts(moving_target="Eleonora", objectname="M103", size=5, path=str(tmpdir))
+    assert error_str in str(invalid_query.value)
+
 
 def test_tesscut_get_cutouts(patch_post, tmpdir):
 
@@ -652,6 +674,17 @@ def test_tesscut_get_cutouts(patch_post, tmpdir):
     assert isinstance(cutout_hdus_list, list)
     assert len(cutout_hdus_list) == 1
     assert isinstance(cutout_hdus_list[0], fits.HDUList)
+
+    # Testing catch for multiple designators'
+    error_str = "Only one of objectname, coordinates, and moving_target may be specified."
+
+    with pytest.raises(InvalidQueryError) as invalid_query:
+        mast.Tesscut.get_cutouts(moving_target="Eleonora", coordinates=coord, size=5)
+    assert error_str in str(invalid_query.value)
+
+    with pytest.raises(InvalidQueryError) as invalid_query:
+        mast.Tesscut.get_cutouts(moving_target="Eleonora", objectname="M103", size=5)
+    assert error_str in str(invalid_query.value)
 
 
 ######################

--- a/astroquery/mast/tests/test_mast_remote.py
+++ b/astroquery/mast/tests/test_mast_remote.py
@@ -197,8 +197,8 @@ class TestMast:
 
     # product functions
     def test_observations_get_product_list_async(self):
- 
-        test_obs = mast.Observations.query_criteria(filters=["NUV","FUV"],objectname="M101")
+
+        test_obs = mast.Observations.query_criteria(filters=["NUV", "FUV"], objectname="M101")
 
         responses = mast.Observations.get_product_list_async(test_obs[0]["obsid"])
         assert isinstance(responses, list)
@@ -247,12 +247,8 @@ class TestMast:
         result = mast.Observations.get_product_list(observations[obsLocs])
         obs_collection = np.unique(list(result['obs_collection']))
         assert isinstance(result, Table)
-<<<<<<< HEAD
         assert len(obs_collection) == 1
         assert obs_collection[0] == 'IUE'
-=======
-        assert len(result) > 10
->>>>>>> adding moving tesscut tests
 
     def test_observations_filter_products(self):
         observations = mast.Observations.query_object("M8", radius=".04 deg")
@@ -714,7 +710,6 @@ class TestMast:
         assert sector_table['camera'][0] == 1
         assert sector_table['ccd'][0] == 1
 
-
     def test_tesscut_download_cutouts(self, tmpdir):
 
         coord = SkyCoord(349.62609, -47.12424, unit="deg")
@@ -760,7 +755,6 @@ class TestMast:
         assert manifest["Local Path"][0][-4:] == "fits"
         for row in manifest:
             assert os.path.isfile(row['Local Path'])
-        
 
     def test_tesscut_get_cutouts(self, tmpdir):
 
@@ -793,7 +787,6 @@ class TestMast:
         assert len(cutout_hdus_list) == 1
         assert isinstance(cutout_hdus_list[0], fits.HDUList)
 
-        
     ###################
     # ZcutClass tests #
     ###################

--- a/astroquery/mast/tests/test_mast_remote.py
+++ b/astroquery/mast/tests/test_mast_remote.py
@@ -291,7 +291,7 @@ class TestMast:
 
     def test_observations_download_file(self, tmpdir):
         test_obs_id = OBSID
-        test_obs = mast.Observations.query_criteria(filters=["NUV","FUV"],objectname="M101")
+        test_obs = mast.Observations.query_criteria(filters=["NUV", "FUV"], objectname="M101")
 
         # pull a single data product
         products = mast.Observations.get_product_list(test_obs[0]["obsid"])
@@ -895,4 +895,3 @@ class TestMast:
         assert isinstance(cutout_list, list)
         assert len(cutout_list) == 1
         assert isinstance(cutout_list[0], fits.HDUList)
-

--- a/astroquery/mast/tests/test_mast_remote.py
+++ b/astroquery/mast/tests/test_mast_remote.py
@@ -743,8 +743,6 @@ class TestMast:
                                      moving_target=True)
         assert error_mt_coord in str(error_msg.value)
 
-
-
     def test_tesscut_download_cutouts(self, tmpdir):
 
         coord = SkyCoord(349.62609, -47.12424, unit="deg")

--- a/astroquery/mast/tests/test_mast_remote.py
+++ b/astroquery/mast/tests/test_mast_remote.py
@@ -11,10 +11,10 @@ from astropy.coordinates import SkyCoord
 from astropy.io import fits
 import astropy.units as u
 
-from astroquery.exceptions import NoResultsWarning
 from astroquery import mast
 
-from ...exceptions import RemoteServiceError, MaxResultsWarning
+from ..utils import ResolverError
+from ...exceptions import InvalidQueryError, MaxResultsWarning, NoResultsWarning, RemoteServiceError
 
 
 OBSID = '1647157'
@@ -702,13 +702,48 @@ class TestMast:
         assert sector_table['camera'][0] > 0
         assert sector_table['ccd'][0] > 0
 
-        sector_table = mast.Tesscut.get_sectors(moving_target="Stichius")
+        # Moving target functionality testing
+
+        moving_target_name = 'Eleonora'
+
+        sector_table = mast.Tesscut.get_sectors(objectname=moving_target_name,
+                                                moving_target=True)
         assert isinstance(sector_table, Table)
         assert len(sector_table) >= 1
-        assert sector_table['sectorName'][0] == "tess-s0001-1-1"
-        assert sector_table['sector'][0] == 1
+        assert sector_table['sectorName'][0] == "tess-s0006-1-1"
+        assert sector_table['sector'][0] == 6
         assert sector_table['camera'][0] == 1
         assert sector_table['ccd'][0] == 1
+
+        error_noname = "Please specify the object name or ID (as understood by the `JPL ephemerides service <https://ssd.jpl.nasa.gov/horizons.cgi>`__) of a moving target such as an asteroid or comet."
+        error_nameresolve = f"Could not resolve {moving_target_name} to a sky position."
+        error_mt_coord = "Only one of moving_target and coordinates may be specified."
+        error_name_coord = "Only one of objectname and coordinates may be specified."
+
+        with pytest.raises(InvalidQueryError) as error_msg:
+            mast.Tesscut.get_sectors(moving_target=True)
+        assert error_noname in str(error_msg.value)
+
+        with pytest.raises(ResolverError) as error_msg:
+            mast.Tesscut.get_sectors(objectname=moving_target_name)
+        assert error_nameresolve in str(error_msg.value)
+
+        with pytest.raises(InvalidQueryError) as error_msg:
+            mast.Tesscut.get_sectors(coordinates=coord, moving_target=True)
+        assert error_mt_coord in str(error_msg.value)
+
+        with pytest.raises(InvalidQueryError) as error_msg:
+            mast.Tesscut.get_sectors(objectname=moving_target_name,
+                                     coordinates=coord)
+        assert error_name_coord in str(error_msg.value)
+
+        with pytest.raises(InvalidQueryError) as error_msg:
+            mast.Tesscut.get_sectors(objectname=moving_target_name,
+                                     coordinates=coord,
+                                     moving_target=True)
+        assert error_mt_coord in str(error_msg.value)
+
+
 
     def test_tesscut_download_cutouts(self, tmpdir):
 
@@ -749,12 +784,48 @@ class TestMast:
         for row in manifest:
             assert os.path.isfile(row['Local Path'])
 
-        manifest = mast.Tesscut.download_cutouts(moving_target="Eleonora", sector=6, size=5, path=str(tmpdir))
+        # Moving target functionality testing
+
+        moving_target_name = 'Eleonora'
+
+        manifest = mast.Tesscut.download_cutouts(objectname=moving_target_name,
+                                                 moving_target=True,
+                                                 sector=6,
+                                                 size=5,
+                                                 path=str(tmpdir))
         assert isinstance(manifest, Table)
         assert len(manifest) == 1
         assert manifest["Local Path"][0][-4:] == "fits"
         for row in manifest:
             assert os.path.isfile(row['Local Path'])
+
+        error_noname = "Please specify the object name or ID (as understood by the `JPL ephemerides service <https://ssd.jpl.nasa.gov/horizons.cgi>`__) of a moving target such as an asteroid or comet."
+        error_nameresolve = f"Could not resolve {moving_target_name} to a sky position."
+        error_mt_coord = "Only one of moving_target and coordinates may be specified."
+        error_name_coord = "Only one of objectname and coordinates may be specified."
+
+        with pytest.raises(InvalidQueryError) as error_msg:
+            mast.Tesscut.download_cutouts(moving_target=True)
+        assert error_noname in str(error_msg.value)
+
+        with pytest.raises(ResolverError) as error_msg:
+            mast.Tesscut.download_cutouts(objectname=moving_target_name)
+        assert error_nameresolve in str(error_msg.value)
+
+        with pytest.raises(InvalidQueryError) as error_msg:
+            mast.Tesscut.download_cutouts(coordinates=coord, moving_target=True)
+        assert error_mt_coord in str(error_msg.value)
+
+        with pytest.raises(InvalidQueryError) as error_msg:
+            mast.Tesscut.download_cutouts(objectname=moving_target_name,
+                                     coordinates=coord)
+        assert error_name_coord in str(error_msg.value)
+
+        with pytest.raises(InvalidQueryError) as error_msg:
+            mast.Tesscut.download_cutouts(objectname=moving_target_name,
+                                     coordinates=coord,
+                                     moving_target=True)
+        assert error_mt_coord in str(error_msg.value)
 
     def test_tesscut_get_cutouts(self, tmpdir):
 
@@ -782,10 +853,45 @@ class TestMast:
         assert len(cutout_hdus_list) >= 1
         assert isinstance(cutout_hdus_list[0], fits.HDUList)
 
-        cutout_hdus_list = mast.Tesscut.get_cutouts(moving_target="Eleonora", sector=6, size=5)
+        # Moving target functionality testing
+
+        moving_target_name = 'Eleonora'
+
+        cutout_hdus_list = mast.Tesscut.get_cutouts(objectname=moving_target_name,
+                                moving_target=True,
+                                sector=6,
+                                size=5)
         assert isinstance(cutout_hdus_list, list)
         assert len(cutout_hdus_list) == 1
         assert isinstance(cutout_hdus_list[0], fits.HDUList)
+
+        error_noname = "Please specify the object name or ID (as understood by the `JPL ephemerides service <https://ssd.jpl.nasa.gov/horizons.cgi>`__) of a moving target such as an asteroid or comet."
+        error_nameresolve = f"Could not resolve {moving_target_name} to a sky position."
+        error_mt_coord = "Only one of moving_target and coordinates may be specified."
+        error_name_coord = "Only one of objectname and coordinates may be specified."
+
+        with pytest.raises(InvalidQueryError) as error_msg:
+            mast.Tesscut.download_cutouts(moving_target=True)
+        assert error_noname in str(error_msg.value)
+
+        with pytest.raises(ResolverError) as error_msg:
+            mast.Tesscut.download_cutouts(objectname=moving_target_name)
+        assert error_nameresolve in str(error_msg.value)
+
+        with pytest.raises(InvalidQueryError) as error_msg:
+            mast.Tesscut.download_cutouts(coordinates=coord, moving_target=True)
+        assert error_mt_coord in str(error_msg.value)
+
+        with pytest.raises(InvalidQueryError) as error_msg:
+            mast.Tesscut.download_cutouts(objectname=moving_target_name,
+                                          coordinates=coord)
+        assert error_name_coord in str(error_msg.value)
+
+        with pytest.raises(InvalidQueryError) as error_msg:
+            mast.Tesscut.download_cutouts(objectname=moving_target_name,
+                                          coordinates=coord,
+                                          moving_target=True)
+        assert error_mt_coord in str(error_msg.value)
 
     ###################
     # ZcutClass tests #

--- a/docs/mast/mast.rst
+++ b/docs/mast/mast.rst
@@ -892,7 +892,7 @@ To access sector information for a particular coordinate, object, or moving targ
 
                 >>> sector_table = Tesscut.get_sectors(objectname="Ceres", moving_target=True)
                 >>> print(sector_table)
-                 sectorName   sector camera  ccd
+                  sectorName   sector camera ccd
                 -------------- ------ ------ ---
                 tess-s0029-1-4     29      1   4
                 tess-s0043-3-3     43      3   3

--- a/docs/mast/mast.rst
+++ b/docs/mast/mast.rst
@@ -816,7 +816,7 @@ Requesting a cutout by moving_target accesses the
 `MAST Moving Target TESScut API <https://mast.stsci.edu/tesscut/docs/getting_started.html#moving-target-cutouts>`__
 and returns a target pixel file, with format described
 `here <https://astrocut.readthedocs.io/en/latest/astrocut/file_formats.html#path-focused-target-pixel-files>`__.
-The moving_target is an optional bool argument where `True` signifies that the accompanying `objectname` input is the object name or ID understood by the
+The moving_target is an optional bool argument where `True` signifies that the accompanying ``objectname`` input is the object name or ID understood by the
 `JPL Horizon ephemerades interface <https://ssd.jpl.nasa.gov/horizons.cgi>`__. The default value for moving_target is set to False. Therefore, a non-moving target can be input simply with either the objectname or coordinates.
 
 .. code-block:: python

--- a/docs/mast/mast.rst
+++ b/docs/mast/mast.rst
@@ -823,7 +823,7 @@ The moving_target is an optional bool argument where `True` signifies that the a
 
                 >>> from astroquery.mast import Tesscut
 
-                  >>> hdulist = Tesscut.get_cutouts(objectname="Eleonora", moving_target=True, size=5, sector=6)
+                >>> hdulist = Tesscut.get_cutouts(objectname="Eleonora", moving_target=True, size=5, sector=6)
                 >>> hdulist[0].info()
                 Filename: <class '_io.BytesIO'>
                 No.    Name      Ver    Type      Cards   Dimensions   Format

--- a/docs/mast/mast.rst
+++ b/docs/mast/mast.rst
@@ -816,14 +816,14 @@ Requesting a cutout by moving_target accesses the
 `MAST Moving Target TESScut API <https://mast.stsci.edu/tesscut/docs/getting_started.html#moving-target-cutouts>`__
 and returns a target pixel file, with format described
 `here <https://astrocut.readthedocs.io/en/latest/astrocut/file_formats.html#path-focused-target-pixel-files>`__.
-The moving_target may be any object name or ID understood by the
-`JPL Horizonf ephemerades interface <https://ssd.jpl.nasa.gov/horizons.cgi>`__.
+The moving_target is an optional bool argument where `True` signifies that the accompanying `objectname` input is the object name or ID understood by the
+`JPL Horizon ephemerades interface <https://ssd.jpl.nasa.gov/horizons.cgi>`__. The default value for moving_target is set to False. Therefore, a non-moving target can be input simply with either the objectname or coordinates.
 
 .. code-block:: python
 
                 >>> from astroquery.mast import Tesscut
 
-                >>> hdulist = Tesscut.get_cutouts(moving_target="Eleonora", size=5, sector=6)
+                  >>> hdulist = Tesscut.get_cutouts(objectname="Eleonora", moving_target=True, size=5, sector=6)
                 >>> hdulist[0].info()
                 Filename: <class '_io.BytesIO'>
                 No.    Name      Ver    Type      Cards   Dimensions   Format
@@ -834,13 +834,11 @@ The moving_target may be any object name or ID understood by the
 
 
 
-The `~astroquery.mast.TesscutClass.download_cutouts` function takes a coordinate, object name
-(i.e. "M104" or "TIC 32449963"), or moving target (i.e. "Eleonora") and cutout size
-(in pixels or an angular quantity) and downloads the cutout target pixel file(s).
+The `~astroquery.mast.TesscutClass.download_cutouts` function takes a coordinate, cutout size
+(in pixels or an angular quantity), or object name
+(i.e. "M104" or "TIC 32449963") and moving target (True or False). It uses these parameters to download the cutout target pixel file(s).
 
-If a given coordinate/object/moving target appears in more than one TESS sector a
-target pixel file will be produced for each sector.  If the cutout area overlaps
-more than one camera or ccd a target pixel file will be produced for each one.
+If a given coordinate/object/moving target appears in more than one TESS sector, a target pixel file will be produced for each sector.  If the cutout area overlaps more than one camera or ccd, a target pixel file will be produced for each one.
 
 .. code-block:: python
 
@@ -892,11 +890,13 @@ To access sector information for a particular coordinate, object, or moving targ
 
                 >>> from astroquery.mast import Tesscut
 
-                >>> sector_table = Tesscut.get_sectors(moving_target="Ceres")
+                >>> sector_table = Tesscut.get_sectors(objectname="Ceres", moving_target=True)
                 >>> print(sector_table)
-                  sectorName   sector camera ccd
+                 sectorName   sector camera  ccd
                 -------------- ------ ------ ---
                 tess-s0029-1-4     29      1   4
+                tess-s0043-3-3     43      3   3
+                tess-s0044-2-4     44      2   4
 
 Zcut
 ====

--- a/docs/mast/mast.rst
+++ b/docs/mast/mast.rst
@@ -306,7 +306,7 @@ with a `~astropy.table.Table` of data products, or a list (or single) obsid as t
 
                 >>> print(manifest)
 
-                                   Local Path                     Status  Message URL 
+                                   Local Path                     Status  Message URL
                 ------------------------------------------------ -------- ------- ----
                     ./mastDownload/IUE/lwp13058/lwp13058.mxlo.gz COMPLETE    None None
                 ./mastDownload/IUE/lwp13058/lwp13058mxlo_vo.fits COMPLETE    None None
@@ -317,12 +317,10 @@ with a `~astropy.table.Table` of data products, or a list (or single) obsid as t
 
                 >>> from astroquery.mast import Observations
 
-                >>> single_obs = Observations.query_criteria(obs_collection="IUE",obs_id="lwp13058")
+                >>> single_obs = Observations.query_criteria(obs_collection="IUE", obs_id="lwp13058")
                 >>> data_products = Observations.get_product_list(single_obs)
-                
-                >>> Observations.download_products(data_products,
-                ...                                productType="SCIENCE",
-                ...                                curl_flag=True)
+
+                >>> table = Observations.download_products(data_products, productType="SCIENCE", curl_flag=True)
 
                 Downloading URL https://mast.stsci.edu/portal/Download/stage/anonymous/public/514cfaa9-fdc1-4799-b043-4488b811db4f/mastDownload_20170629162916.sh to ./mastDownload_20170629162916.sh ... [Done]
 
@@ -340,11 +338,11 @@ the ``local_path`` keyword argument.
 
                 >>> single_obs = Observations.query_criteria(obs_collection="IUE",obs_id="lwp13058")
                 >>> data_products = Observations.get_product_list(single_obs)
-                
+
                 >>> product = data_products[0]["dataURI"]
                 >>> print(product)
                 mast:IUE/url/pub/iue/data/lwp/13000/lwp13058.elbll.gz
-                
+
                 >>> result = Observations.download_file(product)
                 Downloading URL https://mast.stsci.edu/api/v0.1/Download/file?uri=mast:IUE/url/pub/iue/data/lwp/13000/lwp13058.elbll.gz to ./lwp13058.elbll.gz ... [Done]
 
@@ -829,13 +827,13 @@ The moving_target may be any object name or ID understood by the
                 >>> hdulist[0].info()
                 Filename: <class '_io.BytesIO'>
                 No.    Name      Ver    Type      Cards   Dimensions   Format
-                0  PRIMARY       1 PrimaryHDU      54   ()      
-                1  PIXELS        1 BinTableHDU    150   356R x 16C   [D, E, J, 25J, 25E, 25E, 25E, 25E, J, E, E, 38A, D, D, D, D]   
-                2  APERTURE      1 ImageHDU        97   (2136, 2078)   int32   
+                0  PRIMARY       1 PrimaryHDU      54   ()
+                1  PIXELS        1 BinTableHDU    150   355R x 16C   [D, E, J, 25J, 25E, 25E, 25E, 25E, J, E, E, 38A, D, D, D, D]
+                2  APERTURE      1 ImageHDU        97   (2136, 2078)   int32
 
 
 
-                  
+
 The `~astroquery.mast.TesscutClass.download_cutouts` function takes a coordinate, object name
 (i.e. "M104" or "TIC 32449963"), or moving target (i.e. "Eleonora") and cutout size
 (in pixels or an angular quantity) and downloads the cutout target pixel file(s).
@@ -856,7 +854,7 @@ more than one camera or ccd a target pixel file will be produced for each one.
                 Inflating...
 
                 >>> print(manifest)
-                                       Local Path                        
+                                       Local Path
                 ----------------------------------------------------------
                 ./tess-s0009-4-1_107.186960_-70.509190_21x15_astrocut.fits
 
@@ -899,7 +897,7 @@ To access sector information for a particular coordinate, object, or moving targ
                   sectorName   sector camera ccd
                 -------------- ------ ------ ---
                 tess-s0029-1-4     29      1   4
-   
+
 Zcut
 ====
 


### PR DESCRIPTION
Adding functionality to access the new MAST Moving Target TESScut functionality from the astroquery.mast Tesscut class.

Includes:

- New `moving_target` argument to Tesscut class functions, that allows users to make cutouts for named moving targets (asteroids/comets etc).
- Associated documentation
- Associated tests (remote and local)
- Update to mast cloud access documentation to reflect prior code changes (unrelated, just apparently forgot to do the docs when I updated the code)
- General test tweaks to explicitly catch warnings and make sure all the remote tests pass