### PR TITLE
MNT: cleanup deprecations and obsolte checks

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -13,6 +13,11 @@ hsa
 Service fixes and enhancements
 ------------------------------
 
+cadc
+^^^^
+
+- Deprecated keywords and ``run_query`` method have been removed. [#2389]
+
 casda
 ^^^^^
 

--- a/astroquery/cadc/core.py
+++ b/astroquery/cadc/core.py
@@ -70,8 +70,7 @@ class CadcClass(BaseQuery):
     CADCLOGIN_SERVICE_URI = conf.CADCLOGIN_SERVICE_URI
     TIMEOUT = conf.TIMEOUT
 
-    def __init__(self, url=None, tap_plus_handler=None, verbose=None,
-                 auth_session=None):
+    def __init__(self, url=None, auth_session=None):
         """
         Initialize Cadc object
 
@@ -79,8 +78,6 @@ class CadcClass(BaseQuery):
         ----------
         url : str, optional, default 'None;
             a url to use instead of the default
-        tap_plus_handler : deprecated
-        verbose : deprecated
         auth_session: `requests.Session` or `pyvo.auth.authsession.AuthSession`
             A existing authenticated session containing the appropriate
             credentials to be used by the client to communicate with the
@@ -90,10 +87,6 @@ class CadcClass(BaseQuery):
         -------
         Cadc object
         """
-        if tap_plus_handler:
-            raise AttributeError('tap handler no longer supported')
-        if verbose is not None:
-            warnings.warn('verbose deprecated since version 0.4.0')
 
         super(CadcClass, self).__init__()
         self.baseurl = url
@@ -202,19 +195,12 @@ class CadcClass(BaseQuery):
                     self.cadctap._session.cookies.set(
                         CADC_COOKIE_PREFIX, cookie)
 
-    def logout(self, verbose=None):
+    def logout(self):
         """
         Logout. Anonymous access with all the subsequent use of the
         object. Note that the original session is not affected (in case
         it was passed when the object was first instantiated)
-
-        Parameters
-        ----------
-        verbose : deprecated
-
         """
-        if verbose is not None:
-            warnings.warn('verbose deprecated since 0.4.0')
 
         if isinstance(self._auth_session, pyvo.auth.AuthSession):
             # Remove the existing credentials (if any)
@@ -553,7 +539,7 @@ class CadcClass(BaseQuery):
                 result.append(service_def.access_url)
         return result
 
-    def get_tables(self, only_names=False, verbose=None):
+    def get_tables(self, only_names=False):
         """
         Gets all public tables
 
@@ -561,21 +547,18 @@ class CadcClass(BaseQuery):
         ----------
         only_names : bool, optional, default False
             True to load table names only
-        verbose : deprecated
 
         Returns
         -------
         A list of table objects
         """
-        if verbose is not None:
-            warnings.warn('verbose deprecated since 0.4.0')
         table_set = self.cadctap.tables
         if only_names:
             return list(table_set.keys())
         else:
             return list(table_set.values())
 
-    def get_table(self, table, verbose=None):
+    def get_table(self, table):
         """
         Gets the specified table
 
@@ -583,14 +566,11 @@ class CadcClass(BaseQuery):
         ----------
         table : str, mandatory
             full qualified table name (i.e. schema name + table name)
-        verbose : deprecated
 
         Returns
         -------
         A table object
         """
-        if verbose is not None:
-            warnings.warn('verbose deprecated since 0.4.0')
         tables = self.get_tables()
         for t in tables:
             if table == t.name:
@@ -675,46 +655,7 @@ class CadcClass(BaseQuery):
         return self.cadctap.submit_job(query, language='ADQL',
                                        uploads=uploads)
 
-    @deprecated('0.4.0', 'Use exec_sync or create_async instead')
-    def run_query(self, query, operation, output_file=None,
-                  output_format="votable", verbose=None,
-                  background=False, upload_resource=None,
-                  upload_table_name=None):
-        """
-        Runs a query
-
-        Parameters
-        ----------
-        query : str, mandatory
-            query to be executed
-        operation : str, mandatory,
-            'sync' or 'async' to run a synchronous or asynchronous job
-        output_file : str, optional, default None
-            file name where the results are saved if dumpToFile is True.
-            If this parameter is not provided, the jobid is used instead
-        output_format : str, optional, default 'votable'
-            results format, 'csv', 'tsv' and 'votable'
-        verbose : deprecated
-        save_to_file : bool, optional, default 'False'
-            if True, the results are saved in a file instead of using memory
-        background : bool, optional, default 'False'
-            when the job is executed in asynchronous mode,
-            this flag specifies whether the execution will wait until results
-            are available
-        upload_resource : str, optional, default None
-            resource to be uploaded to UPLOAD_SCHEMA
-        upload_table_name : str, required if uploadResource is provided,
-            default None
-            resource temporary table name associated to the uploaded resource
-
-        Returns
-        -------
-        A Job object
-        """
-        raise NotImplementedError('No longer supported. '
-                                  'Use exec_sync or create_async instead.')
-
-    def load_async_job(self, jobid, verbose=None):
+    def load_async_job(self, jobid):
         """
         Loads an asynchronous job
 
@@ -722,20 +663,17 @@ class CadcClass(BaseQuery):
         ----------
         jobid : str, mandatory
             job identifier
-        verbose : deprecated
 
         Returns
         -------
         A Job object
         """
-        if verbose is not None:
-            warnings.warn('verbose deprecated since 0.4.0')
 
         return pyvo.dal.AsyncTAPJob('{}/async/{}'.format(
             self.cadctap.baseurl, jobid), session=self._auth_session)
 
     def list_async_jobs(self, phases=None, after=None, last=None,
-                        short_description=True, verbose=None):
+                        short_description=True):
         """
         Returns all the asynchronous jobs
 
@@ -752,14 +690,11 @@ class CadcClass(BaseQuery):
             corresponding to the TAP ShortJobDescription object (job ID, phase,
             run ID, owner ID and creation ID) whereas if False, a separate GET
             call to each job is performed for the complete job description
-        verbose : deprecated
 
         Returns
         -------
         A list of Job objects
         """
