### PR TITLE
MNT: Bump minversion of astropy and numpy

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -41,6 +41,7 @@ Infrastructure, Utility and Other Changes and Additions
   The API for JPLspec's ``lookup_table.find`` function returns a dictionary
   instead of values (for compatibility w/CDMS).  [#2144]
 
+- Versions of astropy <4 and numpy <1.16 are no longer supported. [#2163]
 
 0.4.3 (2021-07-07)
 ==================

--- a/README.rst
+++ b/README.rst
@@ -43,7 +43,7 @@ Installation and Requirements
 -----------------------------
 
 Astroquery works with Python 3.7 or later.
-As an `astropy`_ affiliate, astroquery requires `astropy`_ version 3.1.2 or later.
+As an `astropy`_ affiliate, astroquery requires `astropy`_ version 4.0 or later.
 
 astroquery uses the `requests <http://docs.python-requests.org/en/latest/>`_
 module to communicate with the internet.  `BeautifulSoup

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -72,8 +72,8 @@ Astroquery works with Python 3.7 or later.
 
 The following packages are required for astroquery installation & use:
 
-* `numpy <http://www.numpy.org>`_ >= 1.15
-* `astropy <http://www.astropy.org>`__ (>=3.1.2)
+* `numpy <http://www.numpy.org>`_ >= 1.16
+* `astropy <http://www.astropy.org>`__ (>=4)
 * `pyVO`_ (>=1.1)
 * `requests <http://docs.python-requests.org/en/latest/>`_
 * `keyring <https://pypi.python.org/pypi/keyring>`_

--- a/setup.cfg
+++ b/setup.cfg
@@ -129,8 +129,8 @@ exclude = _astropy_init.py,version.py
 
 [options]
 install_requires=
-   numpy>=1.15.0
-   astropy>=3.1.2
+   numpy>=1.16
+   astropy>=4.0
    requests>=2.4.3
    beautifulsoup4>=4.3.2
    html5lib>=0.999

--- a/setup.cfg
+++ b/setup.cfg
@@ -50,6 +50,7 @@ filterwarnings =
     ignore::astropy.io.votable.exceptions.W49
     ignore::astropy.io.votable.exceptions.W21
     ignore::astropy.io.votable.exceptions.W42
+    ignore:leap-second auto-update failed:astropy.utils.exceptions.AstropyWarning
     ignore:numpy.ndarray size changed:RuntimeWarning
     ignore:OverflowError converting::astropy
 # Upstream, remove when fixed, PRs have been opened

--- a/tox.ini
+++ b/tox.ini
@@ -34,7 +34,7 @@ deps =
 # minimum numpy to 1.15. mpl while not a dependency, it's required for the
 # tests, and would pull up a newer numpy version if not pinned.
 
-    oldestdeps: astropy==4.0.6
+    oldestdeps: astropy==4.0
     oldestdeps: numpy==1.16
     oldestdeps: matplotlib==3.3.*
     cov: codecov

--- a/tox.ini
+++ b/tox.ini
@@ -34,8 +34,8 @@ deps =
 # minimum numpy to 1.15. mpl while not a dependency, it's required for the
 # tests, and would pull up a newer numpy version if not pinned.
 
-    oldestdeps: astropy==3.1.2
-    oldestdeps: numpy==1.15
+    oldestdeps: astropy==4.0.6
+    oldestdeps: numpy==1.16
     oldestdeps: matplotlib==3.3.*
     cov: codecov
 


### PR DESCRIPTION
* `astropy>=4`
* `numpy>=1.16` (because of `astropy` bump)