### PR TITLE
Add `matplotlib` as a 'docs' dependency

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -9,7 +9,6 @@ python:
        path: .
        extra_requirements:
           - docs
-          - all
 
 sphinx:
    fail_on_warning: true

--- a/setup.cfg
+++ b/setup.cfg
@@ -169,6 +169,7 @@ test=
    flask
    pytest-dependency
 docs=
+   matplotlib
    sphinx-astropy>=1.5
    scipy
 all=


### PR DESCRIPTION
The documentation already contains plots, e.g. https://github.com/astropy/astroquery/blob/aaeccb8911ff027c58060ed45ea6fa4dd65e0b15/docs/linelists/cdms/cdms.rst#L159
`matplotlib` should therefore be listed as a 'docs' dependency. It does not have to be listed in the 'all' dependencies because it is already included indirectly through `aplpy`.

The second commit tells Read the Docs to only install 'docs' dependencies because that should be all that is needed for building the documentation.