-        if verbose is not None:
-            warnings.warn('verbose deprecated since 0.4.0')
 
         return self.cadctap.get_job_list(phases=phases, after=after, last=last,
                                          short_description=short_description)

--- a/astroquery/cadc/core.py
+++ b/astroquery/cadc/core.py
@@ -21,19 +21,11 @@ from bs4 import BeautifulSoup
 from astropy.utils.exceptions import AstropyDeprecationWarning
 from astropy.utils.decorators import deprecated
 from astropy import units as u
+import pyvo
+from pyvo.auth import authsession
+
 from . import conf
 
-try:
-    import pyvo
-    from pyvo.auth import authsession
-except ImportError:
-    print('Please install pyvo. astropy.cadc does not work without it.')
-except AstropyDeprecationWarning as e:
-    if str(e) == 'The astropy.vo.samp module has now been moved to astropy.samp':
-        # CADC does not use samp and this only affects Python 2.7
-        print('AstropyDeprecationWarning: {}'.format(str(e)))
-    else:
-        raise e
 
 __all__ = ['Cadc', 'CadcClass']
 

--- a/astroquery/cadc/tests/test_cadctap.py
+++ b/astroquery/cadc/tests/test_cadctap.py
@@ -16,28 +16,15 @@ from astropy.io.votable.tree import VOTableFile, Resource, Table, Field
 from astropy.io.votable import parse
 from astroquery.utils.commons import parse_coordinates, FileContainer
 from astropy import units as u
-from astropy.utils.exceptions import AstropyDeprecationWarning
 import pytest
 import tempfile
 import requests
