### PR TITLE
Modifying astroquery/sdss package init file to use most current SDSS DR (as well as associated documentation)

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -133,6 +133,10 @@ sdss
 - ``query_region()`` now does a cone search around the specified
   coordinates. [#2477]
 
+- The default data release has been changed to DR17. [#2478]
+
+
+
 Infrastructure, Utility and Other Changes and Additions
 -------------------------------------------------------
 

--- a/astroquery/sdss/__init__.py
+++ b/astroquery/sdss/__init__.py
@@ -19,7 +19,7 @@ class Conf(_config.ConfigNamespace):
     timeout = _config.ConfigItem(
         60,
         'Time limit for connecting to SDSS server.')
-    default_release = _config.ConfigItem(14, 'Default SDSS data release.')
+    default_release = _config.ConfigItem(17, 'Default SDSS data release.')
 
 
 conf = Conf()

--- a/astroquery/sdss/core.py
+++ b/astroquery/sdss/core.py
@@ -20,7 +20,7 @@ from .field_names import (photoobj_defs, specobj_defs,
 __all__ = ['SDSS', 'SDSSClass']
 __doctest_skip__ = ['SDSSClass.*']
 
-
+# Imaging pixelscale 0.396 arcsec
 sdss_arcsec_per_pixel = 0.396 * u.arcsec / u.pixel
 
 

--- a/astroquery/sdss/tests/test_sdss_remote.py
+++ b/astroquery/sdss/tests/test_sdss_remote.py
@@ -202,4 +202,4 @@ class TestSDSSRemote:
         # Regression test for #589
 
         results = sdss.SDSS.query_crossid(large_results)
-        assert len(results) == 894
+        assert len(results) == 845

--- a/docs/sdss/sdss.rst
+++ b/docs/sdss/sdss.rst
@@ -4,6 +4,16 @@
 SDSS Queries (`astroquery.sdss`)
 ********************************
 
+Default Data Release
+====================
+
+The default data release is set to Data Release 17 (DR17), which is
+the final data release of the Sloan Digital Sky Survey IV.  DR17
+contains new optical and infrared spectra from both Apache Point
+Observatory and Las Campanas Observatory. Previously released
+integral-field datacubes and maps, stellar library spectra, as well as
+images, are also included in DR17.  Users may select alternate DR's.
+
 Getting started
 ===============
 


### PR DESCRIPTION
Hi, this PR closes #2365.  The `__init__.py` file in the sdss package as well as some of the related documentation (in sdss.rst) has been slightly modified to reflect and use the latest SDSS data release (DR17). Some package tests have been run.  Please let me know if I need to do anything further.  Thank you. 