### PR TITLE
Hubble related members

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -3,10 +3,17 @@
 
 New Tools and Services
 ----------------------
+esa.hubble
+^^^^^^^^^^
 
+- Added new method ``get_hap_hst_link`` and ``get_member_observations`` to get related observations [#2268]
 
 Service fixes and enhancements
 ------------------------------
+esa.hubble
+^^^^^^^^^^
+
+- Changed query_target method to use TAP instead of AIO [#2268]
 
 casda
 ^^^^^

--- a/astroquery/esa/hubble/core.py
+++ b/astroquery/esa/hubble/core.py
@@ -498,6 +498,9 @@ class ESAHubbleClass(BaseQuery):
             target name to be requested, mandatory
         filename : string
             file name to be used to store the metadata, optional, default None
+        async_job : bool, optional, default 'False'
+            executes the query (job) in asynchronous/synchronous mode (default
+            synchronous)
         output_format : string
             optional, default 'votable'
             output format of the query

--- a/astroquery/esa/hubble/core.py
+++ b/astroquery/esa/hubble/core.py
@@ -121,6 +121,8 @@ class ESAHubbleClass(BaseQuery):
 
     def get_member_observations(self, observation_id):
         """
+        Returns the related members of simple and composite observations
+
         Parameters
         ----------
         observation_id : str, mandatory
@@ -129,8 +131,7 @@ class ESAHubbleClass(BaseQuery):
         Returns
         -------
         A list of strings with the observation_id of the associated
-        observations that can be used in get_product_list and
-        get_obs_products functions
+        observations
         """
         if observation_id is None:
             raise ValueError(self.REQUESTED_OBSERVATION_ID)
@@ -145,6 +146,21 @@ class ESAHubbleClass(BaseQuery):
         return oids
 
     def get_hap_hst_link(self, observation_id):
+        """
+        Returns the related members of hap and hst observations
+
+        Parameters
+        ----------
+        observation_id : string
+           id of the observation to be downloaded, mandatory
+           The identifier of the observation we want to retrieve, regardless
+           of whether it is simple or composite.
+
+        Returns
+        -------
+        A list of strings with the observation_id of the associated
+        observations
+        """
         if observation_id is None:
             raise ValueError(self.REQUESTED_OBSERVATION_ID)
         observation_type = self.get_observation_type(observation_id)
@@ -161,6 +177,20 @@ class ESAHubbleClass(BaseQuery):
         return oids
 
     def get_observation_type(self, observation_id):
+        """
+        Returns the type of an observation
+
+        Parameters
+        ----------
+        observation_id : string
+           id of the observation to be downloaded, mandatory
+           The identifier of the observation we want to retrieve, regardless
+           of whether it is simple or composite.
+
+        Returns
+        -------
+        String with the observation type
+        """
         if observation_id is None:
             raise ValueError(self.REQUESTED_OBSERVATION_ID)
 

--- a/astroquery/esa/hubble/core.py
+++ b/astroquery/esa/hubble/core.py
@@ -515,11 +515,8 @@ class ESAHubbleClass(BaseQuery):
 
         ra, dec = self._query_tap_target(name)
         coordinates = SkyCoord(ra=str(ra), dec=str(dec), unit="deg", frame='icrs')
-
-        if async_job:
-            table = self.cone_search(coordinates, radius, filename=filename, output_format=output_format, async_job=True)
-        else:
-            table = self.cone_search(coordinates, radius, filename=filename, output_format=output_format)
+        table = self.cone_search(coordinates, radius, filename=filename, output_format=output_format,
+                                 async_job=async_job)
 
         return table
 

--- a/astroquery/esa/hubble/core.py
+++ b/astroquery/esa/hubble/core.py
@@ -148,8 +148,9 @@ class ESAHubbleClass(BaseQuery):
         if observation_id is None:
             raise ValueError(self.REQUESTED_OBSERVATION_ID)
         observation_type = self.get_observation_type(observation_id)
-
-        if 'HAP' in observation_type:
+        if 'Composite' in observation_type:
+            raise ValueError("HAP-HST link is only available for simple observations. Input observation is Composite.")
+        elif 'HAP' in observation_type:
             oids = self._select_members(observation_id)
         elif 'HST' in observation_type:
             query = f"select observation_id from ehst.observation where obs_type='HAP Simple' and members like '%{observation_id}%'"

--- a/astroquery/esa/hubble/core.py
+++ b/astroquery/esa/hubble/core.py
@@ -42,7 +42,6 @@ class ESAHubbleClass(BaseQuery):
                           3: "PRODUCT"}
     product_types = ["PRODUCT", "SCIENCE_PRODUCT", "POSTCARD"]
     copying_string = "Copying file to {0}..."
-    obs_id_none = "Please input an observation id"
 
     def __init__(self, tap_handler=None):
         super(ESAHubbleClass, self).__init__()
@@ -182,7 +181,7 @@ class ESAHubbleClass(BaseQuery):
         String with the observation type
         """
         if observation_id is None:
-            raise ValueError(self.obs_id_none)
+            raise ValueError("Please input an observation id")
 
         query = f"select obs_type from ehst.observation where observation_id='{observation_id}'"
         job = self.query_hst_tap(query=query)
@@ -466,14 +465,11 @@ class ESAHubbleClass(BaseQuery):
                             "parameter.")
         if target:
             coord = self._query_tap_target(target)
-            ra = coord.get('RA_DEGREES')
-            dec = coord.get('DEC_DEGREES')
-
-            # ra, dec = self._query_tap_target(target)
         else:
             coord = self._getCoordInput(coordinates)
-            ra = coord.ra.deg
-            dec = coord.dec.deg
+
+        ra = coord.ra.deg
+        dec = coord.dec.deg
 
         if type(radius) == int or type(radius) == float:
             radius_in_grades = Angle(radius, units.arcmin).deg
@@ -505,7 +501,6 @@ class ESAHubbleClass(BaseQuery):
             ra = target_result['RA_DEGREES']
             dec = target_result['DEC_DEGREES']
             return SkyCoord(ra=ra, dec=dec, unit="deg")
-            # return ra, dec
         except KeyError as e:
             raise ValueError("This target cannot be resolved")
 

--- a/astroquery/esa/hubble/core.py
+++ b/astroquery/esa/hubble/core.py
@@ -501,9 +501,9 @@ class ESAHubbleClass(BaseQuery):
         output_format : string
             optional, default 'votable'
             output format of the query
-        verbose : bool
-            optional, default 'False'
-            Flag to display information about the process
+        radius : int
+            optional, default None
+            radius in arcmin (int, float) or quantity of the cone_search
 
         Returns
         -------

--- a/astroquery/esa/hubble/tests/test_esa_hubble.py
+++ b/astroquery/esa/hubble/tests/test_esa_hubble.py
@@ -603,24 +603,3 @@ class TestESAHubble:
             ehst = ESAHubbleClass(self.get_dummy_tap_handler())
             dummy_obs_id = None
             ehst.get_member_observations(dummy_obs_id)
-
-
-"""
-    def test_get_member_observations(self):
-        parameters = {}
-        obs = 'dummyObs'
-        parameters['query'] = f"select observation_id from ehst.observation where members like '%{obs}%'"
-        parameters['name'] = None
-        parameters['output_file'] = None
-        parameters['output_format'] = 'votable'
-        parameters['verbose'] = False
-        parameters['dump_to_file'] = False
-        parameters['upload_resource'] = None
-        parameters['upload_table_name'] = None
-
-        dummyTapHandler = DummyHubbleTapHandler("launch_job", parameters)
-        tap = ESAHubbleClass(dummyTapHandler)
-
-        tap.get_member_observations(observation_id=obs)
-        dummyTapHandler.check_call('launch_job', parameters)
-"""

--- a/astroquery/esa/hubble/tests/test_esa_hubble.py
+++ b/astroquery/esa/hubble/tests/test_esa_hubble.py
@@ -132,12 +132,14 @@ class TestESAHubble:
                           filename="X0MC5101T.vot",
                           verbose=True)
 
-    def test_query_target(self):
-        parameters = {'name': "m31",
-                      'verbose': True}
+    @patch.object(ESAHubbleClass, 'cone_search')
+    @patch.object(ESAHubbleClass, '_query_tap_target')
+    def test_query_target(self, mock_query_tap_target, mock_cone_search):
+        mock_query_tap_target.return_value = 10, 10
+        mock_cone_search.return_value = "test"
         ehst = ESAHubbleClass(self.get_dummy_tap_handler())
-        ehst.query_target(name=parameters['name'],
-                          verbose=parameters['verbose'])
+        table = ehst.query_target(name="test")
+        assert table == "test"
 
     def test_cone_search(self):
         coords = coordinates.SkyCoord("00h42m44.51s +41d16m08.45s",

--- a/astroquery/esa/hubble/tests/test_esa_hubble.py
+++ b/astroquery/esa/hubble/tests/test_esa_hubble.py
@@ -11,8 +11,10 @@ Created on 13 Aug. 2018
 
 
 """
+import numpy as np
 import pytest
 import os
+from unittest.mock import patch
 
 from requests.models import Response
 from astroquery.esa.hubble import ESAHubbleClass
@@ -63,6 +65,13 @@ def ehst_cone_search(request):
     mp.setattr(ESAHubbleClass, 'cone_search', get_cone_mockreturn)
     return mp
 
+
+class MockResponse:
+    observation_id = 'test'
+
+    @staticmethod
+    def pformat():
+        return True
 
 class TestESAHubble:
 
@@ -178,7 +187,7 @@ class TestESAHubble:
                          parameters['verbose'])
         with pytest.raises(ValueError) as err:
             ehst._getCoordInput(1234)