-try:
-    pyvo_OK = True
-    from pyvo.auth import authsession, securitymethods
-    from astroquery.cadc import Cadc, conf
-    import astroquery.cadc.core as cadc_core
-except ImportError:
-    pyvo_OK = False
-    pytest.skip("Install pyvo for the cadc module.", allow_module_level=True)
-except AstropyDeprecationWarning as ex:
-    if str(ex) == \
-            'The astropy.vo.samp module has now been moved to astropy.samp':
-        print('AstropyDeprecationWarning: {}'.format(str(ex)))
-    else:
-        raise ex
-try:
-    from unittest.mock import Mock, patch, PropertyMock
-except ImportError:
-    pytest.skip("Install mock for the cadc tests.", allow_module_level=True)
+
+from pyvo.auth import securitymethods
+from astroquery.cadc import Cadc, conf
+import astroquery.cadc.core as cadc_core
+
+from unittest.mock import Mock, patch, PropertyMock
 
 
 def data_path(filename):
@@ -47,7 +34,6 @@ def data_path(filename):
 
 @patch('astroquery.cadc.core.get_access_url',
        Mock(side_effect=lambda x: 'https://some.url'))
-@pytest.mark.skipif(not pyvo_OK, reason='not pyvo_OK')
 def test_get_tables():
     # default parameters
     table_set = PropertyMock()
@@ -62,7 +48,6 @@ def test_get_tables():
 
 @patch('astroquery.cadc.core.get_access_url',
        Mock(side_effect=lambda x: 'https://some.url'))
-@pytest.mark.skipif(not pyvo_OK, reason='not pyvo_OK')
 def test_get_table():
     table_set = PropertyMock()
     tables_result = [Mock() for _ in range(3)]
@@ -80,7 +65,6 @@ def test_get_table():
 
 @patch('astroquery.cadc.core.get_access_url',
        Mock(side_effect=lambda x: 'https://some.url'))
-@pytest.mark.skipif(not pyvo_OK, reason='not pyvo_OK')
 def test_get_collections():
     cadc = Cadc()
 
@@ -106,7 +90,6 @@ def test_get_collections():
 
 @patch('astroquery.cadc.core.get_access_url',
        Mock(side_effect=lambda x: 'https://some.url'))
-@pytest.mark.skipif(not pyvo_OK, reason='not pyvo_OK')
 def test_load_async_job():
     with patch('astroquery.cadc.core.pyvo.dal.TAPService', autospec=True) as tapservice_mock:
         with patch('astroquery.cadc.core.pyvo.dal.AsyncTAPJob',
@@ -124,7 +107,6 @@ def test_load_async_job():
 @pytest.mark.skip('Disabled until job listing available in pyvo')
 @patch('astroquery.cadc.core.get_access_url',
        Mock(side_effect=lambda x: 'https://some.url'))
-@pytest.mark.skipif(not pyvo_OK, reason='not pyvo_OK')
 def test_list_async_jobs():
     with patch('astroquery.cadc.core.pyvo.dal.TAPService', autospec=True) as tapservice_mock:
         tapservice_mock.return_value.baseurl.return_value = 'https://www.example.com/tap'
@@ -136,7 +118,6 @@ def test_list_async_jobs():
        Mock(side_effect=lambda x, y=None: 'https://some.url'))
 @patch('astroquery.cadc.core.pyvo.dal.TAPService.capabilities', [])  # TAP capabilities not needed
 @patch('astroquery.cadc.core.pyvo.dal.adhoc.DatalinkService.capabilities', [])  # DL capabilities not needed
-@pytest.mark.skipif(not pyvo_OK, reason='not pyvo_OK')
 def test_auth():
     # the Cadc() will cause a remote data call to TAP service capabilities
     # To avoid this, use an anonymous session and replace it with an
@@ -183,7 +164,6 @@ def test_auth():
 
 # make sure that caps is reset at the end of the test
 @patch('astroquery.cadc.core.get_access_url.caps', {})
