### PR TITLE
ALMA: add option to just validate data

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -10,6 +10,11 @@ esa.hubble
 
 Service fixes and enhancements
 ------------------------------
+alma
+^^^^
+
+- Added ``verify_only`` option to check if data downloaded with correct file size [#2263]
+
 esa.hubble
 ^^^^^^^^^^
 

--- a/astroquery/alma/core.py
+++ b/astroquery/alma/core.py
@@ -750,6 +750,7 @@ class AlmaClass(QueryWithLogin):
 
             if verify_only:
                 existing_file_length = os.stat(filename).st_size
+                print(f"{filename}: {existing_file_length}")
                 if 'content-length' in check_filename.headers:
                     length = int(check_filename.headers['content-length'])
                     if length == 0:
@@ -760,8 +761,11 @@ class AlmaClass(QueryWithLogin):
                         log.info(f"Found cached file {filename} with size {existing_file_length} < expected "
                                  f"size {length}.  The download should be continued.")
                     elif existing_file_length > length:
+                        print("Issuing a warning")
                         warnings.warn(f"Found cached file {filename} with size {existing_file_length} > expected "
                                       f"size {length}.  The download is likely corrupted.")
+                    else:
+                        raise ValueError("It should not be possible to reach this state.")
                 else:
                     warnings.warn(f"Could not verify {url} because it has no 'content-length'")
 

--- a/astroquery/alma/core.py
+++ b/astroquery/alma/core.py
@@ -685,7 +685,8 @@ class AlmaClass(QueryWithLogin):
         return data_sizes, totalsize.to(u.GB)
 
     def download_files(self, files, savedir=None, cache=True,
-                       continuation=True, skip_unauthorized=True,):
+                       continuation=True, skip_unauthorized=True,
+                       verify_only=False):
         """
         Given a list of file URLs, download them
 
@@ -706,6 +707,10 @@ class AlmaClass(QueryWithLogin):
             If you receive "unauthorized" responses for some of the download
             requests, skip over them.  If this is False, an exception will be
             raised.
+        verify_only : bool
+            Option to go through the process of checking the files to see if
+            they're the right size, but not actually download them.  This
+            option may be useful if a previous download run failed partway.
         """
 
         if self.USERNAME:
@@ -744,14 +749,15 @@ class AlmaClass(QueryWithLogin):
                                         filename)
 
             try:
-                self._download_file(file_link,
-                                    filename,
-                                    timeout=self.TIMEOUT,
-                                    auth=auth,
-                                    cache=cache,
-                                    method='GET',
-                                    head_safe=False,
-                                    continuation=continuation)
+                if not verify_only:
+                    self._download_file(file_link,
+                                        filename,
+                                        timeout=self.TIMEOUT,
+                                        auth=auth,
+                                        cache=cache,
+                                        method='GET',
+                                        head_safe=False,
+                                        continuation=continuation)
 
                 downloaded_files.append(filename)
             except requests.HTTPError as ex:

--- a/astroquery/alma/core.py
+++ b/astroquery/alma/core.py
@@ -31,6 +31,7 @@ from .tapsql import _gen_pos_sql, _gen_str_sql, _gen_numeric_sql,\
     _gen_science_sql, _gen_spec_res_sql, ALMA_DATE_FORMAT
 from . import conf, auth_urls
 from astroquery.utils.commons import ASTROPY_LT_4_1
+from astroquery.exceptions import CorruptDataWarning
 
 __all__ = {'AlmaClass', 'ALMA_BANDS'}
 
@@ -750,7 +751,6 @@ class AlmaClass(QueryWithLogin):
 
             if verify_only:
                 existing_file_length = os.stat(filename).st_size
-                print(f"{filename}: {existing_file_length}")
                 if 'content-length' in check_filename.headers:
                     length = int(check_filename.headers['content-length'])
                     if length == 0:
@@ -761,9 +761,9 @@ class AlmaClass(QueryWithLogin):
                         log.info(f"Found cached file {filename} with size {existing_file_length} < expected "
                                  f"size {length}.  The download should be continued.")
                     elif existing_file_length > length:
-                        print("Issuing a warning")
                         warnings.warn(f"Found cached file {filename} with size {existing_file_length} > expected "
-                                      f"size {length}.  The download is likely corrupted.")
+                                      f"size {length}.  The download is likely corrupted.",
+                                      CorruptDataWarning)
                     else:
                         raise ValueError("It should not be possible to reach this state.")
                 else:

--- a/astroquery/alma/core.py
+++ b/astroquery/alma/core.py
@@ -748,6 +748,23 @@ class AlmaClass(QueryWithLogin):
                 filename = os.path.join(savedir,
                                         filename)
 
+            if verify_only:
+                existing_file_length = os.stat(filename).st_size
+                if 'content-length' in check_filename.headers:
+                    length = int(check_filename.headers['content-length'])
+                    if length == 0:
+                        warnings.warn('URL {0} has length=0'.format(url))
+                    elif existing_file_length == length:
+                        log.info(f"Found cached file {filename} with expected size {existing_file_length}.")
+                    elif existing_file_length < length:
+                        log.info(f"Found cached file {filename} with size {existing_file_length} < expected "
+                                 f"size {length}.  The download should be continued.")
+                    elif existing_file_length > length:
+                        warnings.warn(f"Found cached file {filename} with size {existing_file_length} > expected "
+                                      f"size {length}.  The download is likely corrupted.")
+                else:
+                    warnings.warn(f"Could not verify {url} because it has no 'content-length'")
+
             try:
                 if not verify_only:
                     self._download_file(file_link,

--- a/astroquery/alma/core.py
+++ b/astroquery/alma/core.py
@@ -764,8 +764,6 @@ class AlmaClass(QueryWithLogin):
                         warnings.warn(f"Found cached file {filename} with size {existing_file_length} > expected "
                                       f"size {length}.  The download is likely corrupted.",
                                       CorruptDataWarning)
-                    else:
-                        raise ValueError("It should not be possible to reach this state.")
                 else:
                     warnings.warn(f"Could not verify {url} because it has no 'content-length'")
 

--- a/astroquery/alma/tests/test_alma_remote.py
+++ b/astroquery/alma/tests/test_alma_remote.py
@@ -686,12 +686,15 @@ def test_verify_html_file(alma, caplog):
     with open(local_filepath, 'ab') as fh:
         fh.write(b"Extra Text")
 
+    print("Trying the failed version now")
     caplog.clear()
-    with warnings.catch_warnings() as ww:
+    with warnings.catch_warnings(record=True) as ww:
         result = alma.download_files(['https://almascience.nao.ac.jp/dataPortal/member.uid___A001_X1284_X1353.qa2_report.html'], verify_only=True)
         assert result
         length = 66336
         existing_file_length = length + 10
+        print(f"WARNING: {str(ww)}")
+        print(f"caplog: {caplog.text}")
         assert f"Found cached file {local_filepath} with size {existing_file_length} > expected size {length}.  The download is likely corrupted." in str(ww)
 
     # manipulate the file: make it small

--- a/astroquery/alma/tests/test_alma_remote.py
+++ b/astroquery/alma/tests/test_alma_remote.py
@@ -13,6 +13,7 @@ from unittest.mock import Mock, MagicMock, patch
 from astropy import coordinates
 from astropy import units as u
 
+from astroquery.exceptions import CorruptDataWarning
 from astroquery.utils.commons import ASTROPY_LT_4_1
 from .. import Alma
 
@@ -674,10 +675,10 @@ def test_verify_html_file(alma, caplog):
 
     # download the file
     result = alma.download_files(['https://almascience.nao.ac.jp/dataPortal/member.uid___A001_X1284_X1353.qa2_report.html'])
-    assert result
+    assert 'member.uid___A001_X1284_X1353.qa2_report.html' in result[0]
 
     result = alma.download_files(['https://almascience.nao.ac.jp/dataPortal/member.uid___A001_X1284_X1353.qa2_report.html'], verify_only=True)
-    assert result
+    assert 'member.uid___A001_X1284_X1353.qa2_report.html' in result[0]
     local_filepath = result[0]
     existing_file_length = 66336
     assert f"Found cached file {local_filepath} with expected size {existing_file_length}." in caplog.text
@@ -686,16 +687,13 @@ def test_verify_html_file(alma, caplog):
     with open(local_filepath, 'ab') as fh:
         fh.write(b"Extra Text")
 
-    print("Trying the failed version now")
     caplog.clear()
-    with warnings.catch_warnings(record=True) as ww:
+    length = 66336
+    existing_file_length = length + 10
+    with pytest.warns(expected_warning=CorruptDataWarning,
+            match=f"Found cached file {local_filepath} with size {existing_file_length} > expected size {length}.  The download is likely corrupted."):
         result = alma.download_files(['https://almascience.nao.ac.jp/dataPortal/member.uid___A001_X1284_X1353.qa2_report.html'], verify_only=True)
-        assert result
-        length = 66336
-        existing_file_length = length + 10
-        print(f"WARNING: {str(ww)}")
-        print(f"caplog: {caplog.text}")
-        assert f"Found cached file {local_filepath} with size {existing_file_length} > expected size {length}.  The download is likely corrupted." in str(ww)
+    assert 'member.uid___A001_X1284_X1353.qa2_report.html' in result[0]
 
     # manipulate the file: make it small
     with open(local_filepath, 'wb') as fh:
@@ -703,7 +701,11 @@ def test_verify_html_file(alma, caplog):
 
     caplog.clear()
     result = alma.download_files(['https://almascience.nao.ac.jp/dataPortal/member.uid___A001_X1284_X1353.qa2_report.html'], verify_only=True)
-    assert result
+    assert 'member.uid___A001_X1284_X1353.qa2_report.html' in result[0]
     length = 66336
     existing_file_length = 10
     assert f"Found cached file {local_filepath} with size {existing_file_length} < expected size {length}.  The download should be continued." in caplog.text
+
+    # cleanup: we don't want `test_download_html_file` to fail if this test is re-run
+    if os.path.exists(local_filepath):
+        os.remove(local_filepath)

--- a/astroquery/exceptions.py
+++ b/astroquery/exceptions.py
@@ -8,7 +8,7 @@ from astropy.utils.exceptions import AstropyWarning
 __all__ = ['TimeoutError', 'InvalidQueryError', 'RemoteServiceError',
            'TableParseError', 'LoginError', 'ResolverError',
            'NoResultsWarning', 'LargeQueryWarning', 'InputWarning',
-           'AuthenticationWarning', 'MaxResultsWarning']
+           'AuthenticationWarning', 'MaxResultsWarning', 'CorruptDataWarning']
 
 
 class TimeoutError(Exception):
@@ -94,6 +94,14 @@ class MaxResultsWarning(AstropyWarning):
     """
     Astroquery warning class to be issued when the maximum allowed
     results are returned.
+    """
+    pass
+
+
+class CorruptDataWarning(AstropyWarning):
+    """
+    Astroquery warning class to be issued when there is a sign that the
+    (partially) downloaded data are corrupt.
     """
     pass
 

--- a/docs/alma/alma.rst
+++ b/docs/alma/alma.rst
@@ -325,6 +325,17 @@ You can also do the downloading all in one step:
 
    >>> myAlma.retrieve_data_from_uid(uids[0])
 
+If you have huge files, sometimes the transfer fails, so you will need to
+restart the download.  By default, the module will resume downloading where the
+failure occurred.  You can check whether the downloads all succeeded before
+triggering a new download by using the ``verify_only`` keyword, which will not
+download but will return useful information about the state of your downloads:
+
+.. code-block:: python
+
+   >>> myAlma.download_files(link_list, cache=True, verify_only=True)
+
+
 Downloading FITS data
 =====================
 


### PR DESCRIPTION
This is a minor improvement to allow going through the data download loop without downloading anything