### PR TITLE
monkey patch services

### DIFF
--- a/astroquery/mast/collections.py
+++ b/astroquery/mast/collections.py
@@ -36,6 +36,8 @@ class CatalogsClass(MastQueryWithLogin):
     Class for querying MAST catalog data.
     """
 
+    _catalogs_filtered_tic = 'Mast.Catalogs.Filtered.Tic'
+    
     def __init__(self):
 
         super().__init__()
@@ -271,7 +273,7 @@ class CatalogsClass(MastQueryWithLogin):
             self._current_connection = self._portal_api_connection
 
             if catalog.lower() == "tic":
-                service = "Mast.Catalogs.Filtered.Tic"
+                service = _catalogs_filtered_tic
                 if coordinates or objectname:
                     service += ".Position"
                 service += ".Rows"  # Using the rowstore version of the query for speed

--- a/astroquery/mast/collections.py
+++ b/astroquery/mast/collections.py
@@ -36,8 +36,6 @@ class CatalogsClass(MastQueryWithLogin):
     Class for querying MAST catalog data.
     """
 
-    _catalogs_filtered_tic = 'Mast.Catalogs.Filtered.Tic'
-    
     def __init__(self):
 
         super().__init__()
@@ -273,7 +271,7 @@ class CatalogsClass(MastQueryWithLogin):
             self._current_connection = self._portal_api_connection
 
             if catalog.lower() == "tic":
-                service = _catalogs_filtered_tic
+                service = "Mast.Catalogs.Filtered.Tic"
                 if coordinates or objectname:
                     service += ".Position"
                 service += ".Rows"  # Using the rowstore version of the query for speed

--- a/astroquery/mast/discovery_portal.py
+++ b/astroquery/mast/discovery_portal.py
@@ -127,9 +127,6 @@ class PortalAPI(BaseQuery):
     _column_configs = dict()
     _current_service = None
 
-    tess_all_name = 'Mast.Catalogs.All.Tic'
-    dd_all_name = 'Mast.Catalogs.All.Disk.Detective'
-
     def __init__(self, session=None):
 
         super(PortalAPI, self).__init__()
@@ -241,10 +238,10 @@ class PortalAPI(BaseQuery):
 
         more = False  # for some catalogs this is not enough information
         if "tess" in fetch_name.lower():
-            all_name = self.test_all_name
+            all_name = "Mast.Catalogs.All.Tic"
             more = True
         elif "dd." in fetch_name.lower():
-            all_name = self.dd_all_name
+            all_name = "Mast.Catalogs.All.DiskDetective"
             more = True
 
         if more:

--- a/astroquery/mast/discovery_portal.py
+++ b/astroquery/mast/discovery_portal.py
@@ -133,6 +133,9 @@ class PortalAPI(BaseQuery):
         self._column_configs = dict()
         self._current_service = None
 
+        self.tess_all_name = 'Mast.Catalogs.All.Tic'
+        self.dd_all_name = 'Mast.Catalogs.All.Disk.Detective'
+
     def _request(self, method, url, params=None, data=None, headers=None,
                  files=None, stream=False, auth=None, retrieve_all=True):
         """
@@ -238,10 +241,10 @@ class PortalAPI(BaseQuery):
 
         more = False  # for some catalogs this is not enough information
         if "tess" in fetch_name.lower():
-            all_name = "Mast.Catalogs.All.Tic"
+            all_name = self.test_all_name
             more = True
         elif "dd." in fetch_name.lower():
-            all_name = "Mast.Catalogs.All.DiskDetective"
+            all_name = self.dd_all_name
             more = True
 
         if more:

--- a/astroquery/mast/discovery_portal.py
+++ b/astroquery/mast/discovery_portal.py
@@ -116,25 +116,25 @@ class PortalAPI(BaseQuery):
     Should be used to facilitate all Portal API queries.
     """
 
