### PR TITLE
Make `astroquery.mast` methods take explicit kwargs 

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -56,6 +56,8 @@ mast
 - Adding the All-Sky PLATO Input Catalog ('plato') as a catalog option for
   methods of ``astroquery.mast.Catalogs``. [#2279]
 
+- Optional keyword arguments for are now keyword only in ``astroquery.mast.Observations``, ``astroquery.mast.Catalogs``, and ``astroquery.mast.Cutouts``. [#2317]
+
 sdss
 ^^^^
 

--- a/astroquery/mast/collections.py
+++ b/astroquery/mast/collections.py
@@ -48,9 +48,9 @@ class CatalogsClass(MastQueryWithLogin):
         self.catalog_limit = None
         self._current_connection = None
 
-    def _parse_result(self, response, verbose=False):
+    def _parse_result(self, response, *, verbose=False):
 
-        results_table = self._current_connection._parse_result(response, verbose)
+        results_table = self._current_connection._parse_result(response, verbose=verbose)
 
         if len(results_table) == self.catalog_limit:
             warnings.warn("Maximum catalog results returned, may not include all sources within radius.",
@@ -59,7 +59,7 @@ class CatalogsClass(MastQueryWithLogin):
         return results_table
 
     @class_or_instance
-    def query_region_async(self, coordinates, radius=0.2*u.deg, catalog="Hsc",
+    def query_region_async(self, coordinates, *, radius=0.2*u.deg, catalog="Hsc",
                            version=None, pagesize=None, page=None, **kwargs):
         """
         Given a sky position and radius, returns a list of catalog entries.
@@ -161,10 +161,10 @@ class CatalogsClass(MastQueryWithLogin):
         for prop, value in kwargs.items():
             params[prop] = value
 
-        return self._current_connection.service_request_async(service, params, pagesize, page)
+        return self._current_connection.service_request_async(service, params, pagesize=pagesize, page=page)
 
     @class_or_instance
-    def query_object_async(self, objectname, radius=0.2*u.deg, catalog="Hsc",
+    def query_object_async(self, objectname, *, radius=0.2*u.deg, catalog="Hsc",
                            pagesize=None, page=None, version=None, **kwargs):
         """
         Given an object name, returns a list of catalog entries.
@@ -208,7 +208,7 @@ class CatalogsClass(MastQueryWithLogin):
                                        version=version, pagesize=pagesize, page=page, **kwargs)
 
     @class_or_instance
-    def query_criteria_async(self, catalog, pagesize=None, page=None, **criteria):
+    def query_criteria_async(self, catalog, *, pagesize=None, page=None, **criteria):
         """
         Given an set of filters, returns a list of catalog entries.
         See column documentation for specific catalogs `here <https://mast.stsci.edu/api/v0/pages.htmll>`__.
@@ -310,7 +310,7 @@ class CatalogsClass(MastQueryWithLogin):
         return self._current_connection.service_request_async(service, params, pagesize=pagesize, page=page)
 
     @class_or_instance
-    def query_hsc_matchid_async(self, match, version=3, pagesize=None, page=None):
+    def query_hsc_matchid_async(self, match, *, version=3, pagesize=None, page=None):
         """
         Returns all the matches for a given Hubble Source Catalog MatchID.
 
@@ -347,10 +347,10 @@ class CatalogsClass(MastQueryWithLogin):
 
         params = {"input": match}
 
-        return self._current_connection.service_request_async(service, params, pagesize, page)
+        return self._current_connection.service_request_async(service, params, pagesize=pagesize, page=page)
 
     @class_or_instance
-    def get_hsc_spectra_async(self, pagesize=None, page=None):
+    def get_hsc_spectra_async(self, *, pagesize=None, page=None):
         """
         Returns all Hubble Source Catalog spectra.
 
@@ -375,7 +375,7 @@ class CatalogsClass(MastQueryWithLogin):
 
         return self._current_connection.service_request_async(service, params, pagesize, page)
 
-    def download_hsc_spectra(self, spectra, download_dir=None, cache=True, curl_flag=False):
+    def download_hsc_spectra(self, spectra, *, download_dir=None, cache=True, curl_flag=False):
         """
         Download one or more Hubble Source Catalog spectra.
 

--- a/astroquery/mast/collections.py
+++ b/astroquery/mast/collections.py
@@ -204,8 +204,13 @@ class CatalogsClass(MastQueryWithLogin):
 
         coordinates = utils.resolve_object(objectname)
 
-        return self.query_region_async(coordinates, radius, catalog,
-                                       version=version, pagesize=pagesize, page=page, **kwargs)
+        return self.query_region_async(coordinates,
+                                       radius=radius,
+                                       catalog=catalog,
+                                       version=version,
+                                       pagesize=pagesize,
+                                       page=page,
+                                       **kwargs)
 
     @class_or_instance
     def query_criteria_async(self, catalog, *, pagesize=None, page=None, **criteria):

--- a/astroquery/mast/cutouts.py
+++ b/astroquery/mast/cutouts.py
@@ -110,7 +110,7 @@ class TesscutClass(MastQueryWithLogin):
                     }
         self._service_api_connection.set_service_params(services, "tesscut")
 
-    def get_sectors(self, coordinates=None, radius=0*u.deg, objectname=None, moving_target=False, mt_type=None):
+    def get_sectors(self, *, coordinates=None, radius=0*u.deg, objectname=None, moving_target=False, mt_type=None):
         """
         Get a list of the TESS data sectors whose footprints intersect
         with the given search area.
@@ -204,7 +204,7 @@ class TesscutClass(MastQueryWithLogin):
             warnings.warn("Coordinates are not in any TESS sector.", NoResultsWarning)
         return Table(sector_dict)
 
-    def download_cutouts(self, coordinates=None, size=5, sector=None, path=".", inflate=True,
+    def download_cutouts(self, *, coordinates=None, size=5, sector=None, path=".", inflate=True,
                          objectname=None, moving_target=False, mt_type=None):
         """
         Download cutout target pixel file(s) around the given coordinates with indicated size.
@@ -316,7 +316,7 @@ class TesscutClass(MastQueryWithLogin):
         localpath_table['Local Path'] = [path+x for x in cutout_files]
         return localpath_table
 
-    def get_cutouts(self, coordinates=None, size=5, sector=None,
+    def get_cutouts(self, *, coordinates=None, size=5, sector=None,
                     objectname=None, moving_target=False, mt_type=None):
         """
         Get cutout target pixel file(s) around the given coordinates with indicated size,
@@ -442,7 +442,7 @@ class ZcutClass(MastQueryWithLogin):
                     "astrocut": {"path": "astrocut"}}
         self._service_api_connection.set_service_params(services, "zcut")
 
-    def get_surveys(self, coordinates, radius="0d"):
+    def get_surveys(self, coordinates, *, radius="0d"):
         """
         Gives a list of deep field surveys available for a position in the sky
 
@@ -481,7 +481,7 @@ class ZcutClass(MastQueryWithLogin):
             warnings.warn("Coordinates are not in an available deep field survey.", NoResultsWarning)
         return survey_json
 
-    def download_cutouts(self, coordinates, size=5, survey=None, cutout_format="fits", path=".", inflate=True, **img_params):
+    def download_cutouts(self, coordinates, *, size=5, survey=None, cutout_format="fits", path=".", inflate=True, **img_params):
         """
         Download cutout FITS/image file(s) around the given coordinates with indicated size.
 
@@ -575,7 +575,7 @@ class ZcutClass(MastQueryWithLogin):
         localpath_table['Local Path'] = [path+x for x in cutout_files]
         return localpath_table
 
-    def get_cutouts(self, coordinates, size=5, survey=None):
+    def get_cutouts(self, coordinates, *, size=5, survey=None):
         """
         Get cutout  FITS file(s) around the given coordinates with indicated size,
         and return them as a list of  `~astropy.io.fits.HDUList` objects.

--- a/astroquery/mast/observations.py
+++ b/astroquery/mast/observations.py
@@ -56,7 +56,7 @@ class ObservationsClass(MastQueryWithLogin):
     _caom_filtered = 'Mast.Caom.Filtered'
     _caom_products = 'Mast.Caom.Products'
 
-    def _parse_result(self, responses, verbose=False):  # Used by the async_to_sync decorator functionality
+    def _parse_result(self, responses, *, verbose=False):  # Used by the async_to_sync decorator functionality
         """
         Parse the results of a list of `~requests.Response` objects and returns an `~astropy.table.Table` of results.
 
@@ -179,7 +179,7 @@ class ObservationsClass(MastQueryWithLogin):
         return position, mashup_filters
 
     @class_or_instance
-    def query_region_async(self, coordinates, radius=0.2*u.deg, pagesize=None, page=None):
+    def query_region_async(self, coordinates, *, radius=0.2*u.deg, pagesize=None, page=None):
         """
         Given a sky position and radius, returns a list of MAST observations.
         See column documentation `here <https://mast.stsci.edu/api/v0/_c_a_o_mfields.html>`__.
@@ -219,10 +219,10 @@ class ObservationsClass(MastQueryWithLogin):
                   'dec': coordinates.dec.deg,
                   'radius': radius.deg}
 
-        return self._portal_api_connection.service_request_async(service, params, pagesize, page)
+        return self._portal_api_connection.service_request_async(service, params, pagesize=pagesize, page=page)
 
     @class_or_instance
-    def query_object_async(self, objectname, radius=0.2*u.deg, pagesize=None, page=None):
+    def query_object_async(self, objectname, *, radius=0.2*u.deg, pagesize=None, page=None):
         """
         Given an object name, returns a list of MAST observations.
         See column documentation `here <https://mast.stsci.edu/api/v0/_c_a_o_mfields.html>`__.
@@ -252,10 +252,10 @@ class ObservationsClass(MastQueryWithLogin):
 
         coordinates = utils.resolve_object(objectname)
 
-        return self.query_region_async(coordinates, radius, pagesize, page)
+        return self.query_region_async(coordinates, radius=radius, pagesize=pagesize, page=page)
 
     @class_or_instance
-    def query_criteria_async(self, pagesize=None, page=None, **criteria):
+    def query_criteria_async(self, *, pagesize=None, page=None, **criteria):
         """
         Given an set of criteria, returns a list of MAST observations.
         Valid criteria are returned by ``get_metadata("observations")``
@@ -302,7 +302,7 @@ class ObservationsClass(MastQueryWithLogin):
 
         return self._portal_api_connection.service_request_async(service, params)
 
-    def query_region_count(self, coordinates, radius=0.2*u.deg, pagesize=None, page=None):
+    def query_region_count(self, coordinates, *, radius=0.2*u.deg, pagesize=None, page=None):
         """
         Given a sky position and radius, returns the number of MAST observations in that region.
 
@@ -343,7 +343,7 @@ class ObservationsClass(MastQueryWithLogin):
 
         return int(self._portal_api_connection.service_request(service, params, pagesize, page)[0][0])
 
-    def query_object_count(self, objectname, radius=0.2*u.deg, pagesize=None, page=None):
+    def query_object_count(self, objectname, *, radius=0.2*u.deg, pagesize=None, page=None):
         """
         Given an object name, returns the number of MAST observations.
 
@@ -369,9 +369,9 @@ class ObservationsClass(MastQueryWithLogin):
 
         coordinates = utils.resolve_object(objectname)
 
-        return self.query_region_count(coordinates, radius, pagesize, page)
+        return self.query_region_count(coordinates, radius=radius, pagesize=pagesize, page=page)
 
-    def query_criteria_count(self, pagesize=None, page=None, **criteria):
+    def query_criteria_count(self, *, pagesize=None, page=None, **criteria):
         """
         Given an set of filters, returns the number of MAST observations meeting those criteria.
 
@@ -450,7 +450,7 @@ class ObservationsClass(MastQueryWithLogin):
 
         return self._portal_api_connection.service_request_async(service, params)
 
-    def filter_products(self, products, mrp_only=False, extension=None, **filters):
+    def filter_products(self, products, *, mrp_only=False, extension=None, **filters):
         """
         Takes an `~astropy.table.Table` of MAST observation data products and filters it based on given filters.
 
@@ -505,7 +505,7 @@ class ObservationsClass(MastQueryWithLogin):
 
         return products[np.where(filter_mask)]
 
-    def download_file(self, uri, local_path=None, base_url=None, cache=True, cloud_only=False):
+    def download_file(self, uri, *, local_path=None, base_url=None, cache=True, cloud_only=False):
         """
         Downloads a single file based on the data URI
 
@@ -582,7 +582,7 @@ class ObservationsClass(MastQueryWithLogin):
 
         return status, msg, url
 
-    def _download_files(self, products, base_dir, cache=True, cloud_only=False,):
+    def _download_files(self, products, base_dir, *, cache=True, cloud_only=False,):
         """
         Takes an `~astropy.table.Table` of data products and downloads them into the directory given by base_dir.
 
@@ -658,7 +658,7 @@ class ObservationsClass(MastQueryWithLogin):
                           'Message': [msg]})
         return manifest
 
