### PR TITLE
Adding python 3.10 to CI

### DIFF
--- a/.github/workflows/ci_tests.yml
+++ b/.github/workflows/ci_tests.yml
@@ -29,7 +29,7 @@ jobs:
 
           - name: docs build
             os: ubuntu-latest
-            python: 3.8
+            python: 3.9
             toxenv: build_docs
             toxargs: -v
 
@@ -41,8 +41,8 @@ jobs:
 
           - name: astropy dev with all dependencies with coverage
             os: ubuntu-latest
-            python: 3.9
-            toxenv: py39-test-alldeps-devastropy-cov
+            python: 3.10
+            toxenv: py310-test-alldeps-devastropy-cov
             toxargs: -v
 
           - name: Python 3.7 with all optional dependencies (MacOS X)

--- a/.github/workflows/ci_tests.yml
+++ b/.github/workflows/ci_tests.yml
@@ -41,7 +41,7 @@ jobs:
 
           - name: astropy dev with all dependencies with coverage
             os: ubuntu-latest
-            python: 3.10
+            python: '3.10'
             toxenv: py310-test-alldeps-devastropy-cov
             toxargs: -v
 

--- a/.github/workflows/ci_tests.yml
+++ b/.github/workflows/ci_tests.yml
@@ -27,12 +27,6 @@ jobs:
             python: 3.x
             toxenv: codestyle
 
-          - name: docs build
-            os: ubuntu-latest
-            python: 3.9
-            toxenv: build_docs
-            toxargs: -v
-
           - name: oldest dependencies
             os: ubuntu-latest
             python: 3.7
@@ -45,16 +39,16 @@ jobs:
             toxenv: py310-test-alldeps-devastropy-cov
             toxargs: -v
 
-          - name: Python 3.7 with all optional dependencies (MacOS X)
+          - name: Python 3.8 with all optional dependencies (MacOS X)
             os: macos-latest
-            python: 3.7
-            toxenv: py37-test-alldeps
+            python: 3.8
+            toxenv: py38-test-alldeps
             toxargs: -v
 
-          - name: Python 3.8 with mandatory dependencies (Windows)
+          - name: Python 3.9 with mandatory dependencies (Windows)
             os: windows-latest
-            python: 3.8
-            toxenv: py38-test
+            python: 3.9
+            toxenv: py39-test
             toxargs: -v
 
     steps:

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -9,7 +9,7 @@ python:
        path: .
        extra_requirements:
           - docs
-          - all_lt_39
+          - all
 
 sphinx:
    fail_on_warning: true

--- a/conftest.py
+++ b/conftest.py
@@ -19,10 +19,6 @@ def pytest_configure(config):
     # keyring doesn't provide __version__ any more
     # PYTEST_HEADER_MODULES['keyring'] = 'keyring'
 
-    del PYTEST_HEADER_MODULES['h5py']
-    del PYTEST_HEADER_MODULES['Scipy']
-    del PYTEST_HEADER_MODULES['Pandas']
-
     # add '_testrun' to the version name so that the user-agent indicates that
     # it's being run in a test
     from astroquery import version

