### PR TITLE
Speed up `mast.Observations.get_cloud_uris()`

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -242,6 +242,12 @@ xmatch
 - Minor internal change to use VOTable as the response format that include
   units, too. [#1375]
 
+mast
+^^^^
+
+- Increased the speed of ``get_cloud_uri`` by obtaining multiple file
+  product paths using a single request.
+
 
 Infrastructure, Utility and Other Changes and Additions
 -------------------------------------------------------

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -245,8 +245,8 @@ xmatch
 mast
 ^^^^
 
-- Increased the speed of ``get_cloud_uri`` by obtaining multiple file
-  product paths using a single request.
+- Increased the speed of ``Observations.get_cloud_uris`` by obtaining multiple
+  URIs from MAST at once. [#2145]
 
 
 Infrastructure, Utility and Other Changes and Additions

--- a/astroquery/mast/cloud.py
+++ b/astroquery/mast/cloud.py
@@ -113,7 +113,7 @@ class CloudAccess:  # pragma:no-cover
 
         # Making sure we got at least 1 URI from the query above.
         if uri_list[0] == None:
-            raise InvalidQueryError("No products found on the cloud for this query.")
+            warnings.warn("Unable to locate file {}.".format(data_product), NoResultsWarning)
         else:
             # Output from ``get_cloud_uri_list`` is always a list even when it's only 1 URI
             return uri_list[0]

--- a/astroquery/mast/cloud.py
+++ b/astroquery/mast/cloud.py
@@ -154,10 +154,11 @@ class CloudAccess:  # pragma:no-cover
                     # Use `head_object` to verify that the product is available on S3 (not all products are)
                     s3_client.head_object(Bucket=self.pubdata_bucket, Key=path)
                     if include_bucket:
-                        path = "s3://{}/{}".format(self.pubdata_bucket, path)
+                        s3_path = "s3://{}/{}".format(self.pubdata_bucket, path)
+                        uri_list.append(s3_path)
                     elif full_url:
                         path = "http://s3.amazonaws.com/{}/{}".format(self._pubdata_bucket, path)
-                    uri_list.append(path)
+                        uri_list.append(path)
                 except self.botocore.exceptions.ClientError as e:
                     if e.response['Error']['Code'] != "404":
                         raise

--- a/astroquery/mast/cloud.py
+++ b/astroquery/mast/cloud.py
@@ -115,6 +115,7 @@ class CloudAccess:  # pragma:no-cover
         if len(uri_list) == 0:
             raise InvalidQueryError("No products found on the cloud for this query.")
         else:
+            # Output from ``get_cloud_uri_list`` is always a list even when it's only 1 URI
             return uri_list[0]
 
     def get_cloud_uri_list(self, data_products, include_bucket=True, full_url=False):

--- a/astroquery/mast/cloud.py
+++ b/astroquery/mast/cloud.py
@@ -112,7 +112,7 @@ class CloudAccess:  # pragma:no-cover
         uri_list = self.get_cloud_uri_list(data_product, include_bucket=include_bucket, full_url=full_url)
 
         # Making sure we got at least 1 URI from the query above.
-        if len(uri_list) == 0:
+        if uri_list[0] == None:
             raise InvalidQueryError("No products found on the cloud for this query.")
         else:
             # Output from ``get_cloud_uri_list`` is always a list even when it's only 1 URI

--- a/astroquery/mast/tests/test_mast_remote.py
+++ b/astroquery/mast/tests/test_mast_remote.py
@@ -403,26 +403,24 @@ class TestMast:
 
         assert len(uri) > 0, f'Product for OBSID {test_obs_id} was not found in the cloud.'
 
-    def test_get_cloud_uris(self):
+    @pytest.mark.parametrize("test_obs_id", ["25568122", "31411"])
+    def test_get_cloud_uris(self, test_obs_id):
         pytest.importorskip("boto3")
-        test_obs_ids = ["25568122", "31411"]
 
-        for test_obs_id in test_obs_ids:
+        # get a product list
+        index = 24 if test_obs_id == "25568122" else 0
+        products = mast.Observations.get_product_list(test_obs_id)[index:]
 
-            # get a product list
-            index = 24 if test_obs_id == "25568122" else 0
-            products = mast.Observations.get_product_list(test_obs_id)[index:]
+        assert len(products) > 0, (f'No products found for OBSID {test_obs_id}.'
+                                    'Unable to move forward with getting URIs from the cloud.')
 
-            assert len(products) > 0, (f'No products found for OBSID {test_obs_id}.'
-                                       'Unable to move forward with getting URIs from the cloud.')
+        # enable access to public AWS S3 bucket
+        mast.Observations.enable_cloud_dataset()
 
-            # enable access to public AWS S3 bucket
-            mast.Observations.enable_cloud_dataset()
+        # get uris
+        uris = mast.Observations.get_cloud_uris(products)
 
-            # get uris
-            uris = mast.Observations.get_cloud_uris(products)
-
-            assert len(uris) > 0, f'Products for OBSID {test_obs_id} were not found in the cloud.'
+        assert len(uris) > 0, f'Products for OBSID {test_obs_id} were not found in the cloud.'
 
     ######################
     # CatalogClass tests #

--- a/astroquery/mast/tests/test_mast_remote.py
+++ b/astroquery/mast/tests/test_mast_remote.py
@@ -405,21 +405,24 @@ class TestMast:
 
     def test_get_cloud_uris(self):
         pytest.importorskip("boto3")
-        test_obs_id = '25568122'
+        test_obs_ids = ["25568122", "31411"]
 
-        # get a product list
-        products = mast.Observations.get_product_list(test_obs_id)[24:]
+        for test_obs_id in test_obs_ids:
 
-        assert len(products) > 0, (f'No products found for OBSID {test_obs_id}. '
-                                   'Unable to move forward with getting URIs from the cloud.')
+            # get a product list
+            index = 24 if test_obs_id == "25568122" else 0
+            products = mast.Observations.get_product_list(test_obs_id)[index:]
 
-        # enable access to public AWS S3 bucket
-        mast.Observations.enable_cloud_dataset()
+            assert len(products) > 0, (f'No products found for OBSID {test_obs_id}.'
+                                       'Unable to move forward with getting URIs from the cloud.')
 
-        # get uris
-        uris = mast.Observations.get_cloud_uris(products)
+            # enable access to public AWS S3 bucket
+            mast.Observations.enable_cloud_dataset()
 
-        assert len(uris) > 0, f'Products for OBSID {test_obs_id} were not found in the cloud.'
+            # get uris
+            uris = mast.Observations.get_cloud_uris(products)
+
+            assert len(uris) > 0, f'Products for OBSID {test_obs_id} were not found in the cloud.'
 
     ######################
     # CatalogClass tests #
@@ -427,6 +430,7 @@ class TestMast:
 
     # query functions
     def test_catalogs_query_region_async(self):
+
         responses = mast.Catalogs.query_region_async("158.47924 -7.30962", catalog="Galex")
         assert isinstance(responses, list)
 

--- a/astroquery/mast/tests/test_mast_remote.py
+++ b/astroquery/mast/tests/test_mast_remote.py
@@ -412,7 +412,7 @@ class TestMast:
         products = mast.Observations.get_product_list(test_obs_id)[index:]
 
         assert len(products) > 0, (f'No products found for OBSID {test_obs_id}.'
-                                    'Unable to move forward with getting URIs from the cloud.')
+                                   'Unable to move forward with getting URIs from the cloud.')
 
         # enable access to public AWS S3 bucket
         mast.Observations.enable_cloud_dataset()

--- a/astroquery/mast/utils.py
+++ b/astroquery/mast/utils.py
@@ -181,7 +181,11 @@ def mast_relative_path(mast_uri):
         response = _simple_request("https://mast.stsci.edu/api/v0.1/path_lookup/",
                                    {"uri": chunk})
         json_response = response.json()
+
         for uri in chunk:
+            # Chunk is a list of tuples where the tuple is
+            # ("uri", "/path/to/product")
+            # so we index for path (index=1)
             path = json_response.get(uri[1])["path"]
             if 'galex' in path:
                 path = path.lstrip("/mast/")

--- a/astroquery/mast/utils.py
+++ b/astroquery/mast/utils.py
@@ -155,22 +155,30 @@ def parse_input_location(coordinates=None, objectname=None):
 
 def mast_relative_path(mast_uri):
     """
-    Given a MAST dataURI, return the associated relative path.
+    Given one or more MAST dataURI(s), return the associated relative path(s).
 
     Parameters
     ----------
-    mast_uri : str
-        The MAST uri.
+    mast_uri : str, list of str
+        The MAST uri(s).
 
     Returns
     -------
-    response : str
-        The associated relative path.
+    response : str, list of str
+        The associated relative path(s).
     """
+    if isinstance(mast_uri, str):
+        uri_list = [("uri", mast_uri)]
+    else:  # mast_uri parameter is a list
+        uri_list = [("uri", uri) for uri in mast_uri]
 
     response = _simple_request("https://mast.stsci.edu/api/v0.1/path_lookup/",
-                               {"uri": mast_uri})
+                               {"uri": uri_list})
     result = response.json()
