### PR TITLE
MAINT: explicitly stating minimum required python version

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -149,6 +149,9 @@ omit =
 [entry_points]
 
 [options]
+
+python_requires = >=3.7
+
 install_requires=
    numpy>=1.16
    astropy>=4.0


### PR DESCRIPTION
We should probably drop 3.7 support, too, nevertheless, we should at least state what we require in the config in addition to the narrative docs.