### PR TITLE
converting input lists to np arrays

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -16,6 +16,11 @@ hsa
 
 - New module to access ESA Herschel mission. [#2122]
 
+mast
+^^^
+
+- Fixed ``Observations.get_product_list`` to handle input lists of obsids. [#2504]
+
 
 Service fixes and enhancements
 ------------------------------

--- a/astroquery/mast/observations.py
+++ b/astroquery/mast/observations.py
@@ -440,9 +440,11 @@ class ObservationsClass(MastQueryWithLogin):
             observations = np.array([observations])
         if isinstance(observations, Table):
             observations = observations['obsid']
+        if isinstance(observations, list):
+            observations = np.array(observations)
 
         observations = observations[observations != ""]
-        if len(observations) == 0:
+        if observations.size == 0:
             raise InvalidQueryError("Observation list is empty, no associated products.")
 
         service = self._caom_products

--- a/astroquery/mast/tests/test_mast.py
+++ b/astroquery/mast/tests/test_mast.py
@@ -441,6 +441,10 @@ def test_observations_get_product_list(patch_post):
     result = mast.Observations.get_product_list(observations[0:4])
     assert isinstance(result, Table)
 
+    in_obsids = ['83229830', '1829332', '26074149', '24556715']
+    result = mast.Observations.get_product_list(in_obsids)
+    assert isinstance(result, Table)
+
 
 def test_observations_filter_products(patch_post):
     products = mast.Observations.get_product_list('2003738726')


### PR DESCRIPTION
`astroquery.mast.Observations.get_product_list` was mishandling lists because the assumed input was a numPy array. This led to incorrect requests being made to our API. This PR adds a conditional to catch for incoming lists to convert them into numPy arrays before handling. 

Before: 
--
<img width="1113" alt="image" src="https://user-images.githubusercontent.com/32107699/186973599-8b1434ad-1e3a-4846-9794-567f92804d0b.png">

After: 
--
<img width="1017" alt="image" src="https://user-images.githubusercontent.com/32107699/186973660-81bedc0a-bd03-45d4-98b6-ca67251f45ed.png">
