### PR TITLE
Fix molecule parsing issue for CDMS

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -24,7 +24,7 @@ jplsbdb
 - Fix a bug for jplsdbd query when the returned physical quantity contains
   a unit with exponential. [#2377]
 
-linelists/cdms
+linelists.cdms
 ^^^^^^^^^^^^^^
 
 - Fix issues with the line name parser and the line data parser; the original

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -24,6 +24,11 @@ jplsbdb
 - Fix a bug for jplsdbd query when the returned physical quantity contains
   a unit with exponential. [#2377]
 
+linelists/cdms
+^^^^^^^^^^^^^^
+
+- Fix issues with the line name parser and the line data parser; the original
+  implementation was incomplete. [#2385]
 
 Infrastructure, Utility and Other Changes and Additions
 -------------------------------------------------------

--- a/astroquery/linelists/cdms/core.py
+++ b/astroquery/linelists/cdms/core.py
@@ -252,7 +252,6 @@ class CDMSClass(BaseQuery):
                             col_starts=list(starts.values()),
                             format='fixed_width', fast_reader=False)
 
-
         result['FREQ'].unit = u.MHz
         result['ERR'].unit = u.MHz
 
@@ -267,7 +266,6 @@ class CDMSClass(BaseQuery):
                     intcol = np.array(list(map(parse_letternumber, result[qnind])),
                                       dtype=int)
                     result[qnind] = intcol
-
 
         # if there is a crash at this step, something went wrong with the query
         # and the _last_query_temperature was not set.  This shouldn't ever

--- a/astroquery/linelists/cdms/setup_package.py
+++ b/astroquery/linelists/cdms/setup_package.py
@@ -9,7 +9,7 @@ def get_package_data():
     paths_test = [os.path.join('data', 'CO.data'),
                   os.path.join('data', 'HC7S.data'),
                   os.path.join('data', 'post_response.html'),
-                 ]
+                  ]
     paths_data = [os.path.join('data', 'catdir.cat')]
 
     return {'astroquery.linelists.cdms.tests': paths_test,

--- a/astroquery/linelists/cdms/setup_package.py
+++ b/astroquery/linelists/cdms/setup_package.py
@@ -7,7 +7,9 @@ import os
 def get_package_data():
 
     paths_test = [os.path.join('data', 'CO.data'),
-                  os.path.join('data', 'HC7S.data')]
+                  os.path.join('data', 'HC7S.data'),
+                  os.path.join('data', 'post_response.html'),
+                 ]
     paths_data = [os.path.join('data', 'catdir.cat')]
 
     return {'astroquery.linelists.cdms.tests': paths_test,

--- a/astroquery/linelists/cdms/setup_package.py
+++ b/astroquery/linelists/cdms/setup_package.py
@@ -6,7 +6,8 @@ import os
 
 def get_package_data():
 
-    paths_test = [os.path.join('data', 'CO.data')]
+    paths_test = [os.path.join('data', 'CO.data'),
+                  os.path.join('data', 'HC7S.data')]
     paths_data = [os.path.join('data', 'catdir.cat')]
 
     return {'astroquery.linelists.cdms.tests': paths_test,

--- a/astroquery/linelists/cdms/tests/data/HC7S.data
+++ b/astroquery/linelists/cdms/tests/data/HC7S.data
@@ -1,0 +1,16 @@
+<!DOCTYPE html
+	PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN"
+	 "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml" lang="en-US" xml:lang="en-US">
+<head>
+<title>Untitled Document</title>
+<meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1" />
+</head>
+<body>
+<pre>
+  100694.0650     0.4909    -3.9202 2  210.7681255 117501 224C6-1C7C7    C5 1C6C6        HC7S
+  100694.0675     0.4909    -3.9237 2  210.7682253 117501 224C6-1C7C6    C5 1C6C5        HC7S
+  100696.6906     0.4909    -3.9202 2  210.7790255 117501 224C6 1C7C7    C5-1C6C6        HC7S
+  100696.6933     0.4909    -3.9237 2  210.7789253 117501 224C6 1C7C6    C5-1C6C5        HC7S
+  100755.6075     0.4921    -4.0157 2  255.1740253 117501 224C7-1C7C6    C6 1C6C5        HC7S
+</pre></body></html>

--- a/astroquery/linelists/cdms/tests/data/post_response.html
+++ b/astroquery/linelists/cdms/tests/data/post_response.html
@@ -1,0 +1,9 @@
+<html><head>
+</head>
+<frameset rows="60,*" bordercolor="#ffffff">
+<frame src="/classic/predictions/cdmstabhead.html" border=0 frameborder=0 framespacing=0 marginheight=30 marginwidth=16 scrolling=no>
+<frame src="/classic/predictions/cdmscache/cdmstab{replace}.html" border=0 frameborder=0 framespacing=0 marginheight=0 marginwidth=12 scrolling=yes>
+</frameset>
+<body>Sorry, your browser does not support frames!<br>
+<a href="/classic/predictions/cdmscache/cdmstab{replace}.html">tabular</a></body>
+</html>

--- a/astroquery/linelists/cdms/tests/test_cdms.py
+++ b/astroquery/linelists/cdms/tests/test_cdms.py
@@ -10,6 +10,7 @@ colname_set = set(['FREQ', 'ERR', 'LGINT', 'DR', 'ELO', 'GUP', 'TAG', 'QNFMT',
                    'Ju', 'Jl', "vu", "F1u", "F2u", "F3u", "vl", "Ku", "Kl",
                    "F1l", "F2l", "F3l", "name", "MOLWT", "Lab"])
 
+
 def data_path(filename):
 
     data_dir = os.path.join(os.path.dirname(__file__), 'data')

--- a/astroquery/linelists/cdms/tests/test_cdms.py
+++ b/astroquery/linelists/cdms/tests/test_cdms.py
@@ -4,8 +4,11 @@ import os
 
 from astropy import units as u
 from astropy.table import Table
-from astroquery.linelists.cdms import CDMS
+from astroquery.linelists.cdms.core import CDMS, parse_letternumber
 
+colname_set = set(['FREQ', 'ERR', 'LGINT', 'DR', 'ELO', 'GUP', 'TAG', 'QNFMT',
+                   'Ju', 'Jl', "vu", "F1u", "F2u", "F3u", "vl", "Ku", "Kl",
+                   "F1l", "F2l", "F3l", "name", "MOLWT", "Lab"])
 
 def data_path(filename):
 
@@ -57,9 +60,54 @@ def test_query():
     tbl = CDMS._parse_result(response)
     assert isinstance(tbl, Table)
     assert len(tbl) == 8
-    assert set(tbl.keys()) == set(['FREQ', 'ERR', 'LGINT', 'DR', 'ELO', 'GUP',
-                                   'TAG', 'QNFMT', 'Ju', 'Jl', "vu", "vl", "Ku", "Kl", "F", "name"])
+    assert set(tbl.keys()) == colname_set
 
     assert tbl['FREQ'][0] == 115271.2018
     assert tbl['ERR'][0] == .0005
     assert tbl['LGINT'][0] == -7.1425
+
+
+def test_parseletternumber():
+    """
+    Very Important:
+    Exactly two characters are available for each quantum number. Therefore, half
+    integer quanta are rounded up ! In addition, capital letters are used to
+    indicate quantum numbers larger than 99. E. g. A0 is 100, Z9 is 359. Small
+    types are used to signal corresponding negative quantum numbers.
+    """
+
+    # examples from the docs
+    assert parse_letternumber("A0") == 100
+    assert parse_letternumber("Z9") == 359
+
+    # inferred?
+    assert parse_letternumber("z9") == -359
+    assert parse_letternumber("ZZ") == 3535
+
+
+def test_hc7s():
+    """
+    Test for a very complicated molecule
+
+    CDMS.query_lines_async(100*u.GHz, 100.755608*u.GHz, molecule='HC7S', parse_name_locally=True)
+    """
+
+    response = MockResponseSpec('HC7S.data')
+    tbl = CDMS._parse_result(response)
+    assert isinstance(tbl, Table)
+    assert len(tbl) == 5
+    assert set(tbl.keys()) == colname_set
+
+    assert tbl['FREQ'][0] == 100694.065
+    assert tbl['ERR'][0] == 0.4909
+    assert tbl['LGINT'][0] == -3.9202
+    assert tbl['MOLWT'][0] == 117
+
+    assert tbl['Ju'][0] == 126
+    assert tbl['Jl'][0] == 125
+    assert tbl['vu'][0] == 127
+    assert tbl['vl'][0] == 126
+    assert tbl['Ku'][0] == -1
+    assert tbl['Kl'][0] == 1
+    assert tbl['F1u'][0] == 127
+    assert tbl['F1l'][0] == 126

--- a/astroquery/linelists/cdms/tests/test_cdms_remote.py
+++ b/astroquery/linelists/cdms/tests/test_cdms_remote.py
@@ -53,3 +53,8 @@ def test_remote_regex():
                                    'TAG', 'QNFMT', 'Ju', 'Jl', "vu", "vl", "Ku", "Kl", "F", "name"])
 
     assert set(tbl['name']) == {'H2CN', 'HC-13-N, v=0'}
+
+
+@pytest.mark.remote_data
+def test_2375():
+    pass

--- a/astroquery/linelists/cdms/tests/test_cdms_remote.py
+++ b/astroquery/linelists/cdms/tests/test_cdms_remote.py
@@ -4,6 +4,7 @@ from astropy import units as u
 from astropy.table import Table
 
 from astroquery.linelists.cdms import CDMS
+from .test_cdms import colname_set
 
 
 @pytest.mark.remote_data
@@ -15,8 +16,8 @@ def test_remote():
                            molecule="018505 H2O+")
     assert isinstance(tbl, Table)
     assert len(tbl) == 116
