### PR TITLE
Fix to allow html downloads with alma package

### DIFF
--- a/astroquery/alma/core.py
+++ b/astroquery/alma/core.py
@@ -722,11 +722,6 @@ class AlmaClass(QueryWithLogin):
                     else:
                         raise(ex)
 
-            if 'text/html' in check_filename.headers.get('Content-Type', ''):
-                raise ValueError("Bad query.  This can happen if you "
-                                 "attempt to download proprietary "
-                                 "data when not logged in")
-
             try:
                 filename = re.search("filename=(.*)",
                                      check_filename.headers['Content-Disposition']).groups()[0]

--- a/astroquery/alma/tests/test_alma_remote.py
+++ b/astroquery/alma/tests/test_alma_remote.py
@@ -649,3 +649,9 @@ def test_big_download_regression(alma):
 
     # this is a big one that fails
     alma.download_files([files['access_url'][3]])
+
+
+@pytest.mark.remote_data
+def test_download_html_file():
+    result = alma.download_files(['https://almascience.nao.ac.jp/dataPortal/member.uid___A001_X1284_X1353.qa2_report.html'])
+    assert result


### PR DESCRIPTION
Fix for #2138 

The problem seems to be left-over code from the time the downloads were using the Web sites.