### PR TITLE
Change RMF matrices version

### DIFF
--- a/astroquery/esa/xmm_newton/core.py
+++ b/astroquery/esa/xmm_newton/core.py
@@ -441,7 +441,7 @@ class XMMNewtonClass(BaseQuery):
                                 elif fname_info["I"] == "PN":
                                     inst = "PN/"
                                     file_name, file_ext = os.path.splitext(rmf_fname)
-                                    rmf_fname = file_name + "_v18.0" + file_ext
+                                    rmf_fname = file_name + "_v20.0" + file_ext
 
                                 link = self._rmf_ftp + inst + rmf_fname
 


### PR DESCRIPTION
Dear Astroquery,

The RMF to be used for the spectral analysis should be generated with the same PPS version as the spectrum, background and ARF. The PPS version can be found in SASVERS keyword in the SPECTRUM file, characters [-6:-3].  Once the sas version is determined, the code should look for the proper version of RMF in the FTP tree.  However, for the current PPS versions available in the archive, i.e v18.0,v19.0 and v20.0, all RMF matrices are equal among the versions and for all instruments, so it is possible to download the last one, v20.0, available in the root FTP stored in 'rmf_ftp'.  In the future, the FTP tree and/or PPS keywords will be modified to make easier to download the appropriate RMF file for each spectrum.

At the moment the version for the RMF matrices is v20.0 so the link to the proper file does not work. Therefore we need this quick patch to get the links to work again.

Kind regards, 

Xmm_newton team