### PR TITLE
Fix fixture usage for remote test

### DIFF
--- a/astroquery/alma/tests/test_alma_remote.py
+++ b/astroquery/alma/tests/test_alma_remote.py
@@ -652,6 +652,6 @@ def test_big_download_regression(alma):
 
 
 @pytest.mark.remote_data
-def test_download_html_file():
+def test_download_html_file(alma):
     result = alma.download_files(['https://almascience.nao.ac.jp/dataPortal/member.uid___A001_X1284_X1353.qa2_report.html'])
     assert result


### PR DESCRIPTION
This was a minor bug added in #2246, the lesson to learn is to run the remote tests before merging a PR.


```
_________________________________________________________________________________________________________________ test_download_html_file __________________________________________________________________________________________________________________

    @pytest.mark.remote_data
    def test_download_html_file():
>       result = alma.download_files(['https://almascience.nao.ac.jp/dataPortal/member.uid___A001_X1284_X1353.qa2_report.html'])
E       AttributeError: 'function' object has no attribute 'download_files'

astroquery/alma/tests/test_alma_remote.py:656: AttributeError
```