### PR TITLE
Remove `six`

### DIFF
--- a/astroquery/alma/core.py
+++ b/astroquery/alma/core.py
@@ -12,8 +12,7 @@ from pkg_resources import resource_filename
 from bs4 import BeautifulSoup
 import pyvo
 
-from six.moves.urllib_parse import urljoin
-import six
+from urllib.parse import urljoin
 from astropy.table import Table, Column, vstack
 from astroquery import log
 from astropy.utils import deprecated
@@ -567,7 +566,7 @@ class AlmaClass(QueryWithLogin):
         """
         if uids is None:
             raise AttributeError('UIDs required')
-        if isinstance(uids, six.string_types + (np.bytes_,)):
+        if isinstance(uids, (str, bytes)):
             uids = [uids]
         if not isinstance(uids, (list, tuple, np.ndarray)):
             raise TypeError("Datasets must be given as a list of strings.")
@@ -811,7 +810,7 @@ class AlmaClass(QueryWithLogin):
         downloaded_files : list
             A list of the downloaded file paths
         """
-        if isinstance(uids, six.string_types + (np.bytes_,)):
+        if isinstance(uids, (str, bytes)):
             uids = [uids]
         if not isinstance(uids, (list, tuple, np.ndarray)):
             raise TypeError("Datasets must be given as a list of strings.")
@@ -1073,7 +1072,7 @@ class AlmaClass(QueryWithLogin):
             data from an ASDM tarball
         """
 
-        if isinstance(urls, six.string_types):
+        if isinstance(urls, str):
             urls = [urls]
         if not isinstance(urls, (list, tuple, np.ndarray)):
             raise TypeError("Datasets must be given as a list of strings.")
@@ -1174,7 +1173,6 @@ class AlmaClass(QueryWithLogin):
         March 2020 - should be removed along with stage_data_prefeb2020
         """
         from ..utils import url_helpers
-        from six import iteritems
         columns = {'mous_uid': [], 'URL': [], 'size': []}
         for entry in data['node_data']:
             # de_type can be useful (e.g., MOUS), but it is not necessarily
@@ -1212,7 +1210,7 @@ class AlmaClass(QueryWithLogin):
 
         columns['size'] = u.Quantity(columns['size'], u.Gbyte)
 
-        tbl = Table([Column(name=k, data=v) for k, v in iteritems(columns)])
+        tbl = Table([Column(name=k, data=v) for k, v in columns.items()])
         return tbl
 
     def get_project_metadata(self, projectid, cache=True):

--- a/astroquery/alma/tests/test_alma.py
+++ b/astroquery/alma/tests/test_alma.py
@@ -1,9 +1,9 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
+from io import StringIO
 import os
 
 import pytest
 from unittest.mock import patch, Mock
-from six import StringIO
 
 from astropy import units as u
 from astropy import coordinates as coord

--- a/astroquery/astrometry_net/core.py
+++ b/astroquery/astrometry_net/core.py
@@ -3,8 +3,6 @@
 
 import json
 
-import six
-from six import string_types
 from astropy.io import fits
 from astroquery import log
 from astropy.stats import sigma_clipped_stats
@@ -137,7 +135,7 @@ class AstrometryNetClass(BaseQuery):
         """
 
         # Check the types and values
-        for key, value in six.iteritems(settings):
+        for key, value in settings.items():
             if key not in self._constraints or value is None:
                 message = ('Setting {} is not allowed. Display all of '
                            'the allowed settings with: '
@@ -284,7 +282,7 @@ class AstrometryNetClass(BaseQuery):
         For a list of the remaining settings, use the method
         `~AstrometryNetClass.show_allowed_settings`.
         """
-        settings = {k: v for k, v in six.iteritems(settings) if v is not None}
+        settings = {k: v for k, v in settings.items() if v is not None}
         self._validate_settings(settings)
         if self._session_id is None:
             self._login()
@@ -363,7 +361,7 @@ class AstrometryNetClass(BaseQuery):
                 settings['center_ra'] = center.ra.degree
                 settings['center_dec'] = center.dec.degree
 
-        settings = {k: v for k, v in six.iteritems(settings) if v is not None}
+        settings = {k: v for k, v in settings.items() if v is not None}
         self._validate_settings(settings)
 
         if force_image_upload or self._no_source_detector:

--- a/astroquery/astrometry_net/tests/test_astrometry_net.py
+++ b/astroquery/astrometry_net/tests/test_astrometry_net.py
@@ -4,7 +4,6 @@ import json
 from distutils.version import LooseVersion
 
 import pytest
