### PR TITLE
TST: add usage of pytest-rerunfailures for remote-tests

### DIFF
--- a/.github/workflows/ci_crontests.yml
+++ b/.github/workflows/ci_crontests.yml
@@ -24,9 +24,9 @@ jobs:
           - name: Python 3.9 with all dependencies with remote data
             os: ubuntu-latest
             python: '3.9'
-            toxenv: py39-test-alldeps-devdeps
+            toxenv: py39-test-alldeps-devdeps-online
             toxargs: -v
-            toxposargs: --remote-data -v --durations=50
+            toxposargs: -v --durations=50
 
           - name: pre-repease dependencies with all dependencies
             os: ubuntu-latest

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 envlist =
-    py{37,38,39,310}-test{,-alldeps,-oldestdeps,-devdeps,-predeps}{,-cov}
+    py{37,38,39,310}-test{,-alldeps,-oldestdeps,-devdeps,-predeps}{,-online}{,-cov}
     codestyle
     build_docs
 requires =
@@ -26,6 +26,10 @@ changedir = .tmp/{envname}
 
 description = run tests
 
+setenv =
+    PYTEST_ARGS = ''
+    online: PYTEST_ARGS = --remote-data=any --reruns=1 --reruns-delay 10
+
 deps =
     devdeps: git+https://github.com/astropy/astropy.git#egg=astropy
     devdeps: git+https://github.com/astropy/pyvo.git#egg=pyvo
@@ -38,6 +42,7 @@ deps =
     oldestdeps: matplotlib==3.3.*
     oldestdeps: pyvo==1.1
     cov: codecov
+    online: pytest-rerunfailures
 
 extras =
     test
@@ -47,8 +52,8 @@ extras =
 commands =
     pip freeze
     # FIXME: there are too many failures in the docs example gallery, ignore it for now
-    !cov: pytest --pyargs astroquery {toxinidir}/docs --ignore={toxinidir}/docs/gallery* {posargs}
-    cov:  pytest --pyargs astroquery {toxinidir}/docs --ignore={toxinidir}/docs/gallery* --cov astroquery --cov-config={toxinidir}/setup.cfg {posargs}
+    !cov: pytest --pyargs astroquery {toxinidir}/docs --ignore={toxinidir}/docs/gallery* {env:PYTEST_ARGS} {posargs}
+    cov:  pytest --pyargs astroquery {toxinidir}/docs --ignore={toxinidir}/docs/gallery* --cov astroquery --cov-config={toxinidir}/setup.cfg {env:PYTEST_ARGS} {posargs}
     cov: coverage xml -o {toxinidir}/coverage.xml
 
 pip_pre =


### PR DESCRIPTION
This PR also adds `online` to tox to deal with remote-data dependencies and cmd options

The actual parameters may need some tuning, as well as keeping an eye on https://github.com/pytest-dev/pytest-rerunfailures/issues/193 as it would be more optimal for us to come back and revisit our failing test at the end of the test run.


Note: second commit temporarily disables the cron conditional, it will need to be removed once we make sure the configs are picked up properly (the CI job will most certainly fail)

To close #2424 