### PR TITLE
Fix simbad remote tests

### DIFF
--- a/astroquery/simbad/core.py
+++ b/astroquery/simbad/core.py
@@ -17,11 +17,11 @@ import astropy.coordinates as coord
 from astropy.table import Table
 import astropy.io.votable as votable
 
-from ..query import BaseQuery
-from ..utils import commons
-from ..exceptions import TableParseError, LargeQueryWarning
+from astroquery.query import BaseQuery
+from astroquery.utils import commons, async_to_sync
+from astroquery.exceptions import TableParseError, LargeQueryWarning
 from . import conf
-from ..utils.process_asyncs import async_to_sync
+
 
 __all__ = ['Simbad', 'SimbadClass', 'SimbadBaseQuery']
 
@@ -183,7 +183,7 @@ class SimbadVOTableResult(SimbadResult):
         self.__table = None
         if not verbose:
             commons.suppress_vo_warnings()
-        super(SimbadVOTableResult, self).__init__(txt, verbose=verbose)
+        super().__init__(txt, verbose=verbose)
 
     @property
     def table(self):
@@ -232,7 +232,7 @@ class SimbadBaseQuery(BaseQuery):
     """
     def _request(self, *args, **kwargs):
         try:
-            response = super(SimbadBaseQuery, self)._request(*args, **kwargs)
+            response = super()._request(*args, **kwargs)
         except requests.exceptions.ConnectionError as ex:
             if 'Errno 61' in str(ex):
                 extratext = ("\n\n"
@@ -302,7 +302,7 @@ class SimbadClass(SimbadBaseQuery):
     _VOTABLE_FIELDS = ['main_id', 'coordinates']
 
     def __init__(self):
-        super(SimbadClass, self).__init__()
+        super().__init__()
         self._VOTABLE_FIELDS = copy.copy(self._VOTABLE_FIELDS)
 
     def list_wildcards(self):

--- a/astroquery/simbad/tests/test_simbad.py
+++ b/astroquery/simbad/tests/test_simbad.py
@@ -38,7 +38,7 @@ DATA_FILES = {
 class MockResponseSimbad(MockResponse):
     query_regex = re.compile(r'query\s+([a-z]+)\s+')
 
-    def __init__(self, script, cache=True, **kwargs):
+    def __init__(self, script, cache=False, **kwargs):
         # preserve, e.g., headers
         super(MockResponseSimbad, self).__init__(**kwargs)
         self.content = self.get_content(script)

--- a/astroquery/simbad/tests/test_simbad_remote.py
+++ b/astroquery/simbad/tests/test_simbad_remote.py
@@ -1,17 +1,21 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 import pytest
+import shutil
+import tempfile
 
-import astropy.coordinates as coord
+from astropy.coordinates import SkyCoord
 import astropy.units as u
 from astropy.table import Table
-from ...utils.testing_tools import MockResponse
-from ... import simbad
+from astroquery.utils.testing_tools import MockResponse
+from astroquery.simbad import Simbad
+# Maybe we need to expose SimbadVOTableResult to be in the public API?
+from astroquery.simbad.core import SimbadVOTableResult
 
 
 # M42 coordinates
-ICRS_COORDS_M42 = coord.SkyCoord("05h35m17.3s -05h23m28s", frame='icrs')
-ICRS_COORDS_SgrB2 = coord.SkyCoord(266.835*u.deg, -28.38528*u.deg, frame='icrs')
-multicoords = coord.SkyCoord([ICRS_COORDS_M42, ICRS_COORDS_SgrB2])
+ICRS_COORDS_M42 = SkyCoord("05h35m17.3s -05h23m28s", frame='icrs')
+ICRS_COORDS_SgrB2 = SkyCoord(266.835*u.deg, -28.38528*u.deg, frame='icrs')
+multicoords = SkyCoord([ICRS_COORDS_M42, ICRS_COORDS_SgrB2])
 
 
 @pytest.mark.remote_data
@@ -19,19 +23,34 @@ class TestSimbad:
 
     @classmethod
     def setup_class(cls):
-        simbad.core.Simbad.ROW_LIMIT = 5
+        Simbad.ROW_LIMIT = 5
 
-    def test_query_criteria1(self):
-        result = simbad.core.Simbad.query_criteria(
+    @pytest.fixture()
+    def temp_dir(self, request):
+        my_temp_dir = tempfile.mkdtemp()
+
+        def fin():
+            shutil.rmtree(my_temp_dir)
+        request.addfinalizer(fin)
+        return my_temp_dir
+
+    def test_query_criteria1(self, temp_dir):
+        simbad = Simbad()
+        simbad.cache_location = temp_dir
+        result = simbad.query_criteria(
             "region(box, GAL, 49.89 -0.3, 0.5d 0.5d)", otype='HII')
         assert isinstance(result, Table)
 
-    def test_query_criteria2(self):
-        result = simbad.core.Simbad.query_criteria(otype='SNR')
+    def test_query_criteria2(self, temp_dir):
+        simbad = Simbad()
+        simbad.cache_location = temp_dir
+        result = simbad.query_criteria(otype='SNR')
         assert isinstance(result, Table)
 
-    def test_query_bibcode_async(self):
-        response = simbad.core.Simbad.query_bibcode_async(
+    def test_query_bibcode_async(self, temp_dir):
+        simbad = Simbad()
+        simbad.cache_location = temp_dir
+        response = simbad.query_bibcode_async(
             '2006ApJ*', wildcard=True)
         assert response is not None
         response.raise_for_status()
@@ -43,76 +62,101 @@ class TestSimbad:
         assert not isinstance(response, MockResponse)
         assert not issubclass(response.__class__, MockResponse)
 
-    def test_query_bibcode(self):
-        result = simbad.core.Simbad.query_bibcode('2006ApJ*', wildcard=True)
+    def test_query_bibcode(self, temp_dir):
+        simbad = Simbad()
+        simbad.cache_location = temp_dir
+        result = simbad.query_bibcode('2006ApJ*', wildcard=True)
         assert isinstance(result, Table)
 
-    def test_query_bibobj_async(self):
-        response = simbad.core.Simbad.query_bibobj_async('2005A&A.430.165F')
+    def test_query_bibobj_async(self, temp_dir):
+        simbad = Simbad()
+        simbad.cache_location = temp_dir
+        response = simbad.query_bibobj_async('2005A&A.430.165F')
         assert response is not None
 
-    def test_query_bibobj(self):
-        result = simbad.core.Simbad.query_bibobj('2005A&A.430.165F')
+    def test_query_bibobj(self, temp_dir):
+        simbad = Simbad()
+        simbad.cache_location = temp_dir
+        result = simbad.query_bibobj('2005A&A.430.165F')
         assert isinstance(result, Table)
 
-    def test_query_catalog_async(self):
-        response = simbad.core.Simbad.query_catalog_async('m')
+    def test_query_catalog_async(self, temp_dir):
+        simbad = Simbad()
+        simbad.cache_location = temp_dir
+        response = simbad.query_catalog_async('m')
         assert response is not None
 
-    def test_query_catalog(self):
-        result = simbad.core.Simbad.query_catalog('m')
+    def test_query_catalog(self, temp_dir):
+        simbad = Simbad()
+        simbad.cache_location = temp_dir
+        result = simbad.query_catalog('m')
         assert isinstance(result, Table)
 
-    def test_query_region_async(self):
-        response = simbad.core.Simbad.query_region_async(
+    def test_query_region_async(self, temp_dir):
+        simbad = Simbad()
+        simbad.cache_location = temp_dir
+        response = simbad.query_region_async(
             ICRS_COORDS_M42, radius=5 * u.deg, equinox=2000.0, epoch='J2000')
 
         assert response is not None
 
-    def test_query_region_async_vector(self):
-        response1 = simbad.core.Simbad.query_region_async(multicoords,
+    def test_query_region_async_vector(self, temp_dir):
+        simbad = Simbad()
+        simbad.cache_location = temp_dir
+        response1 = simbad.query_region_async(multicoords,
                                                           radius=0.5*u.arcsec)
         assert response1.request.body == 'script=votable+%7Bmain_id%2Ccoordinates%7D%0Avotable+open%0Aquery+coo+5%3A35%3A17.3+-80%3A52%3A00+radius%3D0.5s+frame%3DICRS+equi%3D2000.0%0Aquery+coo+17%3A47%3A20.4+-28%3A23%3A07.008+radius%3D0.5s+frame%3DICRS+equi%3D2000.0%0Avotable+close'   # noqa
 
-    def test_query_region(self):
-        result = simbad.core.Simbad.query_region(ICRS_COORDS_M42, radius=5 * u.deg,
-                                                 equinox=2000.0, epoch='J2000')
+    def test_query_region(self, temp_dir):
+        simbad = Simbad()
+        simbad.cache_location = temp_dir
+        result = simbad.query_region(ICRS_COORDS_M42, radius=5 * u.deg,
+                                     equinox=2000.0, epoch='J2000')
         assert isinstance(result, Table)
 
-    def test_query_regions(self):
-        result = simbad.core.Simbad.query_region(multicoords, radius=1 * u.arcmin,
-                                                 equinox=2000.0, epoch='J2000')
+    def test_query_regions(self, temp_dir):
+        simbad = Simbad()
+        simbad.cache_location = temp_dir
+        result = simbad.query_region(multicoords, radius=1 * u.arcmin,
+                                     equinox=2000.0, epoch='J2000')
         assert isinstance(result, Table)
 
-    def test_query_object_async(self):
-        response = simbad.core.Simbad.query_object_async("m [0-9]",
-                                                         wildcard=True)
+    def test_query_object_async(self, temp_dir):
+        simbad = Simbad()
+        simbad.cache_location = temp_dir
+        response = simbad.query_object_async("m [0-9]", wildcard=True)
         assert response is not None
 
-    def test_query_object(self):
-        result = simbad.core.Simbad.query_object("m [0-9]", wildcard=True)
+    def test_query_object(self, temp_dir):
+        simbad = Simbad()
+        simbad.cache_location = temp_dir
+        result = simbad.query_object("m [0-9]", wildcard=True)
         assert isinstance(result, Table)
 
-    def test_query_multi_object(self):
-        result = simbad.core.Simbad.query_objects(['M32', 'M81'])
+    def test_query_multi_object(self, temp_dir):
+        simbad = Simbad()
+        simbad.cache_location = temp_dir
+        result = simbad.query_objects(['M32', 'M81'])
         assert len(result) == 2
         assert len(result.errors) == 0
 
-        result = simbad.core.Simbad.query_objects(['M32', 'M81', 'gHer'])
+        result = simbad.query_objects(['M32', 'M81', 'gHer'])
         # 'gHer' is not a valid Simbad identifier - it should be 'g Her' to
         # get the star
         assert len(result) == 2
         assert len(result.errors) == 1
 
         # test async
-        s = simbad.core.Simbad()
+        s = Simbad()
         response = s.query_objects_async(['M32', 'M81'])
 
-        result = s._parse_result(response, simbad.core.SimbadVOTableResult)
+        result = s._parse_result(response, SimbadVOTableResult)
         assert len(result) == 2
 
-    def test_query_object_ids(self):
-        result = simbad.core.Simbad.query_objectids("Polaris")
+    def test_query_object_ids(self, temp_dir):
+        simbad = Simbad()
+        simbad.cache_location = temp_dir
+        result = simbad.query_objectids("Polaris")
 
         # Today, there are 42 names.  There could be more in the future
         assert len(result) >= 42
@@ -126,47 +170,53 @@ class TestSimbad:
         ('query_bibobj'),
         ('query_bibcode'),
         ('query_objectids')])
-    def test_null_response(self, function):
-        assert (simbad.core.Simbad.__getattribute__(function)('idonotexist')
+    def test_null_response(self, temp_dir, function):
+        simbad = Simbad()
+        simbad.cache_location = temp_dir
+        assert (simbad.__getattribute__(function)('idonotexist')
                 is None)
 
     # Special case of null test: list of nonexistent parameters
-    def test_query_objects_null(self):
-        assert simbad.core.Simbad.query_objects(['idonotexist',
-                                                 'idonotexisteither']) is None
+    def test_query_objects_null(self, temp_dir):
+        simbad = Simbad()
+        simbad.cache_location = temp_dir
+        assert simbad.query_objects(['idonotexist', 'idonotexisteither']) is None
 
     # Special case of null test: zero-sized region
-    def test_query_region_null(self):
-        result = simbad.core.Simbad.query_region(
-            coord.SkyCoord("00h01m0.0s 00h00m0.0s"), radius="0d",
-            equinox=2000.0, epoch='J2000')
+    def test_query_region_null(self, temp_dir):
+        simbad = Simbad()
+        simbad.cache_location = temp_dir
+        result = simbad.query_region(SkyCoord("00h01m0.0s 00h00m0.0s"), radius="0d",
+                                     equinox=2000.0, epoch='J2000')
         assert result is None
 
     # Special case of null test: very small region
-    def test_query_small_region_null(self):
-        result = simbad.core.Simbad.query_region(
-            coord.SkyCoord("00h01m0.0s 00h00m0.0s"), radius=1.0 * u.marcsec,
-            equinox=2000.0, epoch='J2000')
+    def test_query_small_region_null(self, temp_dir):
+        simbad = Simbad()
+        simbad.cache_location = temp_dir
+        result = simbad.query_region(SkyCoord("00h01m0.0s 00h00m0.0s"), radius=1.0 * u.marcsec,
+                                     equinox=2000.0, epoch='J2000')
         assert result is None
 
     # Special case : zero-sized region with one object
-    def test_query_zero_sized_region(self):
-        result = simbad.core.Simbad.query_region(
-            coord.SkyCoord("20h54m05.6889s 37d01m17.380s"), radius="1s",
-            equinox=2000.0, epoch='J2000')
+    def test_query_zero_sized_region(self, temp_dir):
+        simbad = Simbad()
+        simbad.cache_location = temp_dir
+        result = simbad.query_region(SkyCoord("20h54m05.6889s 37d01m17.380s"), radius="1s",
+                                     equinox=2000.0, epoch='J2000')
         # This should find a single star, BD+36 4308
         assert len(result) == 1
 
     def test_simbad_flux_qual(self):
         '''Regression test for issue 680'''
-        request = simbad.core.Simbad()
+        request = Simbad()
         request.add_votable_fields("flux_qual(V)")
         response = request.query_object('algol')
         assert("FLUX_QUAL_V" in response.keys())
 
     def test_multi_vo_fields(self):
         '''Regression test for issue 820'''
-        request = simbad.core.Simbad()
+        request = Simbad()
 
         request.add_votable_fields("flux_qual(V)")
         request.add_votable_fields("flux_qual(R)")

--- a/astroquery/simbad/tests/test_simbad_remote.py
+++ b/astroquery/simbad/tests/test_simbad_remote.py
@@ -21,10 +21,6 @@ multicoords = SkyCoord([ICRS_COORDS_M42, ICRS_COORDS_SgrB2])
 @pytest.mark.remote_data
 class TestSimbad:
 
-    @classmethod
-    def setup_class(cls):
-        Simbad.ROW_LIMIT = 5
-
     @pytest.fixture()
     def temp_dir(self, request):
         my_temp_dir = tempfile.mkdtemp()
@@ -71,14 +67,16 @@ class TestSimbad:
     def test_query_bibobj_async(self, temp_dir):
         simbad = Simbad()
         simbad.cache_location = temp_dir
-        response = simbad.query_bibobj_async('2005A&A.430.165F')
+        response = simbad.query_bibobj_async('2006AJ....131.1163S')
         assert response is not None
 
     def test_query_bibobj(self, temp_dir):
         simbad = Simbad()
+        simbad.ROW_LIMIT = 5
         simbad.cache_location = temp_dir
         result = simbad.query_bibobj('2005A&A.430.165F')
         assert isinstance(result, Table)
+        assert len(result) == 5
 
     def test_query_catalog_async(self, temp_dir):
         simbad = Simbad()
@@ -94,23 +92,26 @@ class TestSimbad:
 
     def test_query_region_async(self, temp_dir):
         simbad = Simbad()
+        # TODO: rewise once ROW_LIMIT is working
+        simbad.TIMEOUT = 100
         simbad.cache_location = temp_dir
         response = simbad.query_region_async(
-            ICRS_COORDS_M42, radius=5 * u.deg, equinox=2000.0, epoch='J2000')
+            ICRS_COORDS_M42, radius=2 * u.deg, equinox=2000.0, epoch='J2000')
 
         assert response is not None
 
     def test_query_region_async_vector(self, temp_dir):
         simbad = Simbad()
         simbad.cache_location = temp_dir
-        response1 = simbad.query_region_async(multicoords,
-                                                          radius=0.5*u.arcsec)
+        response1 = simbad.query_region_async(multicoords, radius=0.5*u.arcsec)
         assert response1.request.body == 'script=votable+%7Bmain_id%2Ccoordinates%7D%0Avotable+open%0Aquery+coo+5%3A35%3A17.3+-80%3A52%3A00+radius%3D0.5s+frame%3DICRS+equi%3D2000.0%0Aquery+coo+17%3A47%3A20.4+-28%3A23%3A07.008+radius%3D0.5s+frame%3DICRS+equi%3D2000.0%0Avotable+close'   # noqa
 
     def test_query_region(self, temp_dir):
         simbad = Simbad()
+        # TODO: rewise once ROW_LIMIT is working
+        simbad.TIMEOUT = 100
         simbad.cache_location = temp_dir
-        result = simbad.query_region(ICRS_COORDS_M42, radius=5 * u.deg,
+        result = simbad.query_region(ICRS_COORDS_M42, radius=2 * u.deg,
                                      equinox=2000.0, epoch='J2000')
         assert isinstance(result, Table)
 


### PR DESCRIPTION
Some of these failures are red herring regarding the module and related to changes to the logging system (see discussion in https://github.com/astropy/astroquery/issues/2195). As a workaround, I opted to use the same temp directory approach as we have in some other modules.

The remaining test failures were then due to some more timeouts as the ROW_LIMIT were not inherited properly in the new instances.

Fixes: #2195