### PR TITLE
Verify SSL certificates for FIRST, MAGPIS

### DIFF
--- a/astroquery/image_cutouts/first/core.py
+++ b/astroquery/image_cutouts/first/core.py
@@ -88,7 +88,7 @@ class FirstClass(BaseQuery):
         if get_query_payload:
             return request_payload
         response = self._request("POST", url=self.URL, data=request_payload,
-                                 timeout=self.TIMEOUT, verify=False)
+                                 timeout=self.TIMEOUT)
         return response
 
 

--- a/astroquery/magpis/core.py
+++ b/astroquery/magpis/core.py
@@ -114,7 +114,7 @@ class MagpisClass(BaseQuery):
         if get_query_payload:
             return request_payload
         response = self._request("POST", url=self.URL, data=request_payload,
-                                 timeout=self.TIMEOUT, verify=False)
+                                 timeout=self.TIMEOUT)
         return response
 
     def list_surveys(self):


### PR DESCRIPTION
Addresses #2345.  `verify=False` was a workaround for the time when this site didn't have valid certificates.