### PR TITLE
Add PLATO to Catalogs

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -31,6 +31,8 @@ mast
 
 - GALEX data is now available to download anonymously from the public STScI S3 buckets. [#2261]
 
+- Adding the All-Sky PLATO Input Catalog ('plato') as a catalog option for methods of ``astroquery.mast.Catalogs``. [#2279]
+
 Infrastructure, Utility and Other Changes and Additions
 -------------------------------------------------------
 

--- a/astroquery/mast/collections.py
+++ b/astroquery/mast/collections.py
@@ -41,7 +41,10 @@ class CatalogsClass(MastQueryWithLogin):
         super().__init__()
 
         services = {"panstarrs": {"path": "panstarrs/{data_release}/{table}.json",
-                                  "args": {"data_release": "dr2", "table": "mean"}}}
+                                  "args": {"data_release": "dr2", "table": "mean"}},
+                    "plato": {"path": "plato/{data_release}/{table}.json",
+                                         "args": {"data_release": ["dr1", "dr2"], "table": "mean"}}}
+
         self._service_api_connection.set_service_params(services, "catalogs", True)
 
         self.catalog_limit = None
@@ -141,9 +144,16 @@ class CatalogsClass(MastQueryWithLogin):
                 if version == 1:
                     service = "Mast.Catalogs.GaiaDR1.Cone"
                 else:
-                    if version not in (2, None):
+                    if version not in (None, 2):
                         warnings.warn("Invalid Gaia version number, defaulting to DR2.", InputWarning)
                     service = "Mast.Catalogs.GaiaDR2.Cone"
+
+            elif catalog.lower() == 'plato':
+                if version in (None, 1):
+                    service = "Mast.Catalogs.Plato.Cone"
+                else:
+                    warnings.warn("Invalid PLATO catalog version number, defaulting to DR1.", InputWarning)
+                    service = "Mast.Catalogs.Plato.Cone"
 
             else:
                 service = "Mast.Catalogs." + catalog + ".Cone"

--- a/astroquery/mast/collections.py
+++ b/astroquery/mast/collections.py
@@ -41,9 +41,7 @@ class CatalogsClass(MastQueryWithLogin):
         super().__init__()
 
         services = {"panstarrs": {"path": "panstarrs/{data_release}/{table}.json",
-                                  "args": {"data_release": "dr2", "table": "mean"}},
-                    "plato": {"path": "plato/{data_release}/{table}.json",
-                                         "args": {"data_release": ["dr1", "dr2"], "table": "mean"}}}
+                                  "args": {"data_release": "dr2", "table": "mean"}}}
 
         self._service_api_connection.set_service_params(services, "catalogs", True)
 

--- a/astroquery/mast/tests/test_mast.py
+++ b/astroquery/mast/tests/test_mast.py
@@ -433,6 +433,9 @@ def test_catalogs_query_region(patch_post):
     result = mast.Catalogs.query_region(regionCoords, radius=0.002 * u.deg, catalog="Sample")
     assert isinstance(result, Table)
 
+    result = mast.Catalogs.query_region(regionCoords, radius=0.002 * u.deg, catalog="plato")
+    assert isinstance(result, Table)
+
 
 def test_catalogs_fabric_query_region(patch_post):
     result = mast.Catalogs.query_region(regionCoords, radius=0.002 * u.deg, catalog="panstarrs", table="mean")

--- a/astroquery/mast/tests/test_mast.py
+++ b/astroquery/mast/tests/test_mast.py
@@ -433,9 +433,6 @@ def test_catalogs_query_region(patch_post):
     result = mast.Catalogs.query_region(regionCoords, radius=0.002 * u.deg, catalog="Sample")
     assert isinstance(result, Table)
 
-    result = mast.Catalogs.query_region(regionCoords, radius=0.002 * u.deg, catalog="plato")
-    assert isinstance(result, Table)
-
 
 def test_catalogs_fabric_query_region(patch_post):
     result = mast.Catalogs.query_region(regionCoords, radius=0.002 * u.deg, catalog="panstarrs", table="mean")

--- a/astroquery/mast/tests/test_mast_remote.py
+++ b/astroquery/mast/tests/test_mast_remote.py
@@ -515,6 +515,11 @@ class TestMast:
         assert isinstance(result, Table)
         assert '441662144' in result['ID']
 
+        result = mast.Catalogs.query_object('M1',
+                                            radius=0.001,
+                                            catalog='plato')
+        assert 'PICidDR1' in result.colnames
+
     def test_catalogs_query_criteria_async(self):
         # without position
         responses = mast.Catalogs.query_criteria_async(catalog="Tic",

--- a/docs/mast/mast.rst
+++ b/docs/mast/mast.rst
@@ -458,7 +458,8 @@ The Catalogs class provides access to a subset of the astronomical catalogs stor
 - The TESS Input Catalog (TIC)
 - The TESS Candidate Target List (CTL)
 - The Disk Detective Catalog
-- PanSTARRS (DR1, DR2)
+- The PanSTARRS Catalog (DR1 and DR2)
+- The PLATO Catalog (DR1 and DR2)
 
 Positional Queries
 ------------------

--- a/docs/mast/mast.rst
+++ b/docs/mast/mast.rst
@@ -459,7 +459,7 @@ The Catalogs class provides access to a subset of the astronomical catalogs stor
 - The TESS Candidate Target List (CTL)
 - The Disk Detective Catalog
 - The PanSTARRS Catalog (DR1 and DR2)
-- The PLATO Catalog (DR1 and DR2)
+- The All-Sky PLATO Input Catalog (DR1)
 
 Positional Queries
 ------------------


### PR DESCRIPTION
*Functionality*: Following the latest MAST patch, this PR adds PLATO as a query option to `astroquery.mast.Catalogs.query_region` and `query_object`.

*Documentation*: `mast.rst` is updated to reflect new PLATO DR1 availability. 

*Testing*: `test_mast_remote.py` is updated with a regression test for `PLATO` query. 