### PR TITLE
Log a warning if there are download duplicates for MAST

### DIFF
--- a/astroquery/exceptions.py
+++ b/astroquery/exceptions.py
@@ -7,9 +7,8 @@ from astropy.utils.exceptions import AstropyWarning
 
 __all__ = ['TimeoutError', 'InvalidQueryError', 'RemoteServiceError',
            'TableParseError', 'LoginError', 'ResolverError',
-           'NoResultsWarning', 'DuplicateResultsWarning', 'LargeQueryWarning',
-           'InputWarning', 'AuthenticationWarning', 'MaxResultsWarning',
-           'CorruptDataWarning']
+           'NoResultsWarning', 'LargeQueryWarning', 'InputWarning',
+           'AuthenticationWarning', 'MaxResultsWarning', 'CorruptDataWarning']
 
 
 class TimeoutError(Exception):
@@ -62,13 +61,6 @@ class ResolverError(Exception):
 
 
 class NoResultsWarning(AstropyWarning):
-    """
-    Astroquery warning class to be issued when a query returns no result.
-    """
-    pass
-
-
-class DuplicateResultsWarning(AstropyWarning):
     """
     Astroquery warning class to be issued when a query returns no result.
     """

--- a/astroquery/mast/observations.py
+++ b/astroquery/mast/observations.py
@@ -31,8 +31,8 @@ from ..query import QueryWithLogin
 from ..utils import commons, async_to_sync
 from ..utils.class_or_instance import class_or_instance
 from ..exceptions import (TimeoutError, InvalidQueryError, RemoteServiceError,
-                          ResolverError, MaxResultsWarning, DuplicateResultsWarning,
-                          NoResultsWarning, InputWarning, AuthenticationWarning)
+                          ResolverError, MaxResultsWarning, NoResultsWarning,
+                          InputWarning, AuthenticationWarning)
 
 from . import conf, utils
 from .core import MastQueryWithLogin
@@ -827,8 +827,8 @@ class ObservationsClass(MastQueryWithLogin):
         unique_products = unique(data_products, keys="dataURI")
         number_unique = len(unique_products)
         if number_unique < number:
-            warnings.warn(f"{number - number_unique} of {number} products were duplicates."
-                          f"Only downloading {number_unique} unique product(s).", DuplicateResultsWarning)
+            log.info(f"{number - number_unique} of {number} products were duplicates. "
+                          f"Only downloading {number_unique} unique product(s).")
 
         return unique_products
 


### PR DESCRIPTION
This is a follow-up PR in response to https://github.com/astropy/astroquery/pull/2497#issuecomment-1238167688

Instead of issuing a `warnings.warn` when duplicate downloads are culled, this PR uses `log.warning`.  I've removed the warning class I'd created and instead just logged the warning.  Test is updated as well.