### PR TITLE
eJWST: remove disclaimer for release

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -7,7 +7,7 @@ New Tools and Services
 esa.jwst
 ^^^^^^^^^^
 
-- New module to provide access to eJWST Science Archive metadata and datasets. [#2140, #2238]
+- New module to provide access to eJWST Science Archive metadata and datasets. [#2140, #2238, #2243]
 
 
 Service fixes and enhancements

--- a/astroquery/esa/jwst/__init__.py
+++ b/astroquery/esa/jwst/__init__.py
@@ -4,13 +4,8 @@
 eJWST Init
 ==========
 
-@author: Raul Gutierrez-Sanchez
-@contact: raul.gutierrez@sciops.esa.int
-
 European Space Astronomy Centre (ESAC)
 European Space Agency (ESA)
-
-Created on 23 oct. 2018
 
 """
 

--- a/docs/esa/jwst.rst
+++ b/docs/esa/jwst.rst
@@ -6,8 +6,6 @@
 JWST TAP+ (`astroquery.esa.jwst`)
 *********************************
 
-**THIS MODULE IS NOT OPERATIVE YET. METHODS WILL NOT WORK UNTIL eJWST ARCHIVE IS OFFICIALLY RELEASED**
-
 The James Webb Space Telescope (JWST) is a collaborative project between NASA,
 ESA, and the Canadian Space Agency (CSA). Although radically different in
 design, and emphasizing the infrared part of the electromagnetic spectrum,


### PR DESCRIPTION
Hi @bsipocz , @keflavich,

This pull request follows #2238, to remove the disclaimer for users, as it is not needed anymore (my fault, I forgot to remove it). As we agreed, release of v0.4.5 should be out by launch, but, at least from our side, you can start right after this pull request is merged to ensure we can solve any unrelated issue and, if they do not appear, everything will be ready even before launch. Everything is in place in this module.

Kind regards and again, many thanks for your help.

Javi