-    uri_result = result.get(mast_uri)
+    uri_result = [result.get(uri[1])["path"] for uri in uri_list]
 
-    return uri_result["path"]
+    # If the input was a single URI string, we return a single string
+    if isinstance(mast_uri, str):
+        return uri_result[0]
+    # Else, return a list of paths
+    return uri_result

--- a/astroquery/mast/utils.py
+++ b/astroquery/mast/utils.py
@@ -200,7 +200,3 @@ def _split_list_into_chunks(input_list, chunk_size):
     """Helper function for `mast_relative_path`."""
     for idx in range(0, len(input_list), chunk_size):
         yield input_list[idx:idx + chunk_size]
-
-
-def mast_path_strip(path, mission):
-    """Helper function to"""

--- a/astroquery/mast/utils.py
+++ b/astroquery/mast/utils.py
@@ -172,13 +172,26 @@ def mast_relative_path(mast_uri):
     else:  # mast_uri parameter is a list
         uri_list = [("uri", uri) for uri in mast_uri]
 
-    response = _simple_request("https://mast.stsci.edu/api/v0.1/path_lookup/",
-                               {"uri": uri_list})
-    result = response.json()
-    uri_result = [result.get(uri[1])["path"] for uri in uri_list]
+    # Split the list into chunks of 50 URIs; this is necessary
+    # to avoid "414 Client Error: Request-URI Too Large".
+    uri_list_chunks = list(_split_list_into_chunks(uri_list, chunk_size=50))
+
+    result = []
+    for chunk in uri_list_chunks:
+        response = _simple_request("https://mast.stsci.edu/api/v0.1/path_lookup/",
+                                   {"uri": chunk})
+        json_response = response.json()
+        for uri in chunk:
+            result.append(json_response.get(uri[1])["path"])
 
     # If the input was a single URI string, we return a single string
     if isinstance(mast_uri, str):