-        assert "Coordinates must be either a string or "\
+        assert "Coordinates must be either a string or " \
                "astropy.coordinates" in err.value.args[0]
 
     def test_query_hst_tap(self):
@@ -349,29 +358,29 @@ class TestESAHubble:
                        'filename': "output_test_query_by_criteria.vot.gz",
                        'output_format': "votable",
                        'verbose': True}
-        test_query = "select o.*, p.calibration_level, p.data_product_type, "\
-                     "pos.ra, pos.dec from ehst.observation AS o JOIN "\
-                     "ehst.plane as p on o.observation_uuid=p.observation_"\
-                     "uuid JOIN ehst.position as pos on p.plane_id = "\
-                     "pos.plane_id where((o.collection LIKE '%HST%') AND "\
-                     "(o.instrument_name LIKE '%WFPC2%') AND "\
-                     "(o.instrument_configuration LIKE '%F606W%') AND "\
-                     "1=CONTAINS(POINT('ICRS', pos.ra, pos.dec),"\
-                     "CIRCLE('ICRS', 10.6847083, 41.26875, "\
+        test_query = "select o.*, p.calibration_level, p.data_product_type, " \
+                     "pos.ra, pos.dec from ehst.observation AS o JOIN " \
+                     "ehst.plane as p on o.observation_uuid=p.observation_" \
+                     "uuid JOIN ehst.position as pos on p.plane_id = " \
+                     "pos.plane_id where((o.collection LIKE '%HST%') AND " \
+                     "(o.instrument_name LIKE '%WFPC2%') AND " \
+                     "(o.instrument_configuration LIKE '%F606W%') AND " \
+                     "1=CONTAINS(POINT('ICRS', pos.ra, pos.dec)," \
+                     "CIRCLE('ICRS', 10.6847083, 41.26875, " \
                      "0.11666666666666667)))"
         parameters3 = {'query': test_query,
                        'output_file': "output_test_query_by_criteria.vot.gz",
                        'output_format': "votable",
                        'verbose': False}
         ehst = ESAHubbleClass(self.get_dummy_tap_handler())