-import six
 
 from ...utils.testing_tools import MockResponse
 from ...exceptions import (InvalidQueryError)
@@ -87,7 +86,7 @@ def test_setting_validation_basic():
     anet = AstrometryNet()
     # This gets us a list of settings, their types, and restrictions.
     constraints = anet._constraints
-    for constraint, vals in six.iteritems(constraints):
+    for constraint, vals in constraints.items():
         if vals['type'] == str or vals['type'] == bool:
             settings = {constraint: 'asdiuhiuas'}
             with pytest.raises(ValueError) as e:

--- a/astroquery/atomic/core.py
+++ b/astroquery/atomic/core.py
@@ -1,9 +1,7 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 
-from six.moves.urllib import parse as urlparse
-from six.moves import map, zip
-from six import StringIO
-import six
+from io import StringIO
+from urllib import parse as urlparse
 
 from collections import defaultdict
 
@@ -292,7 +290,7 @@ class AtomicLineListClass(BaseQuery):
         # only overwrite payload's values if the `input` value is not None
         # to avoid overwriting of the form's default values
         payload = self._default_form_values.copy()
-        for k, v in six.iteritems(input):
+        for k, v in input.items():
             if v is not None:
                 payload[k] = v
         url = urlparse.urljoin(self.FORM_URL, self._default_form.get('action'))
@@ -346,7 +344,7 @@ class AtomicLineListClass(BaseQuery):
 
         # avoid values with size 1 lists
         d = dict(res)
-        for k, v in six.iteritems(d):
+        for k, v in d.items():
             if len(v) == 1:
                 d[k] = v[0]
         return d

--- a/astroquery/besancon/core.py
+++ b/astroquery/besancon/core.py
@@ -8,7 +8,7 @@ import re
 import os
 import warnings
 from astropy.io import ascii
-from six.moves.urllib_error import URLError
+from urllib.error import URLError
 from collections import OrderedDict
 from ..query import BaseQuery
 from ..utils import commons, prepend_docstr_nosections, async_to_sync

--- a/astroquery/besancon/tests/test_besancon.py
+++ b/astroquery/besancon/tests/test_besancon.py
@@ -4,7 +4,6 @@ import os
 from contextlib import contextmanager
 import pytest
 from astropy.io.ascii.tests.common import assert_equal
-from six import string_types
 from ... import besancon
 from ...utils import commons
 from ...utils.testing_tools import MockResponse
@@ -65,7 +64,7 @@ def patch_post(request):
 def patch_get_readable_fileobj(request):
     @contextmanager
     def get_readable_fileobj_mockreturn(filename, **kwargs):
-        if isinstance(filename, string_types):
+        if isinstance(filename, str):
             if '1376235131.430670' in filename:
                 is_binary = kwargs.get('encoding', None) == 'binary'
                 file_obj = open(data_path('1376235131.430670.resu'),

--- a/astroquery/cadc/tests/test_cadctap.py
+++ b/astroquery/cadc/tests/test_cadctap.py
@@ -5,6 +5,8 @@ CadcClass TAP plus
 =============
 
 """
+from io import BytesIO
+from urllib.parse import urlsplit, parse_qs
 import os
 import sys
 
@@ -12,8 +14,6 @@ from astropy.table import Table as AstroTable
 from astropy.io.fits.hdu.hdulist import HDUList
 from astropy.io.votable.tree import VOTableFile, Resource, Table, Field
 from astropy.io.votable import parse
-from six import BytesIO
-from six.moves.urllib_parse import urlsplit, parse_qs
 from astroquery.utils.commons import parse_coordinates, FileContainer
 from astropy import units as u
 from astropy.utils.exceptions import AstropyDeprecationWarning

--- a/astroquery/cosmosim/core.py
+++ b/astroquery/cosmosim/core.py
@@ -12,9 +12,9 @@ import smtplib
 import re
 import os
 import threading
-from six.moves.email_mime_multipart import MIMEMultipart
-from six.moves.email_mime_base import MIMEBase, message
-from six.moves.email_mime_text import MIMEText
+from email.mime.multipart import MIMEMultipart
+from email.mime.base import MIMEBase, message
+from email.mime.text import MIMEText
 
 # Astropy imports
 from astropy.table import Table

--- a/astroquery/esa/hubble/core.py
+++ b/astroquery/esa/hubble/core.py
@@ -25,7 +25,7 @@ from astroquery.utils.tap.core import TapPlus
 from astroquery.utils.tap.model import modelutils
 from astroquery.query import BaseQuery
 from astropy.table import Table
-from six import BytesIO
+from io import BytesIO
 import shutil
 import os
 import json

--- a/astroquery/eso/core.py
+++ b/astroquery/eso/core.py
@@ -11,8 +11,7 @@ import numpy as np
 import re
 from bs4 import BeautifulSoup
 
-from six import BytesIO
-import six
+from io import BytesIO
 from astropy.table import Table, Column
 from astroquery import log
 
@@ -347,7 +346,7 @@ class EsoClass(QueryWithLogin):
             survey_form = self._request("GET", url, cache=cache)
             query_dict = kwargs
             query_dict["wdbo"] = "csv/download"
-            if isinstance(surveys, six.string_types):
+            if isinstance(surveys, str):
                 surveys = surveys.split(",")
             query_dict['collection_name'] = surveys
             if self.ROW_LIMIT >= 0:
@@ -510,7 +509,7 @@ class EsoClass(QueryWithLogin):
 
         """
         _schema_product_ids = schema.Schema(
-            schema.Or(Column, [schema.Or(*six.string_types)]))
+            schema.Or(Column, [schema.Schema(str)]))
         _schema_product_ids.validate(product_ids)
         # Get all headers
         result = []
