### PR TITLE
Refactored query criteria to use ehst.archive table

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -20,8 +20,8 @@ hsa
 Service fixes and enhancements
 ------------------------------
 
-hst
-^^^
+esa.hubble
+^^^^^^^^^^
 
 - Refactored query_criteria to use ehst.archive table therefore making the query
   a lot faster. [#2524]

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -20,6 +20,12 @@ hsa
 Service fixes and enhancements
 ------------------------------
 
+hst
+^^^
+
+- Refactored query_criteria to use ehst.archive table therefore making the query
+  a lot faster. [#2524]
+
 alma
 ^^^^
 

--- a/astroquery/esa/hubble/core.py
+++ b/astroquery/esa/hubble/core.py
@@ -475,7 +475,7 @@ class ESAHubbleClass(BaseQuery):
             radius_in_grades = Angle(radius, units.arcmin).deg
         else:
             radius_in_grades = radius.to(units.deg).value
-        cone_query = "1=CONTAINS(POINT('ICRS', pos.ra, pos.dec)," \
+        cone_query = "1=CONTAINS(POINT('ICRS', ra, dec)," \
                      "CIRCLE('ICRS', {0}, {1}, {2}))". \
             format(str(ra), str(dec), str(radius_in_grades))
         query = "{}{})".format(crit_query, cone_query)

--- a/astroquery/esa/hubble/tests/test_esa_hubble.py
+++ b/astroquery/esa/hubble/tests/test_esa_hubble.py
@@ -275,18 +275,12 @@ class TestESAHubble:
                        'output_file': "output_test_query_by_criteria.vot.gz",
                        'output_format': "votable",
                        'verbose': False}
-        parameters3 = {'query': "select o.*, p.calibration_level, "
-                                "p.data_product_type, pos.ra, pos.dec "
-                                "from ehst.observation "
-                                "AS o JOIN ehst.plane as p on "
-                                "o.observation_uuid=p.observation_uuid "
-                                "JOIN ehst.position as pos on "
-                                "p.plane_id = pos.plane_id where("
-                                "p.calibration_level LIKE '%PRODUCT%' AND "
-                                "p.data_product_type LIKE '%image%' AND "
-                                "o.intent LIKE '%SCIENCE%' AND (o.collection "
-                                "LIKE '%HST%') AND (o.instrument_name LIKE "
-                                "'%WFC3%') AND (o.instrument_configuration "
+        parameters3 = {'query': "select * from ehst.archive where("
+                                "calibration_level=3 AND "
+                                "data_product_type LIKE '%image%' AND "
+                                "intent LIKE '%science%' AND (collection "
+                                "LIKE '%HST%') AND (instrument_name LIKE "
+                                "'%WFC3%') AND (instrument_configuration "
                                 "LIKE '%F555W%'))",
                        'output_file': "output_test_query_by_criteria.vot.gz",
                        'output_format': "votable",
@@ -322,18 +316,12 @@ class TestESAHubble:
                        'output_file': "output_test_query_by_criteria.vot.gz",
                        'output_format': "votable",
                        'verbose': False}
-        parameters3 = {'query': "select o.*, p.calibration_level, "
-                                "p.data_product_type, pos.ra, pos.dec"
-                                " from ehst.observation "
-                                "AS o JOIN ehst.plane as p on "
-                                "o.observation_uuid=p.observation_uuid "
-                                "JOIN ehst.position as pos on p.plane_id "
-                                "= pos.plane_id where("
-                                "p.calibration_level LIKE '%RAW%' AND "
-                                "p.data_product_type LIKE '%image%' AND "
-                                "o.intent LIKE '%SCIENCE%' AND (o.collection "
-                                "LIKE '%HST%') AND (o.instrument_name LIKE "
-                                "'%WFC3%') AND (o.instrument_configuration "
+        parameters3 = {'query': "select * from ehst.archive where("
+                                "calibration_level=1 AND "
+                                "data_product_type LIKE '%image%' AND "
+                                "intent LIKE '%science%' AND (collection "
+                                "LIKE '%HST%') AND (instrument_name LIKE "
+                                "'%WFC3%') AND (instrument_configuration "
                                 "LIKE '%F555W%'))",
                        'output_file': "output_test_query_by_criteria.vot.gz",
                        'output_format': "votable",

--- a/docs/esa/hubble/hubble.rst
+++ b/docs/esa/hubble/hubble.rst
@@ -307,7 +307,7 @@ This last example will provide the ADQL query based on the criteria defined by t
   ...                                   filters = ['F555W', 'F606W'],
   ...                                   get_query = True)
   >>> print(result)
-  select o.*, p.calibration_level, p.data_product_type, pos.ra, pos.dec from ehst.observation AS o JOIN ehst.plane as p on o.observation_uuid=p.observation_uuid JOIN ehst.position as pos on p.plane_id = pos.plane_id where(p.calibration_level LIKE '%PRODUCT%' AND p.data_product_type LIKE '%image%' AND o.intent LIKE '%SCIENCE%' AND (o.collection LIKE '%HLA%') AND (o.instrument_name LIKE '%WFC3%') AND (o.instrument_configuration LIKE '%F555W%' OR o.instrument_configuration LIKE '%F606W%'))
+  select * from ehst.archive where(calibration_level=3 AND data_product_type LIKE '%image%' AND intent LIKE '%science%' AND (collection LIKE '%HLA%') AND (instrument_name LIKE '%WFC3%') AND (instrument_configuration LIKE '%F555W%' OR instrument_configuration LIKE '%F606W%'))
 
 --------------------------------------
 6. Cone searches in the Hubble archive


### PR DESCRIPTION
Dear Astroquery team,

The query_criteria method in Hubble astroquery is using a complex query, joining three big tables and this makes its execution really slow. This query has been refactored to use only ehst.archive table, which contains all the criteria parameters.

Please let me know if any further changes are necessary.

Kind regards,

Javier