### PR TITLE
Fixing typo in cloud.py's CloudAccess() class variable call

### DIFF
--- a/astroquery/mast/cloud.py
+++ b/astroquery/mast/cloud.py
@@ -126,7 +126,7 @@ class CloudAccess:  # pragma:no-cover
             if include_bucket:
                 path = "s3://{}/{}".format(self.pubdata_bucket, path)
             elif full_url:
-                path = "http://s3.amazonaws.com/{}/{}".format(self._pubdata_bucket, path)
+                path = "http://s3.amazonaws.com/{}/{}".format(self.pubdata_bucket, path)
             return path
         except self.botocore.exceptions.ClientError as e:
             if e.response['Error']['Code'] != "404":


### PR DESCRIPTION
Removed the extra underscore in `self._pubdata_bucket`, it should be `self.pubdata_bucket`. Calling `self._pubdata_bucket` leads to an error saying it doesn't exist.