### PR TITLE
Perform unit conversion in `svo_fps` `get_filter_index()`

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -62,6 +62,12 @@ oac
 - Fix bug in parsing events that contain html tags (e.g. in their alias
   field). [#2423]
 
+svo_fps
+^^^^^^^
+
+- The wavelength limits in ``get_filter_index()`` can now be specified using any
+  length unit, not just angstroms. [#2444]
+
 gaia
 ^^^^
 

--- a/astroquery/svo_fps/core.py
+++ b/astroquery/svo_fps/core.py
@@ -68,9 +68,9 @@ class SvoFpsClass(BaseQuery):
 
         Parameters
         ----------
-        wavelength_eff_min : `~astropy.units.Quantity` having units of angstrom, optional
+        wavelength_eff_min : `~astropy.units.Quantity` with units of length, optional
             Minimum value of Wavelength Effective (default is 0 angstrom)
-        wavelength_eff_max : `~astropy.units.Quantity` having units of angstrom, optional
+        wavelength_eff_max : `~astropy.units.Quantity` with units of length, optional
             Maximum value of Wavelength Effective (default is a very large
             quantity FLOAT_MAX angstroms i.e. maximum value of np.float64)
         kwargs : dict
@@ -81,8 +81,8 @@ class SvoFpsClass(BaseQuery):
         astropy.table.table.Table object
             Table containing data fetched from SVO (in response to query)
         """
-        query = {'WavelengthEff_min': wavelength_eff_min.value,
-                 'WavelengthEff_max': wavelength_eff_max.value}
+        query = {'WavelengthEff_min': wavelength_eff_min.to_value(u.angstrom),
+                 'WavelengthEff_max': wavelength_eff_max.to_value(u.angstrom)}
         error_msg = 'No filter found for requested Wavelength Effective range'
         return self.data_from_svo(query=query, error_msg=error_msg, **kwargs)
 

--- a/astroquery/svo_fps/tests/test_svo_fps.py
+++ b/astroquery/svo_fps/tests/test_svo_fps.py
@@ -46,9 +46,14 @@ def get_mockreturn(method, url, params=None, timeout=10, cache=None, **kwargs):
 
 
 def test_get_filter_index(patch_get):
-    table = SvoFps.get_filter_index(TEST_LAMBDA*u.angstrom, (TEST_LAMBDA+100)*u.angstrom)
+    lambda_min = TEST_LAMBDA*u.angstrom
+    lambda_max = lambda_min + 100*u.angstrom
+    table = SvoFps.get_filter_index(lambda_min, lambda_max)
     # Check if column for Filter ID (named 'filterID') exists in table
     assert 'filterID' in table.colnames
+    # Results should not depend on the unit of the wavelength: #2443. If they do then
+    # `get_mockreturn` raises `NotImplementedError`.
+    SvoFps.get_filter_index(lambda_min.to(u.m), lambda_max)
 
 
 def test_get_transmission_data(patch_get):

--- a/astroquery/svo_fps/tests/test_svo_fps_remote.py
+++ b/astroquery/svo_fps/tests/test_svo_fps_remote.py
@@ -1,5 +1,6 @@
 import pytest
 import astropy.io.votable.exceptions
+from astropy import units as u
 
 from ..core import SvoFps
 
@@ -8,7 +9,7 @@ from ..core import SvoFps
 class TestSvoFpsClass:
 
     def test_get_filter_index(self):
-        table = SvoFps.get_filter_index()
+        table = SvoFps.get_filter_index(12_000*u.angstrom, 12_100*u.angstrom)
         # Check if column for Filter ID (named 'filterID') exists in table
         assert 'filterID' in table.colnames
 


### PR DESCRIPTION
The `SvoFpsClass.get_filter_index()` method allows the user to specify wavelength limits. Previously the code assumed that they are always given in angstroms. Now the code converts them to angstroms, allowing the user to specify the wavelengths using any length unit and leading to an early unit conversion error if the limits do not have length units.

Fixes #2443