### PR TITLE
Name convention for ESA modules

### DIFF
--- a/docs/esa/hubble.rst
+++ b/docs/esa/hubble.rst
@@ -2,9 +2,9 @@
 
 .. _astroquery.esa.hubble:
 
-************************************
-esa.hubble (`astroquery.esa.hubble`)
-************************************
+*****************************************
+ESA HST Archive (`astroquery.esa.hubble`)
+*****************************************
 
 The Hubble Space Telescope (HST) is a joint ESA/NASA orbiting astronomical
 observatory operating from the near-infrared into the ultraviolet.  Launched

--- a/docs/esa/jwst.rst
+++ b/docs/esa/jwst.rst
@@ -2,9 +2,9 @@
 
 .. _astroquery.esa.jwst:
 
-*********************************
-JWST TAP+ (`astroquery.esa.jwst`)
-*********************************
+****************************************
+ESA JWST Archive (`astroquery.esa.jwst`)
+****************************************
 
 The James Webb Space Telescope (JWST) is a collaborative project between NASA,
 ESA, and the Canadian Space Agency (CSA). Although radically different in

--- a/docs/esa/xmm_newton.rst
+++ b/docs/esa/xmm_newton.rst
@@ -2,9 +2,9 @@
 
 .. _astroquery.esa.xmm_newton:
 
-****************************************
-xmm_newton (`astroquery.esa.xmm_newton`)
-****************************************
+****************************************************
+ESA XMM-Newton Archive (`astroquery.esa.xmm_newton`)
+****************************************************
 
 
 The X-ray Multi-Mirror Mission, XMM-Newton, is an ESA X-ray observatory launched on 10 December 1999. 


### PR DESCRIPTION
Hi @bsipocz ,

This is a small pull request to use the same naming convention for the titles of the modules under astroquery/esa folder. As you can see, the only changes are the titles of JWST, HST and XMM-Newton modules. 

Just a question, how often is the documentation (https://astroquery.readthedocs.io/en/latest/) updated? I can see 'astroquery v0.4.6.dev2370' but maybe this is happening when releasing...

Thanks a lot!

Regards,

@jespinosaar 