### PR TITLE
Adding warning about non-functioning NRAO module

### DIFF
--- a/astroquery/nrao/__init__.py
+++ b/astroquery/nrao/__init__.py
@@ -4,6 +4,13 @@ Module to query the NRAO Data Archive for observation summaries.
 """
 from astropy import config as _config
 
+import warnings
+
+# Remove module altogether if API update is not done in 6 months (2022-11-02).
+warnings.warn("The legacy NRAO archive this module uses has been retired causing astroquery.nrao to be "
+              "broken. We will remove this exception once the sufficient updates are done to use the new "
+              "NRAO archive API.")
+
 
 class Conf(_config.ConfigNamespace):
     """

--- a/astroquery/nrao/__init__.py
+++ b/astroquery/nrao/__init__.py
@@ -8,7 +8,7 @@ import warnings
 
 # Remove module altogether if API update is not done in 6 months (2022-11-02).
 warnings.warn("The legacy NRAO archive this module uses has been retired causing astroquery.nrao to be "
-              "broken. We will remove this exception once the sufficient updates are done to use the new "
+              "broken. We will remove this exception once sufficient updates are done to use the new "
               "NRAO archive API.")
 
 

--- a/astroquery/nrao/core.py
+++ b/astroquery/nrao/core.py
@@ -9,7 +9,6 @@ import keyring
 
 from io import BytesIO
 
-import numpy as np
 import astropy.units as u
 import astropy.io.votable as votable
 from astropy import coordinates

--- a/astroquery/nrao/tests/test_nrao.py
+++ b/astroquery/nrao/tests/test_nrao.py
@@ -7,6 +7,10 @@ import pytest
 import astropy.units as u
 from astropy.table import Table
 
+# Skip tests in this file until the new API is implemented:
+# https://github.com/astropy/astroquery/issues/2316
+pytest.skip(allow_module_level=True)
+
 from ... import nrao
 from astroquery.utils.mocks import MockResponse
 from ...utils import commons

--- a/astroquery/nrao/tests/test_nrao_remote.py
+++ b/astroquery/nrao/tests/test_nrao_remote.py
@@ -6,6 +6,10 @@ import astropy.coordinates as coord
 from astropy.table import Table
 from astropy import units as u
 
+# Skip tests in this file until the new API is implemented:
+# https://github.com/astropy/astroquery/issues/2316
+pytest.skip(allow_module_level=True)
+
 from astroquery.utils.commons import ASTROPY_LT_4_1
 from ... import nrao
 

--- a/docs/nrao/nrao.rst
+++ b/docs/nrao/nrao.rst
@@ -1,3 +1,7 @@
+.. doctest-skip-all
+.. # Skip tests in this file until the new API is implemented:
+.. # https://github.com/astropy/astroquery/issues/2316
+
 .. _astroquery.nrao:
 
 ********************************


### PR DESCRIPTION
I suggest putting on a 6-months duration for this warning and removing the module after that, unless the updates as per #2316 are done by then.

I don't add a changelog now but also leave off the label, the non-functioning of the module needs to be mentioned if this ends up in a release without the updates PR.