### PR TITLE
Remove last `from __future__` imports

### DIFF
--- a/astroquery/esa/iso/tests/setup_package.py
+++ b/astroquery/esa/iso/tests/setup_package.py
@@ -9,8 +9,6 @@ European Space Agency (ESA)
 
 """
 
-from __future__ import absolute_import
-
 import os
 
 

--- a/astroquery/exoplanet_orbit_database/__init__.py
+++ b/astroquery/exoplanet_orbit_database/__init__.py
@@ -5,8 +5,6 @@ Exoplanet Orbit Database Query Tool
 
 :Author: Brett M. Morris (brettmorris21@gmail.com)
 """
-from __future__ import (absolute_import, division, print_function,
-                        unicode_literals)
 from .exoplanet_orbit_database import (ExoplanetOrbitDatabase,
                                        ExoplanetOrbitDatabaseClass)
 from astropy import config as _config

--- a/astroquery/exoplanet_orbit_database/exoplanet_orbit_database.py
+++ b/astroquery/exoplanet_orbit_database/exoplanet_orbit_database.py
@@ -1,6 +1,4 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
-from __future__ import (absolute_import, division, print_function,
-                        unicode_literals)
 import json
 import os
 

--- a/astroquery/exoplanet_orbit_database/tests/test_exoplanet_orbit_database.py
+++ b/astroquery/exoplanet_orbit_database/tests/test_exoplanet_orbit_database.py
@@ -1,5 +1,3 @@
-from __future__ import (absolute_import, division, print_function,
-                        unicode_literals)
 import os
 
 import pytest

--- a/astroquery/query.py
+++ b/astroquery/query.py
@@ -1,6 +1,4 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
-from __future__ import (absolute_import, division, print_function,
-                        unicode_literals)
 import abc
 import inspect
 import pickle

--- a/astroquery/sdss/core.py
+++ b/astroquery/sdss/core.py
@@ -2,8 +2,6 @@
 """
 Access Sloan Digital Sky Survey database online.
 """
-from __future__ import (absolute_import, division, print_function,
-                        unicode_literals)
 import io
 import warnings
 import numpy as np

--- a/astroquery/sdss/field_names.py
+++ b/astroquery/sdss/field_names.py
@@ -1,7 +1,4 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
-from __future__ import (absolute_import, division, print_function,
-                        unicode_literals)
-
 import json
 import warnings
 


### PR DESCRIPTION
The removed imports had no effect in Python 3.

It can be verified that no `__future__` imports remain by running
```shell
$ git grep __future__
```