### PR TITLE
Make `astroquery` treat `astropy` 5.0rc2 as 5.0

### DIFF
--- a/astroquery/utils/commons.py
+++ b/astroquery/utils/commons.py
@@ -57,7 +57,7 @@ __all__ = ['send_request',
 
 ASTROPY_LT_4_1 = not minversion('astropy', '4.1')
 ASTROPY_LT_4_3 = not minversion('astropy', '4.3')
-ASTROPY_LT_5_0 = not minversion('astropy', '5.0')
+ASTROPY_LT_5_0 = not minversion('astropy', '5.0rc1')
 
 
 @deprecated('0.4.4', alternative='astroquery.query.BaseQuery._request')


### PR DESCRIPTION
@astrofrog mentioned in https://github.com/astropy/astroquery/pull/2196#issuecomment-966227615 that testing `astroquery` with `astropy` 5.0rc2 ends with failure. This is because of code that distinguishes `astropy` 5.0 or later from the preceding versions, which includes the 5.0 release candidates. This pull request makes `astroquery` treat 5.0 release candidates as 5.0. Once `astropy` 5.0 is released and the release candidates have become irrelevant 8ec48b2624fd0d8b9d3d9fb106a8ae90639c2bb1 can be safely reverted.