@@ -678,7 +677,7 @@ class EsoClass(QueryWithLogin):
             raise ValueError("invalid value for 'with_calib', "
                              "it must be 'none', 'raw' or 'processed'")
 
-        if isinstance(datasets, six.string_types):
+        if isinstance(datasets, str):
             return_list = False
             datasets = [datasets]
         else:

--- a/astroquery/eso/tests/test_eso_remote.py
+++ b/astroquery/eso/tests/test_eso_remote.py
@@ -3,7 +3,6 @@ import numpy as np
 import pytest
 import tempfile
 import shutil
-import six
 from ...exceptions import LoginError
 
 from ...eso import Eso
@@ -126,10 +125,10 @@ class TestEso:
         assert len(result) > 0
         assert "MIDI.2014-07-25T02:03:11.561" in result[0]
         result = eso.retrieve_data("MIDI.2014-07-25T02:03:11.561")
-        assert isinstance(result, six.string_types)
+        assert isinstance(result, str)
         result = eso.retrieve_data("MIDI.2014-07-25T02:03:11.561",
                                    request_all_objects=True)
-        assert isinstance(result, six.string_types)
+        assert isinstance(result, str)
 
     @pytest.mark.skipif('not Eso.USERNAME')
     def test_retrieve_data_twice(self):

--- a/astroquery/gaia/core.py
+++ b/astroquery/gaia/core.py
@@ -21,7 +21,6 @@ from astroquery.utils import commons
 from astroquery import log
 from astropy import units
 from astropy.units import Quantity
-import six
 import zipfile
 from astroquery.utils.tap import taputils
 from . import conf
@@ -250,7 +249,7 @@ class GaiaClass(TapPlus):
                                  "'G', 'BP' and 'RP)" % band)
             else:
                 params_dict['BAND'] = band
-        if isinstance(ids, six.string_types):
+        if isinstance(ids, str):
             ids_arg = ids
         else:
             if isinstance(ids, int):

