### PR TITLE
FIX: casda compatibility fix np1.23

### DIFF
--- a/astroquery/casda/core.py
+++ b/astroquery/casda/core.py
@@ -20,8 +20,6 @@ import numpy as np
 # 3. local imports - use relative imports
 from ..query import QueryWithLogin
 from ..utils import commons
-# prepend_docstr is a way to copy docstrings between methods
-from ..utils import prepend_docstr_nosections
 # async_to_sync generates the relevant query tools from _async methods
 from ..utils import async_to_sync
 # import configurable items declared in __init__.py
@@ -245,7 +243,8 @@ class CasdaClass(QueryWithLogin):
             The table with all unreleased (non public) data products filtered out.
         """
         now = str(datetime.now(timezone.utc).strftime('%Y-%m-%dT%H:%M:%S.%f'))
-        return table[(table['obs_release_date'] != '') & (table['obs_release_date'] < now)]
+        return table[(table['obs_release_date'] != '')
+                     & np.array([obs_date < now for obs_date in table['obs_release_date']])]
 
     def _create_job(self, table, service_name, verbose):
         # Use datalink to get authenticated access for each file

--- a/astroquery/casda/tests/test_casda.py
+++ b/astroquery/casda/tests/test_casda.py
@@ -17,10 +17,8 @@ import numpy as np
 from astroquery.casda import Casda
 from astroquery.exceptions import LoginError
 
-try:
-    from unittest.mock import Mock, patch, MagicMock
-except ImportError:
-    pytest.skip("Install mock for the casda tests.", allow_module_level=True)
+from unittest.mock import Mock, MagicMock
+
 
 DATA_FILES = {'CIRCLE': 'cone.xml', 'RANGE': 'box.xml', 'DATALINK': 'datalink.xml', 'RUN_JOB': 'run_job.xml',
               'COMPLETED_JOB': 'completed_job.xml', 'DATALINK_NOACCESS': 'datalink_noaccess.xml',


### PR DESCRIPTION
It came down to the need to iterate over the elements of the masked column, this workaround should do for the time being, but maybe @mhvk can point to a better solution.


I keep it floating whether we will need to changelog until release time.

Fixes: #2440 