### PR TITLE
Make it easier to change Gaia row limit

### DIFF
--- a/astroquery/gaia/core.py
+++ b/astroquery/gaia/core.py
@@ -440,7 +440,7 @@ class GaiaClass(TapPlus):
             else:
                 job = self.launch_job(query, verbose=verbose)
         table = job.get_results()
-        if len(table) == row_limit:
+        if verbose and len(table) == row_limit:
             warn(f'The number of rows in the result matches the current row limit of {row_limit}. '
                  f'You might wish to specify a different "row_limit" value.', MaxResultsWarning)
         return table
@@ -600,7 +600,7 @@ class GaiaClass(TapPlus):
             result = self.launch_job(query=query, output_file=output_file,
                                      output_format=output_format, verbose=verbose,
                                      dump_to_file=dump_to_file)
-        if len(result.get_data()) == row_limit:
+        if verbose and len(result.get_data()) == row_limit:
             warn(f'The number of rows in the result matches the current row limit of {row_limit}. '
                  f'You might wish to specify a different "row_limit" value.', MaxResultsWarning)
         return result

--- a/astroquery/gaia/tests/test_gaia_remote.py
+++ b/astroquery/gaia/tests/test_gaia_remote.py
@@ -13,10 +13,7 @@ def test_query_object_row_limit():
     coord = SkyCoord(ra=280, dec=-60, unit=(u.degree, u.degree), frame='icrs')
     width = u.Quantity(0.1, u.deg)
     height = u.Quantity(0.1, u.deg)
-    msg = ('The number of rows in the result matches the current row limit of 50. You might wish '
-           'to specify a different "row_limit" value.')
-    with pytest.warns(MaxResultsWarning, match=msg):
-        r = Gaia.query_object_async(coordinate=coord, width=width, height=height)
+    r = Gaia.query_object_async(coordinate=coord, width=width, height=height)
 
     assert len(r) == conf.ROW_LIMIT
 
@@ -24,7 +21,7 @@ def test_query_object_row_limit():
     msg = ('The number of rows in the result matches the current row limit of '
            '10. You might wish to specify a different "row_limit" value.')
     with pytest.warns(MaxResultsWarning, match=msg):
-        r = Gaia.query_object_async(coordinate=coord, width=width, height=height)
+        r = Gaia.query_object_async(coordinate=coord, width=width, height=height, verbose=True)
 
     assert len(r) == 10 == Gaia.ROW_LIMIT
 
@@ -38,10 +35,7 @@ def test_cone_search_row_limit():
     Gaia = GaiaClass()
     coord = SkyCoord(ra=280, dec=-60, unit=(u.degree, u.degree), frame='icrs')
     radius = u.Quantity(0.1, u.deg)
-    msg = ('The number of rows in the result matches the current row limit of 50. You might wish '
-           'to specify a different "row_limit" value.')
-    with pytest.warns(MaxResultsWarning, match=msg):
-        j = Gaia.cone_search_async(coord, radius)
+    j = Gaia.cone_search_async(coord, radius)
     r = j.get_results()
 
     assert len(r) == conf.ROW_LIMIT
@@ -50,7 +44,7 @@ def test_cone_search_row_limit():
     msg = ('The number of rows in the result matches the current row limit of 10. You might wish '
            'to specify a different "row_limit" value.')
     with pytest.warns(MaxResultsWarning, match=msg):
-        j = Gaia.cone_search_async(coord, radius)
+        j = Gaia.cone_search_async(coord, radius, verbose=True)
     r = j.get_results()
 
     assert len(r) == 10 == Gaia.ROW_LIMIT

--- a/astroquery/gaia/tests/test_gaiatap.py
+++ b/astroquery/gaia/tests/test_gaiatap.py
@@ -215,10 +215,12 @@ class TestTap(unittest.TestCase):
                                     'table1_oid',
                                     None,
                                     np.int32)
+        # No warning without verbose=True
+        job = tap.query_object_async(sc, radius, row_limit=3)
         msg = ('The number of rows in the result matches the current row limit of 3. You might '
                'wish to specify a different "row_limit" value.')
         with pytest.warns(MaxResultsWarning, match=msg):
-            job = tap.query_object_async(sc, radius, row_limit=3)
+            job = tap.query_object_async(sc, radius, row_limit=3, verbose=True)
 
     def test_cone_search_sync(self):
         connHandler = DummyConnHandler()
@@ -381,10 +383,12 @@ class TestTap(unittest.TestCase):
         # No row limit
         job = tap.cone_search_async(sc, radius, row_limit=-1)
         assert 'TOP' not in job.parameters['query']
+        # No warning without verbose=True
+        job = tap.cone_search_async(sc, radius, row_limit=3)
         msg = ('The number of rows in the result matches the current row limit of 3. You might '
                'wish to specify a different "row_limit" value.')
         with pytest.warns(MaxResultsWarning, match=msg):
-            job = tap.cone_search_async(sc, radius, row_limit=3)
+            job = tap.cone_search_async(sc, radius, row_limit=3, verbose=True)
 
     def __check_results_column(self, results, columnName, description, unit,
                                dataType):

--- a/docs/gaia/gaia.rst
+++ b/docs/gaia/gaia.rst
@@ -124,20 +124,20 @@ degrees around an specific point in RA/Dec coordinates.
    0.020802655215768254 1635721458409799680 ...
    0.021615117161838747 1635721458409799680 ...
   Length = 50 rows
-  MaxResultsWarning: The number of rows in the result matches the current row
-  limit of 50. You might wish to specify a different "row_limit" value.
 
 By default the number of rows returned by a query is limited by the
 ``astroquery.gaia.conf.ROW_LIMIT`` value. This value can be overruled in a
 single function call with the ``row_limit`` argument. Alternatively, if the
 class attribute ``Gaia.ROW_LIMIT`` is set then it will take precedence over
-``conf.ROW_LIMIT``.
+``conf.ROW_LIMIT``. If you call the function with ``verbose=True`` then you
+will be warned if the length of the query result is equal to the row limit.
 
 .. code-block:: python
 
   >>> from astroquery.gaia import conf
   >>> conf.ROW_LIMIT = 8       # Or Gaia.ROW_LIMIT = 8
-  >>> r = Gaia.query_object_async(coordinate=coord, width=width, height=height)
+  >>> r = Gaia.query_object_async(coordinate=coord, width=width, height=height,
+                                  verbose=True)
   >>> r.pprint()
 
            dist             solution_id     ... epoch_photometry_url
@@ -217,8 +217,6 @@ radius argument. The number of rows is limited just like in object queries.
   1635721458409799680 Gaia DR2 6636090334814218752 ...  0.005846434715822121
                   ...                          ... ...                   ...
   Length = 50 rows
-  MaxResultsWarning: The number of rows in the result matches the current row
-  limit of 50. You might wish to specify a different "row_limit" value.
 
 
 1.3. Getting public tables metadata


### PR DESCRIPTION
The first commit of this pull request adds the `row_limit` argument to the `query_object` and `cone_search` families of functions in the Gaia module. It also ensures that the row limit can be changed through the configuration system at runtime.

The second commit makes the previously mentioned functions emit a ~`UserWarning`~ `MaxResultsWarning` if the number of rows in the query result matches the row limit.

Closes #1760