### PR TITLE
BUG: Fix OAC parsing issue

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -38,6 +38,13 @@ linelists.cdms
 - Fix issues with the line name parser and the line data parser; the original
   implementation was incomplete and upstream was not fully documented. [#2385, #2411]
 
+oac
+^^^
+
+- Fix bug in parsing events that contain html tags (e.g. in their alias
+  field). [#2423]
+
+
 Infrastructure, Utility and Other Changes and Additions
 -------------------------------------------------------
 

--- a/astroquery/oac/core.py
+++ b/astroquery/oac/core.py
@@ -12,6 +12,7 @@ and James Guillochon (jguillochon@cfa.harvard.edu)
 
 import json
 import csv
+import re
 
 import astropy.units as u
 from astropy.table import Column, Table
@@ -435,7 +436,12 @@ class OACClass(BaseQuery):
 
     def _format_output(self, raw_output):
         if self.FORMAT == 'csv':
-            split_output = raw_output.splitlines()
+
+            fixed_raw_output = re.sub('<[^<]+?>', '', raw_output)
+            split_output = fixed_raw_output.splitlines()
+
+            # Remove any HTML tags
+
             columns = list(csv.reader([split_output[0]], delimiter=',',
                            quotechar='"'))[0]
             rows = split_output[1:]

--- a/astroquery/oac/tests/test_oac_remote.py
+++ b/astroquery/oac/tests/test_oac_remote.py
@@ -59,25 +59,27 @@ class TestOACClass:
                                 data_format='json')
         assert isinstance(phot, dict)
 
-    @pytest.mark.xfail(reason="Upstream API issue.  See #1130")
     def test_get_photometry(self):
         phot = OAC.get_photometry(event="SN2014J")
         assert isinstance(phot, Table)
+        assert len(phot) > 0
 
     def test_get_photometry_b(self):
         phot = OAC.get_photometry(event="SN2014J")
         assert isinstance(phot, Table)
+        assert len(phot) > 0
 
-    @pytest.mark.xfail(reason="Upstream API issue.  See #1130")
     def test_get_single_spectrum(self):
         spec = OAC.get_single_spectrum(event="SN2014J",
                                        time=self.test_time)
         assert isinstance(spec, Table)
+        assert len(spec) > 0
 
     def test_get_single_spectrum_b(self):
         test_time = 56680
         spec = OAC.get_single_spectrum(event="SN2014J", time=test_time)
         assert isinstance(spec, Table)
+        assert len(spec) > 0
 
     def test_get_spectra(self):
         spec = OAC.get_spectra(event="SN2014J")


### PR DESCRIPTION
This is to fix #1401 as well as to fix the now passing, previously xfailing tests.


First I was thinking of removing the `data_format` kwarg as it shouldn't be the concern of the users of which data format to receive the query response, but parsing the json into an astropy table is not trivial without pulling in pandas as a dependency. So I opted for a regex fix instead.