-    assert set(tbl.keys()) == set(['FREQ', 'ERR', 'LGAIJ', 'DR', 'ELO', 'GUP',
-                                   'TAG', 'QNFMT', 'Ju', 'Jl', "vu", "vl", "Ku", "Kl", "F", "name"])
+    # when 'temperature_for_intensity = 0', we use LGAIJ instead of LGINT
+    assert set(tbl.keys()) == (colname_set | {'LGAIJ'}) - {'LGINT'}
 
     assert tbl['FREQ'][0] == 505366.7875
     assert tbl['ERR'][0] == 49.13
@@ -32,8 +33,7 @@ def test_remote_300K():
                            molecule="018505 H2O+")
     assert isinstance(tbl, Table)
     assert len(tbl) == 116
-    assert set(tbl.keys()) == set(['FREQ', 'ERR', 'LGINT', 'DR', 'ELO', 'GUP',
-                                   'TAG', 'QNFMT', 'Ju', 'Jl', "vu", "vl", "Ku", "Kl", "F", "name"])
+    assert set(tbl.keys()) == colname_set
 
     assert tbl['FREQ'][0] == 505366.7875
     assert tbl['ERR'][0] == 49.13
@@ -50,8 +50,7 @@ def test_remote_regex():
 
     assert isinstance(tbl, Table)
     assert len(tbl) == 557
