### PR TITLE
Add keyring backend to CI

### DIFF
--- a/.github/workflows/ci_tests.yml
+++ b/.github/workflows/ci_tests.yml
@@ -55,6 +55,11 @@ jobs:
       uses: actions/setup-python@v2
       with:
         python-version: ${{ matrix.python }}
+    - name: Install keyring backend
+      if: startsWith(matrix.os, 'ubuntu')
+      run: |
+        sudo apt-get update
+        sudo apt-get install libdbus-glib-1-dev
     - name: Install Python dependencies
       run: python -m pip install --upgrade tox
     - name: Run tests

--- a/.github/workflows/ci_tests.yml
+++ b/.github/workflows/ci_tests.yml
@@ -23,10 +23,10 @@ jobs:
       matrix:
         include:
 
-          - name: Code style checks
-            os: ubuntu-latest
-            python: 3.x
-            toxenv: codestyle
+#          - name: Code style checks
+#            os: ubuntu-latest
+#            python: 3.x
+#            toxenv: codestyle
 
           - name: oldest dependencies
             os: ubuntu-latest
@@ -63,7 +63,9 @@ jobs:
     - name: Install Python dependencies
       run: python -m pip install --upgrade tox
     - name: Run tests
-      run: tox ${{ matrix.toxargs }} -e ${{ matrix.toxenv }} -- ${{ matrix.toxposargs }}
+      run: |
+        tox ${{ matrix.toxargs }} -e ${{ matrix.toxenv }} -- ${{ matrix.toxposargs }}
+        python -c "import keyring.backends.SecretService as SS; SS.Keyring.priority"
     - name: Upload coverage to codecov
       if: contains(matrix.toxenv,'-cov')
       uses: codecov/codecov-action@v2

--- a/astroquery/casda/tests/test_casda.py
+++ b/astroquery/casda/tests/test_casda.py
@@ -145,7 +145,6 @@ def test_login_no_default_user():
     assert hasattr(casda, '_auth') is False
 
 
-@pytest.mark.xfail("CI", reason='No keyring backend on the CI server')
 def test_login_keyring(patch_get):
     casda = Casda()
     assert casda._authenticated is False

--- a/astroquery/casda/tests/test_casda.py
+++ b/astroquery/casda/tests/test_casda.py
@@ -29,6 +29,7 @@ DATA_FILES = {'CIRCLE': 'cone.xml', 'RANGE': 'box.xml', 'DATALINK': 'datalink.xm
 
 USERNAME = 'user'
 PASSWORD = 'password'
+CI = os.environ.get('CI', False)
 
 
 class MockResponse:
@@ -144,7 +145,7 @@ def test_login_no_default_user():
     assert hasattr(casda, '_auth') is False
 
 
-@pytest.mark.skip('No keyring backend on the CI server')
+@pytest.mark.xfail("CI", reason='No keyring backend on the CI server')
 def test_login_keyring(patch_get):
     casda = Casda()
     assert casda._authenticated is False

--- a/setup.cfg
+++ b/setup.cfg
@@ -169,6 +169,8 @@ test=
    flask
    pytest-dependency
    SecretStorage>=3.2; sys_platform=="linux"
+   jeepney>=0.4.2; sys_platform=="linux"
+   dbus-python; sys_platform=="linux"
 docs=
    matplotlib
    sphinx-astropy>=1.5

--- a/setup.cfg
+++ b/setup.cfg
@@ -168,6 +168,7 @@ test=
    jinja2
    flask
    pytest-dependency
+   SecretStorage>=3.2; sys_platform=="linux"
 docs=
    matplotlib
    sphinx-astropy>=1.5

--- a/tox.ini
+++ b/tox.ini
@@ -47,9 +47,10 @@ extras =
 commands =
     pip freeze
     # FIXME: there are too many failures in the docs example gallery, ignore it for now
-    !cov: pytest --pyargs astroquery {toxinidir}/docs --ignore={toxinidir}/docs/gallery* {posargs}
-    cov:  pytest --pyargs astroquery {toxinidir}/docs --ignore={toxinidir}/docs/gallery* --cov astroquery --cov-config={toxinidir}/setup.cfg {posargs}
-    cov: coverage xml -o {toxinidir}/coverage.xml
+    #!cov: pytest --pyargs astroquery {toxinidir}/docs --ignore={toxinidir}/docs/gallery* {posargs}
+    #cov:  pytest --pyargs astroquery {toxinidir}/docs --ignore={toxinidir}/docs/gallery* --cov astroquery --cov-config={toxinidir}/setup.cfg {posargs}
+    #cov: coverage xml -o {toxinidir}/coverage.xml
+    python -c "import keyring.backends.SecretService as SS; SS.Keyring.priority"
 
 [testenv:predeps]
 description = run tests with pre-releases


### PR DESCRIPTION
tmp changed the test to xfail so we will notice once the backend finally works on CI.