### PR TITLE
BUG: Fix SDSS parsing to directly use Table.read

### DIFF
--- a/astroquery/sdss/core.py
+++ b/astroquery/sdss/core.py
@@ -896,21 +896,15 @@ class SDSSClass(BaseQuery):
         table : `~astropy.table.Table`
 
         """
+        if 'error_message' in response.text:
+            raise RemoteServiceError(response.text)
 
-        if 'error_message' in io.BytesIO(response.content):
-            raise RemoteServiceError(response.content)
-        skip_header = 0
-        if response.content.startswith(b'#Table'):
-            skip_header = 1
-        arr = np.atleast_1d(np.genfromtxt(io.BytesIO(response.content),
-                                          names=True, dtype=None,
-                                          delimiter=',', skip_header=skip_header,
-                                          comments='#'))
+        arr = Table.read(response.text, format='ascii.csv', comment="#")
 
         if len(arr) == 0:
             return None
         else:
-            return Table(arr)
+            return arr
 
     def _args_to_payload(self, coordinates=None,
                          fields=None, spectro=False, region=False,

--- a/astroquery/sdss/tests/test_sdss.py
+++ b/astroquery/sdss/tests/test_sdss.py
@@ -145,7 +145,7 @@ def url_tester_crossid(data_release):
 def compare_xid_data(xid, data):
     for col in xid.colnames:
         if xid[col].dtype.type is np.str_:
-            assert xid[col] == data[col]
+            assert all(xid[col] == data[col])
         else:
             assert_allclose(xid[col], data[col])
 

--- a/astroquery/sdss/tests/test_sdss.py
+++ b/astroquery/sdss/tests/test_sdss.py
@@ -196,10 +196,7 @@ def test_sdss_sql(patch_request, patch_get_readable_fileobj, dr):
     xid = sdss.SDSS.query_sql(query, data_release=dr)
     data = Table.read(data_path(DATA_FILES['images_id']),
                       format='ascii.csv', comment='#')
-    # The following line is needed for systems where the default integer type
-    # is int32, the column will then be interpreted as string which makes the
-    # test fail.
-    data['objid'] = data['objid'].astype(np.int64)
+
     compare_xid_data(xid, data)
     url_tester(dr)
 
@@ -237,11 +234,7 @@ def test_sdss_specobj(patch_request, dr):
     xid = sdss.SDSS.query_specobj(plate=2340, data_release=dr)
     data = Table.read(data_path(DATA_FILES['spectra_id']),
                       format='ascii.csv', comment='#')
-    # The following line is needed for systems where the default integer type
-    # is int32, the column will then be interpreted as string which makes the
-    # test fail.
-    data['specobjid'] = data['specobjid'].astype(np.int64)
-    data['objid'] = data['objid'].astype(np.int64)
+
     compare_xid_data(xid, data)
     url_tester(dr)
 
@@ -252,10 +245,6 @@ def test_sdss_photoobj(patch_request, dr):
         run=1904, camcol=3, field=164, data_release=dr)
     data = Table.read(data_path(DATA_FILES['images_id']),
                       format='ascii.csv', comment='#')
-    # The following line is needed for systems where the default integer type
-    # is int32, the column will then be interpreted as string which makes the
-    # test fail.
-    data['objid'] = data['objid'].astype(np.int64)
     compare_xid_data(xid, data)
     url_tester(dr)
 
@@ -265,10 +254,6 @@ def test_list_coordinates(patch_request, dr):
     xid = sdss.SDSS.query_region(coords_list, data_release=dr)
     data = Table.read(data_path(DATA_FILES['images_id']),
                       format='ascii.csv', comment='#')
-    # The following line is needed for systems where the default integer type
-    # is int32, the column will then be interpreted as string which makes the
-    # test fail.
-    data['objid'] = data['objid'].astype(np.int64)
     compare_xid_data(xid, data)
     url_tester_crossid(dr)
 
@@ -278,10 +263,6 @@ def test_column_coordinates(patch_request, dr):
     xid = sdss.SDSS.query_region(coords_column, data_release=dr)
     data = Table.read(data_path(DATA_FILES['images_id']),
                       format='ascii.csv', comment='#')
-    # The following line is needed for systems where the default integer type
-    # is int32, the column will then be interpreted as string which makes the
-    # test fail.
-    data['objid'] = data['objid'].astype(np.int64)
     compare_xid_data(xid, data)
     url_tester_crossid(dr)
 
@@ -306,10 +287,6 @@ def test_query_crossid(patch_request, dr):
     xid = sdss.SDSS.query_crossid(coords_column, data_release=dr)
     data = Table.read(data_path(DATA_FILES['images_id']),
                       format='ascii.csv', comment='#')
-    # The following line is needed for systems where the default integer type
-    # is int32, the column will then be interpreted as string which makes the
-    # test fail.
-    data['objid'] = data['objid'].astype(np.int64)
     compare_xid_data(xid, data)
     url_tester_crossid(dr)
 

--- a/astroquery/sdss/tests/test_sdss.py
+++ b/astroquery/sdss/tests/test_sdss.py
@@ -144,7 +144,7 @@ def url_tester_crossid(data_release):
 
 def compare_xid_data(xid, data):
     for col in xid.colnames:
-        if xid[col].dtype.type is np.string_:
+        if xid[col].dtype.type is np.str_:
             assert xid[col] == data[col]
         else:
             assert_allclose(xid[col], data[col])

--- a/setup.cfg
+++ b/setup.cfg
@@ -39,7 +39,6 @@ filterwarnings =
 # This is a temporary measure, all of these should be fixed:
     ignore:distutils Version classes are deprecated:DeprecationWarning
     ignore::pytest.PytestUnraisableExceptionWarning
-    ignore::numpy.VisibleDeprecationWarning
     ignore:unclosed <ssl.SSLSocket:ResourceWarning
     ignore::UserWarning
     ignore::astroquery.exceptions.InputWarning


### PR DESCRIPTION
The previous solution raised a numpy VisibleDeprecationWarning, so this PR switches away from using np.genfromtxt and then converting to a Table in favour of using the ascii reader to get a Table in one step.