### PR TITLE
MAINT: Run all crontests even if they fail

### DIFF
--- a/.github/workflows/ci_crontests.yml
+++ b/.github/workflows/ci_crontests.yml
@@ -18,7 +18,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     if: github.event_name == 'schedule' && github.repository == 'astropy/astroquery'
     strategy:
-      fail-fast: true
+      fail-fast: false
       matrix:
         include:
           - name: Python 3.9 with all dependencies with remote data


### PR DESCRIPTION
We should let all crontests run to get a good sense of the status of the default branch.