### PR TITLE
Validate `svo_fps` query parameter names locally

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -68,6 +68,9 @@ svo_fps
 - The wavelength limits in ``get_filter_index()`` can now be specified using any
   length unit, not just angstroms. [#2444]
 
+- Queries with invalid parameter names now raise an ``InvalidQueryError``.
+  [#2446]
+
 gaia
 ^^^^
 

--- a/astroquery/svo_fps/tests/test_svo_fps.py
+++ b/astroquery/svo_fps/tests/test_svo_fps.py
@@ -2,6 +2,7 @@ import pytest
 import os
 from astropy import units as u
 
+from astroquery.exceptions import InvalidQueryError
 from astroquery.utils.mocks import MockResponse
 from ..core import SvoFps
 
@@ -66,3 +67,12 @@ def test_get_filter_list(patch_get):
     table = SvoFps.get_filter_list(TEST_FACILITY, TEST_INSTRUMENT)
     # Check if column for Filter ID (named 'filterID') exists in table
     assert 'filterID' in table.colnames
+
+
+def test_invalid_query(patch_get):
+    msg = r"^parameter bad_param is invalid\. For a description of valid query "
+    with pytest.raises(InvalidQueryError, match=msg):
+        SvoFps.data_from_svo(query={"bad_param": 0, "FWHM": 20})
+    msg = r"^parameters invalid_param, bad_param are invalid\. For a description of "
+    with pytest.raises(InvalidQueryError, match=msg):
+        SvoFps.data_from_svo(query={"invalid_param": 0, 'bad_param': -1})

--- a/astroquery/svo_fps/tests/test_svo_fps_remote.py
+++ b/astroquery/svo_fps/tests/test_svo_fps_remote.py
@@ -1,7 +1,11 @@
+from io import BytesIO
+
 import pytest
 from astropy import units as u
+from astropy.io.votable import parse
 
-from ..core import SvoFps
+from astroquery.svo_fps import conf, SvoFps
+from astroquery.svo_fps.core import QUERY_PARAMETERS
 
 
 @pytest.mark.remote_data
@@ -25,3 +29,22 @@ class TestSvoFpsClass:
         table = SvoFps.get_filter_list(test_facility, test_instrument)
         # Check if column for Filter ID (named 'filterID') exists in table
         assert 'filterID' in table.colnames
+
+    def test_query_parameter_names(self):
+        # Checks if `QUERY_PARAMETERS` is up to date.
+        query = {"FORMAT": "metadata"}
+        response = BytesIO(
+            SvoFps._request(
+                "GET", conf.base_url, params=query, timeout=conf.timeout, cache=False
+            ).content
+        )
+        params = {p.name.split(":")[1] for p in parse(response).resources[0].params}
+        # All valid parameters should be present in `QUERY_PARAMETERS`.
+        assert not params.difference(QUERY_PARAMETERS)
+        # Some valid parameter names are not in `params`.
+        for p in QUERY_PARAMETERS.difference(params):
+            # `QUERY_PARAMETERS` also contains names without "_min" or "_max" ending
+            # because "Param_min=a&Param_max=b" can be replaced with "Param=a/b".
+            if p + "_min" not in params:
+                # There's a few extra parameters we didn't get from the server.
+                assert p in {"VERB", "FORMAT", "PhotCalID", "ID"}

--- a/astroquery/svo_fps/tests/test_svo_fps_remote.py
+++ b/astroquery/svo_fps/tests/test_svo_fps_remote.py
@@ -1,5 +1,4 @@
 import pytest
-import astropy.io.votable.exceptions
 from astropy import units as u
 
 from ..core import SvoFps
@@ -26,11 +25,3 @@ class TestSvoFpsClass:
         table = SvoFps.get_filter_list(test_facility, test_instrument)
         # Check if column for Filter ID (named 'filterID') exists in table
         assert 'filterID' in table.colnames
-
-    # Test for failing case (a dummy invalid query)
-    def test_IndexError_in_data_from_svo(self):
-        invalid_query = {'Invalid_param': 0}
-        with pytest.raises(astropy.io.votable.exceptions.E09) as exc:
-            SvoFps.data_from_svo(invalid_query)
-
-        assert 'must have a value attribute' in str(exc)


### PR DESCRIPTION
`SvoFpsClass.data_from_svo()` now checks the names of the query parameters and only connects with the server if all names are valid. This allows replacing a failing remote test that checked for invalid queries with a local test.

Contributes towards #2203