### PR TITLE
Deprecate functions from alma.utils

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -15,7 +15,7 @@ alma
 
 - Added ``verify_only`` option to check if data downloaded with correct file size [#2263]
 
-- Deprecate functionalities from ``alma.utils``. [#2332]
+- Deprecate broken functions from ``alma.utils``. [#2332]
 
 esa.hubble
 ^^^^^^^^^^

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -15,6 +15,8 @@ alma
 
 - Added ``verify_only`` option to check if data downloaded with correct file size [#2263]
 
+- Deprecate functionalities from ``alma.utils``. [#2332]
+
 esa.hubble
 ^^^^^^^^^^
 

--- a/astroquery/alma/tests/test_alma_utils.py
+++ b/astroquery/alma/tests/test_alma_utils.py
@@ -14,38 +14,6 @@ except ImportError:
 from .. import utils
 
 
-@pytest.mark.skipif('not pyregion_OK')
-def test_pyregion_subset():
-    header = dict(naxis=2, crpix1=15, crpix2=15, crval1=0.1, crval2=0.1,
-                  cdelt1=-1. / 3600, cdelt2=1. / 3600., ctype1='GLON-CAR',
-                  ctype2='GLAT-CAR')
-    mywcs = wcs.WCS(header)
-    # circle with radius 10" at 0.1, 0.1
-    shape = Shape('circle', (0.1, 0.1, 10. / 3600.))
-    shape.coord_format = 'galactic'
-    shape.coord_list = (0.1, 0.1, 10. / 3600.)
-    shape.attr = ([], {})
-    data = np.ones([40, 40])
-
-    # The following line raises a DeprecationWarning from pyregion, ignore it
-    with warnings.catch_warnings():
-        warnings.filterwarnings('ignore')
-        (xlo, xhi, ylo, yhi), d = utils.pyregion_subset(shape, data, mywcs)
-
-    # sticky note over check-engine light solution... but this problem is too
-    # large in scope to address here.  See
-    # https://github.com/astropy/astropy/pull/3992
-    assert d.sum() >= 313 & d.sum() <= 315  # VERY approximately pi
-    np.testing.assert_almost_equal(xlo,
-                                   data.shape[0] / 2 - mywcs.wcs.crpix[0] - 1)
-    np.testing.assert_almost_equal(xhi,
-                                   data.shape[0] - mywcs.wcs.crpix[0] - 1)
-    np.testing.assert_almost_equal(ylo,
-                                   data.shape[1] / 2 - mywcs.wcs.crpix[1] - 1)
-    np.testing.assert_almost_equal(yhi,
-                                   data.shape[1] - mywcs.wcs.crpix[1] - 1)
-
-
 frq_sup_str = ('[86.26..88.14GHz,976.56kHz, XX YY] U '
                '[88.15..90.03GHz,976.56kHz, XX YY] U '
                '[98.19..100.07GHz,976.56kHz, XX YY] U '
@@ -63,28 +31,3 @@ def test_parse_frequency_support(frq_sup_str=frq_sup_str, result=franges):
 def approximate_primary_beam_sizes(frq_sup_str=frq_sup_str,
                                    beamsizes=beamsizes):
     assert np.all(utils.approximate_primary_beam_sizes(frq_sup_str) == beamsizes)
-
-
-@pytest.mark.remote_data
-@pytest.mark.skipif('not pyregion_OK')
-@pytest.mark.skip('To be fixed later')
-def test_make_finder_chart():
-    import matplotlib
-    matplotlib.use('agg')
-    if matplotlib.get_backend() != 'agg':
-        pytest.xfail("Matplotlib backend was incorrectly set to {0}, could "
-                     "not run finder chart test.".format(matplotlib.get_backend()))
-
-    result = utils.make_finder_chart('Eta Carinae', 3 * u.arcmin,
-                                     'Eta Carinae')
-    image, catalog, hit_mask_public, hit_mask_private = result
-
-    assert len(catalog) >= 6  # down to 6 on Nov 17, 2016
-    assert 3 in [int(x) for x in hit_mask_public]
-    # Feb 8 2016: apparently the 60s integration hasn't actually been released yet...
-    if 3 in hit_mask_public:
-        assert hit_mask_public[3][256, 256] >= 30.23
-    elif b'3' in hit_mask_public:
-        assert hit_mask_public[b'3'][256, 256] >= 30.23
-    else:
-        raise ValueError("hit_mask keys are not of any known type")

--- a/astroquery/alma/utils.py
+++ b/astroquery/alma/utils.py
@@ -18,6 +18,9 @@ from astroquery.skyview import SkyView
 from astroquery.alma import Alma
 
 
+__all__ = ['parse_frequency_support', 'footprint_to_reg', 'approximate_primary_beam_sizes']
+
+
 @deprecated('0.4.6', 'this function has been deprecated and will be removed in the next release.')
 def pyregion_subset(region, data, mywcs):
     """

--- a/astroquery/alma/utils.py
+++ b/astroquery/alma/utils.py
@@ -10,12 +10,15 @@ from astropy import wcs
 from astroquery import log
 from astropy import units as u
 from astropy.io import fits
+from astropy.utils import deprecated
+
 from astroquery.utils.commons import ASTROPY_LT_4_1
 
 from astroquery.skyview import SkyView
 from astroquery.alma import Alma
 
 
+@deprecated('0.4.6', 'this function has been deprecated and will be removed in the next release.')
 def pyregion_subset(region, data, mywcs):
     """
     Return a subset of an image (``data``) given a region.
@@ -153,6 +156,7 @@ def footprint_to_reg(footprint):
     return reglist
 
 
+@deprecated('0.4.6', 'this function has been deprecated and will be removed in the next release.')
 def add_meta_to_reg(reg, meta):
     reg.meta = meta
     return reg
@@ -181,6 +185,7 @@ def approximate_primary_beam_sizes(frequency_support_str,
     return u.Quantity(beam_sizes)
 
 
+@deprecated('0.4.6', 'this function has been deprecated and will be removed in the next release.')
 def make_finder_chart(target, radius, save_prefix, service=SkyView.get_images,
                       service_kwargs={'survey': ['2MASS-K'], 'pixels': 500},
                       alma_kwargs={'public': False, 'science': False},
@@ -229,6 +234,7 @@ def make_finder_chart(target, radius, save_prefix, service=SkyView.get_images,
                                         **kwargs)
 
 
+@deprecated('0.4.6', 'this function has been deprecated and will be removed in the next release.')
 def make_finder_chart_from_image(image, target, radius, save_prefix,
                                  alma_kwargs={'public': False,
                                               'science': False,
@@ -273,6 +279,7 @@ def make_finder_chart_from_image(image, target, radius, save_prefix,
                                                     **kwargs)
 
 
+@deprecated('0.4.6', 'this function has been deprecated and will be removed in the next release.')
 def make_finder_chart_from_image_and_catalog(image, catalog, save_prefix,
                                              alma_kwargs={'public': False,
                                                           'science': False},


### PR DESCRIPTION
This is to proceed the removals in #2331 with a proper deprecation cycle (even though the functionalities are currently not compatible with the API, so we could just go ahead with #2331 as is)