+    MAST_REQUEST_URL = conf.server + "/api/v0/invoke"
+    COLUMNS_CONFIG_URL = conf.server + "/portal/Mashup/Mashup.asmx/columnsconfig"
+    MAST_DOWNLOAD_URL = conf.server + "/api/v0.1/Download/file"
+    MAST_BUNDLE_URL = conf.server + "/api/v0.1/Download/bundle"
+
+    TIMEOUT = conf.timeout
+    PAGESIZE = conf.pagesize
+
+    _column_configs = dict()
+    _current_service = None
+
+    tess_all_name = 'Mast.Catalogs.All.Tic'
+    dd_all_name = 'Mast.Catalogs.All.Disk.Detective'
+
     def __init__(self, session=None):
 
         super(PortalAPI, self).__init__()
         if session:
             self._session = session
-
-        self.MAST_REQUEST_URL = conf.server + "/api/v0/invoke"
-        self.COLUMNS_CONFIG_URL = conf.server + "/portal/Mashup/Mashup.asmx/columnsconfig"
-        self.MAST_DOWNLOAD_URL = conf.server + "/api/v0.1/Download/file"
-        self.MAST_BUNDLE_URL = conf.server + "/api/v0.1/Download/bundle"
-
-        self.TIMEOUT = conf.timeout
-        self.PAGESIZE = conf.pagesize
-
-        self._column_configs = dict()
-        self._current_service = None
-
-        self.tess_all_name = 'Mast.Catalogs.All.Tic'
-        self.dd_all_name = 'Mast.Catalogs.All.Disk.Detective'
 
     def _request(self, method, url, params=None, data=None, headers=None,
                  files=None, stream=False, auth=None, retrieve_all=True):
@@ -485,6 +485,7 @@ class PortalAPI(BaseQuery):
         headers = {"User-Agent": self._session.headers["User-Agent"],
                    "Content-type": "application/x-www-form-urlencoded",
                    "Accept": "text/plain"}
+
         response = self._request("POST", self.COLUMNS_CONFIG_URL,
                                  data=("colConfigId={}".format(colconf_name)), headers=headers)
 

--- a/astroquery/mast/observations.py
+++ b/astroquery/mast/observations.py
@@ -51,13 +51,6 @@ class ObservationsClass(MastQueryWithLogin):
     Class for querying MAST observational data.
     """
 
-    environment = os.environ['CONDA_DEFAULT_ENV']
-
-    if 'test' in environment.lower():
-        TESTING = '.24test'
-    elif 'ops' in environment.lower():
-        TESTING = None
-
     def _parse_result(self, responses, verbose=False):  # Used by the async_to_sync decorator functionality
         """
         Parse the results of a list of `~requests.Response` objects and returns an `~astropy.table.Table` of results.

--- a/astroquery/mast/observations.py
+++ b/astroquery/mast/observations.py
@@ -158,13 +158,13 @@ class ObservationsClass(MastQueryWithLogin):
         # Build the mashup filter object and store it in the correct service_name entry
         if coordinates or objectname:
             mashup_filters = self._portal_api_connection.build_filter_set(self._caom_cone,
-                                                         self._caom_filtered_position,
-                                                         **criteria)
+                                                            self._caom_filtered_position,
+                                                            **criteria)
             coordinates = utils.parse_input_location(coordinates, objectname)
         else:
             mashup_filters = self._portal_api_connection.build_filter_set(self._caom_cone,
-                                                         self._caom_filtered,
-                                                         **criteria)
+                                                            self._caom_filtered,
+                                                            **criteria)
 
         # handle position info (if any)
         position = None
@@ -173,7 +173,7 @@ class ObservationsClass(MastQueryWithLogin):
             # if radius is just a number we assume degrees
             radius = coord.Angle(radius, u.deg)
 
