### PR TITLE
Fix documentation build

### DIFF
--- a/astroquery/alma/core.py
+++ b/astroquery/alma/core.py
@@ -426,6 +426,10 @@ class AlmaClass(QueryWithLogin):
             maxrec=maxrec,
             **kwargs)
 
+    # SIA_PARAMETERS_DESC contains links that Sphinx can't resolve.
+    for var in ('POLARIZATION_STATES', 'CALIBRATION_LEVELS'):
+        SIA_PARAMETERS_DESC = SIA_PARAMETERS_DESC.replace(f'`pyvo.dam.obscore.{var}`',
+                                                          f'pyvo.dam.obscore.{var}')
     query_sia.__doc__ = query_sia.__doc__.replace('_SIA2_PARAMETERS', SIA_PARAMETERS_DESC)
 
     def query_tap(self, query, maxrec=None):

--- a/astroquery/alma/core.py
+++ b/astroquery/alma/core.py
@@ -20,6 +20,7 @@ from astropy.utils.console import ProgressBar
 from astropy.utils.exceptions import AstropyDeprecationWarning
 from astropy import units as u
 from astropy.time import Time
+from pyvo.dal.sia2 import SIA_PARAMETERS_DESC
 
 from ..exceptions import LoginError
 from ..utils import commons
@@ -397,8 +398,7 @@ class AlmaClass(QueryWithLogin):
 
         Parameters
         ----------
-        **kwargs
-            Parameters for the SIA service.
+        _SIA2_PARAMETERS
 
         Returns
         -------
@@ -425,6 +425,8 @@ class AlmaClass(QueryWithLogin):
             res_format=res_format,
             maxrec=maxrec,
             **kwargs)
+
+    query_sia.__doc__ = query_sia.__doc__.replace('_SIA2_PARAMETERS', SIA_PARAMETERS_DESC)
 
     def query_tap(self, query, maxrec=None):
         """

--- a/astroquery/alma/core.py
+++ b/astroquery/alma/core.py
@@ -397,6 +397,8 @@ class AlmaClass(QueryWithLogin):
 
         Parameters
         ----------
+        **kwargs
+            Parameters for the SIA service.
 
         Returns
         -------

--- a/astroquery/ipac/irsa/irsa_dust/core.py
+++ b/astroquery/ipac/irsa/irsa_dust/core.py
@@ -123,7 +123,7 @@ class IrsaDustClass(BaseQuery):
             to remote server. Defaults to `False`.
 
         Returns
-        --------
+        -------
         list : list
             A list of context-managers that yield readable file-like objects.
         """
@@ -146,7 +146,7 @@ class IrsaDustClass(BaseQuery):
         of URLs to the Irsa-Dust images.
 
         Parameters
-        -----------
+        ----------
         coordinate : str
             Can be either the name of an object or a coordinate string
             If a name, must be resolvable by NED, SIMBAD, 2MASS, or SWAS.
@@ -169,7 +169,7 @@ class IrsaDustClass(BaseQuery):
             to remote server. Defaults to `False`.
 
         Returns
-        --------
+        -------
         url_list : list
             A list of URLs to the FITS images corresponding to the queried
             object.
@@ -203,7 +203,7 @@ class IrsaDustClass(BaseQuery):
             server. Defaults to `~astroquery.ipac.irsa.irsa_dust.IrsaDustClass.TIMEOUT`.
 
         Returns
-        --------
+        -------
         table : `~astropy.table.Table`
         """
         readable_obj = self.get_extinction_table_async(
@@ -289,7 +289,7 @@ class IrsaDustClass(BaseQuery):
             Defaults to `~astroquery.ipac.irsa.irsa_dust.IrsaDustClass.DUST_SERVICE_URL`.
 
         Returns
-        --------
+        -------
         table : `~astropy.table.Table`
             Table representing the query results, (all or as per  specified).
         """