-        return uri_result[0]
+        return result[0]
     # Else, return a list of paths
-    return uri_result
+    return result
+
+
+def _split_list_into_chunks(input_list, chunk_size):
+    """Helper function for `mast_relative_path`."""
+    for idx in range(0, len(input_list), chunk_size):
+        yield input_list[idx:idx + chunk_size]

--- a/astroquery/mast/utils.py
+++ b/astroquery/mast/utils.py
@@ -182,7 +182,12 @@ def mast_relative_path(mast_uri):
                                    {"uri": chunk})
         json_response = response.json()
         for uri in chunk:
-            result.append(json_response.get(uri[1])["path"])
+            path = json_response.get(uri[1])["path"]
+            if 'galex' in path:
+                path = path.lstrip("/mast/")
+            else:
+                path = path.lstrip("/")
+            result.append(path)
 
     # If the input was a single URI string, we return a single string
     if isinstance(mast_uri, str):
@@ -195,3 +200,7 @@ def _split_list_into_chunks(input_list, chunk_size):
     """Helper function for `mast_relative_path`."""
     for idx in range(0, len(input_list), chunk_size):
         yield input_list[idx:idx + chunk_size]
+
+
+def mast_path_strip(path, mission):
+    """Helper function to"""


### PR DESCRIPTION
When using `astroquery.mast`, it is currently very slow to download multiple data products in cloud-enabled mode.

The main reason for the poor performance is that the `Observations.get_cloud_uris()` helper method is very slow at retrieving AWS S3 URIs.  For example, the following example requires >2 minutes to obtain URIs for 186 data products:

<img width="877" alt="Screen Shot 2021-09-07 at 5 44 33 PM" src="https://user-images.githubusercontent.com/817669/132427733-caac98d9-3a17-40f8-86c5-62ccfaadf917.png">

This is unfortunate because slow data access makes the cloud-enabled mode less attractive.

The main reason `Observations.get_cloud_uris()` is slow is because every data products triggers a separate HTTP request to MAST's `path_lookup` API via the `astroquery.mast.utils.mast_relative_path()` helper function.

This PR proposes to modify these functions such that MAST's `path_lookup` API is called in chunks of 50 products at once, allowing `Observations.get_cloud_uris()` to execute much faster.  For example, the demo above is ~7x faster when using this PR branch:

<img width="885" alt="Screen Shot 2021-09-07 at 6 02 26 PM" src="https://user-images.githubusercontent.com/817669/132429000-345da9f3-8fc7-4069-a2b6-813002a225f3.png">

(Note: the remaining 20s used by `get_cloud_uris()` is spent polling every cloud URI to verify that it exists before returning it to the user, because not every MAST product is mirrored in the cloud.  This will be harder to speed up, but fortunately this may be fast when running in the cloud.)