### PR TITLE
Fix string formatting in "dummy handlers"

### DIFF
--- a/astroquery/esa/hsa/tests/dummy_handler.py
+++ b/astroquery/esa/hsa/tests/dummy_handler.py
@@ -40,4 +40,3 @@ class DummyHandler(object):
                                      f"Expected:'{parameters[key]}'")
             else:
                 raise ValueError(f"Parameter '{key}' not found in method '{method_name}'")
-        return True

--- a/astroquery/esa/hubble/tests/dummy_tap_handler.py
+++ b/astroquery/esa/hubble/tests/dummy_tap_handler.py
@@ -49,7 +49,6 @@ class DummyHubbleTapHandler:
                                      f"Found:'{self._parameters[key]}'. Expected:'{parameters[key]}'")
             else:
                 raise ValueError(f"Parameter '{key}' not found in method '{method_name}'")
-        return True
 
     def launch_job(self, query, name=None, output_file=None,
                    output_format="votable", verbose=False, dump_to_file=False,

--- a/astroquery/esa/hubble/tests/dummy_tap_handler.py
+++ b/astroquery/esa/hubble/tests/dummy_tap_handler.py
@@ -18,46 +18,38 @@ from astroquery.utils.tap.model.job import Job
 class DummyHubbleTapHandler:
 
     def __init__(self, method, parameters):
-        self.__invokedMethod = method
+        self._invokedMethod = method
         self._parameters = parameters
 
     def reset(self):
         self._parameters = {}
-        self.__invokedMethod = None
+        self._invokedMethod = None
 
     def check_call(self, method_name, parameters):
         self.check_method(method_name)
         self.check_parameters(parameters, method_name)
 
     def check_method(self, method):
-        if method != self.__invokedMethod:
-            raise Exception("Method '" + str(method) + ""
-                            "' not invoked. (Invoked method is '"
-                            "" + str(self.__invokedMethod)+"')")
+        if method != self._invokedMethod:
+            raise ValueError(f"Method '{method}' is not invoked. (Invoked method "
+                             f"is '{self._invokedMethod}').")
 
     def check_parameters(self, parameters, method_name):
         if parameters is None:
             return len(self._parameters) == 0
         if len(parameters) != len(self._parameters):
-            raise Exception("Wrong number of parameters for method '%s'. "
-                            "Found: %d. Expected %d",
-                            (method_name,
-                             len(self._parameters),
-                             len(parameters)))
+            raise ValueError(f"Wrong number of parameters for method '{method_name}'. "
+                             f"Found: {len(self._parameters)}. Expected {len(parameters)}")
         for key in parameters:
             if key in self._parameters:
                 # check value
                 if self._parameters[key] != parameters[key]:
-                    raise Exception("Wrong '%s' parameter value for method '%s'. \
-                                    Found: '%s'. Expected: '%s'", (
-                        method_name,
-                        key,
-                        self._parameters[key],
-                        parameters[key]))
+                    raise ValueError(f"Wrong '{key}' parameter "
+                                     f"value for method '{method_name}'. "
+                                     f"Found:'{self._parameters[key]}'. Expected:'{parameters[key]}'")
             else:
-                raise Exception("Parameter '%s' not found for method '%s'",
-                                (str(key), method_name))
-        return False
+                raise ValueError(f"Parameter '{key}' not found in method '{method_name}'")
+        return True
 
     def launch_job(self, query, name=None, output_file=None,
                    output_format="votable", verbose=False, dump_to_file=False,

--- a/astroquery/esa/iso/tests/dummy_handler.py
+++ b/astroquery/esa/iso/tests/dummy_handler.py
@@ -30,30 +30,22 @@ class DummyHandler(object):
         if method == self._invokedMethod:
             return
         else:
-            raise ValueError("Method '{}' is not invoked. (Invoked method \
-                             is '{}'.)").format(method, self_invokedMethod)
+            raise ValueError(f"Method '{method}' is not invoked. (Invoked method "
+                             f"is '{self._invokedMethod}').")
 
     def check_parameters(self, parameters, method_name):
         if parameters is None:
             return len(self._parameters) == 0
         if len(parameters) != len(self._parameters):
-            raise ValueError("Wrong number of parameters for method '{}'. \
-                              Found: {}. Expected {}").format(
-                                    method_name,
-                                    len(self._parameters),
-                                    len(parameters))
+            raise ValueError(f"Wrong number of parameters for method '{method_name}'. "
+                             f"Found: {len(self._parameters)}. Expected {len(parameters)}")
         for key in parameters:
             if key in self._parameters:
                 # check value
                 if self._parameters[key] != parameters[key]:
-                    raise ValueError("Wrong '{}' parameter \
-                                     value for method '{}'. \
-                                     Found:'{}'. Expected:'{}'").format(
-                                        method_name,
-                                        key,
-                                        self._parameters[key],
-                                        parameters[key])
+                    raise ValueError(f"Wrong '{key}' parameter "
+                                     f"value for method '{method_name}'. "
+                                     f"Found:'{self._parameters[key]}'. Expected:'{parameters[key]}'")
             else:
-                raise ValueError("Parameter '%s' not found in method '%s'",
-                                 (str(key), method_name))
+                raise ValueError(f"Parameter '{key}' not found in method '{method_name}'")
         return True

--- a/astroquery/esa/iso/tests/dummy_handler.py
+++ b/astroquery/esa/iso/tests/dummy_handler.py
@@ -48,4 +48,3 @@ class DummyHandler(object):
                                      f"Found:'{self._parameters[key]}'. Expected:'{parameters[key]}'")
             else:
                 raise ValueError(f"Parameter '{key}' not found in method '{method_name}'")
-        return True

--- a/astroquery/esa/jwst/tests/DummyDataHandler.py
+++ b/astroquery/esa/jwst/tests/DummyDataHandler.py
@@ -52,7 +52,6 @@ class DummyDataHandler:
             else:
                 raise ValueError(f"Parameter '{str(key)}' not found for "
                                  f"method '{method_name}'")
-        return True
 
     def download_file(self, url=None):
         self.__invokedMethod = 'download_file'

--- a/astroquery/esa/jwst/tests/DummyDataHandler.py
+++ b/astroquery/esa/jwst/tests/DummyDataHandler.py
@@ -45,14 +45,14 @@ class DummyDataHandler:
             if key in self.__parameters:
                 # check value
                 if self.__parameters[key] != parameters[key]:
-                    raise ValueError(f"Wrong '{method_name}' parameter "
-                                     f"value for method '{key}'. "
+                    raise ValueError(f"Wrong '{key}' parameter "
+                                     f"value for method '{method_name}'. "
                                      f"Found: '{self.__parameters[key]}'. "
                                      f"Expected: '{parameters[key]}'")
             else:
                 raise ValueError(f"Parameter '{str(key)}' not found for "
                                  f"method '{method_name}'")
-        return False
+        return True
 
     def download_file(self, url=None):
         self.__invokedMethod = 'download_file'

--- a/astroquery/esa/jwst/tests/DummyTapHandler.py
+++ b/astroquery/esa/jwst/tests/DummyTapHandler.py
@@ -75,7 +75,6 @@ class DummyTapHandler:
             else:
                 raise ValueError(f"Parameter '{str(key)}' not found "
                                  f"for method '{method_name}'")
-        return False
 
     def load_tables(self, only_names=False, include_shared_tables=False,
                     verbose=False):

--- a/astroquery/esa/xmm_newton/tests/dummy_handler.py
+++ b/astroquery/esa/xmm_newton/tests/dummy_handler.py
@@ -31,30 +31,22 @@ class DummyHandler:
         if method == self._invokedMethod:
             return
         else:
-            raise ValueError("Method '{}' is not invoked. (Invoked method \
-                             is '{}'.)").format(method, self._invokedMethod)
+            raise ValueError(f"Method '{method}' is not invoked. (Invoked method "
+                             f"is '{self._invokedMethod}').")
 
     def check_parameters(self, parameters, method_name):
         if parameters is None:
             return len(self._parameters) == 0
         if len(parameters) != len(self._parameters):
-            raise ValueError("Wrong number of parameters for method '{}'. \
-                              Found: {}. Expected {}").format(
-                                    method_name,
-                                    len(self._parameters),
-                                    len(parameters))
+            raise ValueError(f"Wrong number of parameters for method '{method_name}'. "
+                             f"Found: {len(self._parameters)}. Expected {len(parameters)}")
         for key in parameters:
             if key in self._parameters:
                 # check value
                 if self._parameters[key] != parameters[key]:
-                    raise ValueError("Wrong '{}' parameter \
-                                     value for method '{}'. \
-                                     Found:'{}'. Expected:'{}'").format(
-                                        method_name,
-                                        key,
-                                        self._parameters[key],
-                                        parameters[key])
+                    raise ValueError(f"Wrong '{key}' parameter "
+                                     f"value for method '{method_name}'. "
+                                     f"Found:'{self._parameters[key]}'. Expected:'{parameters[key]}'")
             else:
-                raise ValueError("Parameter '%s' not found in method '%s'",
-                                 (str(key), method_name))
+                raise ValueError(f"Parameter '{key}' not found in method '{method_name}'")
         return True

--- a/astroquery/esa/xmm_newton/tests/dummy_handler.py
+++ b/astroquery/esa/xmm_newton/tests/dummy_handler.py
@@ -49,4 +49,3 @@ class DummyHandler:
                                      f"Found:'{self._parameters[key]}'. Expected:'{parameters[key]}'")
             else:
                 raise ValueError(f"Parameter '{key}' not found in method '{method_name}'")
-        return True


### PR DESCRIPTION
Some of the strings in the "dummy handlers" were not properly formatted, as seen below:

```python
# Notice that the parenthesis here are incorrect
ValueError("Method '{}' is not invoked. (Invoked method \
           is '{}'.)").format(method, self._invokedMethod)
```

As discussed [here](https://github.com/astropy/astroquery/pull/2122#discussion_r849801994) this PR fixes the string formatting of these modules and changes said formatting to f-strings:

```python
ValueError(f"Method '{method}' is not invoked. (Invoked method "
           f"is '{self._invokedMethod}').")
```