--- a/astroquery/gaia/tests/DummyTapHandler.py
+++ b/astroquery/gaia/tests/DummyTapHandler.py
@@ -14,7 +14,7 @@ Created on 30 jun. 2016
 
 
 """
-from six.moves.urllib.parse import urlencode
+from urllib.parse import urlencode
 
 CONTENT_TYPE_POST_DEFAULT = "application/x-www-form-urlencoded"
 

--- a/astroquery/heasarc/core.py
+++ b/astroquery/heasarc/core.py
@@ -1,7 +1,7 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 
 import warnings
-from six import StringIO, BytesIO
+from io import StringIO, BytesIO
 from astropy.table import Table
 from astropy.io import fits
 from astropy import coordinates

--- a/astroquery/lamda/core.py
+++ b/astroquery/lamda/core.py
@@ -5,7 +5,7 @@ from astropy import table
 from astroquery import log
 from astropy.utils.console import ProgressBar
 from bs4 import BeautifulSoup
-from six.moves import urllib_parse as urlparse
+from urllib import parse as urlparse
 import re
 import warnings
 

--- a/astroquery/mast/observations.py
+++ b/astroquery/mast/observations.py
@@ -26,7 +26,7 @@ from astroquery import log
 from astropy.utils import deprecated
 from astropy.utils.console import ProgressBarOrSpinner
 
-from six.moves.urllib.parse import quote as urlencode
+from urllib.parse import quote as urlencode
 
 from ..query import QueryWithLogin
 from ..utils import commons, async_to_sync

--- a/astroquery/nasa_ads/core.py
+++ b/astroquery/nasa_ads/core.py
@@ -8,7 +8,7 @@ Module to search the SAO/NASA Astrophysics Data System
 import os
 
 from astropy.table import Table
-from six.moves.urllib.parse import quote as urlencode
+from urllib.parse import quote as urlencode
 
 from ..query import BaseQuery
 from ..utils import async_to_sync

--- a/astroquery/nist/core.py
+++ b/astroquery/nist/core.py
@@ -1,19 +1,16 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 
 
+import html
 import re
 
 import astropy.units as u
 import astropy.io.ascii as asciitable
-from six import PY2
 
 from ..query import BaseQuery
 from ..utils import async_to_sync, prepend_docstr_nosections
 from . import conf
 from ..exceptions import TableParseError
-
-if not PY2:
-    import html  # html is available in Py3 stdlib, but not in Py2
 
 __all__ = ['Nist', 'NistClass']
 
@@ -173,8 +170,7 @@ class NistClass(BaseQuery):
         try:
             table = _strip_blanks(pre)
             table = links_re.sub(r'\1', table)
-            if not PY2:
-                table = html.unescape(table)
+            table = html.unescape(table)
             table = asciitable.read(table, Reader=asciitable.FixedWidth,
                                     data_start=3, delimiter='|')
             return table

--- a/astroquery/nist/tests/test_nist_remote.py
+++ b/astroquery/nist/tests/test_nist_remote.py
@@ -5,7 +5,6 @@ import numpy as np
 
 from astropy.table import Table
 import astropy.units as u
-from six import PY2  # noqa
 
 import pytest
 
@@ -27,7 +26,6 @@ class TestNist:
         # (regression test for 1355)
         assert np.all(result['TP'] == 'T8637')
 
-    @pytest.mark.skipif('PY2')
     def test_unescape_html(self):
         response = nist.core.Nist.query_async(4333 * u.AA, 4334 * u.AA, "V I")
         assert '&dagger;' in response.text

--- a/astroquery/nrao/core.py
+++ b/astroquery/nrao/core.py
@@ -7,11 +7,12 @@ import warnings
 import functools
 import keyring
 
+from io import BytesIO
+
 import numpy as np
 import astropy.units as u
 import astropy.io.votable as votable
 from astropy import coordinates
-import six
 from astropy.table import Table
 from astroquery import log
 from bs4 import BeautifulSoup
@@ -181,19 +182,19 @@ class NraoClass(QueryWithLogin):
             freq_str = ""
 
         obs_bands = kwargs.get('obs_band', 'all')
-        if isinstance(obs_bands, six.string_types):
+        if isinstance(obs_bands, str):
             obs_bands = obs_bands.upper()
         elif isinstance(obs_bands, (list, tuple)):
             obs_bands = [x.upper() for x in obs_bands]
 
         telescope_config = kwargs.get('telescope_config', 'all')
-        if isinstance(telescope_config, six.string_types):
+        if isinstance(telescope_config, str):
             telescope_config = telescope_config.upper()
         elif isinstance(telescope_config, (list, tuple)):
             telescope_config = [x.upper() for x in telescope_config]
 
         telescope_ = kwargs.get('telescope', 'all')
-        if isinstance(telescope_, six.string_types):
+        if isinstance(telescope_, str):
             telescope = Nrao.telescope_code[telescope_]
         elif isinstance(telescope, (list, tuple)):
             telescope = [Nrao.telescope_code[telescope_] for x in telescope_]
@@ -434,7 +435,7 @@ class NraoClass(QueryWithLogin):
         datatype_mapping = {'integer': 'long'}
 
         try:
-            tf = six.BytesIO(new_content.encode())
+            tf = BytesIO(new_content.encode())
             first_table = votable.parse(
                 tf, pedantic=False,
                 datatype_mapping=datatype_mapping).get_first_table()
@@ -464,14 +465,7 @@ class NraoClass(QueryWithLogin):
 
         string_to_parse = htmltable[-1].encode('ascii')
 
-        if six.PY2:
-            from astropy.io.ascii import html
-            from astropy.io.ascii.core import convert_numpy
-            htmlreader = html.HTML({'parser': 'html5lib'})
-            htmlreader.outputter.default_converters.append(convert_numpy(np.unicode))
-            table = htmlreader.read(string_to_parse)
-        else:
-            table = Table.read(string_to_parse.decode('utf-8'), format='ascii.html')
+        table = Table.read(string_to_parse.decode('utf-8'), format='ascii.html')
 
         return table
 

--- a/astroquery/query.py
+++ b/astroquery/query.py
@@ -12,7 +12,6 @@ import os
 import requests
 import textwrap
 
-import six
 from astropy.config import paths
 from astroquery import log
 import astropy.units as u
@@ -91,7 +90,7 @@ class AstroQuery:
                                                  key=_replace_none_iterable)),)
                 elif k is None:
                     request_key += (None,)
-                elif isinstance(k, six.string_types):
+                elif isinstance(k, str):
                     request_key += (k,)
                 else:
                     raise TypeError("{0} must be a dict, tuple, str, or "
@@ -138,15 +137,13 @@ class LoginABCMeta(abc.ABCMeta):
                 bases[0].login(*args, **kwargs)
 
             login.__doc__ = attrs['_login'].__doc__
-            if not six.PY2:
-                login.__signature__ = inspect.signature(attrs['_login'])
+            login.__signature__ = inspect.signature(attrs['_login'])
             setattr(newcls, login.__name__, login)
 
         return newcls
 
 
-@six.add_metaclass(LoginABCMeta)
-class BaseQuery:
+class BaseQuery(metaclass=LoginABCMeta):
     """
     This is the base class for all the query classes in astroquery. It
     is implemented as an abstract class and must not be directly instantiated.

