### PR TITLE
Update module lists in documentation

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -88,75 +88,16 @@ Using astroquery
 ----------------
 
 Importing astroquery on its own doesn't get you much: you need to import each
-sub-module specifically.  Check out the `docs`_
-to find a list of the tools available.  The `API`_
-shows the standard suite of tools common to most modules, e.g. `query_object`
-and `query_region`.
+sub-module specifically.  See the documentation for a list of `Available
+Services <https://astroquery.readthedocs.io/en/latest/#available-services>`_.
+The `API`_ shows the standard suite of tools common to most modules, e.g.
+`query_object` and `query_region`.
 
 To report bugs and request features, please use the issue tracker.  Code
 contributions are very welcome, though we encourage you to follow the `API`_
 and `contributing guidelines
 <https://github.com/astropy/astroquery/blob/main/CONTRIBUTING.rst>`_ as much
 as possible.
-
-List of Modules
----------------
-
-The following modules have been completed using a common API:
-
-  * `ALMA Archive <http://astroquery.readthedocs.io/en/latest/alma/alma.html>`_
-  * `Atomic Line List <http://astroquery.readthedocs.io/en/latest/atomic/atomic.html>`_: A collection of more than 900,000 atomic transitions.
-  * `Besancon <http://astroquery.readthedocs.io/en/latest/besancon/besancon.html>`_: Model of stellar population synthesis in the Galaxy.
-  * `CDS MOC Service <https://astroquery.readthedocs.io/en/latest/cds/cds.html>`_: A collection of all-sky survey coverage maps.
-  * `CADC <https://astroquery.readthedocs.io/en/latest/cadc/cadc.html>`_: Canadian Astronomy Data Centre.
-  * `CASDA <https://astroquery.readthedocs.io/en/latest/casda/casda.html>`_:  CSIRO ASKAP Science Data Archive.
-  * `ESASky <http://astroquery.readthedocs.io/en/latest/esasky/esasky.html>`_: ESASky is a science driven discovery portal providing easy visualizations and full access to the entire sky as observed with ESA Space astronomy missions.
-  * `ESO Archive <http://astroquery.readthedocs.io/en/latest/eso/eso.html>`_
-  * `FIRST <http://astroquery.readthedocs.io/en/latest/image_cutouts/first/first.html>`_: Faint Images of the Radio Sky at Twenty-cm. 20-cm radio images of the extragalactic sky from the VLA.
-  * `Gaia <http://astroquery.readthedocs.io/en/latest/gaia/gaia.html>`_: European Space Agency Gaia Archive.
-  * `ESA XMM <https://astroquery.readthedocs.io/en/latest/esa/xmm_newton.html>`_: European Space Agency XMM-Newton Science Archive.
-  * `ESA Hubble <https://astroquery.readthedocs.io/en/latest/esa/hubble.html>`_: European Space Agency Hubble Science Archive.
-  * `ESA ISO <https://astroquery.readthedocs.io/en/latest/esa/iso.html>`_: European Space Agency ISO Data Archive.
-  * `GAMA database <http://astroquery.readthedocs.io/en/latest/gama/gama.html>`_
-  * `Gemini <http://astroquery.readthedocs.io/en/latest/gemini/gemini.html>`_: Gemini Archive.
-  * `HEASARC <http://astroquery.readthedocs.io/en/latest/heasarc/heasarc.html>`_: NASA's High Energy Astrophysics Science Archive Research Center.
-  * `IBE <http://astroquery.readthedocs.io/en/latest/ibe/ibe.html>`_: IRSA Image Server program interface (IBE) Query Tool provides access to the 2MASS, WISE, and PTF image archives.
-  * `IRSA <http://astroquery.readthedocs.io/en/latest/irsa/irsa.html>`_: NASA/IPAC Infrared Science Archive. Science products for all of NASA's infrared and sub-mm missions.
-  * `IRSA dust <http://astroquery.readthedocs.io/en/latest/irsa/irsa_dust.html>`_: Galactic dust reddening and extinction maps from IRAS 100 um data.
-  * `MAGPIS <http://astroquery.readthedocs.io/en/latest/magpis/magpis.html>`_: Multi-Array Galactic Plane Imaging Survey. 6 and 20-cm radio images of the Galactic plane from the VLA.
-  * `MAST <http://astroquery.readthedocs.io/en/latest/mast/mast.html>`_: Barbara A. Mikulski Archive for Space Telescopes.
-  * `Minor Planet Center <http://astroquery.readthedocs.io/en/latest/mpc/mpc.html>`_
-  * `NASA ADS <http://astroquery.readthedocs.io/en/latest/nasa_ads/nasa_ads.html>`_: SAO/NASA Astrophysics Data System.
-  * `NED <http://astroquery.readthedocs.io/en/latest/ned/ned.html>`_: NASA/IPAC Extragalactic Database. Multiwavelength data from both surveys and publications.
-  * `NIST <http://astroquery.readthedocs.io/en/latest/nist/nist.html>`_: National Institute of Standards and Technology (NIST) atomic lines database.
-  * `NRAO <http://astroquery.readthedocs.io/en/latest/nrao/nrao.html>`_: Science data archive of the National Radio Astronomy Observatory. VLA, JVLA, VLBA and GBT data products.
-  * `NVAS archive <http://astroquery.readthedocs.io/en/latest/nvas/nvas.html>`_
-  * `Simbad <http://astroquery.readthedocs.io/en/latest/simbad/simbad.html>`_: Basic data, cross-identifications, bibliography and measurements for astronomical objects outside the solar system.
-  * `Skyview <http://astroquery.readthedocs.io/en/latest/skyview/skyview.html>`_: NASA SkyView service for imaging surveys.
-  * `Splatalogue <http://astroquery.readthedocs.io/en/latest/splatalogue/splatalogue.html>`_: National Radio Astronomy Observatory (NRAO)-maintained (mostly) molecular radio and millimeter line list service.
-  * `UKIDSS <http://astroquery.readthedocs.io/en/latest/ukidss/ukidss.html>`_: UKIRT Infrared Deep Sky Survey. JHK images of 7500 sq deg. in the northern sky.
-  * `Vamdc <http://astroquery.readthedocs.io/en/latest/vamdc/vamdc.html>`_: VAMDC molecular line database.
-  * `Vizier <http://astroquery.readthedocs.io/en/latest/vizier/vizier.html>`_: Set of 11,000+ published, multiwavelength catalogues hosted by the CDS.
-  * `VO Simple Cone Search <http://astroquery.readthedocs.io/en/latest/vo_conesearch/vo_conesearch.html>`_
-  * `xMatch <http://astroquery.readthedocs.io/en/latest/xmatch/xmatch.html>`_:  Cross-identify sources between very large data sets or between a user-uploaded list and a large catalogue.
-
-These others are functional, but do not follow a common or consistent API:
-
-  * `Alfalfa <http://astroquery.readthedocs.io/en/latest/alfalfa/alfalfa.html>`_: Arecibo Legacy Fast ALFA survey; extragalactic HI radio data.
-  * `CosmoSim <http://astroquery.readthedocs.io/en/latest/cosmosim/cosmosim.html>`_: The CosmoSim database provides results from cosmological simulations performed within different projects: the MultiDark project, the BolshoiP project, and the CLUES project.
-  * `Exoplanet Orbit Database  <http://astroquery.readthedocs.io/en/latest/exoplanet_orbit_database/exoplanet_orbit_database.html>`_
-  * `Fermi <http://astroquery.readthedocs.io/en/latest/fermi/fermi.html>`_: Fermi gamma-ray telescope archive.
-  * `HITRAN <http://astroquery.readthedocs.io/en/latest/hitran/hitran.html>`_: Access to the high-resolution transmission molecular absorption database.
-  * `JPL Horizons <http://astroquery.readthedocs.io/en/latest/jplhorizons/jplhorizons.html>`_: JPL Solar System Dynamics Horizons Service.
-  * `JPL SBDB <http://astroquery.readthedocs.io/en/latest/jplsbdb/jplsbdb.html>`_: JPL Solar System Dynamics Small-Body Database Browser Service.
-  * `Lamda <http://astroquery.readthedocs.io/en/latest/lamda/lamda.html>`_: Leiden Atomic and Molecular Database; energy levels, radiative transitions, and collisional rates for astrophysically relevant atoms and molecules.
-  * `NASA Exoplanet Archive  <http://astroquery.readthedocs.io/en/latest/nasa_exoplanet_archive/nasa_exoplanet_archive.html>`_
-  * `OAC API <http://astroquery.readthedocs.io/en/latest/oac/oac.html>`_: Open Astronomy Catalog REST API Service.
-  * `Ogle <http://astroquery.readthedocs.io/en/latest/ogle/ogle.html>`_: Optical Gravitational Lensing Experiment III; information on interstellar extinction towards the Galactic bulge.
-  * `Open Expolanet Catalog (OEC) <http://astroquery.readthedocs.io/en/latest/open_exoplanet_catalogue/open_exoplanet_catalogue.html>`_
-  * `SDSS <http://astroquery.readthedocs.io/en/latest/sdss/sdss.html>`_: Sloan Digital Sky Survey data, including optical images, spectra, and spectral templates.
-  * `SHA <http://astroquery.readthedocs.io/en/latest/sha/sha.html>`_: Spitzer Heritage Archive; infrared data products from the Spitzer Space Telescope.
-
 
 Citing Astroquery
 -----------------
