### PR TITLE
Revise id_type behavior in jplhorizons.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -35,9 +35,9 @@ jplhorizons
   J2000 to ICRF, following API documentation. [#2154]
 
 - Query ``id_type`` behavior has changed:
-  - ``'majorbody'`` has been removed and the equivalent functionality
-    replaced ``None``.  This implements the Horizons default, which is to
-    search for major bodies first, then fall back to a small body search when
+  - ``'majorbody'`` and ``'id'`` have been removed and the equivalent functionality
+    replaced with ``None``.  ``None`` implements the Horizons default, which is
+    to search for major bodies first, then fall back to a small body search when
     no matches are found.  Horizons does not have a major body only search.
   - The default value was ``'smallbody'`` but it is now ``None``, which
     follows Horizons's default behavior.

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -34,6 +34,16 @@ jplhorizons
   Included in this update, the default reference system is changed from
   J2000 to ICRF, following API documentation. [#2154]
 
+- Query `id_type` behavior and options are changing:
+  - `'majorbody'` has been renamed to `''` (empty string) to represent the
+    Horizons default behavior. The Horizons default to search major bodies
+    first, then fall back to a small body search.  Horizons does not have
+    a major body only search.
+  - The default behavior was `'smallbody'` but this will be changed to the
+    Horizons default in a future version.
+  - Deprecation warnings are raised if `id_type` is `'majorbody'` or
+    was not specified by the user.
+
 Infrastructure, Utility and Other Changes and Additions
 -------------------------------------------------------
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -34,15 +34,13 @@ jplhorizons
   Included in this update, the default reference system is changed from
   J2000 to ICRF, following API documentation. [#2154]
 
-- Query `id_type` behavior and options are changing:
-  - `'majorbody'` has been renamed to `''` (empty string) to represent the
-    Horizons default behavior. The Horizons default to search major bodies
-    first, then fall back to a small body search.  Horizons does not have
-    a major body only search.
-  - The default behavior was `'smallbody'` but this will be changed to the
-    Horizons default in a future version.
-  - Deprecation warnings are raised if `id_type` is `'majorbody'` or
-    was not specified by the user.
+- Query ``id_type`` behavior has changed:
+  - ``'majorbody'`` has been removed and the equivalent functionality
+    replaced ``None``.  This implements the Horizons default, which is to
+    search for major bodies first, then fall back to a small body search when
+    no matches are found.  Horizons does not have a major body only search.
+  - The default value was ``'smallbody'`` but it is now ``None``, which
+    follows Horizons's default behavior.
 
 Infrastructure, Utility and Other Changes and Additions
 -------------------------------------------------------

--- a/astroquery/jplhorizons/core.py
+++ b/astroquery/jplhorizons/core.py
@@ -12,6 +12,7 @@ import warnings
 from astropy.table import Table, Column
 from astropy.io import ascii
 from astropy.time import Time
+from astropy.utils.exceptions import AstropyDeprecationWarning
 
 # 3. local imports - use relative imports
 # commonly required local imports shown below as example
@@ -35,7 +36,7 @@ class HorizonsClass(BaseQuery):
     TIMEOUT = conf.timeout
 
     def __init__(self, id=None, location=None, epochs=None,
-                 id_type='smallbody'):
+                 id_type=None):
         """Instantiate JPL query.
 
         Parameters
@@ -64,11 +65,19 @@ class HorizonsClass(BaseQuery):
             element and vector queries. If no epochs are provided, the current
             time is used.
         id_type : str, optional
-            Identifier type, options: ``'smallbody'``, ``'majorbody'`` (planets
-            but also anything that is not a small body), ``'designation'``,
-            ``'name'``, ``'asteroid_name'``, ``'comet_name'``, ``'id'``
-            (Horizons id number), or ``'smallbody'`` (find the closest match
-            under any id_type), default: ``'smallbody'``
+            Controls Horizons's object selection for ``id``
+            [HORIZONSDOC_SELECTION]_ .  Options: ``'majorbody'`` (DEPRECATED,
+            use ``''``), ``'designation'`` (small body designation), ``'name'``
+            (asteroid or comet name), ``'asteroid_name'``, ``'comet_name'``,
+            ``'id'`` (Horizons ID number), ``'smallbody'`` (asteroid and comet
+            search), or ``''`` (empty string; first search search planets,
+            natural satellites, spacecraft, and special cases, then small
+            bodies).
+
+        References
+        ----------
+
+        .. [HORIZONSDOC_SELECTION] https://ssd.jpl.nasa.gov/?horizons_doc#selection (retrieved 2021 Sep 23).
 
 
         Examples
@@ -101,8 +110,18 @@ class HorizonsClass(BaseQuery):
         self.epochs = epochs
 
         # check for id_type
-        if id_type not in ['smallbody', 'majorbody',
-                           'designation', 'name',
+        if id_type is None:
+            warnings.warn('id_type was not specified, defaulting to a '
+            '"smallbody" search.  This behavior is deprecated and will be '
+            'changed to "" (empty string / Horizons default) in the future.',
+            AstropyDeprecationWarning)
+            id_type = 'smallbody'
+        elif id_type == 'majorbody':
+            warnings.warn('id_type "majorbody" is deprecated and will be '
+            'removed.  For the equivalent search behavior, use "" (empty '
+            'string).', AstropyDeprecationWarning)
+            id_type = ''
+        if id_type not in ['', 'smallbody', 'designation', 'name',
                            'asteroid_name', 'comet_name', 'id']:
             raise ValueError('id_type ({:s}) not allowed'.format(id_type))
         self.id_type = id_type

--- a/astroquery/jplhorizons/core.py
+++ b/astroquery/jplhorizons/core.py
@@ -12,6 +12,7 @@ import warnings
 from astropy.table import Table, Column
 from astropy.io import ascii
 from astropy.time import Time
+from astropy.utils.exceptions import AstropyDeprecationWarning
 
 # 3. local imports - use relative imports
 # commonly required local imports shown below as example
@@ -108,7 +109,11 @@ class HorizonsClass(BaseQuery):
         self.epochs = epochs
 
         # check for id_type
-
+        if id_type in ['majorbody', 'id']:
+            warnings.warn("``id_type``s 'majorbody' and 'id' are deprecated "
+                          "and replaced with ``None``, which has the same "
+                          "functionality.", AstropyDeprecationWarning)
+            id_type = None
         if id_type not in [None, 'smallbody', 'designation', 'name',
                            'asteroid_name', 'comet_name']:
             raise ValueError('id_type ({:s}) not allowed'.format(id_type))

--- a/astroquery/jplhorizons/core.py
+++ b/astroquery/jplhorizons/core.py
@@ -12,7 +12,6 @@ import warnings
 from astropy.table import Table, Column
 from astropy.io import ascii
 from astropy.time import Time
-from astropy.utils.exceptions import AstropyDeprecationWarning
 
 # 3. local imports - use relative imports
 # commonly required local imports shown below as example
@@ -30,7 +29,7 @@ __all__ = ['Horizons', 'HorizonsClass']
 class HorizonsClass(BaseQuery):
     """
     A class for querying the
-    `JPL Horizons <https://ssd.jpl.nasa.gov/horizons.cgi>`_ service.
+    `JPL Horizons <https://ssd.jpl.nasa.gov/horizons/>`_ service.
     """
 
     TIMEOUT = conf.timeout
@@ -48,7 +47,7 @@ class HorizonsClass(BaseQuery):
             orbital element or vector queries. Uses the same codes as JPL
             Horizons. If no location is provided, Earth's center is used for
             ephemerides queries and the Sun's center for elements and vectors
-            queries. Arbitrary topocentic coordinates for ephemerides queries
+            queries. Arbitrary topocentric coordinates for ephemerides queries
             can be provided in the format of a dictionary. The dictionary has to
             be of the form {``'lon'``: longitude in deg (East positive, West
             negative), ``'lat'``: latitude in deg (North positive, South
@@ -66,13 +65,12 @@ class HorizonsClass(BaseQuery):
             time is used.
         id_type : str, optional
             Controls Horizons's object selection for ``id``
-            [HORIZONSDOC_SELECTION]_ .  Options: ``'majorbody'`` (DEPRECATED,
-            use ``''``), ``'designation'`` (small body designation), ``'name'``
-            (asteroid or comet name), ``'asteroid_name'``, ``'comet_name'``,
-            ``'id'`` (Horizons ID number), ``'smallbody'`` (asteroid and comet
-            search), or ``''`` (empty string; first search search planets,
-            natural satellites, spacecraft, and special cases, then small
-            bodies).
+            [HORIZONSDOC_SELECTION]_ .  Options: ``'designation'`` (small body
+            designation), ``'name'`` (asteroid or comet name),
+            ``'asteroid_name'``, ``'comet_name'``, ``'smallbody'`` (asteroid
+            and comet search), or ``None`` (first search search planets,
+            natural satellites, spacecraft, and special cases, and if no
+            matches, then search small bodies).
 
         References
         ----------
@@ -110,19 +108,9 @@ class HorizonsClass(BaseQuery):
         self.epochs = epochs
 
         # check for id_type
-        if id_type is None:
-            warnings.warn('id_type was not specified, defaulting to a '
-            '"smallbody" search.  This behavior is deprecated and will be '
-            'changed to "" (empty string / Horizons default) in the future.',
-            AstropyDeprecationWarning)
-            id_type = 'smallbody'
-        elif id_type == 'majorbody':
-            warnings.warn('id_type "majorbody" is deprecated and will be '
-            'removed.  For the equivalent search behavior, use "" (empty '
-            'string).', AstropyDeprecationWarning)
-            id_type = ''
-        if id_type not in ['', 'smallbody', 'designation', 'name',
-                           'asteroid_name', 'comet_name', 'id']:
+
+        if id_type not in [None, 'smallbody', 'designation', 'name',
+                           'asteroid_name', 'comet_name']:
             raise ValueError('id_type ({:s}) not allowed'.format(id_type))
         self.id_type = id_type
 

--- a/astroquery/jplhorizons/core.py
+++ b/astroquery/jplhorizons/core.py
@@ -75,7 +75,7 @@ class HorizonsClass(BaseQuery):
         References
         ----------
 
-        .. [HORIZONSDOC_SELECTION] https://ssd.jpl.nasa.gov/?horizons_doc#selection (retrieved 2021 Sep 23).
+        .. [HORIZONSDOC_SELECTION] https://ssd.jpl.nasa.gov/horizons/manual.html#select (retrieved 2021 Sep 23).
 
 
         Examples
@@ -86,7 +86,7 @@ class HorizonsClass(BaseQuery):
         ...                      'stop':'2017-02-01',
         ...                      'step':'1d'})
         >>> print(eros)  # doctest: +SKIP
-        JPLHorizons instance "433"; location=568, epochs={'start': '2017-01-01', 'step': '1d', 'stop': '2017-02-01'}, id_type=smallbody
+        JPLHorizons instance "433"; location=568, epochs={'start': '2017-01-01', 'step': '1d', 'stop': '2017-02-01'}, id_type=None
         """
         super(HorizonsClass, self).__init__()
         self.id = id
@@ -135,7 +135,7 @@ class HorizonsClass(BaseQuery):
         ...                         'stop':'2017-02-01',
         ...                         'step':'1d'})
         >>> print(eros)  # doctest: +SKIP
