### PR TITLE
Fix cross-id for very old data releases

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -51,6 +51,7 @@ sdss
 
 - Fix ``query_crossid`` to be able to query larger list of coordinates. [#2305]
 
+- Fix ``query_crossid`` for very old data releases (< DR10). [#2345]
 
 
 Infrastructure, Utility and Other Changes and Additions

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -51,7 +51,7 @@ sdss
 
 - Fix ``query_crossid`` to be able to query larger list of coordinates. [#2305]
 
-- Fix ``query_crossid`` for very old data releases (< DR10). [#2345]
+- Fix ``query_crossid`` for very old data releases (< DR10). [#2318]
 
 
 Infrastructure, Utility and Other Changes and Additions

--- a/astroquery/sdss/core.py
+++ b/astroquery/sdss/core.py
@@ -32,7 +32,8 @@ class SDSSClass(BaseQuery):
     QUERY_URL_SUFFIX_DR_OLD = '/dr{dr}/en/tools/search/x_sql.asp'
     QUERY_URL_SUFFIX_DR_10 = '/dr{dr}/en/tools/search/x_sql.aspx'
     QUERY_URL_SUFFIX_DR_NEW = '/dr{dr}/en/tools/search/x_results.aspx'
-    XID_URL_SUFFIX_OLD = '/dr{dr}/en/tools/crossid/x_crossid.aspx'
+    XID_URL_SUFFIX_OLD = '/dr{dr}/en/tools/crossid/x_crossid.asp'
+    XID_URL_SUFFIX_DR_10 = '/dr{dr}/en/tools/crossid/x_crossid.aspx'
     XID_URL_SUFFIX_NEW = '/dr{dr}/en/tools/search/X_Results.aspx'
     IMAGING_URL_SUFFIX = ('{base}/dr{dr}/{instrument}/photoObj/frames/'
                           '{rerun}/{run}/{camcol}/'
@@ -123,7 +124,7 @@ class SDSSClass(BaseQuery):
                 raise TypeError("radius should be either Quantity or "
                                 "convertible to float.")
 
-        sql_query = 'SELECT '
+        sql_query = 'SELECT\r\n'  # Older versions expect the CRLF to be there.
 
         if specobj_fields is None:
             if photoobj_fields is None:
@@ -1078,8 +1079,10 @@ class SDSSClass(BaseQuery):
         return url
 
     def _get_crossid_url(self, data_release):
-        if data_release < 11:
+        if data_release < 10:
             suffix = self.XID_URL_SUFFIX_OLD
+        elif data_release == 10:
+            suffix = self.XID_URL_SUFFIX_DR_10
         else:
             suffix = self.XID_URL_SUFFIX_NEW
 

--- a/astroquery/sdss/tests/test_sdss.py
+++ b/astroquery/sdss/tests/test_sdss.py
@@ -136,7 +136,9 @@ def url_tester(data_release):
 
 
 def url_tester_crossid(data_release):
-    if data_release < 11:
+    if data_release < 10:
+        baseurl = 'http://skyserver.sdss.org/dr{}/en/tools/crossid/x_crossid.asp'
+    if data_release == 10:
         baseurl = 'http://skyserver.sdss.org/dr{}/en/tools/crossid/x_crossid.aspx'
     if data_release == 11:
         return

--- a/astroquery/sdss/tests/test_sdss_remote.py
+++ b/astroquery/sdss/tests/test_sdss_remote.py
@@ -174,8 +174,7 @@ class TestSDSSRemote:
         assert query1.colnames == ['r', 'psfMag_r']
         assert query2.colnames == ['ra', 'dec', 'r']
 
-    # crossid doesn't work for DR<10, remove limitation once #2303 is fixed
-    @pytest.mark.parametrize("dr", dr_list[2:])
+    @pytest.mark.parametrize("dr", dr_list)
     def test_query_crossid(self, dr):
         query1 = sdss.SDSS.query_crossid(self.coords, data_release=dr)
         query2 = sdss.SDSS.query_crossid([self.coords, self.coords])
@@ -185,8 +184,7 @@ class TestSDSSRemote:
         assert isinstance(query2, Table)
         assert query2['objID'][0] == query1['objID'][0] == query2['objID'][1]
 
-    # crossid doesn't work for DR<10, remove limitation once #2303 is fixed
-    @pytest.mark.parametrize("dr", dr_list[2:])
+    @pytest.mark.parametrize("dr", dr_list)
     def test_spectro_query_crossid(self, dr):
         query1 = sdss.SDSS.query_crossid(self.coords,
                                          specobj_fields=['specObjID', 'z'],


### PR DESCRIPTION
This PR fixes #2303.  I ran the `remote-data` tests on my laptop and everything seems to work.