### PR TITLE
Instantiate MPC class before queries.

### DIFF
--- a/astroquery/mpc/core.py
+++ b/astroquery/mpc/core.py
@@ -542,8 +542,9 @@ class MPCClass(BaseQuery):
         Examples
         --------
         >>> from astroquery.mpc import MPC
-        >>> tab = astroquery.mpc.MPC.get_ephemeris('(24)', location=568,
-        ...            start='2003-02-26', step='100d', number=3)  # doctest: +SKIP
+        >>> tab = MPC().get_ephemeris('(24)', location=568,
+        ...                           start='2003-02-26', step='100d',
+        ...                           number=3)  # doctest: +SKIP
         >>> print(tab)  # doctest: +SKIP
 
         """
@@ -641,7 +642,7 @@ class MPCClass(BaseQuery):
         Examples
         --------
         >>> from astroquery.mpc import MPC
-        >>> obs = MPC.get_observatory_codes()  # doctest: +SKIP
+        >>> obs = MPC().get_observatory_codes()  # doctest: +SKIP
         >>> print(obs[295])  # doctest: +SKIP
         Code Longitude   cos       sin         Name
         ---- --------- -------- --------- -------------
@@ -697,7 +698,7 @@ class MPCClass(BaseQuery):
         Examples
         --------
         >>> from astroquery.mpc import MPC
-        >>> obs = MPC.get_observatory_location('000')
+        >>> obs = MPC().get_observatory_location('000')
         >>> print(obs)  # doctest: +SKIP
         (<Angle 0. deg>, 0.62411, 0.77873, 'Greenwich')
 
@@ -882,7 +883,7 @@ class MPCClass(BaseQuery):
         Examples
         --------
         >>> from astroquery.mpc import MPC
-        >>> MPC.get_observations(12893)  # doctest: +SKIP
+        >>> MPC().get_observations(12893)  # doctest: +SKIP
         <QTable masked=True length=1401>
         number   desig   discovery note1 ...   mag   band observatory
                                          ...   mag

--- a/astroquery/mpc/tests/test_mpc.py
+++ b/astroquery/mpc/tests/test_mpc.py
@@ -21,7 +21,7 @@ parameters = {
 }
 for prefix, (name, kwargs) in parameters.items():
     with open(prefix + '.html', 'w') as outf:
-        response = MPC.get_ephemeris_async(name, unc_links=True, **kwargs)
+        response = MPC().get_ephemeris_async(name, unc_links=True, **kwargs)
         outf.write(response.text)
 ```
 
@@ -29,7 +29,7 @@ For mock testing the object query:
 
 ```
 from astroquery.mpc import MPC
-result = MPC.query_object_async('comet', designation='C/2012 S1')
+result = MPC().query_object_async('comet', designation='C/2012 S1')
 with open('comet_object_C2012S1.json', 'w') as outf:
     outf.write(result.text)
 ```
@@ -121,13 +121,13 @@ def post_mockreturn(self, httpverb, url, data={}, **kwargs):
 
 
 def test_query_object_get_query_payload(patch_get):
-    request_payload = mpc.core.MPC.query_object_async(
+    request_payload = mpc.core.MPC().query_object_async(
         get_query_payload=True, target_type='asteroid', name='ceres')
     assert request_payload == {"name": "ceres", "json": 1, "limit": 1}
 
 
 def test_args_to_object_payload():
-    test_args = mpc.core.MPC._args_to_object_payload(name="eros", number=433)
+    test_args = mpc.core.MPC()._args_to_object_payload(name="eros", number=433)
     assert test_args == {"name": "eros", "number": 433, "json": 1}
 
 
@@ -137,12 +137,12 @@ def test_args_to_object_payload():
     ('asteroid',
         'https://minorplanetcenter.net/web_service/search_orbits')])
 def test_get_mpc_object_endpoint(type, url):
-    query_url = mpc.core.MPC.get_mpc_object_endpoint(target_type=type)
+    query_url = mpc.core.MPC().get_mpc_object_endpoint(target_type=type)
     assert query_url == url
 
 
 def test_args_to_ephemeris_payload():
-    payload = mpc.core.MPC._args_to_ephemeris_payload(
+    payload = mpc.core.MPC()._args_to_ephemeris_payload(
         **DEFAULT_EPHEMERIS_ARGS)
     assert payload == {
         'ty': 'e', 'TextArea': 'Ceres', 'uto': '0', 'igd': 'n', 'ibh': 'n',
@@ -153,36 +153,36 @@ def test_args_to_ephemeris_payload():
 
 
 def test_get_ephemeris_Moon_phase(patch_post):
-    result = mpc.core.MPC.get_ephemeris('2P', location='G37')
+    result = mpc.core.MPC().get_ephemeris('2P', location='G37')
     assert result['Moon phase'][0] >= 0
 
 
 def test_get_ephemeris_Uncertainty(patch_post):
     # this test requires an object with uncertainties != N/A
-    result = mpc.core.MPC.get_ephemeris('1994 XG')
+    result = mpc.core.MPC().get_ephemeris('1994 XG')
     assert result['Uncertainty 3sig'].quantity[0] > 0 * u.arcsec
 
 
 def test_get_ephemeris_Moon_phase_and_Uncertainty(patch_post):
     # this test requires an object with uncertainties != N/A
-    result = mpc.core.MPC.get_ephemeris('1994 XG', location='G37')
+    result = mpc.core.MPC().get_ephemeris('1994 XG', location='G37')
     assert result['Moon phase'][0] >= 0
     assert result['Uncertainty 3sig'].quantity[0] > 0 * u.arcsec
 
 
 def test_get_ephemeris_by_name_fail(patch_post):
     with pytest.raises(InvalidQueryError):
-        mpc.core.MPC.get_ephemeris('test fail')
+        mpc.core.MPC().get_ephemeris('test fail')
 
 
 def test_get_ephemeris_location_str():
-    payload = mpc.core.MPC.get_ephemeris(
+    payload = mpc.core.MPC().get_ephemeris(
         '(1)', location='000', get_query_payload=True)
     assert payload['c'] == '000'
 
 
 def test_get_ephemeris_location_int():
-    payload = mpc.core.MPC.get_ephemeris(
+    payload = mpc.core.MPC().get_ephemeris(
         '(1)', location=0, get_query_payload=True)
     assert payload['c'] == '000'
 
@@ -192,7 +192,7 @@ def test_get_ephemeris_location_int():
     (patch_post, EarthLocation(0 * u.deg, '51d28m31.6s', 65.8 * u.m))
 ))
 def test_get_ephemeris_location_latlonalt(patch_post, location):
-    payload = mpc.core.MPC.get_ephemeris(
+    payload = mpc.core.MPC().get_ephemeris(
         '(1)', location=location, get_query_payload=True)
     assert np.isclose(payload['long'], 0.0)
     assert np.isclose(payload['lat'], 51.47544444444445)
@@ -201,29 +201,29 @@ def test_get_ephemeris_location_latlonalt(patch_post, location):
 
 def test_get_ephemeris_location_array_fail():
     with pytest.raises(ValueError):
-        mpc.core.MPC.get_ephemeris('2P', location=(1, 2, 3, 4))
+        mpc.core.MPC().get_ephemeris('2P', location=(1, 2, 3, 4))
 
 
 def test_get_ephemeris_location_type_fail():
     with pytest.raises(TypeError):
-        mpc.core.MPC.get_ephemeris('2P', location=1.0)
+        mpc.core.MPC().get_ephemeris('2P', location=1.0)
 
 
 @pytest.mark.parametrize('start', ('2001-1-1', Time('2001-1-1')))
 def test_get_ephemeris_start(start):
-    payload = mpc.core.MPC.get_ephemeris(
+    payload = mpc.core.MPC().get_ephemeris(
         '(1)', start=start, get_query_payload=True)
     assert payload['d'] == '2001-01-01 000000'
 
 
 def test_get_ephemeris_start_now():
-    payload = mpc.core.MPC.get_ephemeris('(1)', get_query_payload=True)
+    payload = mpc.core.MPC().get_ephemeris('(1)', get_query_payload=True)
     assert len(payload['d']) == 17
 
 
 def test_get_ephemeris_start_fail():
     with pytest.raises(ValueError):
-        mpc.core.MPC.get_ephemeris('2P', start=2000)
+        mpc.core.MPC().get_ephemeris('2P', start=2000)
 
 
 @pytest.mark.parametrize('step,interval,unit', (
@@ -233,7 +233,7 @@ def test_get_ephemeris_start_fail():
     ('10s', '10', 's')
 ))
 def test_get_ephemeris_step(step, interval, unit):
-    payload = mpc.core.MPC.get_ephemeris(
+    payload = mpc.core.MPC().get_ephemeris(
         '10P', step=step, get_query_payload=True)
     assert payload['i'] == interval
     assert payload['u'] == unit
@@ -241,7 +241,7 @@ def test_get_ephemeris_step(step, interval, unit):
 
 def test_get_ephemeris_step_fail():
     with pytest.raises(ValueError):
-        mpc.core.MPC.get_ephemeris('2P', step='1m')  # units of meters
+        mpc.core.MPC().get_ephemeris('2P', step='1m')  # units of meters
 
 
 @pytest.mark.parametrize('number,step,val', (
@@ -252,28 +252,28 @@ def test_get_ephemeris_step_fail():
     (None, '10s', '301')
 ))
 def test_get_ephemeris_number(number, step, val):
-    payload = mpc.core.MPC.get_ephemeris('10P', number=number, step=step,
+    payload = mpc.core.MPC().get_ephemeris('10P', number=number, step=step,
                                          get_query_payload=True)
     assert payload['l'] == val
 
 
 def test_get_ephemeris_number_fail():
     with pytest.raises(ValueError):
-        mpc.core.MPC.get_ephemeris('2P', number=1500)
+        mpc.core.MPC().get_ephemeris('2P', number=1500)
 
 
 def test_get_ephemeris_ra_format(patch_post):
-    result = mpc.core.MPC.get_ephemeris('2P')
+    result = mpc.core.MPC().get_ephemeris('2P')
     ra0 = Angle(result['RA'])
-    result = mpc.core.MPC.get_ephemeris('2P', ra_format={'unit': 'hourangle'})
+    result = mpc.core.MPC().get_ephemeris('2P', ra_format={'unit': 'hourangle'})
     ra1 = Angle(result['RA'])
     assert np.allclose(ra0.deg, ra1.deg)
 
 
 def test_get_ephemeris_dec_format(patch_post):
-    result = mpc.core.MPC.get_ephemeris('2P')
+    result = mpc.core.MPC().get_ephemeris('2P')
     dec0 = Angle(result['Dec'])
-    result = mpc.core.MPC.get_ephemeris('2P', dec_format={'unit': 'deg'})
+    result = mpc.core.MPC().get_ephemeris('2P', dec_format={'unit': 'deg'})
     dec1 = Angle(result['Dec'])
     assert np.allclose(dec0.deg, dec1.deg)
 
@@ -284,14 +284,14 @@ def test_get_ephemeris_dec_format(patch_post):
     ('geocentric', ('X', 'Y', 'Z'))
 ))
 def test_get_ephemeris_eph_type(eph_type, cols, patch_post):
-    result = mpc.core.MPC.get_ephemeris('2P', eph_type=eph_type)
+    result = mpc.core.MPC().get_ephemeris('2P', eph_type=eph_type)
     for col in cols:
         assert col in result.colnames
 
 
 def test_get_ephemeris_eph_type_fail():
     with pytest.raises(ValueError):
-        mpc.core.MPC.get_ephemeris('2P', eph_type='something else')
+        mpc.core.MPC().get_ephemeris('2P', eph_type='something else')
 
 
 @pytest.mark.parametrize('mu,columns', (
@@ -300,14 +300,14 @@ def test_get_ephemeris_eph_type_fail():
     ('sky', ('dRA cos(Dec)', 'dDec'))
 ))
 def test_get_ephemeris_proper_motion(mu, columns, patch_post):
-    result = mpc.core.MPC.get_ephemeris('2P', proper_motion=mu)
+    result = mpc.core.MPC().get_ephemeris('2P', proper_motion=mu)
     for col in columns:
         assert col in result.colnames
 
 
 def test_get_ephemeris_proper_motion_fail():
     with pytest.raises(ValueError):
-        mpc.core.MPC.get_ephemeris('2P', proper_motion='something else')
+        mpc.core.MPC().get_ephemeris('2P', proper_motion='something else')
 
 
 @pytest.mark.parametrize('mu,unit,columns,units', (
@@ -320,7 +320,7 @@ def test_get_ephemeris_proper_motion_fail():
 ))
 def test_get_ephemeris_proper_motion_unit(mu, unit, columns, units,
                                           patch_post):
-    result = mpc.core.MPC.get_ephemeris(
+    result = mpc.core.MPC().get_ephemeris(
         '2P', proper_motion=mu, proper_motion_unit=unit)
     for col, unit in zip(columns, units):
         assert result[col].unit == u.Unit(unit)
@@ -328,151 +328,151 @@ def test_get_ephemeris_proper_motion_unit(mu, unit, columns, units,
 
 def test_get_ephemeris_proper_motion_unit_fail(patch_post):
     with pytest.raises(ValueError):
-        result = mpc.core.MPC.get_ephemeris('2P', proper_motion_unit='km/s')
+        result = mpc.core.MPC().get_ephemeris('2P', proper_motion_unit='km/s')
 
 
 @pytest.mark.parametrize('suppress_daytime,val', ((True, 'y'), (False, 'n')))
 def test_get_ephemeris_suppress_daytime(suppress_daytime, val):
-    payload = mpc.core.MPC.get_ephemeris('2P', suppress_daytime=suppress_daytime,
+    payload = mpc.core.MPC().get_ephemeris('2P', suppress_daytime=suppress_daytime,
                                          get_query_payload=True)
     assert payload['igd'] == val
 
 
 @pytest.mark.parametrize('suppress_set,val', ((True, 'y'), (False, 'n')))
 def test_get_ephemeris_suppress_set(suppress_set, val):
-    payload = mpc.core.MPC.get_ephemeris('2P', suppress_set=suppress_set,
+    payload = mpc.core.MPC().get_ephemeris('2P', suppress_set=suppress_set,
                                          get_query_payload=True)
     assert payload['ibh'] == val
 
 
 @pytest.mark.parametrize('perturbed,val', ((True, 'y'), (False, 'n')))
 def test_get_ephemeris_perturbed(perturbed, val):
-    payload = mpc.core.MPC.get_ephemeris('2P', perturbed=perturbed,
+    payload = mpc.core.MPC().get_ephemeris('2P', perturbed=perturbed,
                                          get_query_payload=True)
     assert payload['fp'] == val
 
 
 @pytest.mark.parametrize('unc_links', (True, False))
 def test_get_ephemeris_unc_links(unc_links, patch_post):
-    tab = mpc.core.MPC.get_ephemeris('1994 XG', unc_links=unc_links)
+    tab = mpc.core.MPC().get_ephemeris('1994 XG', unc_links=unc_links)
     assert ('Unc. map' in tab.colnames) == unc_links
     assert ('Unc. offsets' in tab.colnames) == unc_links
 
 
 def test_get_observatory_codes(patch_get):
-    result = mpc.core.MPC.get_observatory_codes()
+    result = mpc.core.MPC().get_observatory_codes()
     greenwich = ['000', 0.0, 0.62411, 0.77873, 'Greenwich']
     assert all([r == g for r, g in zip(result[0], greenwich)])
 
 
 def test_get_observatory_location(patch_get):
-    result = mpc.core.MPC.get_observatory_location('000')
+    result = mpc.core.MPC().get_observatory_location('000')
     greenwich = [Angle(0.0, 'deg'), 0.62411, 0.77873, 'Greenwich']
     assert all([r == g for r, g in zip(result, greenwich)])
 
 
 def test_get_observatory_location_fail():
     with pytest.raises(TypeError):
-        mpc.core.MPC.get_observatory_location(0)
+        mpc.core.MPC().get_observatory_location(0)
     with pytest.raises(ValueError):
-        mpc.core.MPC.get_observatory_location('00')
+        mpc.core.MPC().get_observatory_location('00')
 
 
 def test_get_observations(patch_get):
-    result = mpc.core.MPC.get_observations(12893)
+    result = mpc.core.MPC().get_observations(12893)
     assert result['desig'][0] == '1998 QS55'
     assert result['mag'].unit == u.mag
     assert result['RA'].unit == u.deg
     assert result['DEC'].unit == u.deg
     assert result['epoch'].unit == u.d
 
-    result = mpc.core.MPC.get_observations('12893',
+    result = mpc.core.MPC().get_observations('12893',
                                            get_raw_response=True)
 
     assert result[0]['designation'] == "1998 QS55"
 
-    result = mpc.core.MPC.get_observations('12893',
+    result = mpc.core.MPC().get_observations('12893',
                                            get_mpcformat=True)
     assert "12893J93S07X*4 1993 09 17.25833" in str(result)
 
 
 def test_get_observations_target_parsing(patch_get):
-    result = mpc.core.MPC.get_observations(12893, get_query_payload=True)
+    result = mpc.core.MPC().get_observations(12893, get_query_payload=True)
     assert result['object_type'] == 'M' and result['number'] == '12893'
 
-    result = mpc.core.MPC.get_observations(1, get_query_payload=True)
+    result = mpc.core.MPC().get_observations(1, get_query_payload=True)
     assert result['object_type'] == 'M' and result['number'] == '1'
 
-    result = mpc.core.MPC.get_observations(345678, get_query_payload=True)
+    result = mpc.core.MPC().get_observations(345678, get_query_payload=True)
     assert result['object_type'] == 'M' and result['number'] == '345678'
 
-    result = mpc.core.MPC.get_observations('1998 QS55',
+    result = mpc.core.MPC().get_observations('1998 QS55',
                                            get_query_payload=True)
     assert (result['object_type'] == 'M' and
             result['designation'] == '1998 QS55')
 
-    result = mpc.core.MPC.get_observations('P/2010 WK',
+    result = mpc.core.MPC().get_observations('P/2010 WK',
                                            get_query_payload=True)
     assert (result['object_type'] == 'P' and
             result['designation'] == 'P/2010 WK')
 
-    result = mpc.core.MPC.get_observations('C/2013 US10',
+    result = mpc.core.MPC().get_observations('C/2013 US10',
                                            get_query_payload=True)
     assert (result['object_type'] == 'C' and
             result['designation'] == 'C/2013 US10')
 
-    result = mpc.core.MPC.get_observations('C/2008 FK75',
+    result = mpc.core.MPC().get_observations('C/2008 FK75',
                                            get_query_payload=True)
     assert (result['object_type'] == 'C' and
             result['designation'] == 'C/2008 FK75')
 
-    result = mpc.core.MPC.get_observations('1P', get_query_payload=True)
+    result = mpc.core.MPC().get_observations('1P', get_query_payload=True)
     assert result['object_type'] == 'P' and result['number'] == '1'
 
     # test `id_type`
 
-    result = mpc.core.MPC.get_observations('C/2008 FK75',
+    result = mpc.core.MPC().get_observations('C/2008 FK75',
                                            id_type='comet designation',
                                            get_query_payload=True)
     assert (result['object_type'] == 'C' and
             result['designation'] == 'C/2008 FK75')
 
-    result = mpc.core.MPC.get_observations('P/2010 WK',
+    result = mpc.core.MPC().get_observations('P/2010 WK',
                                            id_type='comet designation',
                                            get_query_payload=True)
     assert (result['object_type'] == 'P' and
             result['designation'] == 'P/2010 WK')
 
-    result = mpc.core.MPC.get_observations('1P',
+    result = mpc.core.MPC().get_observations('1P',
                                            id_type='comet number',
                                            get_query_payload=True)
     assert (result['object_type'] == 'P' and result['number'] == '1')
 
-    result = mpc.core.MPC.get_observations(345678,
+    result = mpc.core.MPC().get_observations(345678,
                                            id_type='asteroid number',
                                            get_query_payload=True)
     assert result['object_type'] == 'M' and result['number'] == '345678'
 
-    result = mpc.core.MPC.get_observations('1998 QS55',
+    result = mpc.core.MPC().get_observations('1998 QS55',
                                            id_type='asteroid designation',
                                            get_query_payload=True)
     assert (result['object_type'] == 'M' and
             result['designation'] == '1998 QS55')
 
     with pytest.raises(ValueError):
-        result = mpc.core.MPC.get_observations(
+        result = mpc.core.MPC().get_observations(
             '1998 QS55', id_type='comet designation', get_query_payload=True)
 
     with pytest.raises(ValueError):
-        result = mpc.core.MPC.get_observations(
+        result = mpc.core.MPC().get_observations(
             '1998 QS55', id_type='comet number', get_query_payload=True)
 
     # this should technically not work, but the server allows it
-    result = mpc.core.MPC.get_observations(
+    result = mpc.core.MPC().get_observations(
         '1998 QS55', id_type='asteroid number', get_query_payload=True)
     assert (result['object_type'] == 'M' and result['number'] == '1998 QS55')
 
-    result = mpc.core.MPC.get_observations(
+    result = mpc.core.MPC().get_observations(
         '1P', id_type='comet designation', get_query_payload=True)
     assert (result['object_type'] == 'P' and
             result['designation'] == '1P')

--- a/astroquery/mpc/tests/test_mpc_remote.py
+++ b/astroquery/mpc/tests/test_mpc_remote.py
@@ -14,7 +14,7 @@ class TestMPC:
         ('asteroid', 'eros'),
         ('asteroid', 'pallas')])
     def test_query_object_valid_object_by_name(self, type, name):
-        response = mpc.core.MPC.query_object_async(target_type=type, name=name)
+        response = mpc.core.MPC().query_object_async(target_type=type, name=name)
         assert response.status_code == requests.codes.ok
         assert len(response.json()) == 1
         assert response.json()[0]['name'].lower() == name
@@ -22,7 +22,7 @@ class TestMPC:
     @pytest.mark.parametrize('type, number', [
         ('comet', '103P')])
     def test_query_object_valid_object_by_number(self, type, number):
-        response = mpc.core.MPC.query_object_async(
+        response = mpc.core.MPC().query_object_async(
             target_type=type, number=number)
         assert response.status_code == requests.codes.ok
         assert len(response.json()) == 1
@@ -32,7 +32,7 @@ class TestMPC:
     @pytest.mark.parametrize('type, designation', [
         ('comet', 'C/2012 S1')])
     def test_query_object_valid_object_by_designation(self, type, designation):
-        response = mpc.core.MPC.query_object_async(
+        response = mpc.core.MPC().query_object_async(
             target_type=type, designation=designation)
         assert response.status_code == requests.codes.ok
         assert len(response.json()) == 1
@@ -43,74 +43,74 @@ class TestMPC:
         ('eros'),
         ('pallas')])
     def test_query_object_get_query_payload_remote(self, name):
-        request_payload = mpc.core.MPC.query_object_async(
+        request_payload = mpc.core.MPC().query_object_async(
             get_query_payload=True, target_type='asteroid', name=name)
         assert request_payload == {"name": name, "json": 1, "limit": 1}
 
     def test_query_multiple_objects(self):
-        response = mpc.core.MPC.query_objects_async(
+        response = mpc.core.MPC().query_objects_async(
             target_type='asteroid', epoch_jd=2458200.5, limit=5)
         assert response.status_code == requests.codes.ok
         assert len(response.json()) == 5
 
     def test_query_object_by_nonexistent_name(self):
-        response = mpc.core.MPC.query_object_async(
+        response = mpc.core.MPC().query_object_async(
             target_type='asteroid', name="invalid object")
         assert response.status_code == requests.codes.ok
         assert len(response.json()) == 0
 
     def test_query_object_invalid_parameter(self):
-        response = mpc.core.MPC.query_object_async(
+        response = mpc.core.MPC().query_object_async(
             target_type='asteroid', blah="blah")
         assert response.status_code == requests.codes.ok
         assert "Unrecognized parameter" in str(response.content)
 
     def test_get_observatory_codes(self):
-        response = mpc.core.MPC.get_observatory_codes()
+        response = mpc.core.MPC().get_observatory_codes()
         greenwich = ['000', 0.0, 0.62411, 0.77873, 'Greenwich']
         assert all([r == g for r, g in zip(response[0], greenwich)])
 
     @pytest.mark.parametrize('target', ['(3202)', 'C/2003 A2'])
     def test_get_ephemeris_by_target(self, target):
         # test that query succeeded
-        response = mpc.core.MPC.get_ephemeris(target)
+        response = mpc.core.MPC().get_ephemeris(target)
         assert len(response) > 0
 
     def test_get_ephemeris_target_fail(self):
         # test that query failed
         with pytest.raises(InvalidQueryError):
-            mpc.core.MPC.get_ephemeris('test fail')
+            mpc.core.MPC().get_ephemeris('test fail')
 
     def test_get_observations(self):
         # asteroids
-        a = mpc.core.MPC.get_observations(2)
+        a = mpc.core.MPC().get_observations(2)
         assert a['number'][0] == 2
 
-        a = mpc.core.MPC.get_observations(12893)
+        a = mpc.core.MPC().get_observations(12893)
         assert a['number'][0] == 12893
         assert a['desig'][-1] == '1998 QS55'
-        a = mpc.core.MPC.get_observations("2019 AA")
+        a = mpc.core.MPC().get_observations("2019 AA")
         assert a['desig'][0] == '2019 AA'
-        a = mpc.core.MPC.get_observations("2017 BC136")
+        a = mpc.core.MPC().get_observations("2017 BC136")
         assert a['desig'][0] == '2017 BC136'
 
         # comets
-        a = mpc.core.MPC.get_observations('2P')
+        a = mpc.core.MPC().get_observations('2P')
         assert a['number'][0] == 2
         assert a['comettype'][0] == 'P'
-        a = mpc.core.MPC.get_observations('258P')
+        a = mpc.core.MPC().get_observations('258P')
         assert a['number'][0] == 258
         assert a['comettype'][0] == 'P'
-        a = mpc.core.MPC.get_observations("P/2018 P4")
+        a = mpc.core.MPC().get_observations("P/2018 P4")
         assert a['desig'][0] == "2018 P4"
         with pytest.raises(ValueError):
-            a = mpc.core.MPC.get_observations("2018 P4")
-        a = mpc.core.MPC.get_observations("P/2018 P4")
+            a = mpc.core.MPC().get_observations("2018 P4")
+        a = mpc.core.MPC().get_observations("P/2018 P4")
         assert a['desig'][0] == "2018 P4"
-        a = mpc.core.MPC.get_observations("C/2013 K1")
+        a = mpc.core.MPC().get_observations("C/2013 K1")
         assert a['desig'][0] == "2013 K1"
-        a = mpc.core.MPC.get_observations("P/2019 A4")
+        a = mpc.core.MPC().get_observations("P/2019 A4")
         assert a['desig'][0] == "2019 A4"
 
         with pytest.raises(TypeError):
-            a = mpc.core.MPC.get_observations()
+            a = mpc.core.MPC().get_observations()

--- a/docs/mpc/mpc.rst
+++ b/docs/mpc/mpc.rst
@@ -32,7 +32,7 @@ To return the orbit of Ceres and an ephemeris for the next 20 days:
 
     >>> from astroquery.mpc import MPC
     >>> from pprint import pprint
-    >>> result = MPC.query_object('asteroid', name='ceres')
+    >>> result = MPC().query_object('asteroid', name='ceres')
     >>> pprint(result)
 
     [{'absolute_magnitude': '3.34',
@@ -85,7 +85,7 @@ To return the orbit of Ceres and an ephemeris for the next 20 days:
       'uranus_moid': 15.6642,
       'venus_moid': 1.84632}]
 
-    >>> eph = MPC.get_ephemeris('ceres')
+    >>> eph = MPC().get_ephemeris('ceres')
     >>> print(eph)
     
               Date                  RA                Dec        Delta   r   Elongation Phase  V  Proper motion Direction Uncertainty 3sig Unc. P.A.
@@ -110,8 +110,8 @@ Orbits and parameters
 Search parameters
 -----------------
 
-Individual objects can be found with ``MPC.query_object``, and
-``MPC.query_objects`` can return multiple objects.  Parameters can be
+Individual objects can be found with ``MPC().query_object``, and
+``MPC().query_objects`` can return multiple objects.  Parameters can be
 queried in three manners:
 
     - exact match
@@ -123,7 +123,7 @@ An example of an exact match:
 .. code-block:: python
 
     >>> from astroquery.mpc import MPC
-    >>> result = MPC.query_object('asteroid', name='ceres')
+    >>> result = MPC().query_object('asteroid', name='ceres')
     >>> print(result)
 
     [{'absolute_magnitude': '3.34', 'aphelion_distance': '2.976', 'arc_length': 79247, 'argument_of_perihelion': '73.11528', 'ascending_node': '80.3099167', 'critical_list_numbered_object': False, 'delta_v': 10.5, 'designation': None, 'earth_moid': 1.59353, 'eccentricity': '0.0755347', 'epoch': '2018-03-23.0', 'epoch_jd': '2458200.5', 'first_observation_date_used': '1801-01-31.0', 'first_opposition_used': '1801', 'inclination': '10.59351', 'jupiter_moid': 2.09509, 'km_neo': False, 'last_observation_date_used': '2018-01-20.0', 'last_opposition_used': '2018', 'mars_moid': 0.939285, 'mean_anomaly': '352.23052', 'mean_daily_motion': '0.2141308', 'mercury_moid': 2.18454, 'name': 'Ceres', 'neo': False, 'number': 1, 'observations': 6689, 'oppositions': 114, 'orbit_type': 0, 'orbit_uncertainty': '0', 'p_vector_x': '-0.87827466', 'p_vector_y': '0.33795664', 'p_vector_z': '0.33825868', 'perihelion_date': '2018-04-28.28378', 'perihelion_date_jd': '2458236.78378', 'perihelion_distance': '2.5580384', 'period': '4.6', 'pha': False, 'phase_slope': '0.12', 'q_vector_x': '-0.44248615', 'q_vector_y': '-0.84255514', 'q_vector_z': '-0.30709419', 'residual_rms': '0.6', 'saturn_moid': 6.38856, 'semimajor_axis': '2.7670463', 'tisserand_jupiter': 3.3, 'updated_at': '2018-02-26T17:29:46Z', 'uranus_moid': 15.6642, 'venus_moid': 1.84632}]
@@ -132,7 +132,7 @@ A minimum value:
 
 .. code-block:: python
 
-    >>> result = MPC.query_objects('asteroid', inclination_min=170)
+    >>> result = MPC().query_objects('asteroid', inclination_min=170)
 
 which will get all asteroids with an inclination of greater than or
 equal to 170.
@@ -141,7 +141,7 @@ A maximum value:
 
 .. code-block:: python
 
-    >>> result = MPC.query_objects('asteroid', inclination_max=1.0)
+    >>> result = MPC().query_objects('asteroid', inclination_max=1.0)
     
 which will get all asteroids with an inclination of less than or equal to 1.
 
@@ -150,7 +150,7 @@ can be used in the following fashion:
 
 .. code-block:: python
 
-    >>> result = MPC.query_objects('asteroid', name="is_not_null")
+    >>> result = MPC().query_objects('asteroid', name="is_not_null")
 
 This will, predictably, find all named objects in the MPC
 database--but that would take a while!
@@ -169,7 +169,7 @@ options.
 
 .. code-block:: python
 
-    >>> result = MPC.query_objects('asteroid', order_by_desc="semimajor_axis", limit=10)
+    >>> result = MPC().query_objects('asteroid', order_by_desc="semimajor_axis", limit=10)
 
 This will return the 10 furthest asteroids.
 
@@ -181,7 +181,7 @@ MPC to limit the fields they're interested in.
 
 .. code-block:: python
 
-    >>> result = MPC.query_object('asteroid', name="ceres", return_fields="name,number")
+    >>> result = MPC().query_object('asteroid', name="ceres", return_fields="name,number")
     >>> print(result)
     [{'name': 'Ceres', 'number': 1}]
 


### PR DESCRIPTION
Not instantiating let me to some weird behavior with the cache:
```
E           _pickle.PicklingError: Can't pickle <class 'astropy.utils.masked.core.MaskedQuantity'>: attribute lookup MaskedQuantity on astropy.utils.masked.core failed
```
I don't understand it, but looking at the code, instantiation should be done anyway.

This PR updates docs, doctests, and tests to use `MPC()...` instead of `MPC...`.