--- a/astroquery/sdss/tests/test_sdss.py
+++ b/astroquery/sdss/tests/test_sdss.py
@@ -1,11 +1,11 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 from contextlib import contextmanager
+from urllib.error import URLError
 import os
 import socket
 import numpy as np
 from numpy.testing import assert_allclose
 
-import six
 from astropy.io import fits
 from astropy.table import Column, Table
 import pytest
@@ -78,7 +78,7 @@ def patch_get_readable_fileobj(request):
 def patch_get_readable_fileobj_slow(request):
     @contextmanager
     def get_readable_fileobj_mockreturn(filename, **kwargs):
-        error = six.moves.urllib_error.URLError('timeout')
+        error = URLError('timeout')
         error.reason = socket.timeout()
         raise error
         yield True

--- a/astroquery/sdss/tests/test_sdss_remote.py
+++ b/astroquery/sdss/tests/test_sdss_remote.py
@@ -6,7 +6,7 @@ import pytest
 from astropy import coordinates
 from astropy.table import Table
 
-from six.moves.urllib_error import URLError
+from urllib.error import URLError
 
 from ... import sdss
 from ...exceptions import TimeoutError

--- a/astroquery/simbad/core.py
+++ b/astroquery/simbad/core.py
@@ -9,13 +9,13 @@ import requests
 import json
 import os
 from collections import namedtuple
+from io import BytesIO
 import warnings
 import astropy.units as u
 from astropy.utils.data import get_pkg_data_filename
 import astropy.coordinates as coord
 from astropy.table import Table
 import astropy.io.votable as votable
-from six import BytesIO
 
 from ..query import BaseQuery
 from ..utils import commons

--- a/astroquery/simbad/tests/test_simbad.py
+++ b/astroquery/simbad/tests/test_simbad.py
@@ -2,7 +2,6 @@
 import os
 import re
 
-import six
 import pytest
 import astropy.units as u
 from astropy.table import Table
@@ -131,8 +130,8 @@ def test_parse_result():
                              'The attempted parsed result is in '
                              'self.last_parsed_result.\n Exception: 7:115: '
                              'no element found')
-    assert isinstance(simbad.Simbad.last_response.text, six.string_types)
-    assert isinstance(simbad.Simbad.last_response.content, six.binary_type)
+    assert isinstance(simbad.Simbad.last_response.text, str)
+    assert isinstance(simbad.Simbad.last_response.content, bytes)
 
 
 votable_fields = ",".join(simbad.core.Simbad.get_votable_fields())

--- a/astroquery/skyview/core.py
+++ b/astroquery/skyview/core.py
@@ -1,8 +1,7 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 import pprint
 from bs4 import BeautifulSoup
-from six.moves.urllib import parse as urlparse
-import six
+from urllib import parse as urlparse
 from astropy import units as u
 
 from . import conf
@@ -74,7 +73,7 @@ class SkyViewClass(BaseQuery):
         # only overwrite payload's values if the `input` value is not None
         # to avoid overwriting of the form's default values
         payload = self._default_form_values.copy()
-        for k, v in six.iteritems(input):
+        for k, v in input.items():
             if v is not None:
                 payload[k] = v
         url = urlparse.urljoin(self.URL, form.get('action'))

--- a/astroquery/utils/commons.py
+++ b/astroquery/utils/commons.py
@@ -8,11 +8,11 @@ import warnings
 import os
 import shutil
 import socket
