### PR TITLE
Remove default wavelength limits from `svo_fps` `get_filter_index()`

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -110,6 +110,9 @@ svo_fps
 - Queries with invalid parameter names now raise an ``InvalidQueryError``.
   [#2446]
 
+- The default wavelength range used by ``get_filter_index()`` was far too
+  large. The user must now always specify both upper and lower limits. [#2509]
+
 gaia
 ^^^^
 

--- a/astroquery/svo_fps/core.py
+++ b/astroquery/svo_fps/core.py
@@ -14,8 +14,6 @@ from astroquery.exceptions import InvalidQueryError
 
 __all__ = ['SvoFpsClass', 'SvoFps']
 
-FLOAT_MAX = np.finfo(np.float64).max
-
 # Valid query parameters taken from
 # http://svo2.cab.inta-csic.es/theory/fps/index.php?mode=voservice
 _params_with_range = {"WavelengthRef", "WavelengthMean", "WavelengthEff",
@@ -80,19 +78,17 @@ class SvoFpsClass(BaseQuery):
             # If no table element found in VOTable
             raise IndexError(error_msg)
 
-    def get_filter_index(self, wavelength_eff_min=0*u.angstrom,
-                         wavelength_eff_max=FLOAT_MAX*u.angstrom, **kwargs):
+    def get_filter_index(self, wavelength_eff_min, wavelength_eff_max, **kwargs):
         """Get master list (index) of all filters at SVO
         Optional parameters can be given to get filters data for specified
         Wavelength Effective range from SVO
 
         Parameters
         ----------
-        wavelength_eff_min : `~astropy.units.Quantity` with units of length, optional
-            Minimum value of Wavelength Effective (default is 0 angstrom)
-        wavelength_eff_max : `~astropy.units.Quantity` with units of length, optional
-            Maximum value of Wavelength Effective (default is a very large
-            quantity FLOAT_MAX angstroms i.e. maximum value of np.float64)
+        wavelength_eff_min : `~astropy.units.Quantity` with units of length
+            Minimum value of Wavelength Effective
+        wavelength_eff_max : `~astropy.units.Quantity` with units of length
+            Maximum value of Wavelength Effective
         kwargs : dict
             Passed to `data_from_svo`.  Relevant arguments include ``cache``
 

--- a/astroquery/svo_fps/tests/test_svo_fps.py
+++ b/astroquery/svo_fps/tests/test_svo_fps.py
@@ -47,6 +47,8 @@ def get_mockreturn(method, url, params=None, timeout=10, cache=None, **kwargs):
 
 
 def test_get_filter_index(patch_get):
+    with pytest.raises(TypeError, match="missing 2 required positional arguments"):
+        SvoFps.get_filter_index()
     lambda_min = TEST_LAMBDA*u.angstrom
     lambda_max = lambda_min + 100*u.angstrom
     table = SvoFps.get_filter_index(lambda_min, lambda_max)

--- a/docs/svo_fps/svo_fps.rst
+++ b/docs/svo_fps/svo_fps.rst
@@ -67,8 +67,6 @@ occur. A smaller wavelength range might succeed, but if a large range really is
 required then you can use the ``timeout`` argument to allow for a longer
 response time.
 
-.. doctest-skip-all
-
 Get list of Filters under a specified Facilty and Instrument
 ------------------------------------------------------------
 
@@ -77,14 +75,13 @@ Filters for an arbitrary combination of Facility & Instrument (the Facility
 must be specified, but the Instrument is optional).  The data table returned
 is of the same form as that from `~astroquery.svo_fps.SvoFpsClass.get_filter_index`:
 
-.. code-block:: python
+.. doctest-remote-data::
 
     >>> filter_list = SvoFps.get_filter_list(facility='Keck', instrument='NIRC2')
     >>> filter_list.info
-
-    <Table masked=True length=11>
-            name          dtype  unit
-    -------------------- ------- ----
+    <Table length=11>
+            name          dtype        unit
+    -------------------- ------- ---------------
     FilterProfileService  object
                 filterID  object
           WavelengthUnit  object
@@ -98,25 +95,26 @@ is of the same form as that from `~astroquery.svo_fps.SvoFpsClass.get_filter_ind
     CalibrationReference  object
              Description  object
                 Comments  object
-          WavelengthMean float32   AA
-           WavelengthEff float32   AA
-           WavelengthMin float32   AA
-           WavelengthMax float32   AA
-                WidthEff float32   AA
-           WavelengthCen float32   AA
-         WavelengthPivot float32   AA
-          WavelengthPeak float32   AA
-          WavelengthPhot float32   AA
-                    FWHM float32   AA
+           WavelengthRef float64              AA
+          WavelengthMean float64              AA
+           WavelengthEff float64              AA
+           WavelengthMin float64              AA
+           WavelengthMax float64              AA
+                WidthEff float64              AA
+           WavelengthCen float64              AA
+         WavelengthPivot float64              AA
+          WavelengthPeak float64              AA
+          WavelengthPhot float64              AA
+                    FWHM float64              AA
+                    Fsun float64 erg s / (A cm2)
                PhotCalID  object
                   MagSys  object
-               ZeroPoint float32   Jy
+               ZeroPoint float64              Jy
            ZeroPointUnit  object
-                    Mag0 float32
+                    Mag0 float64
            ZeroPointType  object
-               AsinhSoft float32
+               AsinhSoft float64
         TrasmissionCurve  object
-
 
 Get transmission data for a specific Filter
 -------------------------------------------
@@ -127,40 +125,39 @@ If you know the ``filterID`` of the filter (which you can determine with
 transmission curve data using
 `~astroquery.svo_fps.SvoFpsClass.get_transmission_data`:
 
-.. code-block:: python
+.. doctest-remote-data::
 
     >>> data = SvoFps.get_transmission_data('2MASS/2MASS.H')
-    >>> print(data)
+    >>> print(data)  # doctest: +FLOAT_CMP
     Wavelength Transmission
         AA
     ---------- ------------
-    12890.0          0.0
-    13150.0          0.0
-    13410.0          0.0
-    13680.0          0.0
-    13970.0          0.0
-    14180.0          0.0
-    14400.0       0.0005
-    14620.0       0.0028
-    14780.0       0.0081
-    14860.0       0.0287
-        ...          ...
-    18030.0       0.1077
-    18100.0       0.0707
-    18130.0       0.0051
-    18180.0         0.02
-    18280.0       0.0004
-    18350.0          0.0
-    18500.0        1e-04
-    18710.0          0.0
-    18930.0          0.0
-    19140.0          0.0
+       12890.0          0.0
+       13150.0          0.0
+       13410.0          0.0
+       13680.0          0.0
+       13970.0          0.0
+       14180.0          0.0
+       14400.0       0.0005
+       14620.0 0.0027999999
+       14780.0 0.0081000002
+       14860.0 0.0286999997
+           ...          ...
+       18030.0 0.1076999977
+       18100.0 0.0706999972
+       18130.0 0.0051000002
+       18180.0 0.0199999996
+       18280.0       0.0004
+       18350.0          0.0
+       18500.0       0.0001
+       18710.0          0.0
+       18930.0          0.0
+       19140.0          0.0
     Length = 58 rows
-
 
 These are the data needed to plot the transmission curve for filter:
 
-.. code-block:: python
+.. doctest-skip::
 
     >>> import matplotlib.pyplot as plt
     >>> plt.plot(data['Wavelength'], data['Transmission'])

--- a/docs/svo_fps/svo_fps.rst
+++ b/docs/svo_fps/svo_fps.rst
@@ -1,5 +1,3 @@
-.. doctest-skip-all
-
 .. _astroquery.svo_fps:
 
 **********************************************************
@@ -17,17 +15,19 @@ from the service as astropy tables.
 Get index list of all Filters
 -----------------------------
 
-The filter index (all available filters with their properties) can be listed
-with `~astroquery.svo_fps.SvoFpsClass.get_filter_index`:
+The filter index (the properties of all available filters in a wavelength
+range) can be listed with
+:meth:`~astroquery.svo_fps.SvoFpsClass.get_filter_index`:
 
-.. code-block:: python
+.. doctest-remote-data::
 
+    >>> from astropy import units as u
     >>> from astroquery.svo_fps import SvoFps
-    >>> index = SvoFps.get_filter_index()
+    >>> index = SvoFps.get_filter_index(12_000*u.angstrom, 12_100*u.angstrom)
     >>> index.info
-    <Table masked=True length=5139>
-            name          dtype  unit
-    -------------------- ------- ----
+    <Table length=14>
+            name          dtype        unit
+    -------------------- ------- ---------------
     FilterProfileService  object
                 filterID  object
           WavelengthUnit  object
@@ -41,28 +41,28 @@ with `~astroquery.svo_fps.SvoFpsClass.get_filter_index`:
     CalibrationReference  object
              Description  object
                 Comments  object
-          WavelengthMean float32   AA
-           WavelengthEff float32   AA
-           WavelengthMin float32   AA
-           WavelengthMax float32   AA
-                WidthEff float32   AA
-           WavelengthCen float32   AA
-         WavelengthPivot float32   AA
-          WavelengthPeak float32   AA
-          WavelengthPhot float32   AA
-                    FWHM float32   AA
+           WavelengthRef float64              AA
+          WavelengthMean float64              AA
+           WavelengthEff float64              AA
+           WavelengthMin float64              AA
+           WavelengthMax float64              AA
+                WidthEff float64              AA
+           WavelengthCen float64              AA
+         WavelengthPivot float64              AA
+          WavelengthPeak float64              AA
+          WavelengthPhot float64              AA
+                    FWHM float64              AA
+                    Fsun float64 erg s / (A cm2)
                PhotCalID  object
                   MagSys  object
-               ZeroPoint float32   Jy
+               ZeroPoint float64              Jy
            ZeroPointUnit  object
-                    Mag0 float32
+                    Mag0 float64
            ZeroPointType  object
-               AsinhSoft float32
+               AsinhSoft float64
         TrasmissionCurve  object
 
-There are options to downselect based on the minimum
-and maximum effective wavelength (``wavelength_eff_min``
-and ``wavelength_eff_max``, respectively).
+.. doctest-skip-all
 
 Get list of Filters under a specified Facilty and Instrument
 ------------------------------------------------------------

--- a/docs/svo_fps/svo_fps.rst
+++ b/docs/svo_fps/svo_fps.rst
@@ -128,7 +128,7 @@ transmission curve data using
 .. doctest-remote-data::
 
     >>> data = SvoFps.get_transmission_data('2MASS/2MASS.H')
-    >>> print(data)  # doctest: +FLOAT_CMP
+    >>> print(data)
     Wavelength Transmission
         AA
     ---------- ------------

--- a/docs/svo_fps/svo_fps.rst
+++ b/docs/svo_fps/svo_fps.rst
@@ -62,6 +62,11 @@ range) can be listed with
                AsinhSoft float64
         TrasmissionCurve  object
 
+If the wavelength range contains too many entries then a ``TimeoutError`` will
+occur. A smaller wavelength range might succeed, but if a large range really is
+required then you can use the ``timeout`` argument to allow for a longer
+response time.
+
 .. doctest-skip-all
 
 Get list of Filters under a specified Facilty and Instrument


### PR DESCRIPTION
So far the default behaviour of `get_filter_index()` from `svo_fps` has been to make the wavelength range as large as possible, but that results in a timeout. Now the method requires the user to explicitly set the wavelength limits. Although this is backwards incompatible, in practice the user already had to provide the limits and if they don't then it is better to receive an immediate `TypeError` about missing mandatory arguments than it is to wait a minute before an obscure timeout occurs.

See also 90677c86b69e7ea33a131d7a7cfc8282cd157f6b

Closes #2508