### PR TITLE
Add file_format option for Ned.get_image_list()

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -13,7 +13,7 @@ Service fixes and enhancements
 casda
 ^^^^^^
 
-- Add ability to stage and download non image data which have been found 
+- Add ability to stage and download non image data which have been found
   through the CASDA obscore table. [#2158]
 
 gaia
@@ -21,6 +21,12 @@ gaia
 
 - The bug which caused changing the ``MAIN_GAIA_TABLE`` option to have no
   effect has been fixed [#2153]
+
+ipac.ned
+^^^^^^^^
+
+- Keyword 'file_format' is added to ``get_image_list`` to enable obtaining
+  links to non-fits file formats, too. [#2217]
 
 vizier
 ^^^^^^

--- a/astroquery/ipac/ned/core.py
+++ b/astroquery/ipac/ned/core.py
@@ -427,7 +427,7 @@ class NedClass(BaseQuery):
                           show_progress=True):
         """
         Serves the same purpose as `~NedClass.get_spectra` but returns
-        file-handlers to the remote files rather than downloading them.
+        file-handlers to the remote fits files rather than downloading them.
 
         Parameters
         ----------
@@ -443,7 +443,8 @@ class NedClass(BaseQuery):
 
         """
         image_urls = self.get_image_list(object_name, item='spectra',
-                                         get_query_payload=get_query_payload)
+                                         get_query_payload=get_query_payload,
+                                         file_format='fits')
         if get_query_payload:
             return image_urls
         return [commons.FileContainer(U, encoding='binary',
@@ -487,9 +488,9 @@ class NedClass(BaseQuery):
         url = Ned.SPECTRA_URL if item == 'spectra' else Ned.IMG_DATA_URL
         response = self._request("GET", url=url, params=request_payload,
                                  timeout=Ned.TIMEOUT)
-        return self.extract_image_urls(response.text, file_format=file_format)
+        return self._extract_image_urls(response.text, file_format=file_format)
 
-    def extract_image_urls(self, html_in, file_format='fits'):
+    def _extract_image_urls(self, html_in, file_format='fits'):
         """
         Helper function that uses regexps to extract the image urls from the
         given HTML.

--- a/astroquery/ipac/ned/tests/test_ned.py
+++ b/astroquery/ipac/ned/tests/test_ned.py
@@ -141,7 +141,7 @@ def test_photometry(patch_get):
 
 def test_extract_image_urls():
     html_in = open(data_path(DATA_FILES['extract_urls']), 'r').read()
-    url_list = ned.core.Ned.extract_image_urls(html_in)
+    url_list = ned.core.Ned._extract_image_urls(html_in)
     assert len(url_list) == 5
     for url in url_list:
         assert url.endswith('fits.gz')

--- a/astroquery/ipac/ned/tests/test_ned_remote.py
+++ b/astroquery/ipac/ned/tests/test_ned_remote.py
@@ -93,3 +93,11 @@ class TestNed:
     def test_get_object_notes(self):
         result = ned.core.Ned.get_table('3c 273', table='object_notes')
         assert isinstance(result, Table)
+
+    def test_file_format(self):
+        result_ascii = ned.core.Ned.get_image_list('NGC6060', item='spectra',
+                                                   file_format='NED-ascii')
+        result_fits = ned.core.Ned.get_image_list('NGC6060', item='spectra',
+                                                  file_format='fits')
+        assert len(result_ascii) == 3
+        assert len(result_fits) == 1


### PR DESCRIPTION
It came up in #2213 that we only return links to fits files. This PR enables listing other formats. @dcolombo please let me know if this is a good enough fix to the issue to be able to close it.


However, I don't think that we can ensure parsing these other formats (maybe the votable works out of the box), so I haven't yet added this ability to the other methods like `get_spectra()` and `get_images()`, both of which return a list of HDULists. 

OTOH, we may go one small step further and provide a download method for them?