-@pytest.mark.skipif(not pyvo_OK, reason='not pyvo_OK')
 def test_get_access_url():
     # testing implementation of requests.get method:
     def get(url, **kwargs):
@@ -219,7 +199,6 @@ def test_get_access_url():
        Mock(side_effect=lambda x, y=None: 'https://some.url'))
 @patch('astroquery.cadc.core.pyvo.dal.adhoc.DatalinkService',
        Mock(return_value=Mock(capabilities=[])))  # DL capabilities not needed
-@pytest.mark.skipif(not pyvo_OK, reason='not pyvo_OK')
 def test_get_data_urls():
 
     def get(*args, **kwargs):
@@ -268,7 +247,6 @@ def test_get_data_urls():
 
 @patch('astroquery.cadc.core.get_access_url',
        Mock(side_effect=lambda x, y=None: 'https://some.url'))
-@pytest.mark.skipif(not pyvo_OK, reason='not pyvo_OK')
 def test_misc():
     cadc = Cadc()
 
@@ -302,7 +280,6 @@ def test_misc():
        Mock(return_value=Mock(capabilities=[])))  # TAP capabilities not needed
 @patch('astroquery.cadc.core.pyvo.dal.adhoc.DatalinkService',
        Mock(return_value=Mock(capabilities=[])))  # DL capabilities not needed
-@pytest.mark.skipif(not pyvo_OK, reason='not pyvo_OK')
 def test_get_image_list():
     def get(*args, **kwargs):
         class CapsResponse:
@@ -370,7 +347,6 @@ def test_get_image_list():
 
 @patch('astroquery.cadc.core.get_access_url',
        Mock(side_effect=lambda x, y=None: 'https://some.url'))
-@pytest.mark.skipif(not pyvo_OK, reason='not pyvo_OK')
 def test_exec_sync():
     # save results in a file
     # create the VOTable result
@@ -411,7 +387,6 @@ def test_exec_sync():
 @patch('astroquery.cadc.core.CadcClass.exec_sync', Mock())
 @patch('astroquery.cadc.core.CadcClass.get_image_list',
        Mock(side_effect=lambda x, y, z: ['https://some.url']))
-@pytest.mark.skipif(not pyvo_OK, reason='not pyvo_OK')
 def test_get_images():
     with patch('astroquery.utils.commons.get_readable_fileobj', autospec=True) as readable_fobj_mock:
         readable_fobj_mock.return_value = open(data_path('query_images.fits'), 'rb')
@@ -429,7 +404,6 @@ def test_get_images():
 @patch('astroquery.cadc.core.CadcClass.exec_sync', Mock())
 @patch('astroquery.cadc.core.CadcClass.get_image_list',
        Mock(side_effect=lambda x, y, z: ['https://some.url']))
-@pytest.mark.skipif(not pyvo_OK, reason='not pyvo_OK')
 def test_get_images_async():
     with patch('astroquery.utils.commons.get_readable_fileobj', autospec=True) as readable_fobj_mock:
         readable_fobj_mock.return_value = open(data_path('query_images.fits'), 'rb')

--- a/astroquery/cadc/tests/test_cadctap_remote.py
+++ b/astroquery/cadc/tests/test_cadctap_remote.py
@@ -14,20 +14,10 @@ from astropy.io import fits
 from astropy import units as u
 
 from astroquery.cadc import Cadc
-from astropy.utils.exceptions import AstropyDeprecationWarning
 from astroquery.utils.commons import parse_coordinates, FileContainer
 
-try:
-    pyvo_OK = True
-    import pyvo   # noqa
-    from pyvo.auth import authsession
-except ImportError:
-    pyvo_OK = False
-except AstropyDeprecationWarning as e:
-    if str(e) == 'The astropy.vo.samp module has now been moved to astropy.samp':
-        print('AstropyDeprecationWarning: {}'.format(str(e)))
-    else:
-        raise e
+from pyvo.auth import authsession
+
 
 # to run just one test during development, set this variable to True
 # and comment out the skipif of the single test to run.
