### PR TITLE
Cleanup test decorations

### DIFF
--- a/astroquery/alma/tests/test_alma_remote.py
+++ b/astroquery/alma/tests/test_alma_remote.py
@@ -3,7 +3,7 @@ import tempfile
 import shutil
 import numpy as np
 import pytest
-import warnings
+
 from datetime import datetime
 import os
 from urllib.parse import urlparse
@@ -85,9 +85,6 @@ class TestAlma:
             assert row['frequency'] <= 100
             assert '3' in row['band_list']
 
-    @pytest.mark.skipif("SKIP_SLOW",
-                        reason="Extremely slow due to limitations of "
-                               "the implementation")
     def test_bands(self, alma):
         payload = {'band_list': ['5', '7']}
         result = alma.query(payload)
@@ -116,7 +113,6 @@ class TestAlma:
         for row in result:
             assert 'GRB021004' == row['target_name']
 
-    @pytest.mark.skipif("SKIP_SLOW", reason="Known issue")
     def test_ra_dec(self, alma):
         payload = {'ra_dec': '181.0192d -0.01928d'}
         result = alma.query(payload)
@@ -124,6 +120,7 @@ class TestAlma:
 
     @pytest.mark.skipif("SKIP_SLOW")
     def test_m83(self, temp_dir, alma):
+        # Runs for over 9 minutes
         alma.cache_location = temp_dir
 
         m83_data = alma.query_object('M83', science=True, legacy_columns=True)
@@ -205,6 +202,8 @@ class TestAlma:
         assert len(results) == len(urls)
 
     def test_download_and_extract(self, temp_dir, alma):
+        # TODO: slowish, runs for ~90s
+
         alma.cache_location = temp_dir
         alma._cycle0_tarfile_content_table = {'ID': ''}
 
@@ -247,7 +246,6 @@ class TestAlma:
             'cache_path/' + asdm_url.split('/')[-1])
         assert downloaded_asdm == [os.path.join(temp_dir, 'foo.py')]
 
-    @pytest.mark.skipif("SKIP_SLOW", reason="Known issue")
     def test_doc_example(self, temp_dir, alma):
         alma.cache_location = temp_dir
         m83_data = alma.query_object('M83', legacy_columns=True)
@@ -304,7 +302,7 @@ class TestAlma:
         #                     science=True)
         # assert len(result) == 1
 
-    @pytest.mark.skipif("SKIP_SLOW", reason="ra dec search known issue")
+    @pytest.mark.xfail(reason="ra dec search known issue")
     def test_misc(self, alma):
         # miscellaneous set of common tests
         #
@@ -367,7 +365,6 @@ class TestAlma:
             assert '6' == row['band_list']
             assert 'ginsburg' in row['obs_creator_name'].lower()
 
