### PR TITLE
MAINT: remove xfail from passing test 

### DIFF
--- a/astroquery/alma/tests/test_alma_remote.py
+++ b/astroquery/alma/tests/test_alma_remote.py
@@ -302,7 +302,6 @@ class TestAlma:
         #                     science=True)
         # assert len(result) == 1
 
-    @pytest.mark.xfail(reason="ra dec search known issue")
     def test_misc(self, alma):
         # miscellaneous set of common tests
         #


### PR DESCRIPTION
Currently, 4 remote alma tests are failing, one of them because it is passing as opposed to its xfail mark.

The other three are a different case, locally and on CI I see certificate issues like the one below. One puzzling question is why the tests use the noa.ac.jp mirror, as I recall we kind of hard wired the ESO server not long ago.

Maybe @keflavich or @andamian could have a look? (I suppose the first failure just requires to rework the test, or maybe even removing it as its name suggests that it served as testing the documentation (test_doc_example), however now we have doctest running on the narrative docs.

```
requests.exceptions.SSLError: HTTPSConnectionPool(host='almascience.nao.ac.jp', port=443): Max retries exceeded with url: /dataPortal/member.uid___A001_X1284_X1353.qa2_report.html (Caused by SSLError(SSLCertVerificationError(1, '[SSL: CERTIFICATE_VERIFY_FAILED] certificate verify failed: unable to get local issuer certificate (_ssl.c:1123)')))
```