### PR TITLE
Gaia astroquery 1.1

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,11 +4,19 @@
 New Tools and Services
 ----------------------
 
+gaia
+^^^^
+
+- TAP notifications service is now available for Gaia. If there is notification for the users,
+e.g planned or our unplanned downtimes of the archive, etc. The notification
+will be also visible when accessing the archive through Astroquery. [#2376]
 
 hsa
 ^^^
 
 - New module to access ESA Herschel mission. [#2122]
+
+
 
 Service fixes and enhancements
 ------------------------------
@@ -48,6 +56,13 @@ oac
 
 - Fix bug in parsing events that contain html tags (e.g. in their alias
   field). [#2423]
+
+gaia
+^^^^
+
+- Method 'load_data' now has the parameter 'valid_data' set to False by default.
+With this change the epoch photometry service returns all data associated to
+a given source. [#2376]
 
 
 Infrastructure, Utility and Other Changes and Additions

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -8,14 +8,13 @@ gaia
 ^^^^
 
 - TAP notifications service is now available for Gaia. If there is notification for the users,
-e.g planned or our unplanned downtimes of the archive, etc. The notification
-will be also visible when accessing the archive through Astroquery. [#2376]
+  for example planned or our unplanned downtimes of the archive, etc. The notification
+  will be also visible when accessing the archive through Astroquery. [#2376]
 
 hsa
 ^^^
 
 - New module to access ESA Herschel mission. [#2122]
-
 
 
 Service fixes and enhancements
@@ -61,8 +60,8 @@ gaia
 ^^^^
 
 - Method 'load_data' now has the parameter 'valid_data' set to False by default.
-With this change the epoch photometry service returns all data associated to
-a given source. [#2376]
+  With this change the epoch photometry service returns all data associated
+  to a given source. [#2376]
 
 
 Infrastructure, Utility and Other Changes and Additions

--- a/astroquery/gaia/__init__.py
+++ b/astroquery/gaia/__init__.py
@@ -39,6 +39,8 @@ class Conf(_config.ConfigNamespace):
                                       'MCMC_GSPPHOT',
                                       'MCMC_MSC']
 
+    GAIA_MESSAGES = _config.ConfigItem("notification?action=GetNotifications", "Gaia Messages")
+
 
 conf = Conf()
 

--- a/astroquery/gaia/__init__.py
+++ b/astroquery/gaia/__init__.py
@@ -39,8 +39,6 @@ class Conf(_config.ConfigNamespace):
                                       'MCMC_GSPPHOT',
                                       'MCMC_MSC']
 
-    GAIA_MESSAGES = _config.ConfigItem("notification?action=GetNotifications", "Gaia Messages")
-
 
 conf = Conf()
 

--- a/astroquery/gaia/core.py
+++ b/astroquery/gaia/core.py
@@ -920,6 +920,7 @@ class GaiaClass(TapPlus):
         the status of JWST TAP
         """
         try:
+            print("parsing notification messages")
             subContext = conf.GAIA_MESSAGES
             connHandler = self._TapPlus__getconnhandler()
             response = connHandler.execute_tapget(subContext, False)

--- a/astroquery/gaia/core.py
+++ b/astroquery/gaia/core.py
@@ -162,7 +162,7 @@ class GaiaClass(TapPlus):
         except HTTPError as err:
             log.error("Error logging out data server")
 
-    def load_data(self, ids, data_release=None, data_structure='INDIVIDUAL', retrieval_type="ALL", valid_data=True,
+    def load_data(self, ids, data_release=None, data_structure='INDIVIDUAL', retrieval_type="ALL", valid_data=False,
                   band=None, avoid_datatype_check=False, format="votable", output_file=None,
                   overwrite_output_file=False, verbose=False):
         """Loads the specified table
@@ -189,12 +189,10 @@ class GaiaClass(TapPlus):
             retrieval type identifier. For GAIA DR2 possible values are ['EPOCH_PHOTOMETRY']
             For future GAIA DR3 (Once published), possible values will be ['EPOC_PHOTOMETRY', 'RVS', 'XP_CONTINUOUS',
             'XP_SAMPLED', 'MCMC_GSPPHOT' or 'MCMC_MSC']
-        valid_data : bool, optional, default True
-            By default, the epoch photometry service returns only valid data,
-            that is, all data rows where flux is not null and
-            rejected_by_photometry flag is not true. In order to retrieve
-            all data associated to a given source without this filter,
-            this request parameter should be included (valid_data=False)
+        valid_data : bool, optional, default False
+            By default, the epoch photometry service returns all data associated to a given source.
+            In order to retrieve only valid data, that is, all data rows where flux is not null and
+            rejected_by_photometry flag is not true, this parameter should be included (valid_data=True)
         band : str, optional, default None, valid values: G, BP, RP
             By default, the epoch photometry service returns all the
             available photometry bands for the requested source.
@@ -250,9 +248,9 @@ class GaiaClass(TapPlus):
         params_dict = {}
 
         if not valid_data or str(retrieval_type) == 'ALL':
-            params_dict['VALID_DATA'] = "false"
-        elif valid_data:
             params_dict['VALID_DATA'] = "true"
+        elif valid_data:
+            params_dict['VALID_DATA'] = "false"
 
         if band is not None:
             if band != 'G' and band != 'BP' and band != 'RP':

--- a/astroquery/gaia/core.py
+++ b/astroquery/gaia/core.py
@@ -33,6 +33,7 @@ from astropy.table import Table
 from astropy import units as u
 import warnings
 from astroquery.exceptions import InputWarning
+from collections.abc import Iterable
 
 
 class GaiaClass(TapPlus):
@@ -925,10 +926,14 @@ class GaiaClass(TapPlus):
             connHandler = self._TapPlus__getconnhandler()
             response = connHandler.execute_tapget(subContext, False)
             if response.status == 200:
-                for line in response:
-                    string_message = line.decode("utf-8")
-                    print(string_message[string_message.index('=') + 1:])
-        except OSError as e:
+                if isinstance(response, Iterable):
+                    for line in response:
+                        try:
+                            print(line.decode("utf-8").split('=', 1)[1])
+                        except ValueError as e:
+                            print(e)
+                            pass
+        except OSError:
             print("Status messages could not be retrieved")
 
 

--- a/astroquery/gaia/core.py
+++ b/astroquery/gaia/core.py
@@ -45,6 +45,7 @@ class GaiaClass(TapPlus):
     MAIN_GAIA_TABLE_DEC = conf.MAIN_GAIA_TABLE_DEC
     ROW_LIMIT = conf.ROW_LIMIT
     VALID_DATALINK_RETRIEVAL_TYPES = conf.VALID_DATALINK_RETRIEVAL_TYPES
+    GAIA_MESSAGES = "notification?action=GetNotifications"
 
     def __init__(self, tap_plus_conn_handler=None,
                  datalink_handler=None,
@@ -52,7 +53,7 @@ class GaiaClass(TapPlus):
                  gaia_data_server='https://gea.esac.esa.int/',
                  tap_server_context="tap-server",
                  data_server_context="data-server",
-                 verbose=False, show_messages=True):
+                 verbose=False, show_server_messages=True):
         super(GaiaClass, self).__init__(url=gaia_tap_server,
                                         server_context=tap_server_context,
                                         tap_context="tap",
@@ -76,7 +77,7 @@ class GaiaClass(TapPlus):
             self.__gaiadata = datalink_handler
 
         # Enable notifications
-        if show_messages:
+        if show_server_messages:
             self.get_status_messages()
 
     def login(self, user=None, password=None, credentials_file=None,
@@ -921,18 +922,18 @@ class GaiaClass(TapPlus):
         the status of Gaia TAP
         """
         try:
-            print("parsing notification messages")
-            subContext = conf.GAIA_MESSAGES
+            subContext = self.GAIA_MESSAGES
             connHandler = self._TapPlus__getconnhandler()
             response = connHandler.execute_tapget(subContext, False)
             if response.status == 200:
                 if isinstance(response, Iterable):
                     for line in response:
+
                         try:
                             print(line.decode("utf-8").split('=', 1)[1])
                         except ValueError as e:
                             print(e)
-                        except IndexError as e:
+                        except IndexError:
                             print("Archive down for maintenance")
 
         except OSError:

--- a/astroquery/gaia/core.py
+++ b/astroquery/gaia/core.py
@@ -250,9 +250,9 @@ class GaiaClass(TapPlus):
         params_dict = {}
 
         if not valid_data or str(retrieval_type) == 'ALL':
-            params_dict['VALID_DATA'] = "true"
-        elif valid_data:
             params_dict['VALID_DATA'] = "false"
+        elif valid_data:
+            params_dict['VALID_DATA'] = "true"
 
         if band is not None:
             if band != 'G' and band != 'BP' and band != 'RP':
@@ -917,7 +917,7 @@ class GaiaClass(TapPlus):
 
     def get_status_messages(self):
         """Retrieve the messages to inform users about
-        the status of JWST TAP
+        the status of Gaia TAP
         """
         try:
             print("parsing notification messages")

--- a/astroquery/gaia/core.py
+++ b/astroquery/gaia/core.py
@@ -932,7 +932,9 @@ class GaiaClass(TapPlus):
                             print(line.decode("utf-8").split('=', 1)[1])
                         except ValueError as e:
                             print(e)
-                            pass
+                        except IndexError as e:
+                            print("Archive down for maintenance")
+
         except OSError:
             print("Status messages could not be retrieved")
 

--- a/astroquery/gaia/core.py
+++ b/astroquery/gaia/core.py
@@ -51,7 +51,7 @@ class GaiaClass(TapPlus):
                  gaia_data_server='https://gea.esac.esa.int/',
                  tap_server_context="tap-server",
                  data_server_context="data-server",
-                 verbose=False):
+                 verbose=False, show_messages=True):
         super(GaiaClass, self).__init__(url=gaia_tap_server,
                                         server_context=tap_server_context,
                                         tap_context="tap",
@@ -73,6 +73,10 @@ class GaiaClass(TapPlus):
                                       verbose=verbose)
         else:
             self.__gaiadata = datalink_handler
+
+        # Enable notifications
+        if show_messages:
+            self.get_status_messages()
 
     def login(self, user=None, password=None, credentials_file=None,
               verbose=False):
@@ -910,6 +914,21 @@ class GaiaClass(TapPlus):
                                         upload_resource=upload_resource,
                                         upload_table_name=upload_table_name,
                                         autorun=autorun)
+
+    def get_status_messages(self):
+        """Retrieve the messages to inform users about
+        the status of JWST TAP
+        """
+        try:
+            subContext = conf.GAIA_MESSAGES
+            connHandler = self._TapPlus__getconnhandler()
+            response = connHandler.execute_tapget(subContext, False)
+            if response.status == 200:
+                for line in response:
+                    string_message = line.decode("utf-8")
+                    print(string_message[string_message.index('=') + 1:])
+        except OSError as e:
+            print("Status messages could not be retrieved")
 
 
 Gaia = GaiaClass()

--- a/astroquery/gaia/core.py
+++ b/astroquery/gaia/core.py
@@ -190,9 +190,11 @@ class GaiaClass(TapPlus):
             For future GAIA DR3 (Once published), possible values will be ['EPOC_PHOTOMETRY', 'RVS', 'XP_CONTINUOUS',
             'XP_SAMPLED', 'MCMC_GSPPHOT' or 'MCMC_MSC']
         valid_data : bool, optional, default False
-            By default, the epoch photometry service returns all data associated to a given source.
-            In order to retrieve only valid data, that is, all data rows where flux is not null and
-            rejected_by_photometry flag is not true, this parameter should be included (valid_data=True)
+            By default, the epoch photometry service returns all available data, including
+            data rows where flux is null and/or the rejected_by_photometry flag is set to True.
+            In order to retrieve only valid data (data rows where flux is not null and/or the
+            rejected_by_photometry flag is set to False) this request parameter should be included
+            with valid_data=True.
         band : str, optional, default None, valid values: G, BP, RP
             By default, the epoch photometry service returns all the
             available photometry bands for the requested source.

--- a/astroquery/gaia/tests/test_gaiatap.py
+++ b/astroquery/gaia/tests/test_gaiatap.py
@@ -56,12 +56,12 @@ class TestTap:
                                 headers=None)
         connHandler.set_default_response(dummy_response)
 
-        # show_messages
+        # show_server_messages
         tableRequest = 'notification?action=GetNotifications'
         connHandler.set_response(tableRequest, dummy_response)
 
         tapplus = TapPlus("http://test:1111/tap", connhandler=connHandler)
-        tap = GaiaClass(connHandler, tapplus, show_messages=True)
+        tap = GaiaClass(connHandler, tapplus, show_server_messages=True)
 
     def test_query_object(self):
         conn_handler = DummyConnHandler()
@@ -79,12 +79,12 @@ class TestTap:
                                 headers=None)
         conn_handler.set_default_response(dummy_response)
 
-        # show_messages
+        # show_server_messages
         tableRequest = 'notification?action=GetNotifications'
         conn_handler.set_response(tableRequest, dummy_response)
 
         tapplus = TapPlus("http://test:1111/tap", connhandler=conn_handler)
-        tap = GaiaClass(conn_handler, tapplus, show_messages=True)
+        tap = GaiaClass(conn_handler, tapplus, show_server_messages=True)
         # Launch response: we use default response because the query contains
         # decimals
         response_launch_job = DummyResponse()
@@ -165,7 +165,7 @@ class TestTap:
     def test_query_object_async(self):
         conn_handler = DummyConnHandler()
         tapplus = TapPlus("http://test:1111/tap", connhandler=conn_handler)
-        tap = GaiaClass(conn_handler, tapplus, show_messages=False)
+        tap = GaiaClass(conn_handler, tapplus, show_server_messages=False)
         jobid = '12345'
         # Launch response
         response_launch_job = DummyResponse()
@@ -260,7 +260,7 @@ class TestTap:
     def test_cone_search_sync(self):
         conn_handler = DummyConnHandler()
         tapplus = TapPlus("http://test:1111/tap", connhandler=conn_handler)
-        tap = GaiaClass(conn_handler, tapplus, show_messages=False)
+        tap = GaiaClass(conn_handler, tapplus, show_server_messages=False)
         # Launch response: we use default response because the query contains
         # decimals
         response_launch_job = DummyResponse()
@@ -313,7 +313,7 @@ class TestTap:
     def test_cone_search_async(self):
         conn_handler = DummyConnHandler()
         tapplus = TapPlus("http://test:1111/tap", connhandler=conn_handler)
-        tap = GaiaClass(conn_handler, tapplus, show_messages=False)
+        tap = GaiaClass(conn_handler, tapplus, show_server_messages=False)
         jobid = '12345'
         # Launch response
         response_launch_job = DummyResponse()
@@ -420,7 +420,7 @@ class TestTap:
 
     def test_load_data(self):
         dummy_handler = DummyTapHandler()
-        tap = GaiaClass(dummy_handler, dummy_handler, show_messages=False)
+        tap = GaiaClass(dummy_handler, dummy_handler, show_server_messages=False)
 
         ids = "1,2,3,4"
         retrieval_type = "epoch_photometry"
@@ -459,7 +459,7 @@ class TestTap:
 
     def test_get_datalinks(self):
         dummy_handler = DummyTapHandler()
-        tap = GaiaClass(dummy_handler, dummy_handler, show_messages=False)
+        tap = GaiaClass(dummy_handler, dummy_handler, show_server_messages=False)
         ids = ["1", "2", "3", "4"]
         verbose = True
         parameters = {}
@@ -471,7 +471,7 @@ class TestTap:
     def test_xmatch(self):
         conn_handler = DummyConnHandler()
         tapplus = TapPlus("http://test:1111/tap", connhandler=conn_handler)
-        tap = GaiaClass(conn_handler, tapplus, show_messages=False)
+        tap = GaiaClass(conn_handler, tapplus, show_server_messages=False)
         jobid = '12345'
         # Launch response
         response_launch_job = DummyResponse()
@@ -619,7 +619,7 @@ class TestTap:
     def test_login(self, mock_login):
         conn_handler = DummyConnHandler()
         tapplus = TapPlus("http://test:1111/tap", connhandler=conn_handler)
-        tap = GaiaClass(conn_handler, tapplus, show_messages=False)
+        tap = GaiaClass(conn_handler, tapplus, show_server_messages=False)
         tap.login("user", "password")
         assert (mock_login.call_count == 2)
         mock_login.side_effect = HTTPError("Login error")
@@ -631,7 +631,7 @@ class TestTap:
     def test_login_gui(self, mock_login_gui, mock_login):
         conn_handler = DummyConnHandler()
         tapplus = TapPlus("http://test:1111/tap", connhandler=conn_handler)
-        tap = GaiaClass(conn_handler, tapplus, show_messages=False)
+        tap = GaiaClass(conn_handler, tapplus, show_server_messages=False)
         tap.login_gui()
         assert (mock_login_gui.call_count == 1)
         mock_login_gui.side_effect = HTTPError("Login error")
@@ -642,7 +642,7 @@ class TestTap:
     def test_logout(self, mock_logout):
         conn_handler = DummyConnHandler()
         tapplus = TapPlus("http://test:1111/tap", connhandler=conn_handler)
-        tap = GaiaClass(conn_handler, tapplus, show_messages=False)
+        tap = GaiaClass(conn_handler, tapplus, show_server_messages=False)
         tap.logout()
         assert (mock_logout.call_count == 2)
         mock_logout.side_effect = HTTPError("Login error")

--- a/astroquery/gaia/tests/test_gaiatap.py
+++ b/astroquery/gaia/tests/test_gaiatap.py
@@ -41,10 +41,50 @@ def data_path(filename):
 
 class TestTap:
 
+    def test_show_message(self):
+        connHandler = DummyConnHandler()
+
+        dummy_response = DummyResponse()
+        dummy_response.set_status_code(200)
+        dummy_response.set_message("OK")
+
+        message_text = "1653401204784D[type: -100,-1]=Gaia dev is under maintenance"
+
+        dummy_response.set_data(method='GET',
+                                context=None,
+                                body=message_text,
+                                headers=None)
+        connHandler.set_default_response(dummy_response)
+
+        # show_messages
+        tableRequest = 'notification?action=GetNotifications'
+        connHandler.set_response(tableRequest, dummy_response)
+
+        tapplus = TapPlus("http://test:1111/tap", connhandler=connHandler)
+        tap = GaiaClass(connHandler, tapplus, show_messages=True)
+
     def test_query_object(self):
         conn_handler = DummyConnHandler()
+        # Launch response: we use default response because the query contains
+        # decimals
+        dummy_response = DummyResponse()
+        dummy_response.set_status_code(200)
+        dummy_response.set_message("OK")
+
+        message_text = "1653401204784D[type: -100,-1]=Gaia dev is under maintenance"
+
+        dummy_response.set_data(method='GET',
+                                context=None,
+                                body=message_text,
+                                headers=None)
+        conn_handler.set_default_response(dummy_response)
+
+        # show_messages
+        tableRequest = 'notification?action=GetNotifications'
+        conn_handler.set_response(tableRequest, dummy_response)
+
         tapplus = TapPlus("http://test:1111/tap", connhandler=conn_handler)
-        tap = GaiaClass(conn_handler, tapplus, show_messages=False)
+        tap = GaiaClass(conn_handler, tapplus, show_messages=True)
         # Launch response: we use default response because the query contains
         # decimals
         response_launch_job = DummyResponse()
@@ -395,7 +435,7 @@ class TestTap:
             output_file = os.path.abspath(path_to_end_with)
 
         params_dict = {}
-        params_dict['VALID_DATA'] = "false"
+        params_dict['VALID_DATA'] = "true"
         params_dict['ID'] = ids
         params_dict['FORMAT'] = str(format)
         params_dict['RETRIEVAL_TYPE'] = str(retrieval_type)

--- a/astroquery/gaia/tests/test_gaiatap.py
+++ b/astroquery/gaia/tests/test_gaiatap.py
@@ -44,7 +44,7 @@ class TestTap:
     def test_query_object(self):
         conn_handler = DummyConnHandler()
         tapplus = TapPlus("http://test:1111/tap", connhandler=conn_handler)
-        tap = GaiaClass(conn_handler, tapplus)
+        tap = GaiaClass(conn_handler, tapplus, show_messages=False)
         # Launch response: we use default response because the query contains
         # decimals
         response_launch_job = DummyResponse()
@@ -125,7 +125,7 @@ class TestTap:
     def test_query_object_async(self):
         conn_handler = DummyConnHandler()
         tapplus = TapPlus("http://test:1111/tap", connhandler=conn_handler)
-        tap = GaiaClass(conn_handler, tapplus)
+        tap = GaiaClass(conn_handler, tapplus, show_messages=False)
         jobid = '12345'
         # Launch response
         response_launch_job = DummyResponse()
@@ -220,7 +220,7 @@ class TestTap:
     def test_cone_search_sync(self):
         conn_handler = DummyConnHandler()
         tapplus = TapPlus("http://test:1111/tap", connhandler=conn_handler)
-        tap = GaiaClass(conn_handler, tapplus)
+        tap = GaiaClass(conn_handler, tapplus, show_messages=False)
         # Launch response: we use default response because the query contains
         # decimals
         response_launch_job = DummyResponse()
@@ -273,7 +273,7 @@ class TestTap:
     def test_cone_search_async(self):
         conn_handler = DummyConnHandler()
         tapplus = TapPlus("http://test:1111/tap", connhandler=conn_handler)
-        tap = GaiaClass(conn_handler, tapplus)
+        tap = GaiaClass(conn_handler, tapplus, show_messages=False)
         jobid = '12345'
         # Launch response
         response_launch_job = DummyResponse()
@@ -380,7 +380,7 @@ class TestTap:
 
     def test_load_data(self):
         dummy_handler = DummyTapHandler()
-        tap = GaiaClass(dummy_handler, dummy_handler)
+        tap = GaiaClass(dummy_handler, dummy_handler, show_messages=False)
 
         ids = "1,2,3,4"
         retrieval_type = "epoch_photometry"
@@ -395,7 +395,7 @@ class TestTap:
             output_file = os.path.abspath(path_to_end_with)
 
         params_dict = {}
-        params_dict['VALID_DATA'] = "true"
+        params_dict['VALID_DATA'] = "false"
         params_dict['ID'] = ids
         params_dict['FORMAT'] = str(format)
         params_dict['RETRIEVAL_TYPE'] = str(retrieval_type)
@@ -419,7 +419,7 @@ class TestTap:
 
     def test_get_datalinks(self):
         dummy_handler = DummyTapHandler()
-        tap = GaiaClass(dummy_handler, dummy_handler)
+        tap = GaiaClass(dummy_handler, dummy_handler, show_messages=False)
         ids = ["1", "2", "3", "4"]
         verbose = True
         parameters = {}
@@ -431,7 +431,7 @@ class TestTap:
     def test_xmatch(self):
         conn_handler = DummyConnHandler()
         tapplus = TapPlus("http://test:1111/tap", connhandler=conn_handler)
-        tap = GaiaClass(conn_handler, tapplus)
+        tap = GaiaClass(conn_handler, tapplus, show_messages=False)
         jobid = '12345'
         # Launch response
         response_launch_job = DummyResponse()
@@ -579,7 +579,7 @@ class TestTap:
     def test_login(self, mock_login):
         conn_handler = DummyConnHandler()
         tapplus = TapPlus("http://test:1111/tap", connhandler=conn_handler)
-        tap = GaiaClass(conn_handler, tapplus)
+        tap = GaiaClass(conn_handler, tapplus, show_messages=False)
         tap.login("user", "password")
         assert (mock_login.call_count == 2)
         mock_login.side_effect = HTTPError("Login error")
@@ -591,7 +591,7 @@ class TestTap:
     def test_login_gui(self, mock_login_gui, mock_login):
         conn_handler = DummyConnHandler()
         tapplus = TapPlus("http://test:1111/tap", connhandler=conn_handler)
-        tap = GaiaClass(conn_handler, tapplus)
+        tap = GaiaClass(conn_handler, tapplus, show_messages=False)
         tap.login_gui()
         assert (mock_login_gui.call_count == 1)
         mock_login_gui.side_effect = HTTPError("Login error")
@@ -602,7 +602,7 @@ class TestTap:
     def test_logout(self, mock_logout):
         conn_handler = DummyConnHandler()
         tapplus = TapPlus("http://test:1111/tap", connhandler=conn_handler)
-        tap = GaiaClass(conn_handler, tapplus)
+        tap = GaiaClass(conn_handler, tapplus, show_messages=False)
         tap.logout()
         assert (mock_logout.call_count == 2)
         mock_logout.side_effect = HTTPError("Login error")


### PR DESCRIPTION
Dear Astroquery Team,
This pull request contains a new feature in the Gaia module and an update in the default value of one of the parameters of the method 'load_data'
- Now the users of the Astroquery/Gaia module will know if there is a planned downtime of the Archive or if there is any issue on-going on the Gaia archive.
- For the method 'load_data' it has been updated the default value of the parameter 'valid_data' to 'False'.  With this change the epoch photometry service will returns all data associated to a given source. This change also mimics the behaviours of the current UI of the archive.

Thank you in advance,
all the best,
Maria