--- a/conftest.py
+++ b/conftest.py
@@ -1,0 +1,32 @@
+# Licensed under a 3-clause BSD style license - see LICENSE.rst
+
+from pytest_astropy_header.display import (PYTEST_HEADER_MODULES,
+                                           TESTED_VERSIONS)
+
+
+def pytest_configure(config):
+    config.option.astropy_header = True
+
+    PYTEST_HEADER_MODULES['Astropy'] = 'astropy'
+    PYTEST_HEADER_MODULES['APLpy'] = 'aplpy'
+    PYTEST_HEADER_MODULES['pyregion'] = 'pyregion'
+    PYTEST_HEADER_MODULES['regions'] = 'regions'
+    PYTEST_HEADER_MODULES['pyVO'] = 'pyvo'
+    PYTEST_HEADER_MODULES['mocpy'] = 'mocpy'
+    PYTEST_HEADER_MODULES['astropy-healpix'] = 'astropy_healpix'
+    PYTEST_HEADER_MODULES['vamdclib'] = 'vamdclib'
+
+    # keyring doesn't provide __version__ any more
+    # PYTEST_HEADER_MODULES['keyring'] = 'keyring'
+
+    del PYTEST_HEADER_MODULES['h5py']
+    del PYTEST_HEADER_MODULES['Scipy']
+    del PYTEST_HEADER_MODULES['Pandas']
+
+    # add '_testrun' to the version name so that the user-agent indicates that
+    # it's being run in a test
+    from astroquery import version
+    version.version += '_testrun'
+
+    TESTED_VERSIONS['astroquery'] = version.version
+    TESTED_VERSIONS['astropy_helpers'] = version.astropy_helpers_version

--- a/setup.cfg
+++ b/setup.cfg
@@ -170,21 +170,9 @@ docs=
    sphinx-astropy>=1.5
    scipy
 all=
-# mocpy's dependency cdshealpix doesn't compile with 3.10 yet
-   astropy-healpix
-   boto3
-   regions
-all_lt_310=
    mocpy>=0.5.2
    astropy-healpix
    boto3
-   regions
-# aplpy is not py39 compatible (it requires shapely that doesn't compile
-# pyregion is not py39 compatible
-all_lt_39=
-   mocpy>=0.5.2
    regions
    pyregion
-   astropy-healpix
    aplpy
-   boto3

--- a/setup.cfg
+++ b/setup.cfg
@@ -57,6 +57,8 @@ filterwarnings =
 # Upstream, remove when fixed, PRs have been opened
     ignore::DeprecationWarning:pyvo
     ignore::DeprecationWarning:regions
+# Should ignore these for astropy<5.0
+    ignore:getName|currentThread:DeprecationWarning:astropy
 # This should be cleared once we requre astropy>=4.1
     ignore:tostring\(\) is deprecated. Use tobytes:DeprecationWarning:astropy
 markers =

--- a/setup.cfg
+++ b/setup.cfg
@@ -168,6 +168,11 @@ docs=
    sphinx-astropy>=1.5
    scipy
 all=
+# mocpy's dependency cdshealpix doesn't compile with 3.10 yet
+   astropy-healpix
+   boto3
+   regions
+all_lt_310=
    mocpy>=0.5.2
    astropy-healpix
    boto3

--- a/tox.ini
+++ b/tox.ini
@@ -41,8 +41,9 @@ deps =
 
 extras =
     test
-    !py{37,38}-alldeps: all_lt_39
-    py{39,310}-alldeps: all
+    py{37,38}-alldeps: all_lt_39
+    py39-alldeps: all_lt_310
+    py310-alldeps: all
 
 commands =
     pip freeze

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 envlist =
-    py{37,38,39}-test{,-alldeps,-oldestdeps}{,-devastropy}{,-cov}
+    py{37,38,39,310}-test{,-alldeps,-oldestdeps}{,-devastropy}{,-cov}
     codestyle
     build_docs
 requires =
@@ -41,8 +41,8 @@ deps =
 
 extras =
     test
-    !py39-alldeps: all_lt_39
-    py39-alldeps: all
+    !py{37,38}-alldeps: all_lt_39
+    py{39,310}-alldeps: all
 
 commands =
     pip freeze

--- a/tox.ini
+++ b/tox.ini
@@ -41,9 +41,8 @@ deps =
 
 extras =
     test
-    py{37,38}-alldeps: all_lt_39
-    py39-alldeps: all_lt_310
-    py310-alldeps: all
+    alldeps: all
+
 
 commands =
     pip freeze


### PR DESCRIPTION
- [x] remove docs build from GHA
- [x] add 3.10 to GHA
- [x] revisit 'all' groups in extras require based on which dependencies support 3.10 and 3.9