### PR TITLE
MNT: Do not use deprecated astropy.tests helper functions

### DIFF
--- a/astroquery/esa/hubble/tests/test_esa_hubble_remote.py
+++ b/astroquery/esa/hubble/tests/test_esa_hubble_remote.py
@@ -13,21 +13,12 @@ Created on 13 Jan. 2021
 """
 import tempfile
 
-import unittest
 import os
 
 import pytest
-from astropy.tests.helper import remote_data
-from requests.models import Response
 from astroquery.esa.hubble import ESAHubble
-from astroquery.utils.testing_tools import MockResponse
 from astropy import coordinates
-from unittest.mock import MagicMock
-from astropy.table.table import Table
-import shutil
 import random
-from PIL import Image
-
 
 esa_hubble = ESAHubble()
 

--- a/astroquery/mast/tests/test_mast.py
+++ b/astroquery/mast/tests/test_mast.py
@@ -2,11 +2,11 @@
 
 import os
 import re
-
 from shutil import copyfile
 
+import pytest
+
 from astropy.table import Table
-from astropy.tests.helper import pytest
 from astropy.coordinates import SkyCoord
 from astropy.io import fits
 
@@ -667,7 +667,7 @@ def test_zcut_download_cutouts(patch_post, tmpdir):
 
     # Testing with png
     cutout_table = mast.Zcut.download_cutouts(coordinates=coord, size=5,
-                                             cutout_format="jpg", path=str(tmpdir))
+                                              cutout_format="jpg", path=str(tmpdir))
     assert isinstance(cutout_table, Table)
     assert len(cutout_table) == 3
     assert cutout_table["Local Path"][0][-4:] == ".jpg"
@@ -675,7 +675,7 @@ def test_zcut_download_cutouts(patch_post, tmpdir):
 
     # Testing with img_param
     cutout_table = mast.Zcut.download_cutouts(coordinates=coord, size=5,
-                                             cutout_format="jpg", path=str(tmpdir), invert=True)
+                                              cutout_format="jpg", path=str(tmpdir), invert=True)
     assert isinstance(cutout_table, Table)
     assert len(cutout_table) == 3
     assert cutout_table["Local Path"][0][-4:] == ".jpg"

--- a/astroquery/noirlab/tests/test_noirlab_remote.py
+++ b/astroquery/noirlab/tests/test_noirlab_remote.py
@@ -2,21 +2,21 @@
 # Python library
 
 # External packages
+import pytest
 from astropy import units as u
 from astropy.coordinates import SkyCoord
-from astropy.tests.helper import remote_data
+
 # Local packages
 from .. import Noirlab
 from . import expected as expsia
-# #!import pytest
 
 # performs similar tests as test_module.py, but performs
 # the actual HTTP request rather than monkeypatching them.
 # should be disabled or enabled at will - use the
-# remote_data decorator from astropy:
+# remote_data decorator from pytest-remotedata:
 
 
-@remote_data
+@pytest.mark.remote_data
 class TestNoirlabClass:
 
     def test_query_region_1(self):

--- a/astroquery/vo_conesearch/validator/tests/test_validate.py
+++ b/astroquery/vo_conesearch/validator/tests/test_validate.py
@@ -18,8 +18,8 @@ import pytest
 from numpy.testing import assert_allclose
 
 # ASTROPY
-from astropy.tests.helper import catch_warnings
 from astropy.utils.data import get_pkg_data_filename
+from astropy.utils.exceptions import AstropyUserWarning
 
 # LOCAL
 from .. import conf, validate, tstquery
@@ -83,9 +83,8 @@ class TestConeSearchValidation:
 
 @pytest.mark.remote_data
 def test_tstquery():
-    with catch_warnings() as w:
+    with pytest.warns(AstropyUserWarning, match='too large') as w:
         d = tstquery.parse_cs('ivo://cds.vizier/i/252', cap_index=4)
     assert len(w) == 1
-    assert 'too large' in str(w[0].message)
     assert_allclose([d['RA'], d['DEC'], d['SR']],
                     [45, 0.07460390065517808, 0.1])

--- a/docs/testing.rst
+++ b/docs/testing.rst
@@ -85,7 +85,7 @@ the ``test_module.py`` file.
 -------------------------
 
 The remote tests are much easier.  Just decorate the test class or test
-functions with ``astropy.tests.helper.remote_data``.
+functions with ``@pytest.mark.remote_data``.
 
 ``setup_package.py``
 --------------------

--- a/setup.cfg
+++ b/setup.cfg
@@ -37,6 +37,7 @@ filterwarnings =
     error
     ignore: Experimental:UserWarning:
 # This is a temporary measure, all of these should be fixed:
+    ignore:distutils Version classes are deprecated:DeprecationWarning
     ignore::pytest.PytestUnraisableExceptionWarning
     ignore::numpy.VisibleDeprecationWarning
     ignore: unclosed file:ResourceWarning


### PR DESCRIPTION
This pull request is to remove soon to be deprecated code; also see astropy/astropy#12633 .

Out of scope: `astropy-helpers`