### PR TITLE
Fix Issue 2139: remove cache file if failed query occurs

### DIFF
--- a/astroquery/query.py
+++ b/astroquery/query.py
@@ -115,6 +115,20 @@ class AstroQuery:
             log.debug("Retrieving data from {0}".format(request_file))
         return response
 
+    def remove_cache_file(self, cache_location):
+        """
+        Remove the cache file - may be needed if a query fails during parsing
+        (successful request, but failed return)
+        """
+        request_file = self.request_file(cache_location)
+
+        if os.path.exists(request_file):
+            os.remove(request_file)
+        else:
+            raise OSError(f"Tried to remove cache file {request_file} but "
+                          "it does not exist")
+
+
 
 class LoginABCMeta(abc.ABCMeta):
     """

--- a/astroquery/query.py
+++ b/astroquery/query.py
@@ -129,7 +129,6 @@ class AstroQuery:
                           "it does not exist")
 
 
-
 class LoginABCMeta(abc.ABCMeta):
     """
     The goal of this metaclass is to copy the docstring and signature from

--- a/astroquery/simbad/core.py
+++ b/astroquery/simbad/core.py
@@ -928,7 +928,6 @@ class SimbadClass(SimbadBaseQuery):
         return self._parse_result(response, SimbadObjectIDsResult,
                                   verbose=verbose)
 
-
     def query_objectids_async(self, object_name, cache=True,
                               get_query_payload=False):
         """

--- a/astroquery/simbad/core.py
+++ b/astroquery/simbad/core.py
@@ -928,6 +928,7 @@ class SimbadClass(SimbadBaseQuery):
         return self._parse_result(response, SimbadObjectIDsResult,
                                   verbose=verbose)
 
+
     def query_objectids_async(self, object_name, cache=True,
                               get_query_payload=False):
         """
@@ -1055,6 +1056,12 @@ class SimbadClass(SimbadBaseQuery):
                 return None
         except Exception as ex:
             self.last_table_parse_error = ex
+            try:
+                self._last_query.remove_cache_file(self.cache_location)
+            except OSError:
+                # this is allowed: if `cache` was set to False, this
+                # won't be needed
+                pass
             raise TableParseError("Failed to parse SIMBAD result! The raw "
                                   "response can be found in "
                                   "self.last_response, and the error in "

--- a/astroquery/simbad/tests/test_simbad.py
+++ b/astroquery/simbad/tests/test_simbad.py
@@ -134,8 +134,8 @@ def test_parse_result():
                              'The attempted parsed result is in '
                              'self.last_parsed_result.\n Exception: 7:115: '
                              'no element found')
-    assert isinstance(simbad.Simbad.last_response.text, str)
-    assert isinstance(simbad.Simbad.last_response.content, bytes)
+    assert isinstance(sb.last_response.text, str)
+    assert isinstance(sb.last_response.content, bytes)
 
 
 votable_fields = ",".join(simbad.core.Simbad.get_votable_fields())

--- a/astroquery/simbad/tests/test_simbad.py
+++ b/astroquery/simbad/tests/test_simbad.py
@@ -10,6 +10,7 @@ import numpy as np
 from ... import simbad
 from ...utils.testing_tools import MockResponse
 from ...utils import commons
+from ...query import AstroQuery
 from ...exceptions import TableParseError
 from .test_simbad_remote import multicoords
 
@@ -118,12 +119,15 @@ def test_get_frame_coordinates(coordinates, expected_frame):
 
 
 def test_parse_result():
-    result1 = simbad.core.Simbad._parse_result(
+    sb = simbad.core.Simbad()
+    # need _last_query to be defined
+    sb._last_query = AstroQuery('GET', 'http://dummy')
+    result1 = sb._parse_result(
         MockResponseSimbad('query id '), simbad.core.SimbadVOTableResult)
     assert isinstance(result1, Table)
     with pytest.raises(TableParseError) as ex:
-        simbad.core.Simbad._parse_result(MockResponseSimbad('query error '),
-                                         simbad.core.SimbadVOTableResult)
+        sb._parse_result(MockResponseSimbad('query error '),
+                simbad.core.SimbadVOTableResult)
     assert str(ex.value) == ('Failed to parse SIMBAD result! The raw response '
                              'can be found in self.last_response, and the '
                              'error in self.last_table_parse_error. '


### PR DESCRIPTION
In #2139, it was reported that SIMBAD can sometimes return incomplete VOTables that don't parse correctly.

This implements a general solution of not caching those responses.  It doesn't specifically address the problem, but makes the solution (re-run the query) much easier!

I think without understanding precisely where the issue is coming from, and how often it occurs, we should limit our response to this for now.