### PR TITLE
Deprecate `astroquery/utils/download_file_list.py`

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -29,6 +29,9 @@ Infrastructure, Utility and Other Changes and Additions
 - Adding ``--alma-site`` pytest option for testing to have a control over
   which specific site to test. [#2224]
 
+- The function ``astroquery.utils.download_list_of_fitsfiles()`` has been
+  deprecated. [#2247]
+
 utils.tap
 ^^^^^^^^^
 

--- a/astroquery/utils/download_file_list.py
+++ b/astroquery/utils/download_file_list.py
@@ -6,6 +6,7 @@ import gzip
 from io import StringIO
 
 import astropy.io.fits as fits
+from astropy.utils.decorators import deprecated
 from .commons import get_readable_fileobj
 
 __all__ = ['download_list_of_fitsfiles']
@@ -26,6 +27,7 @@ def validify_filename(filestr):
     return filestr
 
 
+@deprecated('0.4.5')
 def download_list_of_fitsfiles(linklist, output_directory=None,
                                output_prefix=None, save=False,
                                overwrite=False, verbose=False,

--- a/astroquery/utils/tests/test_download_file_list.py
+++ b/astroquery/utils/tests/test_download_file_list.py
@@ -1,0 +1,10 @@
+import pytest
+
+from astropy.utils.exceptions import AstropyDeprecationWarning
+
+from astroquery.utils.download_file_list import download_list_of_fitsfiles
+
+
+def test_download_list_of_fitsfiles_deprecation():
+    with pytest.warns(AstropyDeprecationWarning):
+        download_list_of_fitsfiles([])


### PR DESCRIPTION
The contents of this file were not being used anywhere, so it should be safe to remove even without deprecating first.

EDIT: This pull request will deprecate the module, it will be removed later.