### PR TITLE
MNT: Adding more dev dependency testing

### DIFF
--- a/.github/workflows/ci_tests.yml
+++ b/.github/workflows/ci_tests.yml
@@ -39,6 +39,12 @@ jobs:
             toxenv: py310-test-alldeps-devdeps-cov
             toxargs: -v
 
+          - name: pre-repease dependencies with all dependencies
+            os: ubuntu-latest
+            python: '3.10'
+            toxenv: py310-test-alldeps-predeps
+            toxargs: -v
+
           - name: Python 3.8 with all optional dependencies (MacOS X)
             os: macos-latest
             python: 3.8

--- a/.github/workflows/ci_tests.yml
+++ b/.github/workflows/ci_tests.yml
@@ -33,10 +33,10 @@ jobs:
             toxenv: py37-test-oldestdeps
             toxargs: -v
 
-          - name: astropy dev with all dependencies with coverage
+          - name: dev dependencies with all dependencies with coverage
             os: ubuntu-latest
             python: '3.10'
-            toxenv: py310-test-alldeps-devastropy-cov
+            toxenv: py310-test-alldeps-devdeps-cov
             toxargs: -v
 
           - name: Python 3.8 with all optional dependencies (MacOS X)

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 envlist =
-    py{37,38,39,310}-test{,-alldeps,-oldestdeps}{,-devastropy}{,-cov}
+    py{37,38,39,310}-test{,-alldeps,-oldestdeps,-devdeps,-predeps}{,-cov}
     codestyle
     build_docs
 requires =
@@ -27,12 +27,11 @@ changedir = .tmp/{envname}
 description = run tests
 
 deps =
-    devastropy: git+https://github.com/astropy/astropy.git#egg=astropy
+    devdeps: git+https://github.com/astropy/astropy.git#egg=astropy
+    devdeps: git+https://github.com/astropy/pyvo.git#egg=pyvo
 
-# TODO: Add more versions to oldestdeps. numpy<1.15 could not be installed
-# in CI, a much newer version was pulled in instead, thus setting
-# minimum numpy to 1.15. mpl while not a dependency, it's required for the
-# tests, and would pull up a newer numpy version if not pinned.
+# TODO: Add more versions to oldestdeps.
+# mpl while not a dependency, it's required for the tests, and would pull up a newer numpy version if not pinned.
 
     oldestdeps: astropy==4.0
     oldestdeps: numpy==1.16
@@ -50,6 +49,18 @@ commands =
     !cov: pytest --pyargs astroquery {toxinidir}/docs --ignore={toxinidir}/docs/gallery* {posargs}
     cov:  pytest --pyargs astroquery {toxinidir}/docs --ignore={toxinidir}/docs/gallery* --cov astroquery --cov-config={toxinidir}/setup.cfg {posargs}
     cov: coverage xml -o {toxinidir}/coverage.xml
+
+[testenv:predeps]
+description = run tests with pre-releases
+pip_pre = True
+
+deps = {[testenv]deps}
+passenv = {[testenv]passenv}
+pypi_filter = {[testenv]pypi_filter}
+changedir = {[testenv]changedir}
+extras = {[testenv]extras}
+commands = {[testenv]commands}
+
 
 [testenv:codestyle]
 changedir = {toxinidir}


### PR DESCRIPTION
The main motivation here is to provide downstream testing for pyvo during their dev cycle