### PR TITLE
Astrometry.net: Improvements to API key warnings/errors

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -25,6 +25,12 @@ alma
 
 - Fixed a regression to handle arrays of string input for the ``query`` methods. [#2094]
 
+astrometry.net
+^^^^^^^^^^^^^^
+
+- Avoid duplicated warnings about API key and raise an error only when API key is
+  needed but not set. [#2483]
+
 cadc
 ^^^^
 

--- a/astroquery/astrometry_net/core.py
+++ b/astroquery/astrometry_net/core.py
@@ -33,6 +33,24 @@ import time
 __all__ = ['AstrometryNet', 'AstrometryNetClass']
 
 
+MISSING_API_KEY = """
+Astrometry.net API key not set. You should either set this in the astroquery configuration file using:
+
+    [astrometry_net]
+    api_key = qwdqwjnoi12ioj
+
+or you can set it for this session only using the ``conf`` object:
+
+    from astroquery.astrometry_net import conf
+    conf.api_key = 'qwdqwjnoi12ioj'
+
+or using the ``api_key`` property on the ``AstrometryNet`` class:
+
+    from astroquery.astrometry_net import AstrometryNet
+    AstrometryNet.api_key = 'qwdqwjnoi12ioj'
+""".lstrip()
+
+
 @async_to_sync
 class AstrometryNetClass(BaseQuery):
     """
@@ -71,7 +89,7 @@ class AstrometryNetClass(BaseQuery):
     def api_key(self):
         """ Return the Astrometry.net API key. """
         if not conf.api_key:
-            log.error("Astrometry.net API key not in configuration file")
+            raise RuntimeError(MISSING_API_KEY)
         return conf.api_key
 
     @api_key.setter
@@ -103,18 +121,10 @@ class AstrometryNetClass(BaseQuery):
                             values=key_info['allowed']))
 
     def __init__(self):
-        """ Show a warning message if the API key is not in the configuration file. """
         super().__init__()
-        if not conf.api_key:
-            log.warning("Astrometry.net API key not found in configuration file")
-            log.warning("You need to manually edit the configuration file and add it")
-            log.warning(
-                "You may also register it for this session with AstrometryNet.key = 'XXXXXXXX'")
         self._session_id = None
 
     def _login(self):
-        if not self.api_key:
-            raise RuntimeError('You must set the API key before using this service.')
         login_url = url_helpers.join(self.API_URL, 'login')
         payload = self._construct_payload({'apikey': self.api_key})
         result = self._request('POST', login_url,

--- a/astroquery/astrometry_net/core.py
+++ b/astroquery/astrometry_net/core.py
@@ -37,17 +37,17 @@ MISSING_API_KEY = """
 Astrometry.net API key not set. You should either set this in the astroquery configuration file using:
 
     [astrometry_net]
-    api_key = qwdqwjnoi12ioj
+    api_key = ADD_YOUR_API_KEY_HERE
 
 or you can set it for this session only using the ``conf`` object:
 
     from astroquery.astrometry_net import conf
-    conf.api_key = 'qwdqwjnoi12ioj'
+    conf.api_key = 'ADD_YOUR_API_KEY_HERE'
 
 or using the ``api_key`` property on the ``AstrometryNet`` class:
 
     from astroquery.astrometry_net import AstrometryNet
-    AstrometryNet.api_key = 'qwdqwjnoi12ioj'
+    AstrometryNet.api_key = 'ADD_YOUR_API_KEY_HERE'
 """.lstrip()
 
 

--- a/astroquery/astrometry_net/tests/test_astrometry_net.py
+++ b/astroquery/astrometry_net/tests/test_astrometry_net.py
@@ -13,17 +13,15 @@ def data_path(filename):
     return os.path.join(DATA_DIR, filename)
 
 
-def test_api_key_property(caplog):
+def test_api_key_property():
     """
     Check that an empty key is returned if the api key is not in
     the configuration file and that the expected message shows up in
     the log.
     """
-    caplog.clear()
     anet = AstrometryNet()
-    key = anet.api_key
-    assert not key
-    assert "Astrometry.net API key not in configuration file" in caplog.text
+    with pytest.raises(RuntimeError, match='Astrometry.net API key not set'):
+        anet.api_key
 
 
 def test_empty_settings_property():
@@ -56,9 +54,8 @@ def test_login_fails_with_no_api_key():
     """
     anet = AstrometryNet()
     anet.api_key = ''
-    with pytest.raises(RuntimeError) as e:
+    with pytest.raises(RuntimeError, match='Astrometry.net API key not set'):
         anet._login()
-    assert "You must set the API key before using this service." in str(e.value)
 
 
 def test_construct_payload():


### PR DESCRIPTION
Possible fix for https://github.com/astropy/astroquery/issues/2482 - only raise an error about missing API key when it is needed, otherwise user doesn't have chance to set it before the warning is emitted.