### PR TITLE
Remove deprecated NASA Exoplanet Archive code

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -26,6 +26,11 @@ casda
 - Use the standard ``login`` method for authenticating, which supports the system
   keyring [#2386]
 
+ipac.nexsci.nasa_exoplanet_archive
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+- The deprecated methods ``query_planet()`` and ``query_star()`` have been removed.
+
 jplsbdb
 ^^^^^^^
 

--- a/astroquery/ipac/nexsci/nasa_exoplanet_archive/core.py
+++ b/astroquery/ipac/nexsci/nasa_exoplanet_archive/core.py
@@ -17,7 +17,6 @@ from astropy.coordinates import SkyCoord
 from astropy.io import ascii
 from astropy.io.votable import parse_single_table
 from astropy.table import QTable
-from astropy.utils import deprecated, deprecated_renamed_argument
 from astropy.utils.exceptions import AstropyWarning
 
 # Import astroquery utilities
@@ -629,25 +628,6 @@ class NasaExoplanetArchiveClass(BaseQuery):
 
         return data
 
-    def _handle_all_columns_argument(self, **kwargs):
-        """
-        Deal with the ``all_columns`` argument that was exposed by earlier versions
-
-        This method will warn users about this deprecated argument and update the query syntax
-        to use ``select='*'``.
-        """
-        # We also have to manually pop these arguments from the dict because
-        # `deprecated_renamed_argument` doesn't do that for some reason for all supported astropy
-        # versions (v3.1 was beheaving as expected)
-        kwargs.pop("show_progress", None)
-        kwargs.pop("table_path", None)
-
-        # Deal with `all_columns` properly
-        if kwargs.pop("all_columns", None):
-            kwargs["select"] = kwargs.get("select", "*")
-
-        return kwargs
-
     @class_or_instance
     def _request_to_sql(self, request_payload):
         """Convert request_payload dict to SQL query string to be parsed by TAP."""
@@ -676,52 +656,6 @@ class NasaExoplanetArchiveClass(BaseQuery):
         tap_query = "{0} {1}".format(query_req, query_opt)
 
         return tap_query
-
-    @deprecated(since="v0.4.1", alternative="query_object")
-    @deprecated_renamed_argument(["show_progress", "table_path"],
-                                 [None, None], "v0.4.1", arg_in_kwargs=True)
-    def query_planet(self, planet_name, cache=None, **criteria):
-        """
-        Search the ``exoplanets`` table for a confirmed planet
-
-        Parameters
-        ----------
-        planet_name : str
-            The name of a confirmed planet. If ``regularize`` is ``True``, an attempt will be made
-            to regularize this name using the ``aliastable`` table.
-        cache : bool, optional
-            Should the request result be cached? This can be useful for large repeated queries,
-            but since the data in the archive is updated regularly, this defaults to ``False``.
-        **criteria
-            Any other filtering criteria to apply. Values provided using the ``where`` keyword will
-            be ignored.
-        """
-        criteria = self._handle_all_columns_argument(**criteria)
-        criteria["where"] = "pl_name='{0}'".format(planet_name.strip())
-        return self.query_criteria("exoplanets", cache=cache, **criteria)
-
-    @deprecated(since="v0.4.1", alternative="query_object")
-    @deprecated_renamed_argument(["show_progress", "table_path"],
-                                 [None, None], "v0.4.1", arg_in_kwargs=True)
-    def query_star(self, host_name, cache=None, **criteria):
-        """
-        Search the ``exoplanets`` table for a confirmed planet host
-
-        Parameters
-        ----------
-        host_name : str
-            The name of a confirmed planet host. If ``regularize`` is ``True``, an attempt will be
-            made to regularize this name using the ``aliastable`` table.
-        cache : bool, optional
-            Should the request result be cached? This can be useful for large repeated queries,
-            but since the data in the archive is updated regularly, this defaults to ``False``.
-        **criteria
-            Any other filtering criteria to apply. Values provided using the ``where`` keyword will
-            be ignored.
-        """
-        criteria = self._handle_all_columns_argument(**criteria)
-        criteria["where"] = "pl_hostname='{0}'".format(host_name.strip())
-        return self.query_criteria("exoplanets", cache=cache, **criteria)
 
 
 NasaExoplanetArchive = NasaExoplanetArchiveClass()

--- a/astroquery/ipac/nexsci/nasa_exoplanet_archive/tests/test_nasa_exoplanet_archive.py
+++ b/astroquery/ipac/nexsci/nasa_exoplanet_archive/tests/test_nasa_exoplanet_archive.py
@@ -168,46 +168,6 @@ def test_get_access_url():
     assert get_access_url('aliaslookup') == conf.url_aliaslookup
 
 
-def test_backwards_compat(patch_get):
-    """
-    These are the tests from the previous version of this interface.
-    They query old tables by default and should return InvalidTableError.
-    """
-    NasaExoplanetArchiveMock = NasaExoplanetArchiveClass()
-
-    NasaExoplanetArchiveMock._tap_tables = ['list']
-
-    # test_hd209458b_exoplanets_archive
-    with pytest.warns(AstropyDeprecationWarning):
-        with pytest.raises(InvalidTableError) as error:
-            NasaExoplanetArchiveMock.query_planet("HD 209458 b ")
-        assert "replaced" in str(error)
-
-    # test_hd209458b_exoplanet_archive_coords
-    with pytest.warns(AstropyDeprecationWarning):
-        with pytest.raises(InvalidTableError) as error:
-            NasaExoplanetArchiveMock.query_planet("HD 209458 b ")
-        assert "replaced" in str(error)
-
-    # test_hd209458_stellar_exoplanet
-    with pytest.warns(AstropyDeprecationWarning):
-        with pytest.raises(InvalidTableError) as error:
-            NasaExoplanetArchiveMock.query_star("HD 209458")
-        assert "replaced" in str(error)
-
-    # test_hd136352_stellar_exoplanet_archive
-    with pytest.warns(AstropyDeprecationWarning):
-        with pytest.raises(InvalidTableError) as error:
-            NasaExoplanetArchiveMock.query_star("HD 136352")
-        assert "replaced" in str(error)
-
-    # test_exoplanet_archive_query_all_columns
-    with pytest.warns(AstropyDeprecationWarning):
-        with pytest.raises(InvalidTableError) as error:
-            NasaExoplanetArchiveMock.query_planet("HD 209458 b ", all_columns=True)
-        assert "replaced" in str(error)
-
-
 @pytest.mark.parametrize("table,query", API_TABLES)
 def test_api_tables(patch_get, table, query):
     NasaExoplanetArchiveMock = NasaExoplanetArchiveClass()


### PR DESCRIPTION
The removed code was deprecated by #1700 in v0.4.1 almost two years ago.