### PR TITLE
Cull duplicate dataURIs for MAST in download_products

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -79,6 +79,11 @@ linelists.cdms
 - Fix issues with the line name parser and the line data parser; the original
   implementation was incomplete and upstream was not fully documented. [#2385, #2411]
 
+mast
+^^^^
+
+- Cull duplicate downloads for the same dataURI in ``Observations.download_products()`` [#2497]
+
 oac
 ^^^
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -82,7 +82,8 @@ linelists.cdms
 mast
 ^^^^
 
-- Cull duplicate downloads for the same dataURI in ``Observations.download_products()`` [#2497]
+- Cull duplicate downloads for the same dataURI in ``Observations.download_products()``
+  and duplicate URIs in ``Observations.get_cloud_uris``. [#2497]
 
 oac
 ^^^

--- a/astroquery/exceptions.py
+++ b/astroquery/exceptions.py
@@ -7,8 +7,9 @@ from astropy.utils.exceptions import AstropyWarning
 
 __all__ = ['TimeoutError', 'InvalidQueryError', 'RemoteServiceError',
            'TableParseError', 'LoginError', 'ResolverError',
-           'NoResultsWarning', 'LargeQueryWarning', 'InputWarning',
-           'AuthenticationWarning', 'MaxResultsWarning', 'CorruptDataWarning']
+           'NoResultsWarning', 'DuplicateResultsWarning', 'LargeQueryWarning',
+           'InputWarning', 'AuthenticationWarning', 'MaxResultsWarning',
+           'CorruptDataWarning']
 
 
 class TimeoutError(Exception):
@@ -61,6 +62,13 @@ class ResolverError(Exception):
 
 
 class NoResultsWarning(AstropyWarning):
+    """
+    Astroquery warning class to be issued when a query returns no result.
+    """
+    pass
+
+
+class DuplicateResultsWarning(AstropyWarning):
     """
     Astroquery warning class to be issued when a query returns no result.
     """

--- a/astroquery/mast/observations.py
+++ b/astroquery/mast/observations.py
@@ -715,12 +715,7 @@ class ObservationsClass(MastQueryWithLogin):
             products = vstack(product_lists)
 
         # Remove duplicate products
-        number = len(products)
-        products = unique(products, keys="dataURI")
-        number_unique = len(products)
-        if number_unique < number:
-            warnings.warn(f"{number - number_unique} of {number} products were duplicates."
-                          f"Only downloading {number_unique} unique product(s).", DuplicateResultsWarning)
+        products = self._remove_duplicate_products(products)
 
         # apply filters
         products = self.filter_products(products, mrp_only=mrp_only, **filters)
@@ -773,6 +768,9 @@ class ObservationsClass(MastQueryWithLogin):
             raise RemoteServiceError('Please enable anonymous cloud access by calling `enable_cloud_dataset` method. '
                                      'See MAST Labs documentation for an example: https://mast-labs.stsci.io/#example-data-access-with-astroquery-observations')
 
+        # Remove duplicate products
+        products = self._remove_duplicate_products(products)
+
         return self._cloud_connection.get_cloud_uri_list(data_products, include_bucket, full_url)
 
     def get_cloud_uri(self, data_product, *, include_bucket=True, full_url=False):
@@ -807,6 +805,30 @@ class ObservationsClass(MastQueryWithLogin):
 
         # Query for product URIs
         return self._cloud_connection.get_cloud_uri(data_product, include_bucket, full_url)
+
+    def _remove_duplicate_products(self, data_products):
+        """
+        Removes duplicate data products that have the same dataURI.
+
+        Parameters
+        ----------
+        data_products : `~astropy.table.Table`
+            Table containing products to be checked for duplicates.
+
+        Returns
+        -------
+        unique_products : `~astropy.table.Table`
+            Table containing products with unique dataURIs.
+
+        """
+        number = len(data_products)
+        unique_products = unique(data_products, keys="dataURI")
+        number_unique = len(unique_products)
+        if number_unique < number:
+            warnings.warn(f"{number - number_unique} of {number} products were duplicates."
+                          f"Only downloading {number_unique} unique product(s).", DuplicateResultsWarning)
+
+        return unique_products
 
 
 @async_to_sync

--- a/astroquery/mast/observations.py
+++ b/astroquery/mast/observations.py
@@ -769,7 +769,7 @@ class ObservationsClass(MastQueryWithLogin):
                                      'See MAST Labs documentation for an example: https://mast-labs.stsci.io/#example-data-access-with-astroquery-observations')
 
         # Remove duplicate products
-        products = self._remove_duplicate_products(products)
+        data_products = self._remove_duplicate_products(data_products)
 
         return self._cloud_connection.get_cloud_uri_list(data_products, include_bucket, full_url)
 

--- a/astroquery/mast/observations.py
+++ b/astroquery/mast/observations.py
@@ -19,7 +19,7 @@ from requests import HTTPError
 import astropy.units as u
 import astropy.coordinates as coord
 
-from astropy.table import Table, Row, vstack, MaskedColumn
+from astropy.table import Table, Row, unique, vstack, MaskedColumn
 from astroquery import log
 
 from astropy.utils import deprecated
@@ -713,6 +713,9 @@ class ObservationsClass(MastQueryWithLogin):
                 product_lists.append(self.get_product_list(oid))
 
             products = vstack(product_lists)
+
+        # Remove duplicate products
+        products = unique(products, keys="dataURI")
 
         # apply filters
         products = self.filter_products(products, mrp_only=mrp_only, **filters)

--- a/astroquery/mast/observations.py
+++ b/astroquery/mast/observations.py
@@ -31,7 +31,7 @@ from ..query import QueryWithLogin
 from ..utils import commons, async_to_sync
 from ..utils.class_or_instance import class_or_instance
 from ..exceptions import (TimeoutError, InvalidQueryError, RemoteServiceError,
-                          ResolverError, MaxResultsWarning,
+                          ResolverError, MaxResultsWarning, DuplicateResultsWarning,
                           NoResultsWarning, InputWarning, AuthenticationWarning)
 
 from . import conf, utils
@@ -715,7 +715,12 @@ class ObservationsClass(MastQueryWithLogin):
             products = vstack(product_lists)
 
         # Remove duplicate products
+        number = len(products)
         products = unique(products, keys="dataURI")
+        number_unique = len(products)
+        if number_unique < number:
+            warnings.warn(f"{number - number_unique} of {number} products were duplicates."
+                          f"Only downloading {number_unique} unique product(s).", DuplicateResultsWarning)
 
         # apply filters
         products = self.filter_products(products, mrp_only=mrp_only, **filters)

--- a/astroquery/mast/tests/test_mast_remote.py
+++ b/astroquery/mast/tests/test_mast_remote.py
@@ -275,7 +275,7 @@ class TestMast:
                 assert os.path.isfile(row['Local Path'])
 
         # just get the curl script
-        result = mast.Observations.download_products(test_obs[0]["obsid"],
+        result = mast.Observations.download_products(test_obs_id[0]["obsid"],
                                                      download_dir=str(tmpdir),
                                                      curl_flag=True,
                                                      productType=["SCIENCE"],
@@ -284,16 +284,16 @@ class TestMast:
         assert os.path.isfile(result['Local Path'][0])
 
         # check for row input
-        result1 = mast.Observations.get_product_list(test_obs[0]["obsid"])
+        result1 = mast.Observations.get_product_list(test_obs_id[0]["obsid"])
         result2 = mast.Observations.download_products(result1[0])
         assert isinstance(result2, Table)
         assert os.path.isfile(result2['Local Path'][0])
         assert len(result2) == 1
 
-    def test_observations_download_products_noduplicates(self, tmpdir):
+    def test_observations_download_products_no_duplicates(tmpdir):
 
-        # Pull products for a NIRSpec MSA observation with 6 known duplicates
-        # of the MSA configuration file
+        # Pull products for a JWST NIRSpec MSA observation with 6 known
+        # duplicates of the MSA configuration file, propID=2736
         products = mast.Observations.get_product_list("87602009")
 
         # Filter out everything but the MSA config file
@@ -309,6 +309,15 @@ class TestMast:
 
         # Check that it downloads the MSA config file only once
         assert len(manifest) == 1
+
+        # enable access to public AWS S3 bucket
+        mast.Observations.enable_cloud_dataset()
+
+        # Check duplicate cloud URIs as well
+        with pytest.warns(DuplicateResultsWarning):
+            uris = mast.Observations.get_cloud_uris(products)
+
+        assert len(uris) == 1
 
     def test_observations_download_file(self, tmpdir):
 

--- a/astroquery/mast/tests/test_mast_remote.py
+++ b/astroquery/mast/tests/test_mast_remote.py
@@ -289,6 +289,25 @@ class TestMast:
         assert os.path.isfile(result2['Local Path'][0])
         assert len(result2) == 1
 
+    def test_observations_download_products_noduplicates(self, tmpdir):
+
+        # Pull products for a NIRSpec MSA observation with 6 known duplicates
+        # of the MSA configuration file
+        products = mast.Observations.get_product_list("87602009")
+
+        # Filter out everything but the MSA config file
+        mask = np.char.find(products["dataURI"], "_msa.fits") != -1
+        products = products[mask]
+
+        assert len(products) == 6
+
+        # Download the product
+        manifest = mast.Observations.download_products(products,
+                                                       download_dir=str(tmpdir))
+
+        # Check that it downloads the MSA config file only once
+        assert len(manifest) == 1
+
     def test_observations_download_file(self, tmpdir):
 
         # enabling cloud connection

--- a/astroquery/mast/tests/test_mast_remote.py
+++ b/astroquery/mast/tests/test_mast_remote.py
@@ -14,7 +14,8 @@ import astropy.units as u
 from astroquery import mast
 
 from ..utils import ResolverError
-from ...exceptions import InvalidQueryError, MaxResultsWarning, NoResultsWarning, RemoteServiceError
+from ...exceptions import (InvalidQueryError, MaxResultsWarning, NoResultsWarning,
+                           DuplicateResultsWarning, RemoteServiceError)
 
 
 OBSID = '1647157'
@@ -302,8 +303,9 @@ class TestMast:
         assert len(products) == 6
 
         # Download the product
-        manifest = mast.Observations.download_products(products,
-                                                       download_dir=str(tmpdir))
+        with pytest.warns(DuplicateResultsWarning):
+            manifest = mast.Observations.download_products(products,
+                                                           download_dir=str(tmpdir))
 
         # Check that it downloads the MSA config file only once
         assert len(manifest) == 1


### PR DESCRIPTION
Resolves #2496 

I'm not precisely sure how to test this in a unit test, as I don't understand the mocking system. And there doesn't seem to be any JWST unit tests yet.

Regardless, this is what I see when I run the workflow in the issue above locally.

Before this PR:

```python
>>> manifest = Observations.download_products(data_products)
Downloading URL https://mast.stsci.edu/api/v0.1/Download/file?uri=mast:JWST/product/jw02736008001_01_msa.fits to ./mastDownload/JWST/jw02736008001_03103_00003_nrs2/jw02736008001_01_msa.fits ...
|============================================================================| 567k/567k (100.00%)         1s
Downloading URL https://mast.stsci.edu/api/v0.1/Download/file?uri=mast:JWST/product/jw02736008001_01_msa.fits to ./mastDownload/JWST/jw02736008001_03103_00001_nrs2/jw02736008001_01_msa.fits ...
|============================================================================| 567k/567k (100.00%)         1s
Downloading URL https://mast.stsci.edu/api/v0.1/Download/file?uri=mast:JWST/product/jw02736008001_01_msa.fits to ./mastDownload/JWST/jw02736008001_03103_00002_nrs1/jw02736008001_01_msa.fits ...
|============================================================================| 567k/567k (100.00%)         0s
Downloading URL https://mast.stsci.edu/api/v0.1/Download/file?uri=mast:JWST/product/jw02736008001_01_msa.fits to ./mastDownload/JWST/jw02736008001_03103_00002_nrs2/jw02736008001_01_msa.fits ...
|============================================================================| 567k/567k (100.00%)         1s
Downloading URL https://mast.stsci.edu/api/v0.1/Download/file?uri=mast:JWST/product/jw02736008001_01_msa.fits to ./mastDownload/JWST/jw02736008001_03103_00003_nrs1/jw02736008001_01_msa.fits ...
|============================================================================| 567k/567k (100.00%)         0s
Downloading URL https://mast.stsci.edu/api/v0.1/Download/file?uri=mast:JWST/product/jw02736008001_01_msa.fits to ./mastDownload/JWST/jw02736008001_03103_00003_nrs2/jw02736008001_01_msa.fits ...
|============================================================================| 567k/567k (100.00%)         1s
```

This PR:

```python
manifest = Observations.download_products(data_products)
Downloading URL https://mast.stsci.edu/api/v0.1/Download/file?uri=mast:JWST/product/jw02736008001_01_msa.fits to ./mastDownload/JWST/jw02736008001_03103_00001_nrs1/jw02736008001_01_msa.fits ...
|============================================================================| 567k/567k (100.00%)         0s
```

Any further suggestions or existing examples on how to test this in a unit test would be appreciated.