@@ -41,7 +31,6 @@ skip_slow = True
 class TestCadcClass:
     # now write tests for each method here
     @pytest.mark.skipif(one_test, reason='One test mode')
-    @pytest.mark.skipif(not pyvo_OK, reason='not pyvo_OK')
     def test_get_collections(self):
         cadc = Cadc()
         result = cadc.get_collections()
@@ -62,7 +51,6 @@ class TestCadcClass:
         assert 'Optical' in result['DAO']['Bands']
 
     @pytest.mark.skipif(one_test, reason='One test mode')
-    @pytest.mark.skipif(not pyvo_OK, reason='not pyvo_OK')
     def test_query_region(self):
         cadc = Cadc()
         result = cadc.query_region('08h45m07.5s +54d18m00s', collection='CFHT')
@@ -89,7 +77,6 @@ class TestCadcClass:
         assert len(results) > 20
 
     @pytest.mark.skipif(one_test, reason='One test mode')
-    @pytest.mark.skipif(not pyvo_OK, reason='not pyvo_OK')
     def test_query_name(self):
         cadc = Cadc()
         result1 = cadc.query_name('M31-B14')
@@ -99,7 +86,6 @@ class TestCadcClass:
         assert len(result1) == len(result2)
 
     @pytest.mark.skipif(one_test, reason='One test mode')
-    @pytest.mark.skipif(not pyvo_OK, reason='not pyvo_OK')
     def test_query(self):
         cadc = Cadc()
         result = cadc.exec_sync(
@@ -116,7 +102,6 @@ class TestCadcClass:
     @pytest.mark.skipif(one_test, reason='One test mode')
     @pytest.mark.skip('Disabled for now until pyvo starts supporting '
                       'different output formats')
-    @pytest.mark.skipif(not pyvo_OK, reason='not pyvo_OK')
     def test_query_format(self):
         cadc = Cadc()
         query = "select top 1 observationID, collection from caom2.Observation"
@@ -128,7 +113,6 @@ class TestCadcClass:
                         or 'CADC_PASSWD' not in os.environ),
                         reason='Requires real CADC user/password (CADC_USER '
                                'and CADC_PASSWD environment variables)')
-    @pytest.mark.skipif(not pyvo_OK, reason='not pyvo_OK')
     def test_login_with_user_password(self):
         for auth_session in [None, authsession.AuthSession(),
                              requests.Session()]:
@@ -162,7 +146,6 @@ class TestCadcClass:
     @pytest.mark.skipif('CADC_CERT' not in os.environ,
                         reason='Requires real CADC certificate (CADC_CERT '
                                'environment variable)')
-    @pytest.mark.skipif(not pyvo_OK, reason='not pyvo_OK')
     def test_login_with_cert(self):
         for auth_session in [requests.Session()]:
             cadc = Cadc(auth_session=auth_session)
@@ -191,7 +174,6 @@ class TestCadcClass:
     @pytest.mark.skipif('CADC_CERT' not in os.environ,
                         reason='Requires real CADC certificate (CADC_CERT '
                                'environment variable)')
-    @pytest.mark.skipif(not pyvo_OK, reason='not pyvo_OK')
     def test_authsession(self):
         # repeat previous test
         auth_session = requests.Session()
@@ -211,7 +193,6 @@ class TestCadcClass:
         assert len(result) == 0
 
     @pytest.mark.skipif(one_test, reason='One test mode')
-    @pytest.mark.skipif(not pyvo_OK, reason='not pyvo_OK')
     @pytest.mark.xfail(reason='#2325')
     def test_get_images(self):
         cadc = Cadc()
@@ -224,7 +205,6 @@ class TestCadcClass:
             assert isinstance(image, fits.HDUList)
 
     @pytest.mark.skipif(one_test, reason='One test mode')