-    assert set(tbl.keys()) == set(['FREQ', 'ERR', 'LGINT', 'DR', 'ELO', 'GUP',
-                                   'TAG', 'QNFMT', 'Ju', 'Jl', "vu", "vl", "Ku", "Kl", "F", "name"])
+    assert set(tbl.keys()) == colname_set
 
     assert set(tbl['name']) == {'H2CN', 'HC-13-N, v=0'}
 

--- a/astroquery/linelists/cdms/tests/test_cdms_remote.py
+++ b/astroquery/linelists/cdms/tests/test_cdms_remote.py
@@ -56,7 +56,7 @@ def test_remote_regex():
 
 
 @pytest.mark.remote_data
-def test_2375():
+def test_molecule_with_parens():
     """
     Regression test for 2375
     """

--- a/astroquery/linelists/cdms/tests/test_cdms_remote.py
+++ b/astroquery/linelists/cdms/tests/test_cdms_remote.py
@@ -1,4 +1,5 @@
 import pytest
+import numpy as np
 from astropy import units as u
 from astropy.table import Table
 
@@ -57,4 +58,18 @@ def test_remote_regex():
 
 @pytest.mark.remote_data
 def test_2375():
-    pass
+    """
+    Regression test for 2375
+    """
+    tbl = CDMS.query_lines(232567.224454 * u.MHz, 234435.809432 * u.MHz, molecule='H2C(CN)2', parse_name_locally=True)
+
+    assert len(tbl) == 49
+
+    MC = np.ma.core.MaskedConstant()
+
+    for col, val in zip(tbl[0].colnames,
+                        (232588.7246, 0.2828, -4.1005, 3, '293.85404', 45, 66, 506, 303, 44, 14, 30, MC, MC, MC, 45, 13, 33, MC, MC, MC, 'H2C(CN)2', False)):
+        if val is MC:
+            assert tbl[0][col].mask
+        else:
+            assert tbl[0][col] == val

