### PR TITLE
Allow a frame specification in query_region_async for VizieR queries

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -8,6 +8,15 @@ New Tools and Services
 Service fixes and enhancements
 ------------------------------
 
+vizier
+^^^^^^
+
+- It is now possible to specify 'galatic' centers in region queries to
+  have box queries oriented along the galactic axes [#2152]
+
+splatalogue
+^^^^^^^^^^^
+
 - Splatalogue table merging can now handle unmasked columns [#2136]
 
 

--- a/astroquery/vizier/core.py
+++ b/astroquery/vizier/core.py
@@ -359,8 +359,8 @@ class VizierClass(BaseQuery):
             Constraints on columns of the result. The dictionary contains
             the column name as keys, and the constraints as values.
         frame : str, optional
-            The frame to use for the request. It should be 'fk5', 'icrs', 
-            or 'galactic'. This choice influences the the orientation of 
+            The frame to use for the request. It should be 'fk5', 'icrs',
+            or 'galactic'. This choice influences the the orientation of
             box requests.
 
         Returns

--- a/astroquery/vizier/core.py
+++ b/astroquery/vizier/core.py
@@ -377,11 +377,11 @@ class VizierClass(BaseQuery):
 
         # Process coordinates
         if isinstance(coordinates, (commons.CoordClasses,) + six.string_types):
-            c = commons.parse_coordinates(coordinates).transform_to(frame)
+            target = commons.parse_coordinates(coordinates).transform_to(frame)
 
-            if not c.isscalar:
+            if not target.isscalar:
                 center["-c"] = []
-                for pos in c:
+                for pos in target:
                     if frame == 'galactic':
                         glon_deg = pos.l.to_string(unit="deg", decimal=True, precision=8)
                         glat_deg = pos.b.to_string(unit="deg", decimal=True, precision=8,
@@ -389,20 +389,21 @@ class VizierClass(BaseQuery):
                         center["-c"] += ["G{}{}".format(glon_deg, glat_deg)]
                     else:
                         ra_deg = pos.ra.to_string(unit="deg", decimal=True, precision=8)
-                        dec_deg = pos.dec.to_string(unit="deg", decimal=True,
+                        dec_deg = pos.de
+                        to_string(unit="deg", decimal=True,
                                                     precision=8, alwayssign=True)
                         center["-c"] += ["{}{}".format(ra_deg, dec_deg)]
                 columns += ["_q"]  # Always request reference to input table
             else:
                 if frame == 'galactic':
-                    glon = c.l.to_string(unit='deg', decimal=True, precision=8)
-                    glat = c.b.to_string(unit="deg", decimal=True, precision=8,
-                                         alwayssign=True)
+                    glon = target.l.to_string(unit='deg', decimal=True, precision=8)
+                    glat = target.b.to_string(unit="deg", decimal=True, precision=8,
+                                              alwayssign=True)
                     center["-c"] = "G{glon}{glat}".format(glon=glon, glat=glat)
                 else:
-                    ra = c.ra.to_string(unit='deg', decimal=True, precision=8)
-                    dec = c.dec.to_string(unit="deg", decimal=True, precision=8,
-                                          alwayssign=True)
+                    ra = target.ra.to_string(unit='deg', decimal=True, precision=8)
+                    dec = target.dec.to_string(unit="deg", decimal=True, precision=8,
+                                               alwayssign=True)
                     center["-c"] = "{ra}{dec}".format(ra=ra, dec=dec)
         elif isinstance(coordinates, tbl.Table):
             if (("_RAJ2000" in coordinates.keys()) and ("_DEJ2000" in

--- a/astroquery/vizier/core.py
+++ b/astroquery/vizier/core.py
@@ -389,8 +389,7 @@ class VizierClass(BaseQuery):
                         center["-c"] += ["G{}{}".format(glon_deg, glat_deg)]
                     else:
                         ra_deg = pos.ra.to_string(unit="deg", decimal=True, precision=8)
-                        dec_deg = pos.de
-                        to_string(unit="deg", decimal=True,
+                        dec_deg = pos.dec.to_string(unit="deg", decimal=True,
                                                     precision=8, alwayssign=True)
                         center["-c"] += ["{}{}".format(ra_deg, dec_deg)]
                 columns += ["_q"]  # Always request reference to input table

--- a/astroquery/vizier/tests/test_vizier_remote.py
+++ b/astroquery/vizier/tests/test_vizier_remote.py
@@ -38,9 +38,16 @@ class TestVizierRemote(object):
     def test_query_region_async(self):
         response = vizier.core.Vizier.query_region_async(
             self.target, radius=5 * u.deg, catalog=["HIP", "NOMAD", "UCAC"])
-
         assert response is not None
-
+        response = vizier.core.Vizier.query_region_async(
+            self.target, radius=0.5 * u.deg, catalog="HIP", 
+            frame="galactic")
+        assert response is not None
+        payload = vizier.core.Vizier.query_region_async(
+            self.target, radius=0.5 * u.deg, catalog="HIP", 
+            frame="galactic", get_query_payload=True)
+        assert "-c=G" in payload
+        
     def test_query_Vizier_instance(self):
         v = vizier.core.Vizier(
             columns=['_RAJ2000', 'DEJ2000', 'B-V', 'Vmag', 'Plx'],

--- a/astroquery/vizier/tests/test_vizier_remote.py
+++ b/astroquery/vizier/tests/test_vizier_remote.py
@@ -40,14 +40,14 @@ class TestVizierRemote(object):
             self.target, radius=5 * u.deg, catalog=["HIP", "NOMAD", "UCAC"])
         assert response is not None
         response = vizier.core.Vizier.query_region_async(
-            self.target, radius=0.5 * u.deg, catalog="HIP", 
+            self.target, radius=0.5 * u.deg, catalog="HIP",
             frame="galactic")
         assert response is not None
         payload = vizier.core.Vizier.query_region_async(
-            self.target, radius=0.5 * u.deg, catalog="HIP", 
+            self.target, radius=0.5 * u.deg, catalog="HIP",
             frame="galactic", get_query_payload=True)
         assert "-c=G" in payload
-        
+
     def test_query_Vizier_instance(self):
         v = vizier.core.Vizier(
             columns=['_RAJ2000', 'DEJ2000', 'B-V', 'Vmag', 'Plx'],

--- a/astroquery/vizier/tests/test_vizier_remote.py
+++ b/astroquery/vizier/tests/test_vizier_remote.py
@@ -40,7 +40,6 @@ class TestVizierRemote(object):
             self.target, radius=5 * u.deg, catalog=["HIP", "NOMAD", "UCAC"])
         assert response is not None
 
-    
     def test_query_region_async_galactic(self):
         response = vizier.core.Vizier.query_region_async(
             self.target, radius=0.5 * u.deg, catalog="HIP",

--- a/astroquery/vizier/tests/test_vizier_remote.py
+++ b/astroquery/vizier/tests/test_vizier_remote.py
@@ -39,6 +39,9 @@ class TestVizierRemote(object):
         response = vizier.core.Vizier.query_region_async(
             self.target, radius=5 * u.deg, catalog=["HIP", "NOMAD", "UCAC"])
         assert response is not None
+
+    
+    def test_query_region_async_galactic(self):
         response = vizier.core.Vizier.query_region_async(
             self.target, radius=0.5 * u.deg, catalog="HIP",
             frame="galactic")


### PR DESCRIPTION
The original `query_region_async` in the `VizierClass` always uses fk5 coordinates. This is OK for circular query, but limits box queries to boxes oriented along the equatorial axes. This change adds a parameter to `query_region_async` to allow the user to specify galactic coordinates: as a consequence, the returned queries will adopt boxes oriented along the galactic axes, as indicated in the ASU specification (and as tested).