### PR TITLE
A number of CADC authentication and doc fixes

### DIFF
--- a/astroquery/cadc/core.py
+++ b/astroquery/cadc/core.py
@@ -162,9 +162,9 @@ class CadcClass(BaseQuery):
         # start with a new session
         if not isinstance(self.cadctap._session, (requests.Session,
                                                   authsession.AuthSession)):
-            raise TypeError('Cannot login with user provided session that is '
-                            'not an pyvo.authsession.AuthSession or '
-                            'requests.Session')
+            raise AttributeError('Cannot login with user provided session that is '
+                                 'not an pyvo.authsession.AuthSession or '
+                                 'requests.Session')
         if not certificate_file and not (user and password):
             raise AttributeError('login credentials missing (user/password '
                                  'or certificate)')
@@ -227,6 +227,8 @@ class CadcClass(BaseQuery):
         if isinstance(self._auth_session, pyvo.auth.AuthSession):
             # Remove the existing credentials (if any)
             # PyVO should provide this reset credentials functionality
+            # TODO - this should be implemented in PyVO to avoid this deep
+            # intrusion into that package
             self._auth_session.credentials.credentials = \
                 {key: value for (key, value) in self._auth_session.credentials.credentials.items()
                     if key == pyvo.auth.securitymethods.ANONYMOUS}

--- a/astroquery/cadc/core.py
+++ b/astroquery/cadc/core.py
@@ -603,7 +603,7 @@ class CadcClass(BaseQuery):
                 return t
 
     def exec_sync(self, query, maxrec=None, uploads=None, output_file=None,
-                  output_format='basic'):
+                  output_format='votable'):
         """
         Run a query and return the results or save them in an output_file
 

--- a/astroquery/cadc/core.py
+++ b/astroquery/cadc/core.py
@@ -291,7 +291,7 @@ class CadcClass(BaseQuery):
 
         Parameters
         ----------
-        name: str
+        name : str
                 name of object to query for
 
         Returns
@@ -615,11 +615,11 @@ class CadcClass(BaseQuery):
             SQL to execute
         maxrec : int
             the maximum records to return. defaults to the service default
-        uploads:
+        uploads :
             Temporary tables to upload and run with the queries
-        output_file: str or file handler:
+        output_file : str or file handler
             File to save the results to
-        output_format:
+        output_format :
             Format of the output (default is basic). Must be one
             of the formats supported by `astropy.table`
 
@@ -709,9 +709,9 @@ class CadcClass(BaseQuery):
             when the job is executed in asynchronous mode,
             this flag specifies whether the execution will wait until results
             are available
-        upload_resource: str, optional, default None
+        upload_resource : str, optional, default None
             resource to be uploaded to UPLOAD_SCHEMA
-        upload_table_name: str, required if uploadResource is provided,
+        upload_table_name : str, required if uploadResource is provided,
             default None
             resource temporary table name associated to the uploaded resource
 
@@ -749,13 +749,13 @@ class CadcClass(BaseQuery):
 
         Parameters
         ----------
-        phases: list of str
+        phases : list of str
             Union of job phases to filter the results by.
-        after: datetime
+        after : datetime
             Return only jobs created after this datetime
-        last: int
+        last : int
             Return only the most recent number of jobs
-        short_description: flag - True or False
+        short_description : flag - True or False
             If True, the jobs in the list will contain only the information
             corresponding to the TAP ShortJobDescription object (job ID, phase,
             run ID, owner ID and creation ID) whereas if False, a separate GET
@@ -811,12 +811,19 @@ def get_access_url(service, capability=None):
     """
     Returns the URL corresponding to a service by doing a lookup in the cadc
     registry. It returns the access URL corresponding to cookie authentication.