--- a/docs/linelists/cdms/cdms.rst
+++ b/docs/linelists/cdms/cdms.rst
@@ -33,18 +33,18 @@ each setting yields:
    ...                             min_strength=-500,
    ...                             molecule="028503 CO",
    ...                             get_query_payload=False)
-   >>> response.pprint(max_width=100)
-        FREQ     ERR    LGINT   DR   ELO    GUP  TAG   QNFMT  Ju  Ku  vu  Jl  Kl  vl  F    name
-        MHz      MHz   MHz nm2      1 / cm
-    ----------- ------ ------- --- -------- --- ------ ----- --- --- --- --- --- --- --- -------
-    115271.2018 0.0005 -5.0105   2      0.0   3 -28503   101   1  --  --  --  --  --   0 CO, v=0
-       230538.0 0.0005 -4.1197   2    3.845   5 -28503   101   2  --  --  --  --  --   1 CO, v=0
-    345795.9899 0.0005 -3.6118   2   11.535   7 -28503   101   3  --  --  --  --  --   2 CO, v=0
-    461040.7682 0.0005 -3.2657   2  23.0695   9 -28503   101   4  --  --  --  --  --   3 CO, v=0
-    576267.9305 0.0005 -3.0118   2  38.4481  11 -28503   101   5  --  --  --  --  --   4 CO, v=0
-    691473.0763 0.0005 -2.8193   2  57.6704  13 -28503   101   6  --  --  --  --  --   5 CO, v=0
-     806651.806  0.005 -2.6716   2  80.7354  15 -28503   101   7  --  --  --  --  --   6 CO, v=0
-       921799.7  0.005  -2.559   2 107.6424  17 -28503   101   8  --  --  --  --  --   7 CO, v=0
+   >>> response.pprint(max_width=120)
+        FREQ     ERR    LGINT   DR   ELO    GUP MOLWT TAG QNFMT  Ju  Ku  vu F1u F2u F3u  Jl  Kl  vl F1l F2l F3l   name  Lab
+        MHz      MHz   MHz nm2      1 / cm        u
+    ----------- ------ ------- --- -------- --- ----- --- ----- --- --- --- --- --- --- --- --- --- --- --- --- ------- ----
+    115271.2018 0.0005 -5.0105   2      0.0   3    28 503   101   1  --  --  --  --  --   0  --  --  --  --  -- CO, v=0 True
+       230538.0 0.0005 -4.1197   2    3.845   5    28 503   101   2  --  --  --  --  --   1  --  --  --  --  -- CO, v=0 True
+    345795.9899 0.0005 -3.6118   2   11.535   7    28 503   101   3  --  --  --  --  --   2  --  --  --  --  -- CO, v=0 True
+    461040.7682 0.0005 -3.2657   2  23.0695   9    28 503   101   4  --  --  --  --  --   3  --  --  --  --  -- CO, v=0 True
+    576267.9305 0.0005 -3.0118   2  38.4481  11    28 503   101   5  --  --  --  --  --   4  --  --  --  --  -- CO, v=0 True
+    691473.0763 0.0005 -2.8193   2  57.6704  13    28 503   101   6  --  --  --  --  --   5  --  --  --  --  -- CO, v=0 True
+     806651.806  0.005 -2.6716   2  80.7354  15    28 503   101   7  --  --  --  --  --   6  --  --  --  --  -- CO, v=0 True
+       921799.7  0.005  -2.559   2 107.6424  17    28 503   101   8  --  --  --  --  --   7  --  --  --  --  -- CO, v=0 True
 
 
 