-    @pytest.mark.skipif(not pyvo_OK, reason='not pyvo_OK')
     @pytest.mark.skipif(skip_slow, reason='Avoid timeout errors')
     def test_get_images_against_AS(self):
         cadc = Cadc()
@@ -259,7 +239,6 @@ class TestCadcClass:
         assert len(filtered_resp_urls) == len(image_urls)
 
     @pytest.mark.skipif(one_test, reason='One test mode')
-    @pytest.mark.skipif(not pyvo_OK, reason='not pyvo_OK')
     @pytest.mark.xfail(reason='#2325')
     def test_get_images_async(self):
         cadc = Cadc()
@@ -271,7 +250,6 @@ class TestCadcClass:
             assert isinstance(obj, FileContainer)
 
     @pytest.mark.skipif(one_test, reason='One test mode')
-    @pytest.mark.skipif(not pyvo_OK, reason='not pyvo_OK')
     def test_async(self):
         # test async calls
         cadc = Cadc()
@@ -300,7 +278,6 @@ class TestCadcClass:
         # job.delete()  # BUG in CADC
 
     @pytest.mark.skipif(one_test, reason='One test mode')
-    @pytest.mark.skipif(not pyvo_OK, reason='not pyvo_OK')
     def test_list_tables(self):
         cadc = Cadc()
         table_names = cadc.get_tables(only_names=True)
@@ -320,7 +297,6 @@ class TestCadcClass:
     @pytest.mark.skipif('CADC_CERT' not in os.environ,
                         reason='Requires real CADC certificate (CADC_CERT '
                                'environment variable)')
-    @pytest.mark.skipif(not pyvo_OK, reason='not pyvo_OK')
     @pytest.mark.xfail(reason='#2325')
     def test_list_jobs(self):
         cadc = Cadc()

--- a/astroquery/cadc/tests/test_cadctap_remote.py
+++ b/astroquery/cadc/tests/test_cadctap_remote.py
@@ -18,11 +18,6 @@ from astroquery.utils.commons import parse_coordinates, FileContainer
 
 from pyvo.auth import authsession
 
-
-# to run just one test during development, set this variable to True
-# and comment out the skipif of the single test to run.
-one_test = False
-
 # Skip the very slow tests to avoid timeout errors
 skip_slow = True
 
@@ -30,7 +25,6 @@ skip_slow = True
 @pytest.mark.remote_data
 class TestCadcClass:
     # now write tests for each method here
-    @pytest.mark.skipif(one_test, reason='One test mode')
     def test_get_collections(self):
         cadc = Cadc()
         result = cadc.get_collections()
@@ -50,7 +44,6 @@ class TestCadcClass:
         assert 'Infrared' in result['DAO']['Bands']
         assert 'Optical' in result['DAO']['Bands']
 
-    @pytest.mark.skipif(one_test, reason='One test mode')
     def test_query_region(self):
         cadc = Cadc()
         result = cadc.query_region('08h45m07.5s +54d18m00s', collection='CFHT')
@@ -76,7 +69,6 @@ class TestCadcClass:
         results = cadc.query_region(SkyCoord.from_name('M31'), radius=0.016)
         assert len(results) > 20
 
-    @pytest.mark.skipif(one_test, reason='One test mode')
     def test_query_name(self):
         cadc = Cadc()
         result1 = cadc.query_name('M31-B14')
@@ -85,7 +77,6 @@ class TestCadcClass:
         result2 = cadc.query_name('m31-b14')
         assert len(result1) == len(result2)
 
