### PR TITLE
allow for easy import of CloudAccess() from cloud.py

### DIFF
--- a/astroquery/mast/__init__.py
+++ b/astroquery/mast/__init__.py
@@ -34,6 +34,7 @@ from .cutouts import TesscutClass, Tesscut, ZcutClass, Zcut
 from .observations import Observations, ObservationsClass, MastClass, Mast
 from .collections import Catalogs, CatalogsClass
 from .core import MastQueryWithLogin
+from .cloud import CloudAccess
 from . import utils
 
 __all__ = ['Observations', 'ObservationsClass',
@@ -42,4 +43,5 @@ __all__ = ['Observations', 'ObservationsClass',
            'Tesscut', 'TesscutClass',
            'Zcut', 'ZcutClass',
            'Conf', 'conf', 'utils',
+	   'CloudAccess'
            ]


### PR DESCRIPTION
The `cloud.py` script looks to have a tool that allows for anonymous access to S3. I added the CloudAccess class import to __init__.py for easy import directly from astroquery.mast. 

Side question: The `observations.py` Observations class has similar methods to the ones in CloudAccess class, but prohibits log in when `Observations._cloud_connection` is set to None, so it doesn't facilitate anonymous access without an AWS account. Should these methods be replaced with the ones in CloudAccess? Is there a reason to keep them there? 