-            # build the coordinates string needed by Mast.Caom.Filtered.Position
+            # build the coordinates string needed by ObservationsClass._caom_filtered_position
             position = ', '.join([str(x) for x in (coordinates.ra.deg, coordinates.dec.deg, radius.deg)])
 
         return position, mashup_filters
@@ -327,7 +327,7 @@ class ObservationsClass(MastQueryWithLogin):
         response : int
         """
 
-        # build the coordinates string needed by Mast.Caom.Filtered.Position
+        # build the coordinates string needed by ObservationsClass._caom_filtered_position
         coordinates = commons.parse_coordinates(coordinates)
 
         # if radius is just a number we assume degrees

--- a/astroquery/mast/observations.py
+++ b/astroquery/mast/observations.py
@@ -6,13 +6,10 @@ MAST Observations
 This module contains various methods for querying MAST observations.
 """
 
-
-import ctypes
 import warnings
 import json
 import time
 import os
-import sys
 import uuid
 
 import numpy as np
@@ -39,8 +36,6 @@ from ..exceptions import (TimeoutError, InvalidQueryError, RemoteServiceError,
 
 from . import conf, utils
 from .core import MastQueryWithLogin
-
-import astroquery
 
 __all__ = ['Observations', 'ObservationsClass',
            'MastClass', 'Mast']
@@ -91,10 +86,8 @@ class ObservationsClass(MastQueryWithLogin):
             List of available missions.
         """
 
-        # calling `service` variable
-        service = self.caom_all
-
         # getting all the histogram information
+        service = self.caom_all
         params = {}
         response = self._portal_api_connection.service_request_async(service, params, format='extjs')
         json_response = response[0].json()
@@ -107,7 +100,6 @@ class ObservationsClass(MastQueryWithLogin):
                 missions = list(mission_info.keys())
                 missions.remove('hist')
                 return missions
-
 
     def get_metadata(self, query_type):
         """
@@ -170,7 +162,8 @@ class ObservationsClass(MastQueryWithLogin):
                                                          **criteria)
             coordinates = utils.parse_input_location(coordinates, objectname)
         else:
-            mashup_filters = self._portal_api_connection.build_filter_set(self.caom_cone,                                                     self.caom_filtered,
+            mashup_filters = self._portal_api_connection.build_filter_set(self.caom_cone,
+                                                         self.caom_filtered,
                                                          **criteria)
 
         # handle position info (if any)

--- a/astroquery/mast/observations.py
+++ b/astroquery/mast/observations.py
@@ -7,10 +7,12 @@ This module contains various methods for querying MAST observations.
 """
 
 
+import ctypes
 import warnings
 import json
 import time
 import os
+import sys
 import uuid
 
 import numpy as np

--- a/astroquery/mast/observations.py
+++ b/astroquery/mast/observations.py
@@ -50,11 +50,11 @@ class ObservationsClass(MastQueryWithLogin):
     """
 
     # Calling static class variables
-    caom_all = 'Mast.Caom.All'
-    caom_cone = 'Mast.Caom.Cone'
-    caom_filtered_position = 'Mast.Caom.Filtered.Position'
-    caom_filtered = 'Mast.Caom.Filtered'
-    caom_products = 'Mast.Caom.Products'
+    _caom_all = 'Mast.Caom.All'
+    _caom_cone = 'Mast.Caom.Cone'
+    _caom_filtered_position = 'Mast.Caom.Filtered.Position'
+    _caom_filtered = 'Mast.Caom.Filtered'
+    _caom_products = 'Mast.Caom.Products'
 
     def _parse_result(self, responses, verbose=False):  # Used by the async_to_sync decorator functionality
         """
@@ -87,7 +87,7 @@ class ObservationsClass(MastQueryWithLogin):
         """
 
         # getting all the histogram information
-        service = self.caom_all
+        service = self._caom_all
         params = {}
         response = self._portal_api_connection.service_request_async(service, params, format='extjs')
         json_response = response[0].json()
@@ -117,9 +117,9 @@ class ObservationsClass(MastQueryWithLogin):
         """
 
         if query_type.lower() == "observations":
-            colconf_name = self.caom_cone
+            colconf_name = self._caom_cone
         elif query_type.lower() == "products":
-            colconf_name = self.caom_products
+            colconf_name = self._caom_products
         else:
             raise InvalidQueryError("Unknown query type.")
 
@@ -157,13 +157,13 @@ class ObservationsClass(MastQueryWithLogin):
 
         # Build the mashup filter object and store it in the correct service_name entry
         if coordinates or objectname:
-            mashup_filters = self._portal_api_connection.build_filter_set(self.caom_cone,
-                                                         self.caom_filtered_position,
+            mashup_filters = self._portal_api_connection.build_filter_set(self._caom_cone,
+                                                         self._caom_filtered_position,
                                                          **criteria)
             coordinates = utils.parse_input_location(coordinates, objectname)
         else:
-            mashup_filters = self._portal_api_connection.build_filter_set(self.caom_cone,
-                                                         self.caom_filtered,
+            mashup_filters = self._portal_api_connection.build_filter_set(self._caom_cone,
+                                                         self._caom_filtered,
                                                          **criteria)
 
         # handle position info (if any)
@@ -214,7 +214,7 @@ class ObservationsClass(MastQueryWithLogin):
         # if radius is just a number we assume degrees
         radius = coord.Angle(radius, u.deg)
 
-        service = self.caom_cone
+        service = self._caom_cone
         params = {'ra': coordinates.ra.deg,
                   'dec': coordinates.dec.deg,
                   'radius': radius.deg}
@@ -291,12 +291,12 @@ class ObservationsClass(MastQueryWithLogin):
             raise InvalidQueryError("At least one non-positional criterion must be supplied.")
 
         if position:
-            service = self.caom_filtered_position
+            service = self._caom_filtered_position
             params = {"columns": "*",
                       "filters": mashup_filters,
                       "position": position}
         else:
-            service = self.caom_filtered
+            service = self._caom_filtered
             params = {"columns": "*",
                       "filters": mashup_filters}
 
@@ -336,7 +336,7 @@ class ObservationsClass(MastQueryWithLogin):
         # turn coordinates into the format
         position = ', '.join([str(x) for x in (coordinates.ra.deg, coordinates.dec.deg, radius.deg)])
 
-        service = self.caom_filtered_position
+        service = self._caom_filtered_position
         params = {"columns": "COUNT_BIG(*)",
                   "filters": [],
                   "position": position}
@@ -404,12 +404,12 @@ class ObservationsClass(MastQueryWithLogin):
 
         # send query
         if position:
-            service = self.caom_filtered_position
+            service = self._caom_filtered_position
             params = {"columns": "COUNT_BIG(*)",
                       "filters": mashup_filters,
                       "position": position}
         else:
-            service = self.caom_filtered
+            service = self._caom_filtered
             params = {"columns": "COUNT_BIG(*)",
                       "filters": mashup_filters}
 
@@ -445,7 +445,7 @@ class ObservationsClass(MastQueryWithLogin):
         if len(observations) == 0:
             raise InvalidQueryError("Observation list is empty, no associated products.")
 
-        service = self.caom_products
+        service = self._caom_products
         params = {'obsid': ','.join(observations)}
 
         return self._portal_api_connection.service_request_async(service, params)

--- a/astroquery/mast/observations.py
+++ b/astroquery/mast/observations.py
@@ -51,6 +51,13 @@ class ObservationsClass(MastQueryWithLogin):
     Class for querying MAST observational data.
     """
 
+    environment = os.environ['CONDA_DEFAULT_ENV']
+
+    if 'test' in environment.lower():
+        TESTING = '.24test'
+    elif 'ops' in environment.lower():
+        TESTING = None
+
     def _parse_result(self, responses, verbose=False):  # Used by the async_to_sync decorator functionality
         """
         Parse the results of a list of `~requests.Response` objects and returns an `~astropy.table.Table` of results.
@@ -71,7 +78,17 @@ class ObservationsClass(MastQueryWithLogin):
 
         return self._portal_api_connection._parse_result(responses, verbose)
 
-    def list_missions(self):
+    def overwrite_service(input_service):
+
+        frame = sys._getframe(1)
+
+        # The input parameter that gets called (`service`) will be overwritten by `input_service`
+        frame.f_locals['service'] = input_service
+
+        ctypes.pythonapi.PyFrame_LocalsToFast(ctypes.py_object(frame),
+                                              ctypes.c_int(0))
+
+    def list_missions(self, testing=TESTING):
         """
         Lists data missions archived by MAST and avaiable through `astroquery.mast`.
 
@@ -82,7 +99,7 @@ class ObservationsClass(MastQueryWithLogin):
         """
 
         # getting all the histogram information
-        service = "Mast.Caom.All"
+        service = "Mast.Caom.All" if testing is None else testing
         params = {}
         response = self._portal_api_connection.service_request_async(service, params, format='extjs')
         json_response = response[0].json()

--- a/astroquery/mast/observations.py
+++ b/astroquery/mast/observations.py
@@ -53,6 +53,16 @@ class ObservationsClass(MastQueryWithLogin):
     Class for querying MAST observational data.
     """
 
+    def _overwrite_service(input_service):
+
+        frame = sys._getframe(1)
+
+        # The input parameter that gets called (`service`) will be modified by `input_service`
+        frame.f_locals['service'] = frame.f_locals['service']+in_service
+
+        ctypes.pythonapi.PyFrame_LocalsToFast(ctypes.py_object(frame),
+                                              ctypes.c_int(0))
+
     def _parse_result(self, responses, verbose=False):  # Used by the async_to_sync decorator functionality
         """
         Parse the results of a list of `~requests.Response` objects and returns an `~astropy.table.Table` of results.
@@ -73,16 +83,6 @@ class ObservationsClass(MastQueryWithLogin):
 
         return self._portal_api_connection._parse_result(responses, verbose)
 
-    def overwrite_service(input_service):
-
-        frame = sys._getframe(1)
-
-        # The input parameter that gets called (`service`) will be modified by `input_service`
-        frame.f_locals['service'] = frame.f_locals['service']+in_service
-
-        ctypes.pythonapi.PyFrame_LocalsToFast(ctypes.py_object(frame),
-                                              ctypes.c_int(0))
-
     def list_missions(self, testing=TESTING):
         """
         Lists data missions archived by MAST and avaiable through `astroquery.mast`.
@@ -94,7 +94,7 @@ class ObservationsClass(MastQueryWithLogin):
         """
 
         # getting all the histogram information
-        service = "Mast.Caom.All" if testing is None else testing
+        service = "Mast.Caom.All" if testing is None else _overwrite_service(testing)
         params = {}
         response = self._portal_api_connection.service_request_async(service, params, format='extjs')
         json_response = response[0].json()

--- a/astroquery/mast/observations.py
+++ b/astroquery/mast/observations.py
@@ -40,6 +40,7 @@ from ..exceptions import (TimeoutError, InvalidQueryError, RemoteServiceError,
 from . import conf, utils
 from .core import MastQueryWithLogin
 
+import astroquery
 
 __all__ = ['Observations', 'ObservationsClass',
            'MastClass', 'Mast']
@@ -91,7 +92,7 @@ class ObservationsClass(MastQueryWithLogin):
         """
 
         # calling `service` variable
-        service = ObservationsClass.caom_all
+        service = Observations.caom_all
 
         # getting all the histogram information
         params = {}
@@ -106,6 +107,7 @@ class ObservationsClass(MastQueryWithLogin):
                 missions = list(mission_info.keys())
                 missions.remove('hist')
                 return missions
+
 
     def get_metadata(self, query_type):
         """
@@ -164,7 +166,7 @@ class ObservationsClass(MastQueryWithLogin):
         # Build the mashup filter object and store it in the correct service_name entry
         if coordinates or objectname:
             mashup_filters = self._portal_api_connection.build_filter_set(ObservationsClass.caom_cone,
-                                                                           ObservationsClass.caom_filtercaom_filtered_position,
+                                                                           ObservationsClass.caom_filtered_position,
                                                                            **criteria)
             coordinates = utils.parse_input_location(coordinates, objectname)
         else:

--- a/astroquery/mast/observations.py
+++ b/astroquery/mast/observations.py
@@ -92,7 +92,7 @@ class ObservationsClass(MastQueryWithLogin):
         """
 
         # calling `service` variable
-        service = Observations.caom_all
+        service = self.caom_all
 
         # getting all the histogram information
         params = {}
@@ -125,9 +125,9 @@ class ObservationsClass(MastQueryWithLogin):
         """
 
         if query_type.lower() == "observations":
-            colconf_name = ObservationsClass.caom_cone
+            colconf_name = self.caom_cone
         elif query_type.lower() == "products":
-            colconf_name = ObservationsClass.caom_products
+            colconf_name = self.caom_products
         else:
             raise InvalidQueryError("Unknown query type.")
 
@@ -165,14 +165,13 @@ class ObservationsClass(MastQueryWithLogin):
 
         # Build the mashup filter object and store it in the correct service_name entry
         if coordinates or objectname:
-            mashup_filters = self._portal_api_connection.build_filter_set(ObservationsClass.caom_cone,
-                                                                           ObservationsClass.caom_filtered_position,
-                                                                           **criteria)
+            mashup_filters = self._portal_api_connection.build_filter_set(self.caom_cone,
+                                                         self.caom_filtered_position,
+                                                         **criteria)
             coordinates = utils.parse_input_location(coordinates, objectname)
         else:
-            mashup_filters = self._portal_api_connection.build_filter_set(ObservationsClass.caom_cone,
-                                                                           ObservationsClass.caom_filtered,
-                                                                           **criteria)
+            mashup_filters = self._portal_api_connection.build_filter_set(self.caom_cone,                                                     self.caom_filtered,
+                                                         **criteria)
 
         # handle position info (if any)
         position = None
@@ -222,7 +221,7 @@ class ObservationsClass(MastQueryWithLogin):
         # if radius is just a number we assume degrees
         radius = coord.Angle(radius, u.deg)
 
-        service = ObservationsClass.caom_cone
+        service = self.caom_cone
         params = {'ra': coordinates.ra.deg,
                   'dec': coordinates.dec.deg,
                   'radius': radius.deg}
@@ -299,12 +298,12 @@ class ObservationsClass(MastQueryWithLogin):
             raise InvalidQueryError("At least one non-positional criterion must be supplied.")
 
         if position:
-            service = ObservationsClass.caom_filtered_position
+            service = self.caom_filtered_position
             params = {"columns": "*",
                       "filters": mashup_filters,
                       "position": position}
         else:
-            service = ObservationsClass.caom_filtered
+            service = self.caom_filtered
             params = {"columns": "*",
                       "filters": mashup_filters}
 
@@ -344,7 +343,7 @@ class ObservationsClass(MastQueryWithLogin):
         # turn coordinates into the format
         position = ', '.join([str(x) for x in (coordinates.ra.deg, coordinates.dec.deg, radius.deg)])
 
-        service = ObservationsClass.caom_filtered_position
+        service = self.caom_filtered_position
         params = {"columns": "COUNT_BIG(*)",
                   "filters": [],
                   "position": position}
@@ -412,12 +411,12 @@ class ObservationsClass(MastQueryWithLogin):
 
         # send query
         if position:
-            service = ObservationsClass.caom_filtered_position
+            service = self.caom_filtered_position
             params = {"columns": "COUNT_BIG(*)",
                       "filters": mashup_filters,
                       "position": position}
         else:
-            service = ObservationsClass.caom_filtered
+            service = self.caom_filtered
             params = {"columns": "COUNT_BIG(*)",
                       "filters": mashup_filters}
 
@@ -453,7 +452,7 @@ class ObservationsClass(MastQueryWithLogin):
         if len(observations) == 0:
             raise InvalidQueryError("Observation list is empty, no associated products.")
 
-        service = ObservationsClass.caom_products
+        service = self.caom_products
         params = {'obsid': ','.join(observations)}
 
         return self._portal_api_connection.service_request_async(service, params)

--- a/astroquery/mast/observations.py
+++ b/astroquery/mast/observations.py
@@ -77,8 +77,8 @@ class ObservationsClass(MastQueryWithLogin):
 
         frame = sys._getframe(1)
 
-        # The input parameter that gets called (`service`) will be overwritten by `input_service`
-        frame.f_locals['service'] = input_service
+        # The input parameter that gets called (`service`) will be modified by `input_service`
+        frame.f_locals['service'] = frame.f_locals['service']+in_service
 
         ctypes.pythonapi.PyFrame_LocalsToFast(ctypes.py_object(frame),
                                               ctypes.c_int(0))

--- a/astroquery/mast/observations.py
+++ b/astroquery/mast/observations.py
@@ -93,8 +93,11 @@ class ObservationsClass(MastQueryWithLogin):
             List of available missions.
         """
 
+        # calling `service` variable 
+        service = "Mast.Caom.All"
+        if testing is not None: _overwrite_service(testing)
+
         # getting all the histogram information
-        service = "Mast.Caom.All" if testing is None else _overwrite_service(testing)
         params = {}
         response = self._portal_api_connection.service_request_async(service, params, format='extjs')
         json_response = response[0].json()

--- a/astroquery/mast/services.py
+++ b/astroquery/mast/services.py
@@ -249,6 +249,7 @@ class ServiceAPI(BaseQuery):
             compiled_service_args[service_argument] = found_argument.lower()
 
         request_url = self.REQUEST_URL + service_url.format(**compiled_service_args)
+
         headers = {
             'User-Agent': self._session.headers['User-Agent'],
             'Content-type': 'application/x-www-form-urlencoded',

--- a/astroquery/mast/services.py
+++ b/astroquery/mast/services.py
@@ -101,14 +101,15 @@ class ServiceAPI(BaseQuery):
     Should be used to facilitate all microservice API queries.
     """
 
+    SERVICE_URL = conf.server
+    REQUEST_URL = conf.server + "/api/v0.1/"
+    SERVICES = {}
+
     def __init__(self, session=None):
 
         super().__init__()
         if session:
             self._session = session
-
-        self.REQUEST_URL = conf.server + "/api/v0.1/"
-        self.SERVICES = {}
 
         self.TIMEOUT = conf.timeout
 
@@ -128,7 +129,7 @@ class ServiceAPI(BaseQuery):
             vs. the default of mast.stsci.edu/service_name
         """
 
-        service_url = conf.server
+        service_url = self.SERVICE_URL
         if server_prefix:
             service_url = service_url.replace("mast", f"{service_name}.mast")
         else:


### PR DESCRIPTION
To support our back-end unit testing that will involve patching the `service` variables currently hard-coded in several mast scripts, I'm requesting to have `service` call static class attributes that live outside of the methods, which allows the STScI developers to patch these as necessary for our unit tests. 

Please note: This pull request is time-sensitive, and should take precedent over the other pull requests I have open for astroquery. ~~I aim to have this ready and merged before the end of November.~~

Update: After a shift of the scope for this year, we've changed the timeline to have it ready by early December or beginning of January. 

- [x] Observations
- [x] Catalogs
- [x] Cutouts