### PR TITLE
TST: mark flaky test to be rerun

### DIFF
--- a/astroquery/utils/tests/test_timer.py
+++ b/astroquery/utils/tests/test_timer.py
@@ -34,6 +34,7 @@ def func_to_time(x):
     return y
 
 
+@pytest.mark.flaky(reruns=1, reruns_delay=10)
 def test_timer():
     """Test function timer."""
     p = RunTimePredictor(func_to_time)


### PR DESCRIPTION
to close #2460 as this test keeps failing randomly

Long term I suppose the functionality can be deprecated and removed along with `vo_conesearch` (see https://github.com/astropy/astroquery/issues/2027) as that's the only module that uses the timer.