### PR TITLE
(Minor fix)eJWST - remove login_gui method from documentation

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -8,6 +8,10 @@ New Tools and Services
 Service fixes and enhancements
 ------------------------------
 
+esa.jwst
+^^^^^^^^^^
+
+- Minor fixes, documentation updated. [#2257]
 
 Infrastructure, Utility and Other Changes and Additions
 -------------------------------------------------------

--- a/astroquery/esa/jwst/core.py
+++ b/astroquery/esa/jwst/core.py
@@ -647,17 +647,6 @@ class JwstClass(BaseQuery):
         if token:
             self.set_token(token=token)
 
-    def login_gui(self, *, verbose=False):
-        """Performs a login using a GUI dialog
-        TAP+ only
-
-        Parameters
-        ----------
-        verbose : bool, optional, default 'False'
-            flag to display information about the process
-        """
-        return self.__jwsttap.login_gui(verbose)
-
     def logout(self, *, verbose=False):
         """Performs a logout
         TAP+ only

--- a/astroquery/esa/jwst/data_access.py
+++ b/astroquery/esa/jwst/data_access.py
@@ -10,6 +10,7 @@ European Space Agency (ESA)
 """
 
 from astropy.utils import data
+from . import conf
 
 __all__ = ['JwstDataHandler']
 
@@ -17,7 +18,7 @@ __all__ = ['JwstDataHandler']
 class JwstDataHandler:
     def __init__(self, base_url=None):
         if base_url is None:
-            self.base_url = "http://jwstdummydata.com"
+            self.base_url = conf.JWST_DATA_SERVER
         else:
             self.base_url = base_url
 

--- a/astroquery/esa/jwst/tests/test_jwsttap.py
+++ b/astroquery/esa/jwst/tests/test_jwsttap.py
@@ -1002,14 +1002,6 @@ class TestTap:
         tap.login(user='test_user', password='test_password')
         dummyTapHandler.check_call('login', parameters)
 
-    def test_login_gui(self):
-        dummyTapHandler = DummyTapHandler()
-        tap = JwstClass(tap_plus_handler=dummyTapHandler, show_messages=False)
-        parameters = {}
-        parameters['verbose'] = False
-        tap.login_gui()
-        dummyTapHandler.check_call('login_gui', parameters)
-
     def test_logout(self):
         dummyTapHandler = DummyTapHandler()
         tap = JwstClass(tap_plus_handler=dummyTapHandler, show_messages=False)

--- a/docs/esa/jwst.rst
+++ b/docs/esa/jwst.rst
@@ -651,7 +651,7 @@ To remove asynchronous
 -----------------------
 
 Authenticated users are able to access to TAP+ capabilities (shared tables, persistent jobs, etc.)
-In order to authenticate a user, ``login``, ``login_gui`` or ``login_token_gui`` methods must be called. After a successful
+In order to authenticate a user, ``login`` method must be called. After a successful
 authentication, the user will be authenticated until ``logout`` method is called.
 
 All previous methods (``query_object``, ``cone_search``, ``load_table``, ``load_tables``, ``launch_job``) explained for
@@ -666,18 +666,6 @@ The main differences are:
 
 2.1. Login/Logout
 ~~~~~~~~~~~~~~~~~
-
-Using the graphic interface:
-
-
-*Note: Tkinter module is required to use login_gui method.*
-
-.. code-block:: python
-
-  >>> from astroquery.esa.jwst import Jwst
-  >>> from astroquery.esa.jwst import Jwst
-  >>> Jwst.login_gui()
-
 
 Using the command line:
 


### PR DESCRIPTION
Hi @bsipocz,

I have just realized an error in the documentation, as the login_gui method is not included and should be removed. This pull request aims to fix this.

Thanks in advance!