--- a/astroquery/ipac/ned/core.py
+++ b/astroquery/ipac/ned/core.py
@@ -385,7 +385,7 @@ class NedClass(BaseQuery):
             request.  Defaults to `False`
 
         Returns
-        --------
+        -------
         A list of context-managers that yield readable file-like objects
 
         """
@@ -438,7 +438,7 @@ class NedClass(BaseQuery):
             request.  Defaults to `False`
 
         Returns
-        --------
+        -------
         A list of context-managers that yield readable file-like objects
 
         """

--- a/astroquery/jplspec/core.py
+++ b/astroquery/jplspec/core.py
@@ -191,12 +191,12 @@ class JPLSpecClass(BaseQuery):
         | (I6,X, A13, I6, 7F7.4,  I2)
 
         Parameters
-        -----------
+        ----------
         catfile : str, name of file, default 'catdir.cat'
             The catalog file, installed locally along with the package
 
         Returns
-        --------
+        -------
         Table: `~astropy.table.Table`
             | TAG : The species tag or molecular identifier.
             | NAME : An ASCII name for the species.

--- a/astroquery/linelists/cdms/core.py
+++ b/astroquery/linelists/cdms/core.py
@@ -254,12 +254,12 @@ class CDMSClass(BaseQuery):
         The table is derived from https://cdms.astro.uni-koeln.de/classic/entries/partition_function.html
 
         Parameters
-        -----------
+        ----------
         catfile : str, name of file, default 'catdir.cat'
             The catalog file, installed locally along with the package
 
         Returns
-        --------
+        -------
         Table: `~astropy.table.Table`
             | tag : The species tag or molecular identifier.
             | molecule : An ASCII name for the species.

--- a/astroquery/mast/collections.py
+++ b/astroquery/mast/collections.py
@@ -320,7 +320,7 @@ class CatalogsClass(MastQueryWithLogin):
             one sepcific page of results.
 
         Returns
-        --------
+        -------
         response : list of `~requests.Response`
         """
 
@@ -356,7 +356,7 @@ class CatalogsClass(MastQueryWithLogin):
             one sepcific page of results.
 
         Returns
-        --------
+        -------
         response : list of `~requests.Response`
         """
 
@@ -387,7 +387,7 @@ class CatalogsClass(MastQueryWithLogin):
             will be downloaded that can be used to download the data files at a later time.
 
         Returns
-        --------
+        -------
         response : list of `~requests.Response`
         """
 

--- a/astroquery/mast/observations.py
+++ b/astroquery/mast/observations.py
@@ -76,7 +76,7 @@ class ObservationsClass(MastQueryWithLogin):
         Lists data missions archived by MAST and avaiable through `astroquery.mast`.
 
         Returns
-        --------
+        -------
         response : list
             List of available missions.
         """
@@ -106,7 +106,7 @@ class ObservationsClass(MastQueryWithLogin):
             The query to get metadata for. Options are observations, and products.
 
         Returns
-        --------
+        -------
         response : `~astropy.table.Table`
             The metadata table.
         """

--- a/astroquery/open_exoplanet_catalogue/oec_query.py
+++ b/astroquery/open_exoplanet_catalogue/oec_query.py
@@ -19,7 +19,7 @@ def get_catalogue(filepath=None):
     Parses the Open Exoplanet Catalogue file.
 
     Parameters
-    -----------
+    ----------
     filepath : str or None
         if no filepath is given, remote source is used.
 

--- a/astroquery/vo_conesearch/validator/inspect.py
+++ b/astroquery/vo_conesearch/validator/inspect.py
@@ -138,7 +138,7 @@ class ConeSearchResults:
         If not found, nothing is written out.
 
         Parameters
-        -----------
+        ----------
         key : str
             Catalog key.
 


### PR DESCRIPTION
The newly released `numpydoc` 1.2 emits many warnings about docstrings. The causes of these warnings are addressed by this pull request and the documentation build should now succeed.