-        query_criteria_query = "select o.*, p.calibration_level, "\
-                               "p.data_product_type, pos.ra, pos.dec from "\
-                               "ehst.observation AS o JOIN ehst.plane as p "\
-                               "on o.observation_uuid=p.observation_uuid "\
-                               "JOIN ehst.position as pos on p.plane_id = "\
-                               "pos.plane_id where((o.collection LIKE "\
-                               "'%HST%') AND (o.instrument_name LIKE "\
-                               "'%WFPC2%') AND (o.instrument_configuration "\
+        query_criteria_query = "select o.*, p.calibration_level, " \
+                               "p.data_product_type, pos.ra, pos.dec from " \
+                               "ehst.observation AS o JOIN ehst.plane as p " \
+                               "on o.observation_uuid=p.observation_uuid " \
+                               "JOIN ehst.position as pos on p.plane_id = " \
+                               "pos.plane_id where((o.collection LIKE " \
+                               "'%HST%') AND (o.instrument_name LIKE " \
+                               "'%WFPC2%') AND (o.instrument_configuration " \
                                "LIKE '%F606W%'))"
         ehst.query_criteria = MagicMock(return_value=query_criteria_query)
         target = {'RA_DEGREES': '10.6847083', 'DEC_DEGREES': '41.26875'}