@@ -188,7 +129,6 @@ Maintained by `Adam Ginsburg`_ and `Brigitta Sipocz <https://github.com/bsipocz>
 .. _Download Stable ZIP: https://github.com/astropy/astroquery/zipball/stable
 .. _Download Stable TAR: https://github.com/astropy/astroquery/tarball/stable
 .. _View on Github: https://github.com/astropy/astroquery/
-.. _docs: http://astroquery.readthedocs.io
 .. _Documentation: http://astroquery.readthedocs.io
 .. _astropy.astroquery@gmail.com: mailto:astropy.astroquery@gmail.com
 .. _Adam Ginsburg: http://www.adamgginsburg.com

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -185,23 +185,25 @@ The following modules have been completed using a common API:
   cadc/cadc.rst
   casda/casda.rst
   cds/cds.rst
+  linelists/cdms/cdms.rst
+  dace/dace.rst
   esa/hubble.rst
   esa/iso.rst
   esa/jwst.rst
   esa/xmm_newton.rst
   esasky/esasky.rst
   eso/eso.rst
+  image_cutouts/first/first.rst
   gaia/gaia.rst
   gama/gama.rst
   gemini/gemini.rst
   heasarc/heasarc.rst
   hips2fits/hips2fits.rst
   hitran/hitran.rst
+  ipac/irsa/irsa_dust/irsa_dust.rst
   ipac/irsa/ibe/ibe.rst
   ipac/irsa/irsa.rst
-  ipac/irsa/irsa_dust/irsa_dust.rst
   jplspec/jplspec.rst
-  linelists/cdms/cdms.rst
   magpis/magpis.rst
   mast/mast.rst
   mpc/mpc.rst
@@ -221,7 +223,6 @@ The following modules have been completed using a common API:
   vo_conesearch/vo_conesearch.rst
   vsa/vsa.rst
   xmatch/xmatch.rst
-  dace/dace.rst
 
 
 These others are functional, but do not follow a common & consistent API:
@@ -269,22 +270,22 @@ for each source)
   alfalfa/alfalfa.rst
   exoplanet_orbit_database/exoplanet_orbit_database.rst
   gama/gama.rst
+  ipac/irsa/irsa_dust/irsa_dust.rst
   ipac/irsa/ibe/ibe.rst
   ipac/irsa/irsa.rst
-  ipac/irsa/irsa_dust/irsa_dust.rst
   mast/mast.rst
   ipac/nexsci/nasa_exoplanet_archive.rst
   ipac/ned/ned.rst
   ogle/ogle.rst
   open_exoplanet_catalogue/open_exoplanet_catalogue.rst
   sdss/sdss.rst
-  ipac/irsa/sha/sha.rst
   simbad/simbad.rst
+  ipac/irsa/sha/sha.rst
   ukidss/ukidss.rst
-  vsa/vsa.rst
   vizier/vizier.rst
-  xmatch/xmatch.rst
   vo_conesearch/vo_conesearch.rst
+  vsa/vsa.rst
+  xmatch/xmatch.rst
 
 Archives
 --------
@@ -301,25 +302,25 @@ generally return a table listing the available data first.
   casda/casda.rst
   esa/hubble.rst
   esa/jwst.rst
+  esa/xmm_newton.rst
   eso/eso.rst
   fermi/fermi.rst
   gaia/gaia.rst
+  gemini/gemini.rst
   heasarc/heasarc.rst
   ipac/irsa/ibe/ibe.rst
   ipac/irsa/irsa.rst
   magpis/magpis.rst
-  gemini/gemini.rst
   mast/mast.rst
   ipac/ned/ned.rst
   noirlab/noirlab.rst
   nrao/nrao.rst
   nvas/nvas.rst
   sdss/sdss.rst
+  skyview/skyview.rst
   ipac/irsa/sha/sha.rst
   ukidss/ukidss.rst
   vsa/vsa.rst
-  skyview/skyview.rst
-  esa/xmm_newton.rst
 
 Simulations
 -----------
@@ -342,13 +343,13 @@ well as  cross section and collision rates.  Those services are:
   :maxdepth: 1
 
   atomic/atomic.rst
+  linelists/cdms/cdms.rst
+  hitran/hitran.rst
+  jplspec/jplspec.rst
   lamda/lamda.rst
   nist/nist.rst
   splatalogue/splatalogue.rst
   vamdc/vamdc.rst
-  hitran/hitran.rst
-  linelists/cdms/cdms.rst
-  jplspec/jplspec.rst
 
 Other
 -----
@@ -359,12 +360,12 @@ above categories. Those services are here:
 .. toctree::
   :maxdepth: 1
 
-  nasa_ads/nasa_ads.rst
-  utils/tap.rst
+  astrometry_net/astrometry_net.rst
+  imcce/imcce.rst
   jplhorizons/jplhorizons.rst
   jplsbdb/jplsbdb.rst
-  imcce/imcce.rst
-  astrometry_net/astrometry_net.rst
+  nasa_ads/nasa_ads.rst
+  utils/tap.rst
 
 
 Topical Collections
@@ -376,8 +377,8 @@ topical submodules:
 .. toctree::
   :maxdepth: 1
 
-  solarsystem/solarsystem.rst
   image_cutouts/image_cutouts.rst
+  solarsystem/solarsystem.rst
 
 
 Developer documentation

--- a/docs/solarsystem/solarsystem.rst
+++ b/docs/solarsystem/solarsystem.rst
@@ -16,8 +16,8 @@ The currently available service providers and services are:
 .. toctree::
   :maxdepth: 1
 
-  jpl/jpl.rst
   imcce/imcce.rst
+  jpl/jpl.rst
   mpc/mpc.rst
 
 Reference/API


### PR DESCRIPTION
The module lists in `README.rst`, `docs/index.rst` and `docs/solarsystem/solarsystem.rst` are now alphabetically sorted and agree with each other, and a few broken links in `README.rst` are fixed. Many links now use `https` instead of `http`.