### PR TITLE
Make `astroquery/utils/tap/model/job.Job.save_results()` obey `verbose` setting

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -42,6 +42,10 @@ Infrastructure, Utility and Other Changes and Additions
 - Callback hooks are deleted before caching.  Potentially all cached queries
   prior to this PR will be rendered invalid.  [#2295]
 
+- The modules that make use of the ``astroquery.utils.tap.model.job.Job`` class
+  (e.g. Gaia) no longer print messages about where the results of async queries
+  were written if the ``verbose`` setting is ``False``. [#2299]
+
 
 0.4.5 (2021-12-24)
 ==================

--- a/astroquery/utils/tap/model/job.py
+++ b/astroquery/utils/tap/model/job.py
@@ -299,7 +299,8 @@ class Job:
                     output = self.outputFile
                 else:
                     output = self.outputFileUser
-                print(f"Saving results to: {output}")
+                if verbose:
+                    print(f"Saving results to: {output}")
                 self.connHandler.dump_to_file(output, response)
 
     def wait_for_job_end(self, verbose=False):

--- a/astroquery/utils/tap/model/tests/test_job.py
+++ b/astroquery/utils/tap/model/tests/test_job.py
@@ -35,7 +35,7 @@ def test_job_basic():
         job.get_results()
 
 
-def test_job_get_results():
+def test_job_get_results(capsys, tmpdir):
     job = Job(async_job=True)
     jobid = "12345"
     outputFormat = "votable"
@@ -81,6 +81,14 @@ def test_job_get_results():
     for cn in ['alpha', 'delta', 'source_id', 'table1_oid']:
         if cn not in res.colnames:
             pytest.fail(f"{cn} column name not found: {res.colnames}")
+
+    # Regression test for #2299; messages were printed even with `verbose=False`
+    capsys.readouterr()
+    job._Job__resultInMemory = False
+    job.save_results(verbose=False)
+    assert 'Saving results to:' not in capsys.readouterr().out
+    job.save_results(verbose=True)
+    assert 'Saving results to:' in capsys.readouterr().out
 
 
 def test_job_phase():


### PR DESCRIPTION
The following example
```python
from astropy import units as u
from astropy.coordinates import SkyCoord
from astroquery.gaia import Gaia
sc = SkyCoord(ra=0*u.deg, dec=0*u.deg)
job = Gaia.cone_search(sc, radius=0.1*u.deg, columns=['source_id'], output_file='temp.vot.gz', dump_to_file=True)
```
writes the results to a file but does not print anything because the default `verbose` setting is `False`. However, the corresponding async method produces the following:
```python
job = Gaia.cone_search_async(sc, radius=0.1*u.deg, columns=['source_id'], output_file='temp.vot.gz', dump_to_file=True)
Saving results to: temp.vot.gz
```
This is caused by a missing check of the `verbose` setting, which is fixed here.