@@ -80,16 +80,23 @@ The units of the columns of the query can be displayed by calling
       DR   int64               Column     0
      ELO float64  1 / cm       Column     0
      GUP   int64               Column     0
+   MOLWT   int64       u       Column     0
      TAG   int64               Column     0
    QNFMT   int64               Column     0
       Ju   int64               Column     0
       Ku   int64         MaskedColumn     8
       vu   int64         MaskedColumn     8
-      Jl   int64         MaskedColumn     8
+     F1u   int64         MaskedColumn     8
+     F2u   int64         MaskedColumn     8
+     F3u   int64         MaskedColumn     8
+      Jl   int64               Column     0
       Kl   int64         MaskedColumn     8
       vl   int64         MaskedColumn     8
-       F   int64               Column     0
+     F1l   int64         MaskedColumn     8
+     F2l   int64         MaskedColumn     8
+     F3l   int64         MaskedColumn     8
     name    str7               Column     0
+     Lab    bool               Column     0
 
 These come in handy for converting to other units easily, an example using a
 simplified version of the data above is shown below:
@@ -100,14 +107,14 @@ simplified version of the data above is shown below:
         FREQ     ERR     ELO
         MHz      MHz    1 / cm
     ----------- ------ --------
-   115271.2018 0.0005      0.0
-      230538.0 0.0005    3.845
-   345795.9899 0.0005   11.535
-   461040.7682 0.0005  23.0695
-   576267.9305 0.0005  38.4481
-   691473.0763 0.0005  57.6704
-    806651.806  0.005  80.7354
-      921799.7  0.005 107.6424
+    115271.2018 0.0005      0.0
+       230538.0 0.0005    3.845
+    345795.9899 0.0005   11.535
+    461040.7682 0.0005  23.0695
+    576267.9305 0.0005  38.4481
+    691473.0763 0.0005  57.6704
+     806651.806  0.005  80.7354
+       921799.7  0.005 107.6424
    >>> response['FREQ'].quantity
     <Quantity [115271.2018, 230538.    , 345795.9899, 461040.7682, 576267.9305,
                691473.0763, 806651.806 , 921799.7   ] MHz>


### PR DESCRIPTION
WIP: this fixes only half the problem.  Tests are needed.

Problem is described in #2375: there are molecules with `()`'s in the names that break the regex.  The current fix escapes those automatically.  

There's a second problem: the fixed-width parser fails for some subset of molecules.  Todo:

- [x] figure out what the correct parsing is for H2C(CN)2 (it is not obvious!)
- [x] find a generalized way to parse different molecular files (there does not appear to be a header for any of them?)