-        JPLHorizons instance "433"; location=568, epochs={'start': '2017-01-01', 'step': '1d', 'stop': '2017-02-01'}, id_type=smallbody
+        JPLHorizons instance "433"; location=568, epochs={'start': '2017-01-01', 'step': '1d', 'stop': '2017-02-01'}, id_type=None
         """
         return ('JPLHorizons instance \"{:s}\"; location={:s}, '
                 'epochs={:s}, id_type={:s}').format(

--- a/astroquery/jplhorizons/tests/test_jplhorizons.py
+++ b/astroquery/jplhorizons/tests/test_jplhorizons.py
@@ -219,3 +219,17 @@ def test_no_H(patch_request):
     """testing missing H value (also applies for G, M1, k1, M2, k2)"""
     res = jplhorizons.Horizons(id='1935 UZ').ephemerides()[0]
     assert 'H' not in res
+
+
+def test_id_type_deprecation():
+    """Test deprecation warnings based on issue 1742.
+￼
+￼    https://github.com/astropy/astroquery/pull/2161
+
+    """
+
+    with pytest.warns(AstropyDeprecationWarning):
+        res = jplhorizons.Horizons(id='Ceres', id_type='id')
+
+    with pytest.warns(AstropyDeprecationWarning):
+        res = jplhorizons.Horizons(id='Ceres', id_type='majorbody')

--- a/astroquery/jplhorizons/tests/test_jplhorizons.py
+++ b/astroquery/jplhorizons/tests/test_jplhorizons.py
@@ -16,7 +16,7 @@ from ... import jplhorizons
 DATA_FILES = {'ephemerides': 'ceres_ephemerides.txt',
               'elements': 'ceres_elements.txt',
               'vectors': 'ceres_vectors.txt',
-              '"1935 UZ;"': 'no_H.txt'}
+              '"1935 UZ"': 'no_H.txt'}
 
 
 def data_path(filename):
@@ -27,7 +27,7 @@ def data_path(filename):
 # monkeypatch replacement request function
 def nonremote_request(self, request_type, url, **kwargs):
 
-    if kwargs['params']['COMMAND'] == '"Ceres;"':
+    if kwargs['params']['COMMAND'] == '"Ceres"':
         # pick DATA_FILE based on query type
         query_type = {'OBSERVER': 'ephemerides',
                       'ELEMENTS': 'elements',
@@ -182,7 +182,7 @@ def test_elements_query_payload():
         ('EPHEM_TYPE', 'ELEMENTS'),
         ('MAKE_EPHEM', 'YES'),
         ('OUT_UNITS', 'AU-D'),
-        ('COMMAND', '"Ceres;"'),
+        ('COMMAND', '"Ceres"'),
         ('CENTER', "'500@10'"),
         ('CSV_FORMAT', 'YES'),
         ('ELEM_LABELS', 'YES'),
@@ -202,7 +202,7 @@ def test_vectors_query_payload():
         ('format', 'text'),
         ('EPHEM_TYPE', 'VECTORS'),
         ('OUT_UNITS', 'AU-D'),
-        ('COMMAND', '"Ceres;"'),
+        ('COMMAND', '"Ceres"'),
         ('CENTER', "'500@10'"),
         ('CSV_FORMAT', '"YES"'),
         ('REF_PLANE', 'ECLIPTIC'),
@@ -219,18 +219,3 @@ def test_no_H(patch_request):
     """testing missing H value (also applies for G, M1, k1, M2, k2)"""
     res = jplhorizons.Horizons(id='1935 UZ').ephemerides()[0]
     assert 'H' not in res
-
-
-def test_id_type_deprecation():
-    """Test deprecation warnings based on issue 1742.
-
-    Remove when id_type behavior is changed.
-
-    https://github.com/astropy/astroquery/pull/1742
-
-    """
-    with pytest.warns(AstropyDeprecationWarning):
-        res = jplhorizons.Horizons(id='Ceres')
-
-    with pytest.warns(AstropyDeprecationWarning):
-        res = jplhorizons.Horizons(id='Ceres', id_type='majorbody')

--- a/astroquery/jplhorizons/tests/test_jplhorizons.py
+++ b/astroquery/jplhorizons/tests/test_jplhorizons.py
@@ -6,9 +6,10 @@ import os
 from collections import OrderedDict
 
 from numpy.ma import is_masked
-from ...utils.testing_tools import MockResponse
 from astropy.tests.helper import assert_quantity_allclose
+from astropy.utils.exceptions import AstropyDeprecationWarning
 
+from ...utils.testing_tools import MockResponse
 from ... import jplhorizons
 
 # files in data/ for different query types
@@ -218,3 +219,18 @@ def test_no_H(patch_request):
     """testing missing H value (also applies for G, M1, k1, M2, k2)"""
     res = jplhorizons.Horizons(id='1935 UZ').ephemerides()[0]
     assert 'H' not in res
+
+
+def test_id_type_deprecation():
+    """Test deprecation warnings based on issue 1742.
+
+    Remove when id_type behavior is changed.
+
+    https://github.com/astropy/astroquery/pull/1742
+
+    """
+    with pytest.warns(AstropyDeprecationWarning):
+        res = jplhorizons.Horizons(id='Ceres')
+
+    with pytest.warns(AstropyDeprecationWarning):
+        res = jplhorizons.Horizons(id='Ceres', id_type='majorbody')

--- a/astroquery/jplhorizons/tests/test_jplhorizons_remote.py
+++ b/astroquery/jplhorizons/tests/test_jplhorizons_remote.py
@@ -15,6 +15,7 @@ class TestHorizonsClass:
         # check values of Ceres for a given epoch
         # orbital uncertainty of Ceres is basically zero
         res = jplhorizons.Horizons(id='Ceres', location='500',
+                                   id_type='smallbody',
                                    epochs=2451544.5).ephemerides()[0]
 
         assert res['targetname'] == "1 Ceres (A801 AA)"
@@ -152,7 +153,7 @@ class TestHorizonsClass:
 
     def test_ephemerides_query_six(self):
         # tests optional constrains for ephemerides queries
-        obj = jplhorizons.Horizons(id='3552',
+        obj = jplhorizons.Horizons(id='3552', id_type='smallbody',
                                    location='I33',
                                    epochs={'start': '2018-05-01',
                                            'stop': '2018-08-01',
@@ -169,13 +170,14 @@ class TestHorizonsClass:
 
     def test_ephemerides_query_raw(self):
         res = (jplhorizons.Horizons(id='Ceres', location='500',
-                                    epochs=2451544.5).
+                                    id_type='smallbody', epochs=2451544.5).
                ephemerides(get_raw_response=True))
 
         assert len(res) >= 15400
 
     def test_elements_query(self):
         res = jplhorizons.Horizons(id='Ceres', location='500@10',
+                                   id_type='smallbody',
                                    epochs=[2451544.5,
                                            2451545.5]).elements()[0]
 
@@ -204,6 +206,7 @@ class TestHorizonsClass:
 
     def test_elements_query_two(self):
         obj = jplhorizons.Horizons(id='Ceres', location='500@10',
+                                   id_type='smallbody',
                                    epochs=[2451544.5,
                                            2451545.5])
 
@@ -219,6 +222,7 @@ class TestHorizonsClass:
 
     def test_elements_query_raw(self):
         res = jplhorizons.Horizons(id='Ceres', location='500@10',
+                                   id_type='smallbody',
                                    epochs=2451544.5).elements(
                                        get_raw_response=True)
 
@@ -228,6 +232,7 @@ class TestHorizonsClass:
         # check values of Ceres for a given epoch
         # orbital uncertainty of Ceres is basically zero
         res = jplhorizons.Horizons(id='Ceres', location='500@10',
+                                   id_type='smallbody',
                                    epochs=2451544.5).vectors()[0]
 
         assert res['targetname'] == "1 Ceres (A801 AA)"
@@ -251,6 +256,7 @@ class TestHorizonsClass:
 
     def test_vectors_query_raw(self):
         res = jplhorizons.Horizons(id='Ceres', location='500@10',
+                                   id_type='smallbody',
                                    epochs=2451544.5).vectors(
                                        get_raw_response=True)
 
@@ -259,20 +265,20 @@ class TestHorizonsClass:
     def test_unknownobject(self):
         try:
             jplhorizons.Horizons(id='spamspamspameggsspam', location='500',
-                                 epochs=2451544.5).ephemerides()
+                                 id_type='', epochs=2451544.5).ephemerides()
         except ValueError:
             pass
 
     def test_multipleobjects(self):
         try:
-            jplhorizons.Horizons(id='73P', location='500',
+            jplhorizons.Horizons(id='73P', location='500', id_type='smallbody',
                                  epochs=2451544.5).ephemerides()
         except ValueError:
             pass
 
     def test_uri(self):
         target = jplhorizons.Horizons(id='3552', location='500',
-                                      epochs=2451544.5)
+                                      id_type='smallbody', epochs=2451544.5)
         assert target.uri is None
 
         target.ephemerides()
@@ -299,10 +305,12 @@ class TestHorizonsClass:
 
         am_res = jplhorizons.Horizons(id='Ceres',
                                       location='688',
+                                      id_type='smallbody',
                                       epochs=2451544.5).ephemerides()[0]
 
         user_res = jplhorizons.Horizons(id='Ceres',
                                         location=anderson_mesa,
+                                        id_type='smallbody',
                                         epochs=2451544.5).ephemerides()[0]
 
         assert_quantity_allclose([am_res['RA'], am_res['DEC']],
@@ -321,7 +329,8 @@ class TestHorizonsClass:
         quantities = ('1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,'
                       '21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,'
                       '38,39,40,41,42,43')
-        target = jplhorizons.Horizons(id='301', location='688', epochs=epochs)
+        target = jplhorizons.Horizons(id='301', location='688', epochs=epochs,
+                                      id_type='')
         eph = target.ephemerides(quantities=quantities)
         assert len(eph) == 2
 
@@ -342,6 +351,7 @@ class TestHorizonsClass:
 
         # verify data['a-mass'].filled(99) works:
         target = jplhorizons.Horizons('Ceres', location='I41',
+                                      id_type='smallbody',
                                       epochs=[2458300.5])
         eph = target.ephemerides(quantities='1,8')
         assert len(eph) == 1
@@ -352,7 +362,8 @@ class TestHorizonsClass:
 
     def test_vectors_aberrations(self):
         """Check functionality of `aberrations` options"""
-        obj = jplhorizons.Horizons(id='1', epochs=2458500, location='500@0')
+        obj = jplhorizons.Horizons(id='1', epochs=2458500, location='500@0',
+                                   id_type='smallbody')
 
         vec = obj.vectors(aberrations='geometric')
         assert_quantity_allclose(vec['x'][0], -2.086487005013347)
@@ -364,7 +375,8 @@ class TestHorizonsClass:
         assert_quantity_allclose(vec['x'][0], -2.086576286974797)
 
     def test_vectors_delta_T(self):
-        obj = jplhorizons.Horizons(id='1', epochs=2458500, location='500@0')
+        obj = jplhorizons.Horizons(id='1', epochs=2458500, location='500@0',
+                                   id_type='smallbody')
 
         vec = obj.vectors(delta_T=False)
         assert 'delta_T' not in vec.columns
@@ -373,7 +385,8 @@ class TestHorizonsClass:
         assert_quantity_allclose(vec['delta_T'][0], 69.184373)
 
     def test_ephemerides_extraprecision(self):
-        obj = jplhorizons.Horizons(id='1', epochs=2458500, location='G37')
+        obj = jplhorizons.Horizons(id='1', epochs=2458500, location='G37',
+                                   id_type='smallbody')
 
         vec_simple = obj.ephemerides(extra_precision=False)
         vec_highprec = obj.ephemerides(extra_precision=True)

--- a/astroquery/jplhorizons/tests/test_jplhorizons_remote.py
+++ b/astroquery/jplhorizons/tests/test_jplhorizons_remote.py
@@ -263,18 +263,14 @@ class TestHorizonsClass:
         assert len(res) >= 6412
 
     def test_unknownobject(self):
-        try:
+        with pytest.raises(ValueError):
             jplhorizons.Horizons(id='spamspamspameggsspam', location='500',
-                                 id_type='', epochs=2451544.5).ephemerides()
-        except ValueError:
-            pass
+                                 epochs=2451544.5).ephemerides()
 
     def test_multipleobjects(self):
-        try:
+        with pytest.raises(ValueError):
             jplhorizons.Horizons(id='73P', location='500', id_type='smallbody',
                                  epochs=2451544.5).ephemerides()
-        except ValueError:
-            pass
 
     def test_uri(self):
         target = jplhorizons.Horizons(id='3552', location='500',
@@ -329,8 +325,7 @@ class TestHorizonsClass:
         quantities = ('1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,'
                       '21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,'
                       '38,39,40,41,42,43')
-        target = jplhorizons.Horizons(id='301', location='688', epochs=epochs,
-                                      id_type='')
+        target = jplhorizons.Horizons(id='301', location='688', epochs=epochs)
         eph = target.ephemerides(quantities=quantities)
         assert len(eph) == 2
 

--- a/docs/jplhorizons/jplhorizons.rst
+++ b/docs/jplhorizons/jplhorizons.rst
@@ -10,8 +10,8 @@ JPL Horizons Queries (`astroquery.jplhorizons`/astroquery.solarsystem.jpl.horizo
 
    The default search behavior has changed.  In v0.4.3 and earlier, the default
    ``id_type`` was ``'smallbody'``.  With v0.4.4, the default is ``None``, which
-   aligns with JPL Hoirizons's `default behavior
-   <https://ssd.jpl.nasa.gov/?horizons_doc#selection>`_: search major bodies
+   implements JPL Horizons's `default behavior
+   <https://ssd.jpl.nasa.gov/horizons/manual.html#select>`_: search major bodies
    first, and if no major bodies are found, then search small bodies.
 
 .. Note::
@@ -40,28 +40,26 @@ In order to query information for a specific Solar System body, a
    >>> from astroquery.jplhorizons import Horizons
    >>> obj = Horizons(id='Ceres', location='568', epochs=2458133.33546)
    >>> print(obj)
-   JPLHorizons instance "Ceres"; location=568, epochs=[2458133.33546], id_type=smallbody
+   JPLHorizons instance "Ceres"; location=568, epochs=[2458133.33546], id_type=None
 
 ``id`` refers to the target identifier and is mandatory; the exact
 string will be used in the query to the Horizons system.
 
-``location`` means either the observer's location (e.g., Horizons
-ephemerides query) or the body relative to which orbital elements are
-provided (e.g., Horizons orbital elements or vectors query); the same
-codes as used by Horizons are used here, which includes `MPC
-Observatory codes`_. The default is ``location=None``, which uses a
-geocentric location for ephemerides queries and the Sun as central body
-for orbital elements and state vector queries. User-defined
-topocentric locations for ephemerides queries can be provided, too, in
-the form of a dictionary. The dictionary has to be formatted as
-follows: {``'lon'``: longitude in degrees (East positive, West
-negative), ``'lat'``: latitude in degrees (North positive, South
-negative), ``'elevation'``: elevation in km above the reference
-ellipsoid}. In addition, ``'body'`` can be set to the Horizons body ID
-of the central body if different from Earth; by default, it is
-assumed that this location is on Earth if it has not been specifically
-set. The following example uses the coordinates of the `Statue of
-Liberty
+``location`` means either the observer's location (e.g., Horizons ephemerides
+query) or the body relative to which orbital elements are provided (e.g.,
+Horizons orbital elements or vectors query); the same codes as `used by Horizons
+<https://ssd.jpl.nasa.gov/horizons/manual.html#center>`_ are used here, which
+includes `MPC Observatory codes`_. The default is ``location=None``, which uses
+a geocentric location for ephemerides queries and the Sun as central body for
+orbital elements and state vector queries. User-defined topocentric locations
+for ephemerides queries can be provided, too, in the form of a dictionary. The
+dictionary has to be formatted as follows: {``'lon'``: longitude in degrees
+(East positive, West negative), ``'lat'``: latitude in degrees (North positive,
+South negative), ``'elevation'``: elevation in km above the reference
+ellipsoid}. In addition, ``'body'`` can be set to the Horizons body ID of the
+central body if different from Earth; by default, it is assumed that this
+location is on Earth if it has not been specifically set. The following example
+uses the coordinates of the `Statue of Liberty
 <https://www.google.com/maps/place/Statue+of+Liberty+National+Monument/@40.6892534,-74.0466891,17z/data=!3m1!4b1!4m5!3m4!1s0x89c25090129c363d:0x40c6a5770d25022b!8m2!3d40.6892494!4d-74.0445004>`_
 as the observer's location:
 
@@ -71,33 +69,42 @@ as the observer's location:
     >>> obj = Horizons(id='Ceres',
     ...                location=statue_of_liberty,
     ...                epochs=2458133.33546)
-    JPLHorizons instance "Ceres"; location={'lon': -74.0466891, 'lat': 40.6892534, 'elevation': 0.093}, epochs=[2458133.33546], id_type=smallbody
+    JPLHorizons instance "Ceres"; location={'lon': -74.0466891, 'lat': 40.6892534, 'elevation': 0.093}, epochs=[2458133.33546], id_type=None
 
 
 
-``epochs`` is either a scalar or list of Julian Dates (floats or
-strings) in the case of discrete epochs, or, in
-the case of a range of
-epochs, a dictionary that has to include the keywords ``start``,
-``stop`` (both using the following format "YYYY-MM-DD [HH:MM:SS]"),
-and ``step`` (e.g., ``'1m'`` for one minute, ``'3h'``three hours,
-``'10d'`` for ten days). Note that all input epochs, both calendar
-dates/times and Julian Dates, refer to UTC for ephemerides queries, TDB for
-element queries, and CT for vector queries. By default,
-``epochs=None``, which uses the current date and time.
+``epochs`` is either a scalar or list of Julian dates (floats or strings) in the
+case of discrete epochs, or, in the case of a range of epochs, a dictionary that
+has to include the keywords ``start``, ``stop`` (both using the following format
+"YYYY-MM-DD [HH:MM:SS]"), and ``step`` (e.g., ``'1m'`` for one minute,
+``'3h'`` three hours, ``'10d'`` for ten days). Note that all input epochs, both
+calendar dates/times and Julian Dates, refer to UTC for ephemerides queries, TDB
+for element queries and vector queries. By default, ``epochs=None``, which uses
+the current date and time.
 
-``id_type`` describes what type of target identifier has been provided
-in order to minimize the risk of confusion when identifying the
-target: ``smallbody`` (default; refers to an asteroid or comet),
-``majorbody`` (planets or satellites), ``designation`` (any type of
-asteroid or comet designation), ``name`` (any type of target name),
-``asteroid_name`` (name of an asteroid), or ``comet_name`` (name of a
-comet). In order to minimize confusion, try to be as specific as
-possible; namely, in the case of comets, make use of ``comet_name``
-(e.g., "Halley") and ``designation`` (e.g., "73P"). In the case of
-ambiguities in the name resolving, a list of matching objects will be
-provided. In order to select an object from this list, provide the
-respective id number or record number as ``id`` and use ``id_type=id``:
+``id_type`` controls how `Horizons resolves the ``id``
+<https://ssd.jpl.nasa.gov/horizons/manual.html#select>_` to match a Solar System
+body:
+
++--------------------+------------------------------------------------------------------------------------------------------------------------------------------+
+| ``id_type``        | Query behavior                                                                                                                           |
++====================+==========================================================================================================================================+
+| ``None`` (default) | Searches major bodies (planets, natural satellites, spacecraft, special cases) first, and if none are found, then searches small bodies. |
++--------------------+------------------------------------------------------------------------------------------------------------------------------------------+
+| ``smallbody``      | Limits the search to small solar system bodies (comets and asteroids).                                                                   |
++--------------------+------------------------------------------------------------------------------------------------------------------------------------------+
+| ``designation``    | Limits the search to small body designations, e.g., 73P or 2014 MU69.                                                                    |
++--------------------+------------------------------------------------------------------------------------------------------------------------------------------+
+| ``name``           | Limits the search to asteroid or comet names, e.g., Halley will match 1P/Halley and (2688) Halley.                                       |
++--------------------+------------------------------------------------------------------------------------------------------------------------------------------+
+| ``asteroid_name``  | Limits the search to asteroid names, e.g., Don Quixote.                                                                                  |
++--------------------+------------------------------------------------------------------------------------------------------------------------------------------+
+| ``comet_name``     | Limits the search to comet names, e.g., Encke will only match comet 2P/Encke, and not (9134) Encke.                                      |
++--------------------+------------------------------------------------------------------------------------------------------------------------------------------+
+
+In the case of ambiguities in the name resolution, a list of matching objects
+will be provided. In order to select an object from this list, provide the
+respective id number or record number as ``id`` and use ``id_type=None``:
 
 .. code-block:: python
 
@@ -112,25 +119,28 @@ respective id number or record number as ``id`` and use ``id_type=id``:
        90000035    1796    2P              Encke
        90000036    1805    2P              Encke
 	    ...     ...    ...               ...
-   >>> print(Horizons(id='90000034', id_type='id').ephemerides())
+   >>> print(Horizons(id='90000034', id_type=None).ephemerides())
    targetname       datetime_str          datetime_jd    ... RA_3sigma DEC_3sigma
       ---               ---                    d         ...   arcsec    arcsec
    ---------- ------------------------ ----------------- ... --------- ----------
      2P/Encke 2018-Jan-17 05:06:07.709 2458135.712589224 ...        --         --
 
 
-Querying JPL Horizons
----------------------
 
-The `JPL Horizons <https://ssd.jpl.nasa.gov/horizons.cgi>`_ system provides ephemerides, orbital elements, and
-state vectors for almost all known Solar System bodies. These queries
-are provided through three functions:
+The `JPL Horizons`_ system provides ephemerides, orbital elements, and state
+vectors for almost all known Solar System bodies. These queries are provided
+through three functions:
+:meth:`~astroquery.jplhorizons.HorizonsClass.ephemerides`,
+:meth:`~astroquery.jplhorizons.HorizonsClass.elements`, and
+:meth:`~astroquery.jplhorizons.HorizonsClass.vectors`.
 
-:meth:`~astroquery.jplhorizons.HorizonsClass.ephemerides` returns
-ephemerides for a given observer location (``location``) and epoch or
-range of epochs (``epochs``) in the form of an astropy table. The
-following example queries the ephemerides of asteroid (1) Ceres for
-a range of dates as seen from Maunakea:
+Ephemerides
+-----------
+
+:meth:`~astroquery.jplhorizons.HorizonsClass.ephemerides` returns ephemerides
+for a given observer location (``location``) and epoch or range of epochs
+(``epochs``) in the form of an astropy table. The following example queries the
+ephemerides of asteroid (1) Ceres for a range of dates as seen from Mauna Kea:
 
 .. code-block:: python
 
@@ -156,70 +166,66 @@ The following fields are available for each ephemerides query:
 .. code-block:: python
 
    >>> print(eph.columns)
-   <TableColumns names=('targetname','datetime_str','datetime_jd','H','G','solar_presence','flags','RA','DEC','RA_rate','DEC_rate','AZ','EL','airmass','magextinct','V','surfbright','illumination','EclLon','EclLat','r','r_rate','delta','delta_rate','lighttime','elong','elongFlag','alpha','sunTargetPA','velocityPA','ObsEclLon','ObsEclLat','GlxLon','GlxLat','RA_3sigma','DEC_3sigma')>
+   <TableColumns names=('targetname','datetime_str','datetime_jd','H','G','solar_presence','flags','RA','DEC','RA_app','DEC_app','RA_rate','DEC_rate','AZ','EL','AZ_rate','EL_rate','sat_X','sat_Y','sat_PANG','siderealtime','airmass','magextinct','V','surfbright','illumination','illum_defect','sat_sep','sat_vis','ang_width','PDObsLon','PDObsLat','PDSunLon','PDSunLat','SubSol_ang','SubSol_dist','NPole_ang','NPole_dist','EclLon','EclLat','r','r_rate','delta','delta_rate','lighttime','vel_sun','vel_obs','elong','elongFlag','alpha','lunar_elong','lunar_illum','sat_alpha','sunTargetPA','velocityPA','OrbPlaneAng','constellation','TDB-UT','ObsEclLon','ObsEclLat','NPole_RA','NPole_DEC','GlxLon','GlxLat','solartime','earth_lighttime','RA_3sigma','DEC_3sigma','SMAA_3sigma','SMIA_3sigma','Theta_3sigma','Area_3sigma','RSS_3sigma','r_3sigma','r_rate_3sigma','SBand_3sigma','XBand_3sigma','DoppDelay_3sigma','true_anom','hour_angle','alpha_true','PABLon','PABLat')>
 
-The values in these columns are the same as those defined in the
-Horizons `Definition of Observer Table Quantities`_; names have been
-simplified in a few cases. Quantities ``H`` and ``G`` are the target's
-Solar System absolute magnitude and photometric phase curve slope,
-respectively. In the case of comets, ``H`` and ``G`` are replaced by ``M1``,
-``M2``, ``k1``, ``k2``, and ``phasecoeff``; please refer to the `Horizons
-documentation`_ for definitions.
+The values in these columns are the same as those defined in the Horizons
+`Definition of Observer Table Quantities`_; names have been simplified in a few
+cases. Quantities ``H`` and ``G`` are the target's Solar System absolute
+magnitude and photometric phase curve slope, respectively. In the case of
+comets, ``H`` and ``G`` are replaced by ``M1``, ``M2``, ``k1``, ``k2``, and
+``phasecoeff``; please refer to the `Horizons documentation`_ for definitions.
 
-Optional parameters of
-:meth:`~astroquery.jplhorizons.HorizonsClass.ephemerides` are
-corresponding to optional features of the Horizons system:
-``airmass_lessthan`` sets an upper limit to airmass,
-``solar_elongation`` enables the definition of a solar elongation
-range, ``max_hour_angle`` sets a cutoff of the hour angle,
-``skip_daylight=True`` reject epochs during daylight, ``rate_cutoff``
-allows to reject targets with sky motion rates higher than provided
-(in units of arcsec/h), ``refraction`` accounts for refraction in the
-computation of the ephemerides (disabled by default), and
-``refsystem`` defines the coordinate reference system used (ICRF by
-default).. For comets, the options ``closest_apparation`` and
-``no_fragments`` are available, which select the closest apparition in
-time and reject fragments, respectively. Note that these options
-should only be used for comets and will crash the query for other
-object types. Extra precision in the queried properties can be
-requested using the ``extra_precision`` option. Furthermore,
-``get_query_payload=True`` skips the query and only returns the query
-payload, whereas ``get_raw_response=True`` the raw query response
-instead of the astropy table returns.
+Optional parameters of :meth:`~astroquery.jplhorizons.HorizonsClass.ephemerides`
+correspond to optional features of the Horizons system: ``airmass_lessthan``
+sets an upper limit to airmass, ``solar_elongation`` enables the definition of a
+solar elongation range, ``max_hour_angle`` sets a cutoff of the hour angle,
+``skip_daylight=True`` rejects epochs during daylight, ``rate_cutoff`` rejects
+targets with sky motion rates higher than provided (in units of arcsec/h),
+``refraction`` accounts for refraction in the computation of the ephemerides
+(disabled by default), and ``refsystem`` defines the coordinate reference system
+used (ICRF by default). For comets, the options ``closest_apparition`` and
+``no_fragments`` are available, which selects the closest apparition in time and
+limits fragment matching (73P-B would only match 73P-B), respectively.  Note
+that these options should only be used for comets and will crash the query for
+other object types. Extra precision in the queried properties can be requested
+using the ``extra_precision`` option.  Furthermore, ``get_query_payload=True``
+skips the query and only returns the query payload, whereas
+``get_raw_response=True`` returns the raw query response instead of the astropy
+table.
 
-:meth:`~astroquery.jplhorizons.HorizonsClass.ephemerides` queries by
-default all available quantities from the JPL Horizons servers. This
-might take a while. If you are only interested in a subset of the
-available quantities, you can query only those. The corresponding
-optional parameter to be set is ``quantities``. This parameter uses
-the same numerical codes as JPL Horizons defined in the `JPL Horizons
-User Manual Definition of Observer Table Quantities
-<https://ssd.jpl.nasa.gov/?horizons_doc#table_quantities>`_. For
-instance, if you only want to query astrometric RA and Dec, you can
-use ``quantities=1``; if you only want the heliocentric and geocentric
-distances, you can use ``quantities='19,20'`` (note that in this case
-a string with comma-separated codes has to be provided).
+:meth:`~astroquery.jplhorizons.HorizonsClass.ephemerides` queries by default all
+available quantities from the JPL Horizons servers. This might take a while. If
+you are only interested in a subset of the available quantities, you can query
+only those. The corresponding optional parameter to be set is ``quantities``.
+This parameter uses the same numerical codes as JPL Horizons defined in the `JPL
+Horizons User Manual Definition of Observer Table Quantities
+<https://ssd.jpl.nasa.gov/horizons/manual.html#observer-table>`_. For instance,
+if you only want to query astrometric RA and Dec, you can use ``quantities=1``;
+if you only want the heliocentric and geocentric distances, you can use
+``quantities='19,20'`` (note that in this case a string with comma-separated
+codes has to be provided).
 
 
+Orbital elements
+----------------
 
-:meth:`~astroquery.jplhorizons.HorizonsClass.elements` returns orbital
-elements relative to some Solar System body (``location``, referred to as
-"CENTER" in Horizons) and for a given epoch or a range of epochs
-(``epochs``) in the form of an astropy table. The following example
-queries the osculating elements of asteroid (433) Eros for a given
-data relative to the Sun:
+:meth:`~astroquery.jplhorizons.HorizonsClass.elements` returns orbital elements
+relative to some Solar System body (``location``, referred to as "CENTER" in
+Horizons) and for a given epoch or a range of epochs (``epochs``) in the form of
+an astropy table. The following example queries the osculating elements of
+asteroid (433) Eros for a given date relative to the Sun:
 
 .. code-block:: python
 
    >>> from astroquery.jplhorizons import Horizons
    >>> obj = Horizons(id='433', location='500@10',
-   ...		      epochs=2458133.33546)
+   ...                epochs=2458133.33546)
    >>> el = obj.elements()
    >>> print(el)
        targetname      datetime_jd  ...       Q            P
           ---               d       ...       AU           d
    ------------------ ------------- ... ------------- ------------
-   433 Eros (1898 DQ) 2458133.33546 ... 1.78244263804 642.93873484
+   433 Eros (A898 PA) 2458133.33546 ... 1.78244263804 642.93873484
 
 
 The following fields are queried:
@@ -229,20 +235,20 @@ The following fields are queried:
    >>> print(el.columns)
    <TableColumns names=('targetname','datetime_jd','datetime_str','H','G','e','q','incl','Omega','w','Tp_jd','n','M','nu','a','Q','P')>
 
-Optional parameters of
-:meth:`~astroquery.jplhorizons.HorizonsClass.elements` include
-``refsystem``, which defines the coordinate reference system used
-(ICRF by default), ``refplane`` which defines the reference plane of
-the orbital elements queried, and ``tp_type``, which switches between
-a relative and absolute representation of the time of perihelion
-passage.  For comets, the options ``closest_apparation`` and
-``no_fragments`` are available, which select the closest apparition in
-time and reject fragments, respectively. Note that these options
-should only be used for comets and will crash the query for other
-object types. Furthermore,``get_query_payload=True``, which skips the
-query and only returns the query payload, and
-``get_raw_response=True``, which returns the raw query response
-instead of the astropy table, are available.
+Optional parameters of :meth:`~astroquery.jplhorizons.HorizonsClass.elements`
+include ``refsystem``, which defines the coordinate reference system used (ICRF
+by default), ``refplane`` which defines the reference plane of the orbital
+elements queried, and ``tp_type``, which switches between a relative and
+absolute representation of the time of perihelion passage.  For comets, the
+options ``closest_apparition`` and ``no_fragments`` are available, which select
+the closest apparition in time and reject fragments, respectively. Note that
+these options should only be used for comets and will crash the query for other
+object types. Also available are ``get_query_payload=True``, which skips the
+query and only returns the query payload, and ``get_raw_response=True``, which
+returns the raw query response instead of the astropy table.
+
+Vectors
+-------
 
 :meth:`~astroquery.jplhorizons.HorizonsClass.vectors` returns the
 state vector of the target body in cartesian coordinates relative to
@@ -285,37 +291,35 @@ The following fields are queried:
    <TableColumns names=('targetname','datetime_jd','datetime_str','H','G','x','y','z','vx','vy','vz','lighttime','range','range_rate')>
 
 
-Similar to the other :class:`~astroquery.jplhorizons.HorizonsClass`
-functions, optional parameters of
-:meth:`~astroquery.jplhorizons.HorizonsClass.vectors` are
-``get_query_payload=True``, which skips the query and only returns the
-query payload, and ``get_raw_response=True``, which returns the raw
-query response instead of the astropy table. For comets, the options
-``closest_apparation`` and ``no_fragments`` are available, which
-select the closest apparition in time and reject fragments,
-respectively. Note that these options should only be used for comets
-and will crash the query for other object types. Options
-``aberrations`` and ``delta_T`` provide different choices for
-aberration corrections as well as a measure for time-varying
-differences between TDB and UT time-scales, respectively.
+Similar to the other :class:`~astroquery.jplhorizons.HorizonsClass` functions,
+optional parameters of :meth:`~astroquery.jplhorizons.HorizonsClass.vectors` are
+``get_query_payload=True``, which skips the query and only returns the query
+payload, and ``get_raw_response=True``, which returns the raw query response
+instead of the astropy table. For comets, the options ``closest_apparation`` and
+``no_fragments`` are available, which select the closest apparition in time and
+reject fragments, respectively. Note that these options should only be used for
+comets and will crash the query for other object types. Options ``aberrations``
+and ``delta_T`` provide different choices for aberration corrections as well as
+a measure for time-varying differences between TDB and UT time-scales,
+respectively.
 
 
 How to Use the Query Tables
 ===========================
 
-`astropy table`_ created by the query functions are extremely
-versatile and easy to use. Since all query functions return the same
-type of table, they can all be used in the same way.
+`astropy table`_ objects created by the query functions are extremely versatile
+and easy to use. Since all query functions return the same type of table, they
+can all be used in the same way.
 
-We provide some examples to illustrate how to use them based on the
-following JPL Horizons ephemerides query of near-Earth asteroid (3552)
-Don Quixote since its year of Discovery:
+We provide some examples to illustrate how to use them based on the following
+JPL Horizons ephemerides query of near-Earth asteroid (3552) Don Quixote since
+its year of Discovery:
 
 .. code-block:: python
 
    >>> from astroquery.jplhorizons import Horizons
    >>> obj = Horizons(id='3552', location='568',
-   ...		      epochs={'start':'2010-01-01', 'stop':'2019-12-31',
+   ...                epochs={'start':'2010-01-01', 'stop':'2019-12-31',
    ...                        'step':'1y'})
    >>> eph = obj.ephemerides()
 
@@ -325,128 +329,102 @@ As we have seen before, we can display a truncated version of table
 .. code-block:: python
 
    >>> print(eph)
-           targetname            datetime_str   ... RA_3sigma DEC_3sigma
-              ---                    ---        ...   arcsec    arcsec
-   -------------------------- ----------------- ... --------- ----------
-   3552 Don Quixote (1983 SA) 1983-Jan-01 00:00 ...     0.159      0.141
-   3552 Don Quixote (1983 SA) 1984-Jan-01 00:00 ...     0.187      0.231
-   3552 Don Quixote (1983 SA) 1985-Jan-01 00:00 ...     0.138      0.147
-   3552 Don Quixote (1983 SA) 1986-Jan-01 00:00 ...     0.117      0.123
-   3552 Don Quixote (1983 SA) 1987-Jan-01 00:00 ...     0.106      0.104
-   3552 Don Quixote (1983 SA) 1988-Jan-01 00:00 ...     0.095      0.089
-                          ...               ... ...       ...        ...
-   3552 Don Quixote (1983 SA) 2013-Jan-01 00:00 ...     0.106      0.107
-   3552 Don Quixote (1983 SA) 2014-Jan-01 00:00 ...     0.095      0.092
-   3552 Don Quixote (1983 SA) 2015-Jan-01 00:00 ...     0.083      0.079
-   3552 Don Quixote (1983 SA) 2016-Jan-01 00:00 ...      0.07      0.067
-   3552 Don Quixote (1983 SA) 2017-Jan-01 00:00 ...     0.061      0.062
-   3552 Don Quixote (1983 SA) 2018-Jan-01 00:00 ...     0.126      0.089
-   3552 Don Quixote (1983 SA) 2019-Jan-01 00:00 ...     0.174      0.174
-   Length = 37 rows
+           targetname            datetime_str   ...  PABLon   PABLat 
+              ---                    ---        ...   deg      deg   
+   -------------------------- ----------------- ... -------- --------
+   3552 Don Quixote (1983 SA) 2010-Jan-01 00:00 ...   8.0371  18.9349
+   3552 Don Quixote (1983 SA) 2011-Jan-01 00:00 ...  85.4082  34.5611
+   3552 Don Quixote (1983 SA) 2012-Jan-01 00:00 ... 109.2959  30.3834
+   3552 Don Quixote (1983 SA) 2013-Jan-01 00:00 ... 123.0777   26.136
+   3552 Don Quixote (1983 SA) 2014-Jan-01 00:00 ... 133.9392  21.8962
+   3552 Don Quixote (1983 SA) 2015-Jan-01 00:00 ... 144.2701  17.1908
+   3552 Don Quixote (1983 SA) 2016-Jan-01 00:00 ... 156.1007  11.1447
+   3552 Don Quixote (1983 SA) 2017-Jan-01 00:00 ... 174.0245   1.3487
+   3552 Don Quixote (1983 SA) 2018-Jan-01 00:00 ... 228.9956 -21.6723
+   3552 Don Quixote (1983 SA) 2019-Jan-01 00:00 ...  45.1979  32.3885
 
 
-Please note the formatting of this table, which is done
-automatically. Above the dashes in the first two lines, you have the
-column name and its unit. Every column is assigned a unit from
-`astropy units`_. We will learn later how to use these units.
+Please note the formatting of this table, which is done automatically. Above the
+dashes in the first two lines, you have the column name and its unit. Every
+column is assigned a unit from `astropy units`_. We will learn later how to use
+these units.
 
 
 Columns
 -------
 
-We can get at list of all the columns in this table with
-
+We can get at list of all the columns in this table with:
 .. code-block:: python
 
    >>> print(eph.columns)
-   <TableColumns names=('targetname','datetime_str','datetime_jd','H','G','solar_presence','flags','RA','DEC','RA_rate','DEC_rate','AZ','EL','airmass','magextinct','V','surfbright','illumination','EclLon','EclLat','r','r_rate','delta','delta_rate','lighttime','elong','elongFlag','alpha','sunTargetPA','velocityPA','ObsEclLon','ObsEclLat','GlxLon','GlxLat','RA_3sigma','DEC_3sigma')>
+   <TableColumns names=('targetname','datetime_str','datetime_jd','H','G','solar_presence','flags','RA','DEC','RA_app','DEC_app','RA_rate','DEC_rate','AZ','EL','AZ_rate','EL_rate','sat_X','sat_Y','sat_PANG','siderealtime','airmass','magextinct','V','surfbright','illumination','illum_defect','sat_sep','sat_vis','ang_width','PDObsLon','PDObsLat','PDSunLon','PDSunLat','SubSol_ang','SubSol_dist','NPole_ang','NPole_dist','EclLon','EclLat','r','r_rate','delta','delta_rate','lighttime','vel_sun','vel_obs','elong','elongFlag','alpha','lunar_elong','lunar_illum','sat_alpha','sunTargetPA','velocityPA','OrbPlaneAng','constellation','TDB-UT','ObsEclLon','ObsEclLat','NPole_RA','NPole_DEC','GlxLon','GlxLat','solartime','earth_lighttime','RA_3sigma','DEC_3sigma','SMAA_3sigma','SMIA_3sigma','Theta_3sigma','Area_3sigma','RSS_3sigma','r_3sigma','r_rate_3sigma','SBand_3sigma','XBand_3sigma','DoppDelay_3sigma','true_anom','hour_angle','alpha_true','PABLon','PABLat')>
 
-
-We can address each column individually by indexing it using its name
-as provided in this list. For instance, we can get all RAs for Don
-Quixote by using
+We can address each column individually by indexing it using its name as
+provided in this list. For instance, we can get all RAs for Don Quixote by using
 
 
 .. code-block:: python
 
    >>> print(eph['RA'])
-
-      RA
-      deg
+       RA   
+      deg   
    ---------
-   209.43762
-   357.85696
-    86.22996
-   122.10393
-   137.91137
-   148.42444
-         ...
-   136.60019
-   147.44945
-   156.58965
-   166.32128
-   180.69918
+   345.50204
+    78.77158
+   119.85659
+   136.60021
+   147.44947
+   156.58967
+   166.32129
+    180.6992
    232.11974
-    16.10662
-   Length = 37 rows
+     16.1066
 
 
-This column is formatted like the entire table; it has a column name
-and a unit. We can select several columns at a time, for instance RA
-and DEC for each epoch
+This column is formatted like the entire table; it has a column name and a unit.
+We can select several columns at a time, for instance RA and DEC for each epoch
 
 .. code-block:: python
-
    >>> print(eph['datetime_str', 'RA', 'DEC'])
-      datetime_str       RA       DEC
-          ---           deg       deg
-   ----------------- --------- ---------
-   1983-Jan-01 00:00 209.43762 -25.92118
-   1984-Jan-01 00:00 357.85696  28.74791
-   1985-Jan-01 00:00  86.22996  60.90524
-   1986-Jan-01 00:00 122.10393  53.19306
-   1987-Jan-01 00:00 137.91137  44.95184
-   1988-Jan-01 00:00 148.42444  37.01774
-                 ...       ...       ...
-   2013-Jan-01 00:00 136.60019  45.82408
-   2014-Jan-01 00:00 147.44945  37.79874
-   2015-Jan-01 00:00 156.58965  29.23058
-   2016-Jan-01 00:00 166.32128  18.48173
-   2017-Jan-01 00:00 180.69918   1.20453
-   2018-Jan-01 00:00 232.11974 -37.95539
-   2019-Jan-01 00:00  16.10662  45.50296
-   Length = 37 rows
+      datetime_str       RA      DEC   
+          ---           deg      deg   
+   ----------------- --------- --------
+   2010-Jan-01 00:00 345.50204 13.43621
+   2011-Jan-01 00:00  78.77158 61.48831
+   2012-Jan-01 00:00 119.85659 54.21955
+   2013-Jan-01 00:00 136.60021 45.82409
+   2014-Jan-01 00:00 147.44947 37.79876
+   2015-Jan-01 00:00 156.58967 29.23058
+   2016-Jan-01 00:00 166.32129 18.48174
+   2017-Jan-01 00:00  180.6992  1.20453
+   2018-Jan-01 00:00 232.11974 -37.9554
+   2019-Jan-01 00:00   16.1066 45.50296
 
 
-We can use the same representation to do math with these columns. For
-instance, let's calculate the total rate of the object by calculating
-the geometric mean of 'RA_rate' and 'DEC_rate':
+We can use the same representation to do math with these columns. For instance,
+let's calculate the total rate of the object by summing 'RA_rate' and 'DEC_rate'
+in quadrature:
 
 .. code-block:: python
 
    >>> import numpy as np
    >>> print(np.sqrt(eph['RA_rate']**2 + eph['DEC_rate']**2))
-      dRA*cosD
+        dRA*cosD     
    ------------------
-   58.69696313151559
-   51.59679292260421
-   25.793090188451636
-   20.994411962530627
-   17.258738465267385
-   14.376579229218054
-   11.73881436960752
-                  ...
-   17.679841379965037
-   14.775806762375074
-   11.874884148540735
-    7.183280208160058
-    7.2955985010416375
-   94.84821056509183
-   23.952455011994072
+    86.18728612153883
+   26.337249029653798
+   21.520859656742434
+   17.679843758686584
+   14.775809055378625
+   11.874886005626538
+    7.183281978025435
+    7.295600209387093
+    94.84824546372009
+   23.952470898018017
 
-Please note that the column is wrong (it uses the title of the first
-column used), and that there is no unit (this will be fixed with the
-use of astropy QTables in the future).
+
+Please note that the column name is wrong (copied from the name of the first
+column used), and that the unit is lost.
 
 Units
 -----
@@ -459,56 +437,45 @@ h`` - arcseconds per hour:
 .. code-block:: python
 
    >>> print(eph['RA_rate'])
-    RA_rate
+    RA_rate  
    arcsec / h
    ----------
-     44.35495
-     49.20015
-     -24.5561
-     -20.0651
-     -15.0293
-     -11.6761
-          ...
+     72.35438
+     -23.8239
+     -20.7151
      -15.5509
       -12.107
      -9.32616
      -5.80004
-     3.115849
-      85.2272
-     19.02546
-   Length = 37 rows
+     3.115853
+     85.22719
+     19.02548
 
 
-The unit of this column can be easily converted to any other unit
-describing the same dimensions. For instance, we can turn ``RA_rate``
-into ``arcsec / s``:
+The unit of this column can be easily converted to any other unit describing the
+same dimensions. For instance, we can turn ``RA_rate`` into ``arcsec / s``:
 
 .. code-block:: python
 
    >>> eph['RA_rate'].convert_unit_to('arcsec/s')
    >>> print(eph['RA_rate'])
-          RA_rate
-         arcsec / s
+          RA_rate        
+         arcsec / s      
    ----------------------
-     0.012320819444444445
-     0.013666708333333333
-    -0.006821138888888889
-    -0.005573638888888889
-    -0.004174805555555556
-    -0.003243361111111111
-                      ...
+      0.02009843888888889
+   -0.0066177499999999995
+    -0.005754194444444445
     -0.004319694444444445
    -0.0033630555555555553
    -0.0025905999999999998
    -0.0016111222222222222
-    0.0008655136111111111
-      0.02367422222222222
-               0.00528485
-   Length = 37 rows
+    0.0008655147222222222
+     0.023674219444444443
+     0.005284855555555556
 
 
-Please refer to the `astropy table`_ and `astropy units`_
-documentations for more information.
+Please refer to the `astropy table`_ and `astropy units`_ documentations for
+more information.
 
 Hints and Tricks
 ================
@@ -517,49 +484,46 @@ Checking the original JPL Horizons output
 -----------------------------------------
 
 Once either of the query methods has been called, the retrieved raw response is
-stored in the attribute ``raw_response``. Inspecting this response can help
-to understand issues with your query, or you can process the results
-differently.
+stored in the attribute ``raw_response``. Inspecting this response can help to
+understand issues with your query, or you can process the results differently.
 
-For all query types, the query URI (the URI is what you would put into
-the URL field of your web browser) that is used to request the data
-from the JPL Horizons server can be obtained from the
-:class:`~astroquery.jplhorizons.HorizonsClass` object after a query
-has been performed (before the query only ``None`` would be returned):
+For all query types, the query URI (the URI is what you would put into the URL
+field of your web browser) that is used to request the data from the JPL
+Horizons server can be obtained from the
+:class:`~astroquery.jplhorizons.HorizonsClass` object after a query has been
+performed (before the query only ``None`` would be returned):
 
    >>> print(obj.uri)
-   https://ssd.jpl.nasa.gov/api/horizons.api?format=text&EPHEM_TYPE=VECTORS&OUT_UNITS=AU-D&COMMAND=%222012+TC4%3B%22&CENTER=%27257%27&CSV_FORMAT=%22YES%22&REF_PLANE=ECLIPTIC&REF_SYSTEM=ICRF&TP_TYPE=ABSOLUTE&VEC_LABELS=YES&OBJ_DATA=YES&START_TIME=2017-10-01&STOP_TIME=2017-10-02&STEP_SIZE=10m
+   https://ssd.jpl.nasa.gov/api/horizons.api?format=text&EPHEM_TYPE=OBSERVER&QUANTITIES=%271%2C2%2C3%2C4%2C5%2C6%2C7%2C8%2C9%2C10%2C11%2C12%2C13%2C14%2C15%2C16%2C17%2C18%2C19%2C20%2C21%2C22%2C23%2C24%2C25%2C26%2C27%2C28%2C29%2C30%2C31%2C32%2C33%2C34%2C35%2C36%2C37%2C38%2C39%2C40%2C41%2C42%2C43%27&COMMAND=%223552%22&SOLAR_ELONG=%220%2C180%22&LHA_CUTOFF=0&CSV_FORMAT=YES&CAL_FORMAT=BOTH&ANG_FORMAT=DEG&APPARENT=AIRLESS&REF_SYSTEM=ICRF&EXTRA_PREC=NO&CENTER=%27568%27&START_TIME=%222010-01-01%22&STOP_TIME=%222019-12-31%22&STEP_SIZE=%221y%22&SKIP_DAYLT=NO
 
-If your query failed, it might be useful for you to put the URI into a
-web browser to get more information why it failed. Please note that
-``uri`` is an attribute of
-:class:`~astroquery.jplhorizons.HorizonsClass` and not the results
+If your query failed, it might be useful for you to put the URI into a web
+browser to get more information why it failed. Please note that ``uri`` is an
+attribute of :class:`~astroquery.jplhorizons.HorizonsClass` and not the results
 table.
 
 Date Formats
 ------------
 
-JPL Horizons puts somewhat strict guidelines on the date formats:
-individual epochs have to be provided as Julian Dates, whereas epoch
-ranges have to be provided as ISO dates (YYYY-MM-DD HH-MM UT). If you
-have your epoch dates in one of these formats but you need the other
-format, make use of :class:`astropy.time.Time` for the conversion. An
-example is provided here:
+JPL Horizons puts somewhat strict guidelines on the date formats: individual
+epochs have to be provided as Julian dates, whereas epoch ranges have to be
+provided as ISO dates (YYYY-MM-DD HH-MM UT). If you have your epoch dates in one
+of these formats but you need the other format, make use of
+:class:`astropy.time.Time` for the conversion. An example is provided here:
 
 .. doctest-requires:: astropy
 
     >>> from astropy.time import Time
     >>> mydate_fromiso = Time('2018-07-23 15:55:23')  # pass date as string
-    >>> print(mydate_fromiso.jd)  # convert Time object to Julian Date
+    >>> print(mydate_fromiso.jd)  # convert Time object to Julian date
     2458323.163460648
     >>> mydate_fromjd = Time(2458323.163460648, format='jd')
     >>> print(mydate_fromjd.iso) # convert Time object to ISO
     2018-07-23 15:55:23.000
 
-:class:`astropy.time.Time` allows you to convert dates across a wide
-range of formats. Please note that when reading in Julian Dates, you
-have to specify the date format as ``'jd'``, as the integer passed to
-:class:`~astropy.time.Time` is ambiguous.
+:class:`astropy.time.Time` allows you to convert dates across a wide range of
+formats. Please note that when reading in Julian dates, you have to specify the
+date format as ``'jd'``, as number passed to :class:`~astropy.time.Time` is
+ambiguous.
 
 Keep Queries Short
 ------------------
@@ -578,8 +542,8 @@ Reference Frames
 
 The coordinate reference frame for Horizons output is controlled by the
 ``refplane`` and ``refsystem`` keyword arguments.  See the `Horizons
-documentation`_ for details. Some
-output reference frames are included in astropy's `~astropy.coordinates`
+documentation`_ for details. Some output reference frames are included in
+astropy's `~astropy.coordinates`:
 
 +----------------+--------------+----------------+----------------+---------------------------------+
 | Method         | ``location`` | ``refplane``   | ``refsystem``  | astropy frame                   |
@@ -600,8 +564,7 @@ For example, get the barycentric coordinates of Jupiter as an astropy
    >>> from astropy.time import Time
    >>> from astroquery.jplhorizons import Horizons
    >>> epoch = Time('2021-01-01')
-   >>> q = Horizons('599', id_type='majorbody', location='@0',
-   ...              epochs=epoch.tdb.jd)
+   >>> q = Horizons('599', location='@0', epochs=epoch.tdb.jd)
    >>> tab = q.vectors(refplane='earth')
    >>> c = SkyCoord(tab['x'].quantity, tab['y'].quantity, tab['z'].quantity,
    ...              representation_type='cartesian', frame='icrs',
@@ -616,10 +579,11 @@ For example, get the barycentric coordinates of Jupiter as an astropy
 Acknowledgements
 ================
 
-This submodule makes use of the `JPL Horizons <https://ssd.jpl.nasa.gov/horizons.cgi>`_ system.
+This submodule makes use of the `JPL Horizons
+<https://ssd.jpl.nasa.gov/horizons/>`_ system.
 
-The development of this submodule is in part funded through NASA PDART
-Grant No. 80NSSC18K0987 to the `sbpy project <http://sbpy.org>`_.
+The development of this submodule is in part funded through NASA PDART Grant No.
+80NSSC18K0987 to the `sbpy project <http://sbpy.org>`_.
 
 
 Reference/API
@@ -632,5 +596,5 @@ Reference/API
 .. _MPC Observatory codes: http://minorplanetcenter.net/iau/lists/ObsCodesF.html
 .. _astropy table: http://docs.astropy.org/en/stable/table/index.html
 .. _astropy units: http://docs.astropy.org/en/stable/units/index.html
-.. _Definition of Observer Table Quantities: http://ssd.jpl.nasa.gov/?horizons_doc#table_quantities
-.. _Horizons documentation: http://ssd.jpl.nasa.gov/?horizons_doc
+.. _Definition of Observer Table Quantities: https://ssd.jpl.nasa.gov/horizons/manual.html#observer-table
+.. _Horizons documentation: https://ssd.jpl.nasa.gov/horizons/manual.html#observer-table

--- a/docs/jplhorizons/jplhorizons.rst
+++ b/docs/jplhorizons/jplhorizons.rst
@@ -6,11 +6,18 @@
 JPL Horizons Queries (`astroquery.jplhorizons`/astroquery.solarsystem.jpl.horizons)
 ***********************************************************************************
 
+.. Warning::
+
+   The default search behavior has changed.  In v0.4.3 and earlier, the default
+   ``id_type`` was ``'smallbody'``.  With v0.4.4, the default is ``None``, which
+   aligns with JPL Hoirizons's `default behavior
+   <https://ssd.jpl.nasa.gov/?horizons_doc#selection>`_: search major bodies
+   first, and if no major bodies are found, then search small bodies.
+
 .. Note::
 
    Due to serverside changes the ``jplhorizons`` module requires astroquery v0.4.1 or newer.
    Previous versions are not expected to function, please upgrade the package if you observe any issues.
-
 
 Overview
 ========


### PR DESCRIPTION
This PR is in response to issue #1742.  Queries with `id_type == 'majorbody'` imply only major solar system bodies will be matched, but the behavior is that if no major body matches the query string, a small body search is performed.  Furthermore, our current default is to search for small bodies, but it may be better to align our default with Horizons's default.

Documentation on the current API behavior: https://ssd.jpl.nasa.gov/horizons/manual.html#select

* Rename `'majorbody'` to `''`, in better alignment with the API.
* Set the `id_type` default to `None`, but preserve the current behavior as a `'smallbody'`.  In the future, replace this with `''`.
* Raise a deprecation warning if `'majorbody'` or `None` are used.