### PR TITLE
Enable calling `Gaia.query_object()` with both `columns` and `radius`

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -13,6 +13,13 @@ esa.jwst
 
 - Minor fixes, documentation updated. [#2257]
 
+gaia
+^^^^
+
+- The ``query_object()`` and ``query_object_async()`` methods of
+  ``astroquery.gaia.Gaia`` no longer ignore their ``columns`` argument when
+  ``radius`` is specified. [#2249]
+
 Infrastructure, Utility and Other Changes and Additions
 -------------------------------------------------------
 

--- a/astroquery/gaia/core.py
+++ b/astroquery/gaia/core.py
@@ -386,8 +386,8 @@ class GaiaClass(TapPlus):
         coord = self.__getCoordInput(coordinate, "coordinate")
         job = None
         if radius is not None:
-            job = self.__cone_search(coord, radius,
-                                     async_job=async_job, verbose=verbose)
+            job = self.__cone_search(coord, radius, async_job=async_job,
+                                     verbose=verbose, columns=columns)
         else:
             raHours, dec = commons.coord_to_radec(coord)
             ra = raHours * 15.0  # Converts to degrees

--- a/astroquery/gaia/tests/test_gaia_remote.py
+++ b/astroquery/gaia/tests/test_gaia_remote.py
@@ -6,6 +6,15 @@ from .. import GaiaClass
 
 
 @pytest.mark.remote_data
+def test_query_object_columns_with_radius():
+    # Regression test: `columns` were ignored if `radius` was provided [#2025]
+    Gaia = GaiaClass()
+    sc = SkyCoord(ra=0*u.deg, dec=0*u.deg)
+    table = Gaia.query_object_async(sc, radius=10*u.arcsec, columns=['ra'])
+    assert table.colnames == ['ra', 'dist']
+
+
+@pytest.mark.remote_data
 def test_query_object_row_limit():
     Gaia = GaiaClass()
     coord = SkyCoord(ra=280, dec=-60, unit=(u.degree, u.degree), frame='icrs')


### PR DESCRIPTION
Currently `Gaia.query_object()` and `Gaia.query_object_async()` ignore their `columns` argument if `radius` is specified. This pull request provides the bugfix.

Fixes #2025