### PR TITLE
fix for issue2124: don't verify JPL requests

### DIFF
--- a/astroquery/jplspec/core.py
+++ b/astroquery/jplspec/core.py
@@ -121,7 +121,7 @@ class JPLSpecClass(BaseQuery):
         # BaseQuery classes come with a _request method that includes a
         # built-in caching system
         response = self._request(method='POST', url=self.URL, data=payload,
-                                 timeout=self.TIMEOUT, cache=cache)
+                                 timeout=self.TIMEOUT, cache=cache, verify=False)
 
         return response
 


### PR DESCRIPTION
all in the title.  JPL is web-1.0, we shouldn't be using https

a remote test would be a  good idea...