### PR TITLE
Alma deprecation cleanup

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -20,6 +20,12 @@ esa.hubble
 
 - Changed query_target method to use TAP instead of AIO [#2268]
 
+alma
+^^^^
+
+- Deprecated keywords and ``stage_data`` method has been removed. Optional
+  keyword arguments are now keyword only. [#2309]
+
 casda
 ^^^^^
 

--- a/astroquery/alma/core.py
+++ b/astroquery/alma/core.py
@@ -7,11 +7,13 @@ import re
 import tarfile
 import string
 import requests
+import warnings
+
 from pkg_resources import resource_filename
 from bs4 import BeautifulSoup
 import pyvo
-
 from urllib.parse import urljoin
+
 from astropy.table import Table, Column, vstack
 from astroquery import log
 from astropy.utils.console import ProgressBar

--- a/astroquery/alma/core.py
+++ b/astroquery/alma/core.py
@@ -1132,52 +1132,6 @@ class AlmaClass(QueryWithLogin):
         print("Alma.query(payload=dict(project_code='2017.1.01355.L', "
               "source_name_alma='G008.67'))")
 
-    def _json_summary_to_table(self, data, base_url):
-        """
-        Special tool to convert some JSON metadata to a table Obsolete as of
-        March 2020 - should be removed along with stage_data_prefeb2020
-        """
-        from ..utils import url_helpers
-        columns = {'mous_uid': [], 'URL': [], 'size': []}
-        for entry in data['node_data']:
-            # de_type can be useful (e.g., MOUS), but it is not necessarily
-            # specified
-            # file_name and file_key *must* be specified.
-            is_file = \
-                (entry['file_name'] != 'null' and entry['file_key'] != 'null')
-            if is_file:
-                # "de_name": "ALMA+uid://A001/X122/X35e",
-                columns['mous_uid'].append(entry['de_name'][5:])
-                if entry['file_size'] == 'null':
-                    columns['size'].append(np.nan * u.Gbyte)
-                else:
-                    columns['size'].append(
-                        (int(entry['file_size']) * u.B).to(u.Gbyte))
-                # example template for constructing url:
-                # https://almascience.eso.org/dataPortal/requests/keflavich/940238268/ALMA/
-                # uid___A002_X9d6f4c_X154/2013.1.00546.S_uid___A002_X9d6f4c_X154.asdm.sdm.tar
-                # above is WRONG... except for ASDMs, when it's right
-                # should be:
-                # 2013.1.00546.S_uid___A002_X9d6f4c_X154.asdm.sdm.tar/2013.1.00546.S_uid___A002_X9d6f4c_X154.asdm.sdm.tar
-                #
-                # apparently ASDMs are different from others:
-                # templates:
-                # https://almascience.eso.org/dataPortal/requests/keflavich/946895898/ALMA/
-                # 2013.1.00308.S_uid___A001_X196_X93_001_of_001.tar/2013.1.00308.S_uid___A001_X196_X93_001_of_001.tar
-                # uid___A002_X9ee74a_X26f0/2013.1.00308.S_uid___A002_X9ee74a_X26f0.asdm.sdm.tar
-                url = url_helpers.join(base_url,
-                                       entry['file_key'],
-                                       entry['file_name'])
-                if 'null' in url:
-                    raise ValueError("The URL {0} was created containing "
-                                     "'null', which is invalid.".format(url))
-                columns['URL'].append(url)
-
-        columns['size'] = u.Quantity(columns['size'], u.Gbyte)
-
-        tbl = Table([Column(name=k, data=v) for k, v in columns.items()])
-        return tbl
-
     def get_project_metadata(self, projectid, *, cache=True):
         """
         Get the metadata - specifically, the project abstract - for a given project ID.

--- a/astroquery/alma/core.py
+++ b/astroquery/alma/core.py
@@ -365,7 +365,7 @@ class AlmaClass(QueryWithLogin):
             return legacy_result
         return result
 
-    def query_sia(self, pos=None, band=None, time=None, pol=None,
+    def query_sia(self, *, pos=None, band=None, time=None, pol=None,
                   field_of_view=None, spatial_resolution=None,
                   spectral_resolving_power=None, exptime=None,
                   timeres=None, publisher_did=None,
@@ -480,7 +480,7 @@ class AlmaClass(QueryWithLogin):
                              "on github.")
         return self.dataarchive_url
 
-    def get_data_info(self, uids, expand_tarfiles=False,
+    def get_data_info(self, uids, *, expand_tarfiles=False,
                       with_auxiliary=True, with_rawdata=True):
 
         """
@@ -618,7 +618,8 @@ class AlmaClass(QueryWithLogin):
 
         return data_sizes, totalsize.to(u.GB)
 
-    def download_files(self, files, savedir=None, cache=True,
+
+    def download_files(self, files, *, savedir=None, cache=True,
                        continuation=True, skip_unauthorized=True,
                        verify_only=False):
         """
@@ -754,7 +755,7 @@ class AlmaClass(QueryWithLogin):
 
         return response
 
-    def retrieve_data_from_uid(self, uids, cache=True):
+    def retrieve_data_from_uid(self, uids, *, cache=True):
         """
         Stage & Download ALMA data.  Will print out the expected file size
         before attempting the download.
@@ -787,7 +788,7 @@ class AlmaClass(QueryWithLogin):
         downloaded_files = self.download_files(file_urls)
         return downloaded_files
 
-    def _get_auth_info(self, username, store_password=False,
+    def _get_auth_info(self, username, *, store_password=False,
                        reenter_password=False):
         """
         Get the auth info (user, password) for use in another function
@@ -965,7 +966,7 @@ class AlmaClass(QueryWithLogin):
             self._cycle0_table.rename_column('col2', 'uid')
         return self._cycle0_table
 
-    def get_files_from_tarballs(self, downloaded_files, regex=r'.*\.fits$',
+    def get_files_from_tarballs(self, downloaded_files, *, regex=r'.*\.fits$',
                                 path='cache_path', verbose=True):
         """
         Given a list of successfully downloaded tarballs, extract files
@@ -1015,7 +1016,7 @@ class AlmaClass(QueryWithLogin):
 
         return filelist
 
-    def download_and_extract_files(self, urls, delete=True, regex=r'.*\.fits$',
+    def download_and_extract_files(self, urls, *, delete=True, regex=r'.*\.fits$',
                                    include_asdm=False, path='cache_path',
                                    verbose=True):
         """
@@ -1175,7 +1176,7 @@ class AlmaClass(QueryWithLogin):
         tbl = Table([Column(name=k, data=v) for k, v in columns.items()])
         return tbl
 
-    def get_project_metadata(self, projectid, cache=True):
+    def get_project_metadata(self, projectid, *, cache=True):
         """
         Get the metadata - specifically, the project abstract - for a given project ID.
         """

--- a/astroquery/alma/core.py
+++ b/astroquery/alma/core.py
@@ -620,7 +620,6 @@ class AlmaClass(QueryWithLogin):
 
         return data_sizes, totalsize.to(u.GB)
 
-
     def download_files(self, files, *, savedir=None, cache=True,
                        continuation=True, skip_unauthorized=True,
                        verify_only=False):

--- a/astroquery/alma/tests/test_alma_remote.py
+++ b/astroquery/alma/tests/test_alma_remote.py
@@ -506,29 +506,6 @@ def test_project_metadata(alma):
 
 
 @pytest.mark.remote_data
-@pytest.mark.skip('Not working for now - Investigating')
-def test_staging_postfeb2020(alma):
-
-    tbl = alma.get_data_info('uid://A001/X121/X4ba')
-
-    assert 'mous_uid' in tbl.colnames
-
-    assert '2013.1.00269.S_uid___A002_X9de499_X3d6c.asdm.sdm.tar' in tbl['name']
-
-
-@pytest.mark.remote_data
-@pytest.mark.skip('Not working for now - Investigating')
-def test_staging_uptofeb2020(alma):
-    tbl = alma.get_data_info('uid://A001/X121/X4ba')
-
-    assert 'mous_uid' in tbl.colnames
-
-    names = [x.split("/")[-1] for x in tbl['URL']]
-
-    assert '2013.1.00269.S_uid___A002_X9de499_X3d6c.asdm.sdm.tar' in names
-
-
-@pytest.mark.remote_data
 def test_data_info_stacking(alma):
     alma.get_data_info(['uid://A001/X13d5/X1d', 'uid://A002/X3216af/X31',
                         'uid://A001/X12a3/X240'])

--- a/astroquery/alma/tests/test_alma_remote.py
+++ b/astroquery/alma/tests/test_alma_remote.py
@@ -75,13 +75,6 @@ class TestAlma:
         # "The Brick", g0.253, is in this one
         # assert b'2011.0.00217.S' in result_c['Project code'] # missing cycle 1 data
 
-    def test_docs_example(self, temp_dir, alma):
-        alma.cache_location = temp_dir
-
-        rslt = alma.query(payload=dict(obs_creator_name='*Ginsburg*'))
-
-        assert 'ADS/JAO.ALMA#2013.1.00269.S' in rslt['obs_publisher_did']
-
     def test_freq(self, alma):
         payload = {'frequency': '85..86'}
         result = alma.query(payload)
@@ -141,22 +134,6 @@ class TestAlma:
         # Except it has.  On May 18, 2016, there were 47.
         assert len(link_list) >= 47
 
-        # test re-staging
-        # (has been replaced with warning)
-        # with pytest.raises(requests.HTTPError) as ex:
-        #    link_list = alma.stage_data(uids)
-        # assert ex.value.args[0] == ('Received an error 405: this may indicate you have '
-        #                            'already staged the data.  Try downloading the '
-        #                            'file URLs directly with download_files.')
-
-        # log.warning doesn't actually make a warning
-        # link_list = alma.stage_data(uids)
-        # w = recwarn.pop()
-        # assert (str(w.message) == ('Error 405 received.  If you have previously staged the '
-        #                           'same UIDs, the result returned is probably correct,'
-        #                           ' otherwise you may need to create a fresh astroquery.Alma instance.'))
-
-
     def test_data_proprietary(self, alma):
         # public
         assert not alma.is_proprietary('uid://A001/X12a3/Xe9')
@@ -198,7 +175,7 @@ class TestAlma:
                 file_url = url
                 break
         assert file_url
-        alma.download_files([file_url], temp_dir)
+        alma.download_files([file_url], savedir=temp_dir)
         assert os.stat(os.path.join(temp_dir, file)).st_size
 
         # mock downloading an entire program
@@ -206,8 +183,7 @@ class TestAlma:
         alma.download_files = download_files_mock
         alma.retrieve_data_from_uid([uid])
 
-        comparison = download_files_mock.mock_calls[0][1] == data_info_tar[
-            'access_url']
+        comparison = download_files_mock.mock_calls[0][1] == data_info_tar['access_url']
         assert comparison.all()
 
     def test_download_data(self, temp_dir, alma):
@@ -224,7 +200,7 @@ class TestAlma:
         alma._download_file = download_mock
         urls = [x['access_url'] for x in data_info
                 if fitsre.match(x['access_url'])]
-        results = alma.download_files(urls, temp_dir)
+        results = alma.download_files(urls, savedir=temp_dir)
         alma._download_file.call_count == len(results)
         assert len(results) == len(urls)
 

--- a/docs/alma/alma.rst
+++ b/docs/alma/alma.rst
@@ -310,9 +310,7 @@ are >100 GB!
         ...
 
 The new ```get_data_info``` method can be used to get information about the
-data such as the file names, their urls, sizes etc (this method replaces
-```stage_data```, which served the same role in older versions of astroquery
-but is now deprecated):
+data such as the file names, their urls, sizes etc.
 
 .. doctest-remote-data::
 


### PR DESCRIPTION
I was run into these very old deprecations from prior using pyvo while investigating an upstream bug report, and couldn't resist to do a bit of cleanup.

@andamian - are you OK with the change of making kwargs kwarg only? I needed that for the methods where some of the deprecated ones got removed, and then had a bold thought and did it for all methods.