### PR TITLE
Expand contribution guidelines

### DIFF
--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -6,6 +6,11 @@ Please see `astropy's contributing guildelines
 <http://www.astropy.org/contribute.html>`__ for a general guide to the
 workflow involving git, etc.  Everything below is astroquery-specific.
 
+We strongly encourage draft pull requests to be opened early in development.
+If you are thinking of contributing a new module, please open a pull request
+as soon as you start developing code and mark it "WIP" (work in progress).
+
+
 New Features
 ------------
 We welcome any and all new features!  If you have your own little query tool
@@ -54,6 +59,14 @@ from, provides access to its own `_request` method.  This custom `_request`
 method is a wrapper around the `requests.request` function that provides
 important astroquery-specific utility, including caching, HTTP header
 generation, progressbars, and local writing-to-disk.
+
+Dependencies
+------------
+New contributions are generally not allowed to bring along additional dependencies.
+
+File reading, table parsing, etc. should be done with astropy tables.
+
+
 
 .. _astroquery API: docs/api.rst
 .. _template: docs/template.rst

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -65,8 +65,8 @@ Dependencies
 New contributions are generally not allowed to bring along additional dependencies.
 
 The astropy ecosystem tools should be used whenever possible.
-For example, astropy.table should be used for table handling,
-astropy.io.ascii for ascii-table parsing, and astropy.units for unit and quantity
+For example, `astropy.table` should be used for table handling,
+`astropy.io.ascii` for ascii-table parsing, and `astropy.units` for unit and quantity
 handling.
 
 

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -8,7 +8,7 @@ workflow involving git, etc.  Everything below is astroquery-specific.
 
 We strongly encourage draft pull requests to be opened early in development.
 If you are thinking of contributing a new module, please open a pull request
-as soon as you start developing code and mark it "WIP" (work in progress).
+as soon as you start developing code and mark it as a Draft PR on github.
 
 
 New Features
@@ -64,7 +64,10 @@ Dependencies
 ------------
 New contributions are generally not allowed to bring along additional dependencies.
 
-File reading, table parsing, etc. should be done with astropy tables.
+The astropy ecosystem tools should be used whenever possible.
+For example, astropy.table should be used for table handling,
+astropy.io.ascii for ascii-table parsing, and astropy.units for unit and quantity
+handling.
 
 
 

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -66,7 +66,7 @@ New contributions are generally not allowed to bring along additional dependenci
 
 The astropy ecosystem tools should be used whenever possible.
 For example, `astropy.table` should be used for table handling,
-`astropy.io.ascii` for ascii-table parsing, and `astropy.units` for unit and quantity
+or `astropy.units` for unit and quantity
 handling.
 
 


### PR DESCRIPTION
Our contributing guidelines were not explicit about dependencies and timing of PRs, so I suggest we expand those guidelines.