### PR TITLE
Fix for remote tests: atomic

### DIFF
--- a/astroquery/atomic/core.py
+++ b/astroquery/atomic/core.py
@@ -246,7 +246,7 @@ class AtomicLineListClass(BaseQuery):
         return response
 
     def _parse_result(self, response):
-        data = StringIO(BeautifulSoup(response.text).find('pre').text.strip())
+        data = StringIO(BeautifulSoup(response.text, 'html5').find('pre').text.strip())
         # `header` is e.g.:
         # "u'-LAMBDA-VAC-ANG-|-SPECTRUM--|TT|--------TERM---------|---J-J---|----LEVEL-ENERGY--CM-1----'"
         # `colnames` is then
@@ -306,7 +306,7 @@ class AtomicLineListClass(BaseQuery):
         if self.__default_form_values is None:
             response = self._request("GET", url=self.FORM_URL, data={},
                                      timeout=self.TIMEOUT, cache=True)
-            bs = BeautifulSoup(response.text)
+            bs = BeautifulSoup(response.text, 'html5')
             self._default_form = form = bs.find('form')
             self.__default_form_values = self._get_default_form_values(form)
 

--- a/astroquery/atomic/tests/test_atomic_remote.py
+++ b/astroquery/atomic/tests/test_atomic_remote.py
@@ -12,7 +12,7 @@ def test_default_form_values():
     default_response = AtomicLineList._request(
         method="GET", url=AtomicLineList.FORM_URL,
         data={}, timeout=AtomicLineList.TIMEOUT)
-    bs = BeautifulSoup(default_response.text)
+    bs = BeautifulSoup(default_response.text, 'html5')
     form = bs.find('form')
 
     default_form_values = AtomicLineList._get_default_form_values(form)

--- a/astroquery/atomic/tests/test_atomic_remote.py
+++ b/astroquery/atomic/tests/test_atomic_remote.py
@@ -30,7 +30,7 @@ def test_default_form_values():
 
 @pytest.mark.remote_data
 def test_query_with_default_params():
-    table = AtomicLineList.query_object()
+    table = AtomicLineList.query_object(cache=False)
     assert isinstance(table, Table)
     assert len(table) == 500
     assert str(table[:5]) == '''
@@ -49,7 +49,8 @@ def test_query_with_wavelength_params():
         wavelength_range=(15 * u.nm, 200 * u.Angstrom),
         wavelength_type='Air',
         wavelength_accuracy=20,
-        element_spectrum='C II-IV')
+        element_spectrum='C II-IV',
+        cache=False)
     assert isinstance(result, Table)
     assert result.colnames == ['LAMBDA VAC ANG', 'SPECTRUM', 'TT',
                               'CONFIGURATION', 'TERM', 'J J', 'A_ki',
@@ -67,7 +68,7 @@ def test_query_with_wavelength_params():
 
 @pytest.mark.remote_data
 def test_empty_result_set():
-    result = AtomicLineList.query_object(wavelength_accuracy=0)
+    result = AtomicLineList.query_object(wavelength_accuracy=0, cache=False)
     assert isinstance(result, Table)
     assert not result
     assert len(result) == 0
@@ -78,7 +79,7 @@ def test_lower_upper_ranges():
     result = AtomicLineList.query_object(
         lower_level_energy_range=u.Quantity((600 * u.cm**(-1), 1000 * u.cm**(-1))),
         upper_level_energy_range=u.Quantity((15000 * u.cm**(-1), 100000 * u.cm**(-1))),
-        element_spectrum='Ne III')
+        element_spectrum='Ne III', cache=False)
     assert isinstance(result, Table)
 
     assert np.all(result['LAMBDA VAC ANG'] ==


### PR DESCRIPTION
See https://github.com/astropy/astroquery/issues/2203

The "fix" locally was to:

1. specify the BeautifulSoup parser (this is OK)
2. change the tests so they don't use caching.  This is _not_ OK, there shouldn't be caching in the tests anyway.