-    :param service: the service the capability belongs to. It can be identified
-    by a CADC uri ('ivo://cadc.nrc.ca/) which is looked up in the CADC registry
-    or by the URL where the service capabilities is found.
-    :param capability: uri representing the capability for which the access
-    url is sought
-    :return: the access url
+
+    Parameters
+    ----------
+    service : str
+        the service the capability belongs to. It can be identified
+        by a CADC uri ('ivo://cadc.nrc.ca/) which is looked up in the CADC registry
+        or by the URL where the service capabilities is found.
+    capability : str
+        uri representing the capability for which the access url is sought
+
+    Returns
+    -------
+    The access url
 
     Note
     ------

--- a/astroquery/cadc/tests/test_cadctap.py
+++ b/astroquery/cadc/tests/test_cadctap.py
@@ -204,6 +204,8 @@ def test_get_access_url():
 
 @patch('astroquery.cadc.core.get_access_url',
        Mock(side_effect=lambda x, y=None: 'https://some.url'))
+@patch('astroquery.cadc.core.pyvo.dal.adhoc.DatalinkService',
+       Mock(return_value=Mock(capabilities=[])))  # DL capabilities not needed
 @pytest.mark.skipif(not pyvo_OK, reason='not pyvo_OK')
 def test_get_data_urls():
 
@@ -283,6 +285,8 @@ def test_misc():
 
 @patch('astroquery.cadc.core.get_access_url',
        Mock(side_effect=lambda x, y=None: 'https://some.url'))
+@patch('astroquery.cadc.core.pyvo.dal.TAPService',
+       Mock(return_value=Mock(capabilities=[])))  # TAP capabilities not needed
 @pytest.mark.skipif(not pyvo_OK, reason='not pyvo_OK')
 def test_get_image_list():
     def get(*args, **kwargs):

--- a/astroquery/cadc/tests/test_cadctap.py
+++ b/astroquery/cadc/tests/test_cadctap.py
@@ -287,6 +287,8 @@ def test_misc():
        Mock(side_effect=lambda x, y=None: 'https://some.url'))
 @patch('astroquery.cadc.core.pyvo.dal.TAPService',
        Mock(return_value=Mock(capabilities=[])))  # TAP capabilities not needed
+@patch('astroquery.cadc.core.pyvo.dal.adhoc.DatalinkService',
+       Mock(return_value=Mock(capabilities=[])))  # DL capabilities not needed
 @pytest.mark.skipif(not pyvo_OK, reason='not pyvo_OK')
 def test_get_image_list():
     def get(*args, **kwargs):
@@ -375,7 +377,7 @@ def test_exec_sync():
     votable.to_xml(buffer)
     cadc = Cadc(auth_session=requests.Session())
     response = Mock()
-    response.to_table.return_value = buffer.getvalue()
+    response.to_table.return_value = table.to_table()
     cadc.cadctap.search = Mock(return_value=response)
     output_file = '{}/test_vooutput.xml'.format(tempfile.tempdir)
     cadc.exec_sync('some query', output_file=output_file)

--- a/astroquery/cadc/tests/test_cadctap_remote.py
+++ b/astroquery/cadc/tests/test_cadctap_remote.py
@@ -151,6 +151,12 @@ class TestCadcClass:
                 format(now.strftime('%Y-%m-%dT%H:%M:%S.%f'))
             result = cadc.exec_sync(query)
             assert len(result) == 0
+            # login in again
+            cadc.login(os.environ['CADC_USER'], os.environ['CADC_PASSWD'])
+            query = "select top 1 * from caom2.Plane where metaRelease>'{}'". \
+                format(now.strftime('%Y-%m-%dT%H:%M:%S.%f'))
+            result = cadc.exec_sync(query)
+            assert len(result) == 1
 
     @pytest.mark.skipif(one_test, reason='One test mode')
     @pytest.mark.skipif('CADC_CERT' not in os.environ,

--- a/docs/cadc/cadc.rst
+++ b/docs/cadc/cadc.rst
@@ -454,8 +454,8 @@ Query saving results in a file:
 
     >>> from astroquery.cadc import Cadc
     >>> cadc = Cadc()
-    >>> job = cadc.exec_sync("SELECT TOP 10 observationID, obsID FROM caom2.Observation AS Observation",
-    ...                      output_file='test_output_noauth.tsv')
+    >>> job = cadc.exec_sync("SELECT TOP 10 observationID, obsID FROM caom2.Observation",
+    ...                      output_file='test_output_noauth.xml')
 
 
 1.5 Synchronous query with temporary uploaded table
@@ -470,6 +470,44 @@ to return the content of that table would be ``SELECT * FROM tap_upload.temp_tab
 Multiple temporary tables to be used at once can be specified as such.
 
 More details about temporary table upload can be found in the IVOA TAP specification.
+
+.. doctest-remote-data::
+
+    >>> from astroquery.cadc import Cadc
+    >>> cadc = Cadc()
+    >>> # save a few observations on a local file
+    >>> results = cadc.exec_sync("SELECT TOP 3 observationID FROM caom2.Observation",
+    ...                          output_file='my_observations.xml')
+    >>> print(results)
+    >>> # now use them to join with the remote table
+    >>> results = cadc.exec_sync("SELECT o.observationID, intent FROM caom2.Observation o "
+    ...                          "JOIN tap_upload.test_upload tu ON o.observationID=tu.observationID",
+    ...                           uploads={'test_upload': 'my_datasets.xml'})
+    >>> print(results)
+
+.. testcleanup::
+
+    >>> import os
+    >>> if os.path.isfile('my_observations.xml'):
+    ...  os.remove('my_observations.xml')
+
+This will produce an output similar to:
+
+                  observationID
+    ----------------------------------
+                c13a_060826_044314_ori
+    tess2021167190903-s0039-1-3-0210-s
+                             tu1657207
+
+and
+              observationID             intent
+    ---------------------------------- -------
+                c13a_060826_044314_ori science
+    tess2021167190903-s0039-1-3-0210-s science
+                             tu1657207 science
+
+The feature allows a user to save the results of a query to use them later or
+correlate them with data in other TAP services.
 
 
 1.6 Asynchronous query

--- a/docs/cadc/cadc.rst
+++ b/docs/cadc/cadc.rst
@@ -479,11 +479,22 @@ More details about temporary table upload can be found in the IVOA TAP specifica
     >>> results = cadc.exec_sync("SELECT TOP 3 observationID FROM caom2.Observation",
     ...                          output_file='my_observations.xml')
     >>> print(results)
+                  observationID
+    ----------------------------------
+                c13a_060826_044314_ori
+    tess2021167190903-s0039-1-3-0210-s
+                             tu1657207
     >>> # now use them to join with the remote table
     >>> results = cadc.exec_sync("SELECT o.observationID, intent FROM caom2.Observation o "
     ...                          "JOIN tap_upload.test_upload tu ON o.observationID=tu.observationID",
     ...                           uploads={'test_upload': 'my_datasets.xml'})
     >>> print(results)
+              observationID             intent
+    ---------------------------------- -------
+                c13a_060826_044314_ori science
+    tess2021167190903-s0039-1-3-0210-s science
+                             tu1657207 science
+
 
 .. testcleanup::
 
@@ -491,20 +502,6 @@ More details about temporary table upload can be found in the IVOA TAP specifica
     >>> if os.path.isfile('my_observations.xml'):
     ...  os.remove('my_observations.xml')
 
-This will produce an output similar to:
-
-                  observationID
-    ----------------------------------
-                c13a_060826_044314_ori
-    tess2021167190903-s0039-1-3-0210-s
-                             tu1657207
-
-and
-              observationID             intent
-    ---------------------------------- -------
-                c13a_060826_044314_ori science
-    tess2021167190903-s0039-1-3-0210-s science
-                             tu1657207 science
 
 The feature allows a user to save the results of a query to use them later or
 correlate them with data in other TAP services.

--- a/docs/cadc/cadc.rst
+++ b/docs/cadc/cadc.rst
@@ -495,7 +495,7 @@ More details about temporary table upload can be found in the IVOA TAP specifica
 
     >>> import os
     >>> if os.path.isfile('my_observations.xml'):
-    ...  os.remove('my_observations.xml')
+    ...    os.remove('my_observations.xml')
 
 
 The feature allows a user to save the results of a query to use them later or

--- a/docs/cadc/cadc.rst
+++ b/docs/cadc/cadc.rst
@@ -429,7 +429,7 @@ Query without saving results in a file:
     >>> from astroquery.cadc import Cadc
     >>> cadc = Cadc()
     >>> results = cadc.exec_sync("SELECT top 100 observationID, intent FROM caom2.Observation")
-    >>> print(results)
+    >>> print(results)  # doctest: +IGNORE_OUTPUT
               observationID               intent
     ---------------------------------- -----------
         VLASS2.2.T18t28.J204443+293000     science
@@ -473,7 +473,7 @@ More details about temporary table upload can be found in the IVOA TAP specifica
     >>> # save a few observations on a local file
     >>> results = cadc.exec_sync("SELECT TOP 3 observationID FROM caom2.Observation",
     ...                          output_file='my_observations.xml')
-    >>> print(results)
+    >>> print(results)  # doctest: +IGNORE_OUTPUT
                   observationID
     ----------------------------------
                 c13a_060826_044314_ori
@@ -482,8 +482,8 @@ More details about temporary table upload can be found in the IVOA TAP specifica
     >>> # now use them to join with the remote table
     >>> results = cadc.exec_sync("SELECT o.observationID, intent FROM caom2.Observation o "
     ...                          "JOIN tap_upload.test_upload tu ON o.observationID=tu.observationID",
-    ...                           uploads={'test_upload': 'my_datasets.xml'})
-    >>> print(results)
+    ...                          uploads={'test_upload': 'my_observations.xml'})
+    >>> print(results)  # doctest: +IGNORE_OUTPUT
               observationID             intent
     ---------------------------------- -------
                 c13a_060826_044314_ori science

--- a/docs/cadc/cadc.rst
+++ b/docs/cadc/cadc.rst
@@ -16,11 +16,6 @@ This package allows the access to the data at the `CADC
 Basic Access
 ============
 
-.. note::
-
-    ``astroquery.cadc`` is dependent on the ``pyvo`` package. Please
-    install it prior to using the ``astroquery.cadc`` module.
-
 The CADC hosts a number of collections and
 `~astroquery.cadc.CadcClass.get_collections` returns a list of all
 these collections:

--- a/docs/cadc/cadc.rst
+++ b/docs/cadc/cadc.rst
@@ -461,24 +461,15 @@ Query saving results in a file:
 1.5 Synchronous query with temporary uploaded table
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-A table can be uploaded to the server in order to be used in a query.
+A temporary table can be uploaded to the server from a local file and used in a query.
+The ``uploads`` argument in ``exec_sync`` is a map where the key is the name of the
+table and the value is the name of the ``VOTable`` temporary file with the content.
+In the query, the temporary table is referred to as ``tap_upload.table_name``.
+For example, if ``uploads = {'temp_table': 'table_file_name'}``, then the simplest query
+to return the content of that table would be ``SELECT * FROM tap_upload.temp_table``.
+Multiple temporary tables to be used at once can be specified as such.
 
-
-.. doctest-skip::
-
-    >>> from astroquery.cadc import Cadc
-    >>> cadc = Cadc()
-    >>> upload_resource = 'data/votable.xml'
-    >>> j = cadc.exec_sync("SELECT * FROM tap_upload.test_table_upload",
-    ...                    uploads=upload_resource,
-    ...                    output_file="test_output_table")
-    >>> print(j.get_results())
-             uri                    contentChecksum            ...   contentType
-                                                               ...
-    --------------------- ------------------------------------ ... ----------------
-    ad:IRIS/I001B1H0.fits md5:b6ead425ae84289246e4528bbdd7da9a ... application/fits
-    ad:IRIS/I001B2H0.fits md5:a6b082ca530bf5db5a691985d0c1a6ca ... application/fits
-    ad:IRIS/I001B3H0.fits md5:2ada853a8ae135e16504aeba4e47489e ... application/fits
+More details about temporary table upload can be found in the IVOA TAP specification.
 
 
 1.6 Asynchronous query

--- a/setup.cfg
+++ b/setup.cfg
@@ -32,7 +32,7 @@ astropy_header = true
 text_file_format = rst
 xfail_strict = true
 remote_data_strict = true
-addopts = --doctest-rst
+#addopts = --doctest-rst
 filterwarnings =
     error
     ignore: Experimental:UserWarning:

--- a/setup.cfg
+++ b/setup.cfg
@@ -32,7 +32,7 @@ astropy_header = true
 text_file_format = rst
 xfail_strict = true
 remote_data_strict = true
-#addopts = --doctest-rst
+addopts = --doctest-rst
 filterwarnings =
     error
     ignore: Experimental:UserWarning:


### PR DESCRIPTION
- Added fix to use an authentication connection with `datalink` service (and not only with the tap service)
- Fixed a problem to handle a different type of exception raised the upstream stack (`HTTPError`)
- A few fixes to make documentation examples testable.