### PR TITLE
BUG: ALMA Bugfix: wrong data dtype in a comparison

### DIFF
--- a/astroquery/alma/core.py
+++ b/astroquery/alma/core.py
@@ -594,7 +594,7 @@ class AlmaClass(QueryWithLogin):
                 result['semantics'].astype(str), '#aux') == -1]
         if not with_rawdata:
             result = result[np.core.defchararray.find(
-                result['semantics'], '#progenitor') == -1]
+                result['semantics'].astype(str), '#progenitor') == -1]
         # if expand_tarfiles:
         # identify the tarballs that can be expandable and replace them
         # with the list of components

--- a/astroquery/alma/core.py
+++ b/astroquery/alma/core.py
@@ -591,7 +591,7 @@ class AlmaClass(QueryWithLogin):
         result.remove_rows(to_delete)
         if not with_auxiliary:
             result = result[np.core.defchararray.find(
-                result['semantics'], '#aux') == -1]
+                result['semantics'].astype(str), '#aux') == -1]
         if not with_rawdata:
             result = result[np.core.defchararray.find(
                 result['semantics'], '#progenitor') == -1]


### PR DESCRIPTION
The `result['semantics']` column was being loaded as an `'object'` dtype, not a string dtype, resulting in a failure.

```python
g038_dan = Alma.query({'project_code': '2016.1.00766.S', 'source_name_alma': 'G0.38+0.04'})
g038_dan_files = Alma.get_data_info(g038_dan['member_ous_uid'], expand_tarfiles=True, with_auxiliary=False, with_rawdata=False)
```
gave
```
---------------------------------------------------------------------------
TypeError                                 Traceback (most recent call last)
/scratch/local/45915091/ipykernel_1791/194421952.py in <module>
      1 g038_dan = Alma.query({'project_code': '2016.1.00766.S', 'source_name_alma': 'G0.38+0.04'})
----> 2 g038_dan_files = Alma.get_data_info(g038_dan['member_ous_uid'], expand_tarfiles=True, with_auxiliary=False, with_rawdata=False)
      3 #Alma.download_files([x for x in g038_dan_files['access_url'] if '001.tar' in x])
      4 g038_dan_files

/blue/adamginsburg/adamginsburg/repos/astroquery/astroquery/alma/core.py in get_data_info(self, uids, expand_tarfiles, with_auxiliary, with_rawdata)
    585         result.remove_rows(to_delete)
    586         if not with_auxiliary:
--> 587             result = result[np.core.defchararray.find(
    588                 result['semantics'], '#aux') == -1]
    589         if not with_rawdata:

/orange/adamginsburg/miniconda3/envs/python39/lib/python3.9/site-packages/numpy/core/overrides.py in find(*args, **kwargs)

/orange/adamginsburg/miniconda3/envs/python39/lib/python3.9/site-packages/numpy/core/defchararray.py in find(a, sub, start, end)
    713 
    714     """
--> 715     return _vec_string(
    716         a, int_, 'find', [sub, start] + _clean_args(end))
    717 

TypeError: string operation on non-string array
```