### PR TITLE
ALMA: fix a deprecation issue

### DIFF
--- a/astroquery/alma/core.py
+++ b/astroquery/alma/core.py
@@ -577,7 +577,7 @@ class AlmaClass(QueryWithLogin):
             if res.status[0] != 'OK':
                 raise Exception('ERROR {}: {}'.format(res.status[0],
                                                       res.status[1]))
-            temp = res.table
+            temp = res.to_table()
             if ASTROPY_LT_4_1:
                 # very annoying
                 for col in [x for x in temp.colnames

--- a/astroquery/alma/core.py
+++ b/astroquery/alma/core.py
@@ -646,9 +646,11 @@ class AlmaClass(QueryWithLogin):
         query = "select distinct data_rights from ivoa.obscore where " \
                 "obs_id='{}'".format(uid)
         result = self.query_tap(query)
-        if not result or len(result.table) == 0:
+        if result:
+            tableresult = result.to_table()
+        if not result or len(tableresult) == 0:
             raise AttributeError('{} not found'.format(uid))
-        if len(result.table) == 1 and result.table[0][0] == 'Public':
+        if len(tableresult) == 1 and tableresult[0][0] == 'Public':
             return False
         return True
 

--- a/astroquery/alma/tests/test_alma.py
+++ b/astroquery/alma/tests/test_alma.py
@@ -381,7 +381,7 @@ def test_tap():
 def test_get_data_info():
     datalink_mock = Mock()
     dl_result = Table.read(data_path('alma-datalink.xml'), format='votable')
-    mock_response = Mock(table=dl_result)
+    mock_response = Mock(to_table=Mock(return_value=dl_result))
     mock_response.status = ['OK']
     datalink_mock.run_sync.return_value = mock_response
     alma = Alma()


### PR DESCRIPTION
The `get_data_info` and `is_proprietary` methods triggers a deprecation warning:
```python
WARNING: AstropyDeprecationWarning: Using the table property is deprecated. Please use se to_table() instead. [pyvo.dal.query]
```

This fixes the issue.