-    @pytest.mark.skipif("SKIP_SLOW")
     def test_user(self, alma):
         # miscellaneous set of tests from current users
         rslt = alma.query({'band_list': [6], 'project_code': '2012.1.*'},
@@ -380,7 +377,6 @@ class TestAlma:
     # This has been reported, as it is definitely a bug.
     @pytest.mark.xfail
     @pytest.mark.bigdata
-    @pytest.mark.skipif("SKIP_SLOW")
     def test_cycle1(self, temp_dir, alma):
         # About 500 MB
         alma.cache_location = temp_dir
@@ -427,7 +423,7 @@ class TestAlma:
         assert len(data) == 6
 
     @pytest.mark.skipif("SKIP_SLOW")
-    @pytest.mark.skip("Not working anymore")
+    @pytest.mark.xfail(reason="Not working anymore")
     def test_cycle0(self, temp_dir, alma):
         # About 20 MB
         alma.cache_location = temp_dir

--- a/astroquery/alma/tests/test_alma_remote.py
+++ b/astroquery/alma/tests/test_alma_remote.py
@@ -40,7 +40,7 @@ def alma(request):
     """
     alma = Alma()
     alma_site = request.config.getoption('--alma-site',
-                                         'almascience.org')
+                                         'almascience.eso.org')
     alma.archive_url = 'https://{}'.format(alma_site)
     return alma
 

--- a/astroquery/conftest.py
+++ b/astroquery/conftest.py
@@ -53,7 +53,7 @@ def pytest_addoption(parser):
     parser.addoption(
         '--alma-site',
         action='store',
-        default='almascience.org',
+        default='almascience.eso.org',
         help='ALMA site (almascience.nrao.edu, almascience.eso.org or '
              'almascience.nao.ac.jp for example)'
     )


### PR DESCRIPTION
remove obsolete slow marks and change known failures to xfail

Most of these slow tests were decorated way back, and since then they seemed to be fixed. There are also a handful of tests that got decorated with skip due to a know failure, I've changed those to xfail which better reflects on their status.

So overall the changes are 36 pass 14 skip to 41 pass 4 skip 5 xfail, total runtime from 6 min to 7.25 min

The current durations:

```
============================================================================ slowest 50 durations ============================================================================
84.72s call     astroquery/alma/tests/test_alma_remote.py::TestAlma::test_download_and_extract
62.84s call     astroquery/alma/tests/test_alma_remote.py::TestAlma::test_stage_data
56.75s call     astroquery/alma/tests/test_alma_remote.py::TestAlma::test_bands
45.53s call     astroquery/alma/tests/test_alma_remote.py::TestAlma::test_data_info
33.90s call     astroquery/alma/tests/test_alma_remote.py::TestAlma::test_download_data
22.22s call     astroquery/alma/tests/test_alma_remote.py::test_download_html_file
14.68s call     astroquery/alma/tests/test_alma_remote.py::TestAlma::test_doc_example
12.94s call     astroquery/alma/tests/test_alma_remote.py::TestAlma::test_stage_data_listall
11.04s call     astroquery/alma/tests/test_alma_remote.py::test_verify_html_file
11.04s call     astroquery/alma/tests/test_alma_utils.py::test_make_finder_chart
10.98s call     astroquery/alma/tests/test_alma_remote.py::test_staging_stacking
8.35s call     astroquery/alma/tests/test_alma_remote.py::TestAlma::test_freq
5.54s call     astroquery/alma/tests/test_alma_remote.py::TestAlma::test_SgrAstar
5.31s call     astroquery/alma/tests/test_alma_remote.py::TestAlma::test_public
4.91s call     astroquery/alma/tests/test_alma_remote.py::TestAlma::test_user
4.64s call     astroquery/alma/tests/test_alma_remote.py::TestAlma::test_keywords
4.02s call     astroquery/alma/tests/test_alma_remote.py::TestAlma::test_query
3.95s call     astroquery/alma/tests/test_alma_remote.py::TestAlma::test_stage_data_json
3.88s call     astroquery/alma/tests/test_alma_remote.py::test_staging_postfeb2020
3.87s call     astroquery/alma/tests/test_alma_remote.py::test_staging_uptofeb2020
3.68s call     astroquery/alma/tests/test_alma_remote.py::TestAlma::test_data_proprietary
3.63s call     astroquery/alma/tests/test_alma_remote.py::TestAlma::test_misc
2.82s call     astroquery/alma/tests/test_alma_remote.py::TestAlma::test_alma_source_name
2.74s call     astroquery/alma/tests/test_alma_remote.py::TestAlma::test_equivalent_columns
2.67s call     astroquery/alma/tests/test_alma_remote.py::TestAlma::test_docs_example
2.33s call     astroquery/alma/tests/test_alma_remote.py::TestAlma::test_ra_dec
2.19s call     astroquery/alma/tests/test_alma_remote.py::TestAlma::test_cycle1
2.09s call     astroquery/alma/tests/test_alma_remote.py::test_project_metadata
0.25s setup    astroquery/alma/tests/test_alma_remote.py::TestAlma::test_SgrAstar
0.09s call     astroquery/alma/tests/test_alma.py::test_gen_pos_sql
0.04s call     astroquery/alma/tests/test_alma_utils.py::test_pyregion_subset
0.03s call     astroquery/alma/tests/test_alma.py::test_query
0.02s call     astroquery/alma/tests/test_alma.py::test_get_data_info
0.01s call     astroquery/alma/tests/test_alma.py::test_galactic_query
0.01s setup    astroquery/alma/tests/test_alma_remote.py::TestAlma::test_equivalent_columns
0.01s call     astroquery/alma/tests/test_alma.py::test_sia
0.01s call     astroquery/alma/tests/test_alma.py::test_tap

(13 durations < 0.005s hidden.  Use -vv to show these durations.)
```

