### PR TITLE
Fix changing `simbad` config items at runtime

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -93,6 +93,10 @@ simbad
   radius as a string in ``query_region()`` and ``query_region_async()``.
   [#2494]
 
+- It is now possible to apply changes through the configuration system at
+  runtime. However, if the corresponding class or instance variables have been
+  specified then they still take precedence. [#2292]
+
 svo_fps
 ^^^^^^^
 

--- a/astroquery/simbad/core.py
+++ b/astroquery/simbad/core.py
@@ -266,8 +266,8 @@ class SimbadClass(SimbadBaseQuery):
     (http://simbad.u-strasbg.fr/simbad/sim-help?Page=sim-url)
 
     """
-    SIMBAD_URL = 'http://' + conf.server + '/simbad/sim-script'
-    TIMEOUT = conf.timeout
+    SIMBAD_URL = ''
+    TIMEOUT = None
     WILDCARDS = {
         '*': 'Any string of characters (including an empty one)',
         '?': 'Any character (exactly one character)',
@@ -286,7 +286,7 @@ class SimbadClass(SimbadBaseQuery):
         'query_bibobj_async': 'query bibobj'
     }
 
-    ROW_LIMIT = conf.row_limit
+    ROW_LIMIT = None
 
     # also find a way to fetch the votable fields table from
     # <http://simbad.u-strasbg.fr/simbad/sim-help?Page=sim-fscript#VotableFields>
@@ -297,6 +297,18 @@ class SimbadClass(SimbadBaseQuery):
     def __init__(self):
         super().__init__()
         self._VOTABLE_FIELDS = self._VOTABLE_FIELDS.copy()
+
+    @property
+    def _row_limit(self):
+        return conf.row_limit if self.ROW_LIMIT is None else self.ROW_LIMIT
+
+    @property
+    def _simbad_url(self):
+        return self.SIMBAD_URL or f'https://{conf.server}/simbad/sim-script'
+
+    @property
+    def _timeout(self):
+        return conf.timeout if self.TIMEOUT is None else self.TIMEOUT
 
     def list_wildcards(self):
         """
@@ -496,8 +508,8 @@ class SimbadClass(SimbadBaseQuery):
 
         request_payload = self._args_to_payload(caller='query_criteria_async',
                                                 *args, **kwargs)
-        response = self._request("POST", self.SIMBAD_URL, data=request_payload,
-                                 timeout=self.TIMEOUT, cache=cache)
+        response = self._request("POST", self._simbad_url, data=request_payload,
+                                 timeout=self._timeout, cache=cache)
         return response
 
     def query_object(self, object_name, wildcard=False, verbose=False,
@@ -560,8 +572,8 @@ class SimbadClass(SimbadBaseQuery):
         if get_query_payload:
             return request_payload
 
-        response = self._request("POST", self.SIMBAD_URL, data=request_payload,
-                                 timeout=self.TIMEOUT, cache=cache)
+        response = self._request("POST", self._simbad_url, data=request_payload,
+                                 timeout=self._timeout, cache=cache)
         return response
 
     def query_objects(self, object_names, wildcard=False, verbose=False,
@@ -694,8 +706,8 @@ class SimbadClass(SimbadBaseQuery):
         if get_query_payload:
             return request_payload
 
-        response = self._request("POST", self.SIMBAD_URL, data=request_payload,
-                                 timeout=self.TIMEOUT, cache=cache)
+        response = self._request("POST", self._simbad_url, data=request_payload,
+                                 timeout=self._timeout, cache=cache)
         return response
 
     def query_catalog(self, catalog, verbose=False, cache=True,
@@ -751,8 +763,8 @@ class SimbadClass(SimbadBaseQuery):
         if get_query_payload:
             return request_payload
 
-        response = self._request("POST", self.SIMBAD_URL, data=request_payload,
-                                 timeout=self.TIMEOUT, cache=cache)
+        response = self._request("POST", self._simbad_url, data=request_payload,
+                                 timeout=self._timeout, cache=cache)
         return response
 
     def query_bibobj(self, bibcode, verbose=False, get_query_payload=False):
@@ -805,8 +817,8 @@ class SimbadClass(SimbadBaseQuery):
         if get_query_payload:
             return request_payload
 
-        response = self._request("POST", self.SIMBAD_URL, data=request_payload,
-                                 timeout=self.TIMEOUT, cache=cache)
+        response = self._request("POST", self._simbad_url, data=request_payload,
+                                 timeout=self._timeout, cache=cache)
         return response
 
     def query_bibcode(self, bibcode, wildcard=False, verbose=False,
@@ -873,8 +885,8 @@ class SimbadClass(SimbadBaseQuery):
         if get_query_payload:
             return request_payload
 
-        response = self._request("POST", self.SIMBAD_URL, cache=cache,
-                                 data=request_payload, timeout=self.TIMEOUT)
+        response = self._request("POST", self._simbad_url, data=request_payload,
+                                 timeout=self._timeout, cache=cache)
 
         return response
 
@@ -929,8 +941,8 @@ class SimbadClass(SimbadBaseQuery):
         if get_query_payload:
             return request_payload
 
-        response = self._request("POST", self.SIMBAD_URL, data=request_payload,
-                                 timeout=self.TIMEOUT, cache=cache)
+        response = self._request("POST", self._simbad_url, data=request_payload,
+                                 timeout=self._timeout, cache=cache)
 
         return response
 
@@ -960,8 +972,8 @@ class SimbadClass(SimbadBaseQuery):
         votable_header = self._get_query_header(get_raw)
         votable_footer = self._get_query_footer(get_raw)
 
-        if self.ROW_LIMIT > 0:
-            script = "set limit " + str(self.ROW_LIMIT)
+        if self._row_limit > 0:
+            script = "set limit " + str(self._row_limit)
         script = "\n".join([script, votable_header, command])
         using_wildcard = False
         if kwargs.get('wildcard'):

--- a/astroquery/simbad/tests/test_simbad.py
+++ b/astroquery/simbad/tests/test_simbad.py
@@ -389,6 +389,28 @@ def test_query_criteria2(patch_post):
     assert 'otype=SNR' in S._last_query.data['script']
 
 
+def test_config_runtime_change():
+    sb = simbad.Simbad()
+
+    assert sb._row_limit == 0
+    with simbad.conf.set_temp('row_limit', 7):
+        assert sb._row_limit == 7
+        sb.ROW_LIMIT = 3
+        assert sb._row_limit == 3
+
+    assert sb._simbad_url == 'https://simbad.u-strasbg.fr/simbad/sim-script'
+    with simbad.conf.set_temp('server', 'simbad.harvard.edu'):
+        assert sb._simbad_url == 'https://simbad.harvard.edu/simbad/sim-script'
+        sb.SIMBAD_URL = 'asdfg'
+        assert sb._simbad_url == 'asdfg'
+
+    assert sb._timeout == 60
+    with simbad.conf.set_temp('timeout', 5):
+        assert sb._timeout == 5
+        sb.TIMEOUT = 3
+        assert sb._timeout == 3
+
+
 def test_simbad_settings1():
     sb = simbad.core.Simbad()
     assert sb.get_votable_fields() == ['main_id', 'coordinates']

--- a/docs/simbad/simbad.rst
+++ b/docs/simbad/simbad.rst
@@ -245,10 +245,9 @@ instance to query the ESO catalog:
 
 .. code-block:: python
 
-    >>> from astroquery.simbad import Simbad
-    >>> limitedSimbad = Simbad()
-    >>> limitedSimbad.ROW_LIMIT = 6
-    >>> result_table = limitedSimbad.query_catalog('eso')
+    >>> from astroquery.simbad import conf, Simbad
+    >>> with conf.set_temp("row_limit", 6):
+    >>>     result_table = Simbad.query_catalog("eso")
     >>> print(result_table)
 
     MAIN_ID              RA      ... COO_WAVELENGTH     COO_BIBCODE
@@ -532,39 +531,57 @@ Customizing the default settings
 ================================
 
 There may be times when you wish to change the defaults that have been set for
-the Simbad queries.
+the Simbad queries. Items defined through the `astropy configuration system
+<https://docs.astropy.org/en/stable/config/index.html>`_ can be modified
+persistently by editing the ``astroquery`` configuration file, or for the
+duration of the active Python session at runtime. For every such configuration
+item there also exists a corresponding class attribute, which provides an
+alternative way of changing the defaults, but if one of those attributes is
+modified then the corresponding configuration item becomes inactive.
 
 Changing the row limit
 ----------------------
 
+By default the number of rows in the query results is not limited (done by
+specifying the limit to be 0). However, for some queries the results can be
+very large. In such cases it may be useful to set a limit to the number of
+rows. This can be done through the :attr:`~astroquery.simbad.Conf.row_limit`
+configuration item, or the corresponding
+:attr:`~astroquery.simbad.SimbadClass.ROW_LIMIT` class attribute::
 
-To fetch all the rows in the result, the row limit must be set to 0. However for some
-queries, results are likely to be very large, in such cases it may be best to
-limit the rows to a smaller number. If you want to do this only for the current
-python session then:
-
-.. code-block:: python
-
+    >>> from astroquery.simbad import conf
+    >>> with conf.set_temp("row_limit", 10):
+    ...     # Row limit is set to 10 within this code block.
+    ...     pass
     >>> from astroquery.simbad import Simbad
-    >>> Simbad.ROW_LIMIT = 15 # now any query fetches at most 15 rows
-
-If you would like to make your choice persistent, then you can do this by
-modifying the setting in the Astroquery configuration file.
+    >>> # Setting the row limit to 15 for the instance.
+    >>> Simbad.ROW_LIMIT = 15
 
 Changing the timeout
 --------------------
 
+The timeout is the time limit in seconds for establishing the connection with
+the Simbad server and by default it is set to 60 seconds. It can be modified
+through the :attr:`~astroquery.simbad.Conf.timeout` configuration item, or the
+corresponding :attr:`~astroquery.simbad.SimbadClass.TIMEOUT` class attribute.
 
-The timeout is the time limit in seconds for establishing connection with the
-Simbad server and by default it is set to 100 seconds. You may want to modify
-this - again you can do this at run-time if you want to adjust it only for the
-current session. To make it persistent, you must modify the setting in the
-Astroquery configuration file.
+Changing the server
+-------------------
 
-.. code-block:: python
+By default all queries are sent to ``simbad.u-strasbg.fr``, but it is also
+possible to connect to the mirror at ``simbad.harvard.edu`` instead. This can
+be specified through the :attr:`~astroquery.simbad.Conf.server` configuration
+item::
+
+    >>> from astroquery.simbad import conf
+    >>> conf.server = "simbad.u-strasbg.fr"
+
+The corresponding class attribute is
+:attr:`~astroquery.simbad.SimbadClass.SIMBAD_URL`, and differently from the
+configuration item it requires the entire URL to be specified::
 
     >>> from astroquery.simbad import Simbad
-    >>> Simbad.TIMEOUT = 60 # sets the timeout to 60s
+    >>> Simbad.SIMBAD_URL = "http://simbad.u-strasbg.fr/simbad/sim-script"
 
 Specifying which VOTable fields to include in the result
 --------------------------------------------------------


### PR DESCRIPTION
Previously changing `simbad` config items at runtime had no effect. Now the config items are read when they are needed, unless the user has specified the corresponding class or instance variable, in which case the latter takes precedence.

Relevant for #2291