@@ -419,14 +428,14 @@ class TestESAHubble:
                                       output_format=parameters1
                                       ['output_format'],
                                       verbose=parameters1['verbose'])
-        assert "Please use only target or coordinates as"\
-            "parameter." in err.value.args[0]
+        assert "Please use only target or coordinates as" \
+               "parameter." in err.value.args[0]
 
     def test_query_criteria_no_params(self):
         ehst = ESAHubbleClass(self.get_dummy_tap_handler())
         ehst.query_criteria(async_job=False,
                             output_file="output_test_query_"
-                            "by_criteria.vot.gz",
+                                        "by_criteria.vot.gz",
                             output_format="votable",
                             verbose=True)
         parameters = {'query': "select o.*, p.calibration_level, "
@@ -445,8 +454,173 @@ class TestESAHubble:
             ehst.query_criteria(instrument_name=[1],
                                 async_job=False,
                                 output_file="output_test_query_"
-                                "by_criteria.vot.gz",
+                                            "by_criteria.vot.gz",
                                 output_format="votable",
                                 verbose=True)
-        assert "One of the lists is empty or there are "\
+        assert "One of the lists is empty or there are " \
                "elements that are not strings" in err.value.args[0]
+
+    def test_get_decoded_string(self):
+        ehst = ESAHubbleClass(self.get_dummy_tap_handler())
+        dummy = '\x74\x65\x73\x74'
+        decoded_string = ehst.get_decoded_string(dummy)
+        assert decoded_string == 'test'
+
+    def test_get_decoded_string_unicodedecodeerror(self):
+        ehst = ESAHubbleClass(self.get_dummy_tap_handler())
+        dummy = '\xd0\x91'
+        decoded_string = ehst.get_decoded_string(dummy)
+        assert decoded_string == dummy
+
+    def test_get_decoded_string_attributeerror(self):
+        ehst = ESAHubbleClass(self.get_dummy_tap_handler())
+        dummy = True
+        decoded_string = ehst.get_decoded_string(dummy)
+        assert decoded_string == dummy
+
+    @patch.object(ESAHubbleClass, 'query_hst_tap')
+    def test__select_composite(self, mock_query):
+        arr = {'a': np.array([1, 4], dtype=np.int32),
+               'b': [2.0, 5.0],
+               'observation_id': ['x', 'y']}
+        data_table = Table(arr)
+        ehst = ESAHubbleClass(self.get_dummy_tap_handler())
+        mock_query.return_value = data_table
+        dummy_obs_id = "1234"
+        oids = ehst._select_composite(dummy_obs_id)
+        assert oids == ['x', 'y']
+
+    @patch.object(ESAHubbleClass, 'query_hst_tap')
+    def test__select_members(self, mock_query):
+        arr = {'a': np.array([1, 4], dtype=np.int32),
+               'b': [2.0, 5.0],
+               'members': ['caom:HST/test', 'y']}
+        data_table = Table(arr)
+        ehst = ESAHubbleClass(self.get_dummy_tap_handler())
+        mock_query.return_value = data_table
+        dummy_obs_id = "1234"
+        oids = ehst._select_members(dummy_obs_id)
+        assert oids == ['test']
+
+    @patch.object(ESAHubbleClass, 'query_hst_tap')
+    def test_get_observation_type(self, mock_query):
+        arr = {'a': np.array([1, 4], dtype=np.int32),
+               'b': [2.0, 5.0],
+               'obs_type': ['HST Test', 'y']}
+        data_table = Table(arr)
+        ehst = ESAHubbleClass(self.get_dummy_tap_handler())
+        mock_query.return_value = data_table
+        dummy_obs_id = "1234"
+        oids = ehst.get_observation_type(dummy_obs_id)
+        assert oids == 'HST Test'
+
+    def test_get_observation_type_attributeerror(self):
+        with pytest.raises(AttributeError):
+            ehst = ESAHubbleClass(self.get_dummy_tap_handler())
+            dummy_obs_id = None
+            ehst.get_observation_type(dummy_obs_id)
+
+    @patch.object(ESAHubbleClass, 'query_hst_tap')
+    def test_get_observation_type_valueerror(self, mock_query):
+        with pytest.raises(ValueError):
+            arr = {'a': np.array([], dtype=np.int32),
+                   'b': [],
+                   'obs_type': []}
+            data_table = Table(arr)
+            ehst = ESAHubbleClass(self.get_dummy_tap_handler())
+            mock_query.return_value = data_table
+            dummy_obs_id = '1234'
+            ehst.get_observation_type(dummy_obs_id)
+
+    @patch.object(ESAHubbleClass, 'query_hst_tap')
+    @patch.object(ESAHubbleClass, 'get_observation_type')
+    def test_get_hst_link(self, mock_observation_type, mock_query):
+        mock_observation_type.return_value = "HST"
+        arr = {'a': np.array([1], dtype=np.int32),
+               'b': [2.0],
+               'observation_id': ['1234']}
+        data_table = Table(arr)
+        ehst = ESAHubbleClass(self.get_dummy_tap_handler())
+        mock_query.return_value = data_table
+        dummy_obs_id = "1234"
+        oids = ehst.get_hap_hst_link(dummy_obs_id)
+        assert oids == ['1234']
+
+    @patch.object(ESAHubbleClass, 'get_observation_type')
+    @patch.object(ESAHubbleClass, '_select_members')
+    def test_get_hap_link(self, mock_select_members, mock_observation_type):
+        mock_select_members.return_value = 'test'
+        mock_observation_type.return_value = "HAP"
+        ehst = ESAHubbleClass(self.get_dummy_tap_handler())
+        dummy_obs_id = "1234"
+        oids = ehst.get_hap_hst_link(dummy_obs_id)
+        assert oids == 'test'
+
+    @patch.object(ESAHubbleClass, 'get_observation_type')
+    def test_get_hap_hst_link_valueerror(self, mock_observation_type):
+        with pytest.raises(ValueError):
+            mock_observation_type.return_value = "valueerror"
+            ehst = ESAHubbleClass(self.get_dummy_tap_handler())
+            dummy_obs_id = "1234"
+            ehst.get_hap_hst_link(dummy_obs_id)
+
+    def test_get_hap_hst_link_attributeerror(self):
+        with pytest.raises(AttributeError):
+            ehst = ESAHubbleClass(self.get_dummy_tap_handler())
+            dummy_obs_id = None
+            ehst.get_hap_hst_link(dummy_obs_id)
+
+    @patch.object(ESAHubbleClass, '_select_members')
+    @patch.object(ESAHubbleClass, 'get_observation_type')
+    def test_get_member_observations_composite(self, mock_observation_type, mock_select_members):
+        mock_observation_type.return_value = "Composite"
+        ehst = ESAHubbleClass(self.get_dummy_tap_handler())
+        mock_select_members.return_value = 'test'
+        dummy_obs_id = "1234"
+        oids = ehst.get_member_observations(dummy_obs_id)
+        assert oids == 'test'
+
+    @patch.object(ESAHubbleClass, '_select_composite')
+    @patch.object(ESAHubbleClass, 'get_observation_type')
+    def test_get_member_observations_simple(self, mock_observation_type, mock_select_composite):
+        mock_observation_type.return_value = "Simple"
+        ehst = ESAHubbleClass(self.get_dummy_tap_handler())
+        mock_select_composite.return_value = 'test'
+        dummy_obs_id = "1234"
+        oids = ehst.get_member_observations(dummy_obs_id)
+        assert oids == 'test'
+
+    @patch.object(ESAHubbleClass, 'get_observation_type')
+    def test_get_member_observations_valueerror(self, mock_observation_type):
+        with pytest.raises(ValueError):
+            mock_observation_type.return_value = "valueerror"
+            ehst = ESAHubbleClass(self.get_dummy_tap_handler())
+            dummy_obs_id = "1234"
+            ehst.get_member_observations(dummy_obs_id)
+
+    def test_get_member_observations_attributeerror(self):
+        with pytest.raises(AttributeError):
+            ehst = ESAHubbleClass(self.get_dummy_tap_handler())
+            dummy_obs_id = None
+            ehst.get_member_observations(dummy_obs_id)
+
+
+"""
+    def test_get_member_observations(self):
+        parameters = {}
+        obs = 'dummyObs'
+        parameters['query'] = f"select observation_id from ehst.observation where members like '%{obs}%'"
+        parameters['name'] = None
+        parameters['output_file'] = None
+        parameters['output_format'] = 'votable'
+        parameters['verbose'] = False
+        parameters['dump_to_file'] = False
+        parameters['upload_resource'] = None
+        parameters['upload_table_name'] = None
+
+        dummyTapHandler = DummyHubbleTapHandler("launch_job", parameters)
+        tap = ESAHubbleClass(dummyTapHandler)
+
+        tap.get_member_observations(observation_id=obs)
+        dummyTapHandler.check_call('launch_job', parameters)
+"""

--- a/astroquery/esa/hubble/tests/test_esa_hubble.py
+++ b/astroquery/esa/hubble/tests/test_esa_hubble.py
@@ -73,6 +73,7 @@ class MockResponse:
     def pformat():
         return True
 
+
 class TestESAHubble:
 
     def get_dummy_tap_handler(self):
@@ -568,6 +569,14 @@ class TestESAHubble:
         with pytest.raises(AttributeError):
             ehst = ESAHubbleClass(self.get_dummy_tap_handler())
             dummy_obs_id = None
+            ehst.get_hap_hst_link(dummy_obs_id)
+
+    @patch.object(ESAHubbleClass, 'get_observation_type')
+    def test_get_hap_hst_link_compositeerror(self, mock_observation_type):
+        with pytest.raises(ValueError):
+            mock_observation_type.return_value = "HAP Composite"
+            ehst = ESAHubbleClass(self.get_dummy_tap_handler())
+            dummy_obs_id = "1234"
             ehst.get_hap_hst_link(dummy_obs_id)
 
     @patch.object(ESAHubbleClass, '_select_members')

--- a/astroquery/esa/hubble/tests/test_esa_hubble_remote.py
+++ b/astroquery/esa/hubble/tests/test_esa_hubble_remote.py
@@ -115,10 +115,11 @@ class TestEsaHubbleRemoteData:
         result = esa_hubble.get_hap_hst_link('jec071i9q')
         assert result == ['hst_16316_71_acs_sbc_f150lp_jec071i9']
 
+
 """
     def test_query_target(self):
         temp_file = self.temp_folder.name + "/" + "m31_query.xml"
-        table = esa_hubble.query_target("m31", temp_file)
+        table = esa_hubble.query_target("m3", temp_file)
         assert os.path.exists(temp_file)
         assert 'OBSERVATION_ID' in table.columns
 """

--- a/astroquery/esa/hubble/tests/test_esa_hubble_remote.py
+++ b/astroquery/esa/hubble/tests/test_esa_hubble_remote.py
@@ -40,15 +40,14 @@ def remove_last_job():
 
 @pytest.mark.remote_data
 class TestEsaHubbleRemoteData:
-
     obs_query = "select top 2050 o.observation_id from ehst.observation o"
 
     top_obs_query = "select top 100 o.observation_id from ehst.observation o"
 
-    hst_query = "select top 50 o.observation_id from ehst.observation "\
+    hst_query = "select top 50 o.observation_id from ehst.observation " \
                 "o where o.collection='HST'"
 
-    top_artifact_query = "select top 50 a.artifact_id, a.observation_id "\
+    top_artifact_query = "select top 50 a.artifact_id, a.observation_id " \
                          " from ehst.artifact a"
 
     temp_folder = create_temp_folder()
@@ -75,12 +74,6 @@ class TestEsaHubbleRemoteData:
         esa_hubble.get_artifact(artifact_id, temp_file)
         assert os.path.exists(temp_file)
 
-    def test_query_target(self):
-        temp_file = self.temp_folder.name + "/" + "m31_query.xml"
-        table = esa_hubble.query_target("m31", temp_file)
-        assert os.path.exists(temp_file)
-        assert 'OBSERVATION_ID' in table.columns
-
     def test_cone_search(self):
         esa_hubble = ESAHubble()
         c = coordinates.SkyCoord("00h42m44.51s +41d16m08.45s", frame='icrs')
@@ -90,3 +83,42 @@ class TestEsaHubbleRemoteData:
         assert 'observation_id' in table.columns
         assert len(table) > 0
         remove_last_job()
+
+    # tests for get_related_members
+    def test_hst_composite_to_hst_simple(self):
+        esa_hubble = ESAHubble()
+        result = esa_hubble.get_member_observations('jdrz0c010')
+        assert result == ['jdrz0cjxq', 'jdrz0cjyq']
+
+    def test_hst_simple_to_hst_composite(self):
+        esa_hubble = ESAHubble()
+        result = esa_hubble.get_member_observations('jdrz0cjxq')
+        assert result == ['jdrz0c010']
+
+    def test_hap_composite_to_hap_simple(self):
+        esa_hubble = ESAHubble()
+        result = esa_hubble.get_member_observations('hst_15446_4v_acs_wfc_f606w_jdrz4v')
+        assert result == ['hst_15446_4v_acs_wfc_f606w_jdrz4vkv', 'hst_15446_4v_acs_wfc_f606w_jdrz4vkw']
+
+    def test_hap_simple_to_hap_composite(self):
+        esa_hubble = ESAHubble()
+        result = esa_hubble.get_member_observations('hst_16316_71_acs_sbc_f150lp_jec071i9')
+        assert result == ['hst_16316_71_acs_sbc_f150lp_jec071']
+
+    def test_hap_simple_to_hst_simple(self):
+        esa_hubble = ESAHubble()
+        result = esa_hubble.get_hap_hst_link('hst_16316_71_acs_sbc_f150lp_jec071i9')
+        assert result == ['jec071i9q']
+
+    def test_hst_simple_to_hap_simple(self):
+        esa_hubble = ESAHubble()
+        result = esa_hubble.get_hap_hst_link('jec071i9q')
+        assert result == ['hst_16316_71_acs_sbc_f150lp_jec071i9']
+
+"""
+    def test_query_target(self):
+        temp_file = self.temp_folder.name + "/" + "m31_query.xml"
+        table = esa_hubble.query_target("m31", temp_file)
+        assert os.path.exists(temp_file)
+        assert 'OBSERVATION_ID' in table.columns
+"""

--- a/astroquery/esa/hubble/tests/test_esa_hubble_remote.py
+++ b/astroquery/esa/hubble/tests/test_esa_hubble_remote.py
@@ -115,11 +115,8 @@ class TestEsaHubbleRemoteData:
         result = esa_hubble.get_hap_hst_link('jec071i9q')
         assert result == ['hst_16316_71_acs_sbc_f150lp_jec071i9']
 
-
-"""
     def test_query_target(self):
         temp_file = self.temp_folder.name + "/" + "m31_query.xml"
-        table = esa_hubble.query_target("m3", temp_file)
+        table = esa_hubble.query_target(name="m3", filename=temp_file)
         assert os.path.exists(temp_file)
-        assert 'OBSERVATION_ID' in table.columns
-"""
+        assert 'observation_id' in table.columns

--- a/docs/esa/hubble.rst
+++ b/docs/esa/hubble.rst
@@ -339,9 +339,9 @@ votable). The result of the query will be stored in the file
 result.get_results() or printing it by doing print(result).
 
 
