### PR TITLE
Recommend a better way to mark remote data tests in remote test modules

### DIFF
--- a/astroquery/atomic/tests/test_atomic_remote.py
+++ b/astroquery/atomic/tests/test_atomic_remote.py
@@ -6,8 +6,9 @@ from astropy.table import Table
 
 from ...atomic import AtomicLineList
 
+pytestmark = pytest.mark.remote_data
 
-@pytest.mark.remote_data
+
 def test_default_form_values():
     default_response = AtomicLineList._request(
         method="GET", url=AtomicLineList.FORM_URL,
@@ -28,7 +29,6 @@ def test_default_form_values():
         'wave': u'Angstrom'}
 
 
-@pytest.mark.remote_data
 def test_query_with_default_params():
     table = AtomicLineList.query_object(cache=False)
     assert isinstance(table, Table)
@@ -43,7 +43,6 @@ LAMBDA VAC ANG SPECTRUM  TT CONFIGURATION TERM  J J    A_ki   LEVEL ENERGY  CM 1
        1.02916   Zn XXX  E1         1*-6*  1-6 1/2-* 1.33E+12 0.00 - 97174700.00'''.strip()
 
 
-@pytest.mark.remote_data
 def test_query_with_wavelength_params():
     result = AtomicLineList.query_object(
         wavelength_range=(15 * u.nm, 200 * u.Angstrom),
@@ -66,7 +65,6 @@ def test_query_with_wavelength_params():
                             '0.00 -   502481.80']))
 
 
-@pytest.mark.remote_data
 def test_empty_result_set():
     result = AtomicLineList.query_object(wavelength_accuracy=0, cache=False)
     assert isinstance(result, Table)
@@ -74,7 +72,6 @@ def test_empty_result_set():
     assert len(result) == 0
 
 
-@pytest.mark.remote_data
 def test_lower_upper_ranges():
     result = AtomicLineList.query_object(
         lower_level_energy_range=u.Quantity((600 * u.cm**(-1), 1000 * u.cm**(-1))),

--- a/docs/testing.rst
+++ b/docs/testing.rst
@@ -84,8 +84,14 @@ the ``test_module.py`` file.
 ``test_module_remote.py``
 -------------------------
 
-The remote tests are much easier.  Just decorate the test class or test
-functions with ``@pytest.mark.remote_data``.
+The remote tests are much easier. The file must contain the following::
+
+    import pytest
+
+    pytestmark = pytest.mark.remote_data
+
+This ensures that the test functions in remote test module are only executed if
+the ``--remote-data`` flag is used.
 
 ``setup_package.py``
 --------------------


### PR DESCRIPTION
Currently many test modules define a class that contains the test functions as methods. This has been convenient because marking the class with the `pytest.mark.remote_data` decorator applies the mark to all its methods, removing the need to mark each function individually. However, if all remote tests are in a separate module like the documentation already recommends then the [`pytestmark`](https://docs.pytest.org/en/7.1.x/reference/reference.html?highlight=pytestmark#globalvar-pytestmark) global variable could be used instead. The classes in remote test modules would not be needed and removing them would save one level of indentation.

This pull request updates the documentation to recommend `pytestmark`, and introduces it in the `atomic` sub-package as an example.