### PR TITLE
Turn off default verbosity for TapPlus

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -24,6 +24,11 @@ Infrastructure, Utility and Other Changes and Additions
 - Adding ``--alma-site`` pytest option for testing to have a control over
   which specific site to test. [#2224]
 
+utils.tap
+^^^^^^^^^
+
+- Changing the default verbosity of TapPlus to False. [#2228]
+
 
 0.4.4 (2021-11-17)
 ==================

--- a/astroquery/utils/tap/core.py
+++ b/astroquery/utils/tap/core.py
@@ -724,7 +724,7 @@ class TapPlus(Tap):
                  table_edit_context=None,
                  data_context=None,
                  datalink_context=None,
-                 verbose=True):
+                 verbose=False):
         """Constructor
 
         Parameters


### PR DESCRIPTION
This is to close #1722 

We had multiple user reports that defaulting to being verbose is not their preference (it was mostly users of the gaia module, see #1722 and linked issues therein). 
Now as I review the eJWST module, I run into this again, and while we turned off the default verbosity for gaia, I think it's probably better to change that in TapPlus. 

As I read the code, the rest of the tap module has defaults to set False, so I suppose there is nothing controversial about this.

cc @jcsegovia and @jespinosaar 