--------------------------------
+------------------------------------------------------
 9. Getting related members of HAP and HST observations
--------------------------------
+------------------------------------------------------
 
 This function takes in an observation id of a Composite or Simple observation.
 If the observation is Simple the method returns the Composite observation that
@@ -356,9 +356,9 @@ method returns the simple observations that make it up.
   >>> print(result)
 
 
--------------------------------
+--------------------------------------------------------
 10. Getting link between Simple HAP and HST observations
--------------------------------
+--------------------------------------------------------
 
 This function takes in an observation id of a Simple HAP or HST observation and
 returns the corresponding HAP or HST observation

--- a/docs/esa/hubble.rst
+++ b/docs/esa/hubble.rst
@@ -339,6 +339,39 @@ votable). The result of the query will be stored in the file
 result.get_results() or printing it by doing print(result).
 
 
+-------------------------------
+9. Getting related members of HAP and HST observations
+-------------------------------
+
+This function takes in an observation id of a Composite or Simple observation.
+If the observation is Simple the method returns the Composite observation that
+is built on this simple observation. If the observation is Composite then the
+method returns the simple observations that make it up.
+
+.. code-block:: python
+
+  >>> from astroquery.esa.hubble import ESAHubble
+  >>> esahubble = ESAHubble()
+  >>> result = esahubble.get_member_observations("jdrz0c010")
+  >>> print(result)
+
+
+-------------------------------
+10. Getting link between Simple HAP and HST observations
+-------------------------------
+
+This function takes in an observation id of a Simple HAP or HST observation and
+returns the corresponding HAP or HST observation
+
+.. code-block:: python
+
+  >>> from astroquery.esa.hubble import ESAHubble
+  >>> esahubble = ESAHubble()
+  >>> result = esahubble.get_hap_hst_link("hst_16316_71_acs_sbc_f150lp_jec071i9")
+  >>> print(result)
+
+
+
 Reference/API
 =============
 


### PR DESCRIPTION
These changes allow users to get related members of HST and HAP observations. Query_target method has been refactored to use the TAP instead of AIO. 