-    def download_products(self, products, download_dir=None,
+    def download_products(self, products, *, download_dir=None,
                           cache=True, curl_flag=False, mrp_only=False, cloud_only=False, **filters):
         """
         Download data products.
@@ -734,7 +734,7 @@ class ObservationsClass(MastQueryWithLogin):
 
         return manifest
 
-    def get_cloud_uris(self, data_products, include_bucket=True, full_url=False):
+    def get_cloud_uris(self, data_products, *, include_bucket=True, full_url=False):
         """
         Takes an `~astropy.table.Table` of data products and returns the associated cloud data uris.
 
@@ -763,7 +763,7 @@ class ObservationsClass(MastQueryWithLogin):
 
         return self._cloud_connection.get_cloud_uri_list(data_products, include_bucket, full_url)
 
-    def get_cloud_uri(self, data_product, include_bucket=True, full_url=False):
+    def get_cloud_uri(self, data_product, *, include_bucket=True, full_url=False):
         """
         For a given data product, returns the associated cloud URI.
         If the product is from a mission that does not support cloud access an
@@ -806,7 +806,7 @@ class MastClass(MastQueryWithLogin):
     more flexible but less user friendly than `ObservationsClass`.
     """
 
-    def _parse_result(self, responses, verbose=False):  # Used by the async_to_sync decorator functionality
+    def _parse_result(self, responses, *, verbose=False):  # Used by the async_to_sync decorator functionality
         """
         Parse the results of a list of `~requests.Response` objects and returns an `~astropy.table.Table` of results.
 
@@ -827,7 +827,7 @@ class MastClass(MastQueryWithLogin):
         return self._portal_api_connection._parse_result(responses, verbose)
 
     @class_or_instance
-    def service_request_async(self, service, params, pagesize=None, page=None, **kwargs):
+    def service_request_async(self, service, params, *, pagesize=None, page=None, **kwargs):
         """
         Given a Mashup service and parameters, builds and excecutes a Mashup query.
         See documentation `here <https://mast.stsci.edu/api/v0/class_mashup_1_1_mashup_request.html>`__

--- a/astroquery/mast/observations.py
+++ b/astroquery/mast/observations.py
@@ -715,7 +715,7 @@ class ObservationsClass(MastQueryWithLogin):
             products = vstack(product_lists)
 
         # apply filters
-        products = self.filter_products(products, mrp_only, **filters)
+        products = self.filter_products(products, mrp_only=mrp_only, **filters)
 
         if not len(products):
             warnings.warn("No products to download.", NoResultsWarning)
@@ -726,11 +726,15 @@ class ObservationsClass(MastQueryWithLogin):
             download_dir = '.'
 
         if curl_flag:  # don't want to download the files now, just the curl script
-            manifest = self._download_curl_script(products, download_dir)
+            manifest = self._download_curl_script(products,
+                                                  download_dir)
 
         else:
             base_dir = download_dir.rstrip('/') + "/mastDownload"
-            manifest = self._download_files(products, base_dir, cache, cloud_only)
+            manifest = self._download_files(products,
+                                            base_dir=base_dir,
+                                            cache=cache,
+                                            cloud_only=cloud_only)
 
         return manifest
 

--- a/astroquery/mast/tests/test_mast_remote.py
+++ b/astroquery/mast/tests/test_mast_remote.py
@@ -516,7 +516,7 @@ class TestMast:
         assert '441662144' in result['ID']
 
         result = mast.Catalogs.query_object('M1',
-                                            radius=0.001,
+                                            radius=0.2,
                                             catalog='plato')
         assert 'PICidDR1' in result.colnames
 


### PR DESCRIPTION
Make methods for the `astroquery.mast` services (Observations, Catalogs, Cutouts) take explicit keyword arguments to avoid hiccups in the API calls that we've seen in the past. Closes https://github.com/astropy/astroquery/issues/2267.

make kwargs explicit:
- [x] Observations
- [x] Catalogs
- [x] Cutouts
- [x] update tests
- [x] changelog entry