### PR TITLE
Fix `astroquery.utils.system_tools.in_ipynb()`

### DIFF
--- a/astroquery/utils/system_tools.py
+++ b/astroquery/utils/system_tools.py
@@ -40,21 +40,9 @@ def gunzip(filename):
     else:
         return filename
 
+
 # If there is an update issue of astropy#2793 that got merged, this should
 # be replaced with it.
 
-
 def in_ipynb():
-    try:
-        cfg = get_ipython().config
-        app = cfg['IPKernelApp']
-        # ipython 1.0 console has no 'parent_appname',
-        # but ipynb does
-        if ('parent_appname' in app and
-                app['parent_appname'] == 'ipython-notebook'):
-            return True
-        else:
-            return False
-    except NameError:
-        # NameError will occur if this is called from python (not ipython)
-        return False
+    return 'JPY_PARENT_PID' in os.environ


### PR DESCRIPTION
The purpose of `astroquery.utils.system_tools.in_ipynb()` is to recognize if it is being called from a `.ipynb` notebook or not, but the current function seems to always return `False`. The function in this pull request returns `False` if it is called from `ipython`, but `True` if called from `jupyter notebook` or `jupyter lab`, at least for the versions I'm using.
```shell
ipython --version
7.19.0
jupyter-notebook --version
6.1.5
jupyter-lab --version
3.0.16
```