### PR TITLE
Fix SDSS CrossID method not working for spec data and for DR17 (photo and spec)

### DIFF
--- a/astroquery/sdss/core.py
+++ b/astroquery/sdss/core.py
@@ -81,7 +81,7 @@ class SDSSClass(BaseQuery):
         radius : str or `~astropy.units.Quantity` object, optional The
             string must be parsable by `~astropy.coordinates.Angle`. The
             appropriate `~astropy.units.Quantity` object from
-            `astropy.units` may also be used. Defaults to 2 arcsec.
+            `astropy.units` may also be used. Defaults to 5 arcsec.
         timeout : float, optional
             Time limit (in seconds) for establishing successful connection with
             remote server.  Defaults to `SDSSClass.TIMEOUT`.

--- a/astroquery/sdss/core.py
+++ b/astroquery/sdss/core.py
@@ -168,7 +168,7 @@ class SDSSClass(BaseQuery):
         if get_query_payload:
             return request_payload
         url = self._get_crossid_url(data_release)
-        response = self._request("POST", url, params=request_payload,
+        response = self._request("POST", url, data=request_payload,
                                  timeout=timeout, cache=cache)
         return response
 

--- a/astroquery/sdss/core.py
+++ b/astroquery/sdss/core.py
@@ -144,7 +144,10 @@ class SDSSClass(BaseQuery):
 
         sql_query += ',dbo.fPhotoTypeN(p.type) as type \
                       FROM #upload u JOIN #x x ON x.up_id = u.up_id \
-                      JOIN PhotoObjAll p ON p.objID = x.objID ORDER BY x.up_id'
+                      JOIN PhotoObjAll p ON p.objID = x.objID '
+        if specobj_fields:
+            sql_query += 'JOIN SpecObjAll s ON p.objID = s.bestObjID '
+        sql_query += 'ORDER BY x.up_id'
 
         data = "obj_id ra dec \n"
         data += " \n ".join(['{0} {1} {2}'.format(obj_names[i],

--- a/astroquery/sdss/tests/test_sdss_remote.py
+++ b/astroquery/sdss/tests/test_sdss_remote.py
@@ -174,3 +174,16 @@ class TestSDSSRemote:
 
         assert isinstance(query2, Table)
         assert query2['objID'][0] == query1['objID'][0] == query2['objID'][1]
+
+    def test_spectro_query_crossid(self):
+        query1 = sdss.SDSS.query_crossid_async(
+            self.coords, specobj_fields=['specObjID', 'z'], cache=False)
+        query2 = sdss.SDSS.query_crossid_async(
+            [self.coords, self.coords], 
+            specobj_fields=['specObjID', 'z'], 
+            cache=False)
+        assert isinstance(query1, Table)
+        assert query1['specObjID'][0] == 845594848269461504
+
+        assert isinstance(query2, Table)
+        assert query2['specObjID'][0] == query2['specObjID'][1] == query1['specObjID'][0]

--- a/astroquery/sdss/tests/test_sdss_remote.py
+++ b/astroquery/sdss/tests/test_sdss_remote.py
@@ -179,8 +179,8 @@ class TestSDSSRemote:
         query1 = sdss.SDSS.query_crossid_async(
             self.coords, specobj_fields=['specObjID', 'z'], cache=False)
         query2 = sdss.SDSS.query_crossid_async(
-            [self.coords, self.coords], 
-            specobj_fields=['specObjID', 'z'], 
+            [self.coords, self.coords],
+            specobj_fields=['specObjID', 'z'],
             cache=False)
         assert isinstance(query1, Table)
         assert query1['specObjID'][0] == 845594848269461504


### PR DESCRIPTION
# Sumary

This PR aims to fix the following errors in the `astroquery.sdss.SDSS.query_crossid_async()` method:

1. Fix documentation typo about default value of the `radius` param (bcef71672fdb6d47a535479f7252af71cef34c63)
2. Fix spec query not working for DR >= 12 (777f80b4db026360cd461d93498d7da8e86c8f14)
3. Fix photo and spec query not working for DR 17 (4fb7217d125d42ea52a2b5d47f2cfc82050228cb)

# Details about each fix

## 1. Documentation typo

Changed documentation to the right value of the default radius param

Commit: bcef71672fdb6d47a535479f7252af71cef34c63


## 2. Spec query for DR >= 12

Spec queries for DR >= 12 are resulting in a 500 (Internal Server Error) HTTP response 
becouse the query string formed by this method is invalid when requesting columns of
SpecObj table. The query properly includes the spec columns but forgot the 
`JOIN` statement with the SpecObj table.

Commit: 777f80b4db026360cd461d93498d7da8e86c8f14


## 3. Photo and spec query for DR 17

Both kind of queries to the DR 17 API results in a 500 (Internal Server Error) HTTP response 
becouse this API requires parameters to be sent in the request body as a payload.
Passing the parans via `data` attribute instead of the `params` attribute of the
http client solves the issue, since previous data releases (DR >= 12) allows this approach too.

Commit: 4fb7217d125d42ea52a2b5d47f2cfc82050228cb


# Tests Results

All DR >= 12 where tested for photo and spec query. 
All requests returned 200 status code and the method returned an correct `astropy.table.table.Table` instance.

Test code:

```python
from astroquery.sdss import SDSS
from astropy import coordinates as coord
import numpy as np
from astropy import units as u
from astroquery import log
log.setLevel('TRACE')

pos = coord.SkyCoord(
  ra=np.array([359.970818400315, 0.1286587799259]), 
  dec=np.array([-1.21788544571165, -1.21302218898355]), 
  frame='icrs', 
  unit='deg'
)
result = SDSS.query_crossid(
  coordinates=pos, 
  photoobj_fields=['objID', 'ra', 'dec'],
  specobj_fields=['specObjID', 'z'], 
  data_release=17,
  radius=2*u.arcsec,
  cache=False
)
```

> Note about DR < 12:
> Queries in data realeases < 12 results in a 404 HTTP status code, before and after this changes.
> Looks like services for old DRs have been removed 


## DR 12 (200 OK)


```http
200 OK http://skyserver.sdss.org/dr12/en/tools/search/X_Results.aspx
Cache-Control: private
Content-Type: text/plain; charset=utf-8
Content-Encoding: gzip
Vary: Accept-Encoding
Server: Microsoft-IIS/8.5
Access-Control-Allow-Origin: *
Content-Disposition: attachment;filename="Skyserver_CrossID1/16/2022 1:11:46 PM.csv"
X-AspNet-Version: 4.0.30319
X-Powered-By: ASP.NET
Date: Sun, 16 Jan 2022 13:11:45 GMT
Content-Length: 322
```
```
#Table1
obj_id,objID,ra,dec,obj_id1,specObjID,z,type
obj_0,1237663275780276471,359.970818399119,-1.21788545489075,1237663275780276471,435757928612390912,0.1629147,GALAXY
obj_1,1237663275780341888,0.128658777722677,-1.21302220589001,1237663275780341888,435746658618206208,0.07535086,GALAXY
```



## DR 13 (200 OK)


```http
200 OK http://skyserver.sdss.org/dr13/en/tools/search/X_Results.aspx
Cache-Control: private
Content-Type: text/plain; charset=utf-8
Content-Encoding: gzip
Vary: Accept-Encoding
Server: Microsoft-IIS/8.5
Access-Control-Allow-Origin: *
Content-Disposition: attachment;filename="Skyserver_Radial1/16/2022 1:14:47 PM.csv"
X-AspNet-Version: 4.0.30319
X-Powered-By: ASP.NET
Date: Sun, 16 Jan 2022 13:14:47 GMT
Content-Length: 325
```
```
#Table1
obj_id,objID,ra,dec,obj_id1,specObjID,z,type
obj_0,1237663275780276471,359.970818400315,-1.21788544571165,1237663275780276471,435757928612390912,0.1629147,GALAXY
obj_1,1237663275780341888,0.1286587799259,-1.21302218898355,1237663275780341888,435746658618206208,0.07535086,GALAXY
```



## DR 14 (200 OK)


```http
200 OK http://skyserver.sdss.org/dr14/en/tools/search/X_Results.aspx
Cache-Control: private
Content-Type: text/plain; charset=utf-8
Content-Encoding: gzip
Vary: Accept-Encoding
Server: Microsoft-IIS/8.5
Access-Control-Allow-Origin: *
Content-Disposition: attachment;filename="Skyserver_SQL1/16/2022 1:15:18 PM.csv"
X-AspNet-Version: 4.0.30319
X-Powered-By: ASP.NET
Date: Sun, 16 Jan 2022 13:15:18 GMT
Content-Length: 325
```
```
#Table1
obj_id,objID,ra,dec,obj_id1,specObjID,z,type
obj_0,1237663275780276471,359.970818400315,-1.21788544571165,1237663275780276471,435757928612390912,0.1629147,GALAXY
obj_1,1237663275780341888,0.1286587799259,-1.21302218898355,1237663275780341888,435746658618206208,0.07535086,GALAXY
```



## DR 15 (200 OK)


```http
200 OK http://skyserver.sdss.org/dr15/en/tools/search/X_Results.aspx
Cache-Control: private
Content-Type: text/plain; charset=utf-8
Content-Encoding: gzip
Vary: Accept-Encoding
Server: Microsoft-IIS/8.5
Access-Control-Allow-Origin: *
Content-Disposition: attachment;filename="Skyserver_CrossID1/16/2022 1:15:42 PM.csv"
X-AspNet-Version: 4.0.30319
X-Powered-By: ASP.NET
Date: Sun, 16 Jan 2022 13:15:42 GMT
Content-Length: 325
```
```
#Table1
obj_id,objID,ra,dec,obj_id1,specObjID,z,type
obj_0,1237663275780276471,359.970818400315,-1.21788544571165,1237663275780276471,435757928612390912,0.1629147,GALAXY
obj_1,1237663275780341888,0.1286587799259,-1.21302218898355,1237663275780341888,435746658618206208,0.07535086,GALAXY
```



## DR 16 (200 OK)


```http
200 OK http://skyserver.sdss.org/dr16/en/tools/search/X_Results.aspx
Cache-Control: private
Content-Type: text/plain; charset=utf-8
Content-Encoding: gzip
Vary: Accept-Encoding
Server: Microsoft-IIS/8.5
Access-Control-Allow-Origin: *
Content-Disposition: attachment;filename="Skyserver_SQL1/16/2022 1:15:58 PM.csv"
X-AspNet-Version: 4.0.30319
X-Powered-By: ASP.NET
Date: Sun, 16 Jan 2022 13:15:57 GMT
Content-Length: 325
```
```
#Table1
obj_id,objID,ra,dec,obj_id1,specObjID,z,type
obj_0,1237663275780276471,359.970818400315,-1.21788544571165,1237663275780276471,435757928612390912,0.1629147,GALAXY
obj_1,1237663275780341888,0.1286587799259,-1.21302218898355,1237663275780341888,435746658618206208,0.07535086,GALAXY
```



## DR 17 (200 OK)


```http
200 OK http://skyserver.sdss.org/dr17/en/tools/search/X_Results.aspx
Transfer-Encoding: chunked
Content-Type: text/plain
Content-Encoding: gzip
Vary: Accept-Encoding
Server: Kestrel
Content-Disposition: attachment;filename="Skyserver_CrossID1/16/2022 1:06:29 PM.csv"
X-Powered-By: ASP.NET
Date: Sun, 16 Jan 2022 13:06:29 GMT
```
```
#Table1
obj_id,objID,ra,dec,obj_id1,specObjID,z,type
obj_0,1237663275780276471,359.970818400315,-1.21788544571165,1237663275780276471,435757928612390912,0.1629147,GALAXY
obj_1,1237663275780341888,0.1286587799259,-1.21302218898355,1237663275780341888,435746658618206208,0.07535086,GALAXY
```