-    @pytest.mark.skipif(one_test, reason='One test mode')
     def test_query(self):
         cadc = Cadc()
         result = cadc.exec_sync(
@@ -99,7 +90,6 @@ class TestCadcClass:
         result = cadc.exec_sync(query)
         assert len(result) == 0
 
-    @pytest.mark.skipif(one_test, reason='One test mode')
     @pytest.mark.skip('Disabled for now until pyvo starts supporting '
                       'different output formats')
     def test_query_format(self):
@@ -108,7 +98,6 @@ class TestCadcClass:
         result = cadc.exec_sync(query, output_format='csv')
         print(result)
 
-    @pytest.mark.skipif(one_test, reason='One test mode')
     @pytest.mark.skipif(('CADC_USER' not in os.environ
                         or 'CADC_PASSWD' not in os.environ),
                         reason='Requires real CADC user/password (CADC_USER '
@@ -142,7 +131,6 @@ class TestCadcClass:
             result = cadc.exec_sync(query)
             assert len(result) == 1
 
-    @pytest.mark.skipif(one_test, reason='One test mode')
     @pytest.mark.skipif('CADC_CERT' not in os.environ,
                         reason='Requires real CADC certificate (CADC_CERT '
                                'environment variable)')
@@ -170,7 +158,6 @@ class TestCadcClass:
             result = cadc.exec_sync(query)
             assert len(result) == 0
 
-    @pytest.mark.skipif(one_test, reason='One test mode')
     @pytest.mark.skipif('CADC_CERT' not in os.environ,
                         reason='Requires real CADC certificate (CADC_CERT '
                                'environment variable)')
@@ -192,7 +179,6 @@ class TestCadcClass:
         result = cadc.exec_sync(query)
         assert len(result) == 0
 
-    @pytest.mark.skipif(one_test, reason='One test mode')
     @pytest.mark.xfail(reason='#2325')
     def test_get_images(self):
         cadc = Cadc()
@@ -204,7 +190,6 @@ class TestCadcClass:
         for image in images:
             assert isinstance(image, fits.HDUList)
 
-    @pytest.mark.skipif(one_test, reason='One test mode')
     @pytest.mark.skipif(skip_slow, reason='Avoid timeout errors')
     def test_get_images_against_AS(self):
         cadc = Cadc()
@@ -238,7 +223,6 @@ class TestCadcClass:
 
         assert len(filtered_resp_urls) == len(image_urls)
 
-    @pytest.mark.skipif(one_test, reason='One test mode')
     @pytest.mark.xfail(reason='#2325')
     def test_get_images_async(self):
         cadc = Cadc()
@@ -249,7 +233,6 @@ class TestCadcClass:
         for obj in readable_objs:
             assert isinstance(obj, FileContainer)
 
-    @pytest.mark.skipif(one_test, reason='One test mode')
     def test_async(self):
         # test async calls
         cadc = Cadc()
@@ -277,7 +260,6 @@ class TestCadcClass:
             assert expected['observationID'][ii] == result['observationID'][ii]
         # job.delete()  # BUG in CADC
 
-    @pytest.mark.skipif(one_test, reason='One test mode')
     def test_list_tables(self):
         cadc = Cadc()
         table_names = cadc.get_tables(only_names=True)
@@ -293,7 +275,6 @@ class TestCadcClass:
         table = cadc.get_table('caom2.Observation')
         assert 'caom2.Observation' == table.name
 
-    @pytest.mark.skipif(one_test, reason='One test mode')
     @pytest.mark.skipif('CADC_CERT' not in os.environ,
                         reason='Requires real CADC certificate (CADC_CERT '
                                'environment variable)')

--- a/docs/cadc/cadc.rst
+++ b/docs/cadc/cadc.rst
@@ -35,28 +35,7 @@ these collections:
     CFHTTERAPIX : {'Description': 'The CFHTTERAPIX collection at the CADC', 'Bands': ['Infrared|Optical', 'Optical', 'Infrared']}
     CFHTWIRWOLF : {'Description': 'The CFHTWIRWOLF collection at the CADC', 'Bands': ['Infrared']}
     CGPS : {'Description': 'The CGPS collection at the CADC', 'Bands': ['Infrared', 'Radio', 'Millimeter', '', 'Millimeter|Infrared']}
-    CHANDRA : {'Description': 'The CHANDRA collection at the CADC', 'Bands': ['X-ray']}
-    DAO : {'Description': 'The DAO collection at the CADC', 'Bands': ['', 'Infrared|Optical', 'Infrared', 'Optical']}
-    DAOCADC : {'Description': 'The DAOCADC collection at the CADC', 'Bands': ['Optical', '']}
-    DAOPLATES : {'Description': 'The DAOPLATES collection at the CADC', 'Bands': ['Optical', '']}
-    DRAO : {'Description': 'The DRAO collection at the CADC', 'Bands': ['Radio']}
-    FUSE : {'Description': 'The FUSE collection at the CADC', 'Bands': ['UV|EUV', '']}
-    GEMINI : {'Description': 'The GEMINI collection at the CADC', 'Bands': ['Infrared|Optical|UV|EUV|X-ray|Ga', 'Infrared', 'Optical', 'Infrared|Optical', 'Optical|UV', '']}
-    GEMINICADC : {'Description': 'The GEMINICADC collection at the CADC', 'Bands': ['', 'Infrared|Optical', 'Infrared']}
-    HST : {'Description': 'The HST collection at the CADC', 'Bands': ['', 'Infrared', 'Optical', 'UV']}
-    HSTHLA : {'Description': 'The HSTHLA collection at the CADC', 'Bands': ['Optical', 'Infrared', 'UV', 'Infrared|Optical', 'Infrared|Optical|UV', 'Optical|UV']}
-    IRIS : {'Description': 'The IRIS collection at the CADC', 'Bands': ['Millimeter|Infrared', 'Infrared']}
-    JCMT : {'Description': 'The JCMT collection at the CADC', 'Bands': ['', 'Millimeter']}
-    JCMTLS : {'Description': 'The JCMTLS collection at the CADC', 'Bands': ['Millimeter', '']}
-    JWST : {'Description': 'The JWST collection at the CADC', 'Bands': ['', 'Infrared']}
-    MACHO : {'Description': 'The MACHO collection at the CADC', 'Bands': ['Optical']}
-    MOST : {'Description': 'The MOST collection at the CADC', 'Bands': ['Optical']}
-    NEOSSAT : {'Description': 'The NEOSSAT collection at the CADC', 'Bands': ['Optical']}
-    NGVS : {'Description': 'The NGVS collection at the CADC', 'Bands': ['Infrared|Optical', '', 'Optical']}
-    NOAO : {'Description': 'The NOAO collection at the CADC', 'Bands': ['Optical', 'Infrared']}
-    OMM : {'Description': 'The OMM collection at the CADC', 'Bands': ['Optical', 'Infrared', '']}
-    RACS : {'Description': 'The RACS collection at the CADC', 'Bands': ['Radio']}
-    SDSS : {'Description': 'The SDSS collection at the CADC', 'Bands': ['Infrared', 'Optical']}
+    ...
     SUBARU : {'Description': 'The SUBARU collection at the CADC', 'Bands': ['Optical']}
     SUBARUCADC : {'Description': 'The SUBARUCADC collection at the CADC', 'Bands': ['Optical', 'Infrared|Optical']}
     TESS : {'Description': 'The TESS collection at the CADC', 'Bands': ['Optical']}

--- a/docs/cadc/cadc.rst
+++ b/docs/cadc/cadc.rst
@@ -595,8 +595,7 @@ After a successful authentication, user credentials will be used
 until the `~astroquery.cadc.CadcClass.logout` method is called.
 
 All previous methods (`~astroquery.cadc.CadcClass.get_tables`,
-`~astroquery.cadc.CadcClass.get_table`,
-`~astroquery.cadc.CadcClass.run_query`) explained for non authenticated
+`~astroquery.cadc.CadcClass.get_table`) explained for non authenticated
 users are applicable for authenticated ones.
 
 


### PR DESCRIPTION
* PyVO is a required dependency now.

* individual tests can be run with either `python setup.py -t testfilename::testfunctionname` or as `pytest testfilename -k testfunctionname`

* 0.4.0 has been a while ago, deprecations are likely can be removed now