+from io import BytesIO, StringIO
+from urllib.error import URLError
 
 import requests
 
-from six.moves.urllib_error import URLError
-import six
 import astropy.units as u
 from astropy import coordinates as coord
 from collections import OrderedDict
@@ -131,7 +131,7 @@ def radius_to_unit(radius, unit='degree'):
     """
     rad = coord.Angle(radius)
 
-    if isinstance(unit, six.string_types):
+    if isinstance(unit, str):
         if hasattr(rad, unit):
             return getattr(rad, unit)
         elif hasattr(rad, f"{unit}s"):
@@ -162,7 +162,7 @@ def parse_coordinates(coordinates):
     astropy.units.UnitsError
     TypeError
     """
-    if isinstance(coordinates, six.string_types):
+    if isinstance(coordinates, str):
         try:
             c = ICRSCoordGenerator(coordinates)
             warnings.warn("Coordinate string is being interpreted as an "
@@ -442,11 +442,10 @@ class FileContainer:
         Return the file as an io.StringIO object
         """
         s = self.get_string()
-        # TODO: replace with six.BytesIO
         try:
-            return six.BytesIO(s)
+            return BytesIO(s)
         except TypeError:
-            return six.StringIO(s)
+            return StringIO(s)
 
     def __repr__(self):
         if hasattr(self, '_fits'):
@@ -467,5 +466,5 @@ def parse_votable(content):
     """
     Parse a votable in string format
     """
-    tables = votable.parse(six.BytesIO(content), pedantic=False)
+    tables = votable.parse(BytesIO(content), pedantic=False)
     return tables

--- a/astroquery/utils/download_file_list.py
+++ b/astroquery/utils/download_file_list.py
@@ -3,8 +3,8 @@ import re
 import string
 import os
 import gzip
+from io import StringIO
 
-from six import StringIO
 import astropy.io.fits as fits
 from .commons import get_readable_fileobj
 

--- a/astroquery/utils/progressbar.py
+++ b/astroquery/utils/progressbar.py
@@ -1,8 +1,8 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 import gzip
 import sys
-from six import StringIO
-from six.moves import urllib
+from io import StringIO
+from urllib.request import build_opener
 from astropy.io import fits
 
 
@@ -57,7 +57,7 @@ def retrieve(url, outfile, opener=None, overwrite=False):
     """
 
     if opener is None:
-        opener = urllib.build_opener()
+        opener = build_opener()
 
     page = opener.open(url)
 

--- a/astroquery/utils/tap/conn/tapconn.py
+++ b/astroquery/utils/tap/conn/tapconn.py
@@ -24,7 +24,7 @@ except ImportError:
 import mimetypes
 import time
 
-from six.moves.urllib.parse import urlencode
+from urllib.parse import urlencode
 
 from astroquery.utils.tap.xmlparser import utils
 from astroquery.utils.tap import taputils

--- a/astroquery/utils/tap/conn/tests/DummyConnHandler.py
+++ b/astroquery/utils/tap/conn/tests/DummyConnHandler.py
@@ -16,7 +16,7 @@ Created on 30 jun. 2016
 """
 from astroquery.utils.tap import taputils
 
-from six.moves.urllib.parse import urlencode
+from urllib.parse import urlencode
 
 import requests
 

--- a/astroquery/utils/tap/core.py
+++ b/astroquery/utils/tap/core.py
@@ -25,7 +25,6 @@ from astroquery.utils.tap.xmlparser.groupSaxParser import GroupSaxParser
 from astroquery.utils.tap.xmlparser.sharedItemsSaxParser import SharedItemsSaxParser  # noqa
 from astroquery.utils.tap.xmlparser import utils
 from astroquery.utils.tap.model.filter import Filter
-import six
 import requests
 from astroquery import log
 import getpass
@@ -1246,7 +1245,7 @@ class TapPlus(Tap):
             print("Retrieving datalink.")
         if ids is None:
             raise ValueError("Missing mandatory argument 'ids'")
-        if isinstance(ids, six.string_types):
+        if isinstance(ids, str):
             ids_arg = f"ID={ids}"
         else:
             if isinstance(ids, int):
@@ -1369,7 +1368,7 @@ class TapPlus(Tap):
                 user = ins.readline().strip()
                 password = ins.readline().strip()
         if user is None:
-            user = six.moves.input("User: ")
+            user = input("User: ")
             if user is None:
                 print("Invalid user name")
                 return
@@ -1934,7 +1933,7 @@ class TapPlus(Tap):
                 user = ins.readline().strip()
                 password = ins.readline().strip()
         if user is None:
-            user = six.moves.input("User: ")
+            user = input("User: ")
             if user is None:
                 log.info("Invalid user name")
                 return

--- a/astroquery/utils/tap/gui/login.py
+++ b/astroquery/utils/tap/gui/login.py
@@ -15,30 +15,28 @@ Created on 30 jun. 2016
 
 """
 
-import six
-
 try:
-    from six.moves.tkinter import Tk as TKTk
+    from tkinter import Tk as TKTk
 except ImportError:
     TKTk = None
 
 try:
-    from six.moves.tkinter import Toplevel as TKToplevel
+    from tkinter import Toplevel as TKToplevel
 except ImportError:
     TKToplevel = None
 
 try:
-    from six.moves.tkinter import Button as TKButton
+    from tkinter import Button as TKButton
 except ImportError:
     TKButton = None
 
 try:
-    from six.moves.tkinter import Label as TKLabel
+    from tkinter import Label as TKLabel
 except ImportError:
     TKLabel = None
 
 try:
-    from six.moves.tkinter import Entry as TKEntry
+    from tkinter import Entry as TKEntry
 except ImportError:
     TKEntry = None
 

--- a/astroquery/utils/tap/xmlparser/utils.py
+++ b/astroquery/utils/tap/xmlparser/utils.py
@@ -18,28 +18,17 @@ Created on 30 jun. 2016
 import io
 from astropy import units as u
 from astropy.table import Table as APTable
-import six
 
 
 def util_create_string_from_buffer(buffer):
-    if six.PY2:
-        # 2.7
-        return ''.join(x.encode('utf-8') for x in buffer)
-    else:
-        # 3.0
-        return ''.join(map(str, buffer))
+    return ''.join(map(str, buffer))
 
 
 def read_http_response(response, outputFormat, correct_units=True):
     astropyFormat = get_suitable_astropy_format(outputFormat)
-    if six.PY2:
-        # 2.7
-        result = APTable.read(response, format=astropyFormat)
-    else:
-        # 3.0
-        # If we want to use astropy.table, we have to read the data
-        data = io.BytesIO(response.read())
-        result = APTable.read(data, format=astropyFormat)
+    # If we want to use astropy.table, we have to read the data
+    data = io.BytesIO(response.read())
+    result = APTable.read(data, format=astropyFormat)
 
     if correct_units:
         for cn in result.colnames:

--- a/astroquery/utils/tests/test_utils.py
+++ b/astroquery/utils/tests/test_utils.py
@@ -6,10 +6,9 @@ import requests
 import pytest
 import tempfile
 import textwrap
+import urllib
 
 import astropy.coordinates as coord
-from six.moves import urllib
-import six
 from astropy.io import fits
 import astropy.io.votable as votable
 import astropy.units as u
@@ -404,7 +403,7 @@ def test_payload_return(cls=DummyQuery):
     result = DummyQuery.query(get_query_payload=True)
     assert isinstance(result, dict)
     result = DummyQuery.query(get_query_payload=False)
-    assert isinstance(result, six.string_types)
+    assert isinstance(result, str)
 
 
 fitsfilepath = os.path.join(os.path.dirname(__file__),

--- a/astroquery/utils/url_helpers.py
+++ b/astroquery/utils/url_helpers.py
@@ -1,8 +1,5 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
-try:
-    from six.moves.urllib_parse import SplitResult, urlsplit
-except ImportError:
-    from six.moves.urllib_parse import SplitResult, urlsplit
+from urllib.parse import SplitResult, urlsplit
 import os.path
 
 
@@ -17,7 +14,7 @@ def urljoin_keep_path(url, path):
     --------
     >>> urljoin_keep_path('http://example.com/foo', 'bar')
     'http://example.com/foo/bar'
-    >>> from six.moves.urllib import parse as urlparse
+    >>> from urllib import parse as urlparse
     >>> urlparse.urljoin('http://example.com/foo', 'bar')
     'http://example.com/bar'
 

--- a/astroquery/vizier/core.py
+++ b/astroquery/vizier/core.py
@@ -7,8 +7,8 @@ import json
 import copy
 import re
 
-import six
-from six import BytesIO
+from io import BytesIO
+
 import astropy.units as u
 import astropy.coordinates as coord
 import astropy.table as tbl
@@ -33,7 +33,7 @@ __doctest_skip__ = ['VizierClass.*']
 @async_to_sync
 class VizierClass(BaseQuery):
 
-    _str_schema = schema.Or(*six.string_types)
+    _str_schema = schema.Schema(str)
     _schema_columns = schema.Schema([_str_schema],
                                     error="columns must be a list of strings")
     _schema_ucd = schema.Schema(_str_schema, error="ucd must be string")
@@ -260,7 +260,7 @@ class VizierClass(BaseQuery):
             Returned if asynchronous method used
         """
 
-        if not isinstance(catalog, six.string_types + (votable.tree.Resource,)):
+        if not isinstance(catalog, (str, votable.tree.Resource)):
             catalog = list(catalog)
         data_payload = self._args_to_payload(catalog=catalog)
         if get_query_payload:
@@ -376,7 +376,7 @@ class VizierClass(BaseQuery):
         columns = []
 
         # Process coordinates
-        if isinstance(coordinates, (commons.CoordClasses,) + six.string_types):
+        if isinstance(coordinates, (commons.CoordClasses, str)):
             target = commons.parse_coordinates(coordinates).transform_to(frame)
 
             if not target.isscalar:
@@ -553,7 +553,7 @@ class VizierClass(BaseQuery):
         catalog = kwargs.get('catalog') or self.catalog
 
         if catalog is not None:
-            if isinstance(catalog, six.string_types):
+            if isinstance(catalog, str):
                 body['-source'] = catalog
             elif isinstance(catalog, list):
                 catalog = [item.name if hasattr(item, 'name') else item
@@ -843,7 +843,7 @@ class VizierKeyword(list):
 
     @keywords.setter
     def keywords(self, values):
-        if isinstance(values, six.string_types):
+        if isinstance(values, str):
             values = list(values)
         keys = [key.lower() for key in self.keyword_dict]
         values = [val.lower() for val in values]

--- a/astroquery/vizier/tests/test_vizier.py
+++ b/astroquery/vizier/tests/test_vizier.py
@@ -5,13 +5,11 @@ from numpy import testing as npt
 import pytest
 from astropy.table import Table
 import astropy.units as u
-import six
+
 from ... import vizier
 from ...utils import commons
 from ...utils.testing_tools import MockResponse
 
-if six.PY3:
-    str, = six.string_types
 
 VO_DATA = {'HIP,NOMAD,UCAC': "viz.xml",
            'NOMAD,UCAC': "viz.xml",

--- a/astroquery/wfau/core.py
+++ b/astroquery/wfau/core.py
@@ -7,9 +7,8 @@ import time
 from math import cos, radians
 import requests
 from bs4 import BeautifulSoup
-from io import StringIO
+from io import BytesIO, StringIO
 
-from six import BytesIO
 import astropy.units as u
 import astropy.coordinates as coord
 import astropy.io.votable as votable

--- a/astroquery/xmatch/core.py
+++ b/astroquery/xmatch/core.py
@@ -1,6 +1,7 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 
-import six
+from io import StringIO
+
 from astropy.io import ascii
 import astropy.units as u
 from astropy.table import Table
@@ -114,13 +115,13 @@ class XMatchClass(BaseQuery):
         query parameters accordingly.
         '''
         catstr = 'cat{0}'.format(cat_index)
-        if isinstance(cat, six.string_types):
+        if isinstance(cat, str):
             payload[catstr] = cat
         elif isinstance(cat, Table):
             # write the Table's content into a new, temporary CSV-file
             # so that it can be pointed to via the `files` option
             # file will be closed when garbage-collected
-            fp = six.StringIO()
+            fp = StringIO()
             cat.write(fp, format='ascii.csv')
             fp.seek(0)
             kwargs['files'] = {catstr: ('cat1.csv', fp.read())}
@@ -158,7 +159,7 @@ class XMatchClass(BaseQuery):
 
         # table_id can actually be a Table instance, there is no point in
         # comparing those to stings
-        if not isinstance(table_id, six.string_types):
+        if not isinstance(table_id, str):
             return False
 
         if (table_id[:7] == 'vizier:'):

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -79,7 +79,6 @@ The following packages are required for astroquery installation & use:
 * `keyring <https://pypi.python.org/pypi/keyring>`_
 * `Beautiful Soup <https://www.crummy.com/software/BeautifulSoup/>`_
 * `html5lib <https://pypi.python.org/pypi/html5lib>`_
-* `six <http://pypi.python.org/pypi/six/>`_
 
 and for running the tests:
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -137,7 +137,6 @@ install_requires=
    html5lib>=0.999
    keyring>=4.0
    pyvo>=1.1
-   six
 tests_require =
    pytest-doctestplus>=0.10.1
    pytest-astropy


### PR DESCRIPTION
`six` is a package that enables writing code that would work with both Python 2 and 3, but since #2102 the minimum Python version supported by `astroquery` is 3.7, so `six` should be removed.

Contributes towards #1870.