### PR TITLE
Shorten `esa/jwst` and `gaia` tests

### DIFF
--- a/astroquery/esa/jwst/tests/test_jwsttap.py
+++ b/astroquery/esa/jwst/tests/test_jwsttap.py
@@ -233,9 +233,7 @@ class TestTap:
 
         # Launch response: we use default response because the
         # query contains decimals
-        responseLaunchJob = DummyResponse()
-        responseLaunchJob.set_status_code(200)
-        responseLaunchJob.set_message("OK")
+        responseLaunchJob = DummyResponse(200)
         jobDataFile = data_path('job_1.vot')
         jobData = utils.read_file_content(jobDataFile)
         responseLaunchJob.set_data(method='POST',
@@ -372,9 +370,7 @@ class TestTap:
         tap = JwstClass(tap_plus_handler=tapplus, show_messages=False)
         jobid = '12345'
         # Launch response
-        responseLaunchJob = DummyResponse()
-        responseLaunchJob.set_status_code(303)
-        responseLaunchJob.set_message("OK")
+        responseLaunchJob = DummyResponse(303)
         # list of list (httplib implementation for headers in response)
         launchResponseHeaders = [['location', 'http://test:1111/tap/async/' + jobid]]
         responseLaunchJob.set_data(method='POST',
@@ -383,9 +379,7 @@ class TestTap:
                                    headers=launchResponseHeaders)
         connHandler.set_default_response(responseLaunchJob)
         # Phase response
-        responsePhase = DummyResponse()
-        responsePhase.set_status_code(200)
-        responsePhase.set_message("OK")
+        responsePhase = DummyResponse(200)
         responsePhase.set_data(method='GET',
                                context=None,
                                body="COMPLETED",
@@ -393,9 +387,7 @@ class TestTap:
         req = "async/" + jobid + "/phase"
         connHandler.set_response(req, responsePhase)
         # Results response
-        responseResultsJob = DummyResponse()
-        responseResultsJob.set_status_code(200)
-        responseResultsJob.set_message("OK")
+        responseResultsJob = DummyResponse(200)
         jobDataFile = data_path('job_1.vot')
         jobData = utils.read_file_content(jobDataFile)
         responseResultsJob.set_data(method='GET',
@@ -461,9 +453,7 @@ class TestTap:
         tap = JwstClass(tap_plus_handler=tapplus, show_messages=False)
         # Launch response: we use default response because the
         # query contains decimals
-        responseLaunchJob = DummyResponse()
-        responseLaunchJob.set_status_code(200)
-        responseLaunchJob.set_message("OK")
+        responseLaunchJob = DummyResponse(200)
         jobDataFile = data_path('job_1.vot')
         jobData = utils.read_file_content(jobDataFile)
         responseLaunchJob.set_data(method='POST',
@@ -553,9 +543,7 @@ class TestTap:
         tap = JwstClass(tap_plus_handler=tapplus, show_messages=False)
         jobid = '12345'
         # Launch response
-        responseLaunchJob = DummyResponse()
-        responseLaunchJob.set_status_code(303)
-        responseLaunchJob.set_message("OK")
+        responseLaunchJob = DummyResponse(303)
         # list of list (httplib implementation for headers in response)
         launchResponseHeaders = [['location', 'http://test:1111/tap/async/' + jobid]]
         responseLaunchJob.set_data(method='POST',
@@ -568,9 +556,7 @@ class TestTap:
         radius = Quantity(1.0, u.deg)
         connHandler.set_default_response(responseLaunchJob)
         # Phase response
-        responsePhase = DummyResponse()
-        responsePhase.set_status_code(200)
-        responsePhase.set_message("OK")
+        responsePhase = DummyResponse(200)
         responsePhase.set_data(method='GET',
                                context=None,
                                body="COMPLETED",
@@ -578,9 +564,7 @@ class TestTap:
         req = "async/" + jobid + "/phase"
         connHandler.set_response(req, responsePhase)
         # Results response
-        responseResultsJob = DummyResponse()
-        responseResultsJob.set_status_code(200)
-        responseResultsJob.set_message("OK")
+        responseResultsJob = DummyResponse(200)
         jobDataFile = data_path('job_1.vot')
         jobData = utils.read_file_content(jobDataFile)
         responseResultsJob.set_data(method='GET',

--- a/astroquery/esa/jwst/tests/test_jwsttap.py
+++ b/astroquery/esa/jwst/tests/test_jwsttap.py
@@ -236,10 +236,7 @@ class TestTap:
         responseLaunchJob = DummyResponse(200)
         jobDataFile = data_path('job_1.vot')
         jobData = utils.read_file_content(jobDataFile)
-        responseLaunchJob.set_data(method='POST',
-                                   context=None,
-                                   body=jobData,
-                                   headers=None)
+        responseLaunchJob.set_data(method='POST', body=jobData)
         # The query contains decimals: force default response
         connHandler.set_default_response(responseLaunchJob)
         sc = SkyCoord(ra=29.0, dec=15.0, unit=(u.degree, u.degree),
@@ -373,27 +370,18 @@ class TestTap:
         responseLaunchJob = DummyResponse(303)
         # list of list (httplib implementation for headers in response)
         launchResponseHeaders = [['location', 'http://test:1111/tap/async/' + jobid]]
-        responseLaunchJob.set_data(method='POST',
-                                   context=None,
-                                   body=None,
-                                   headers=launchResponseHeaders)
+        responseLaunchJob.set_data(method='POST', headers=launchResponseHeaders)
         connHandler.set_default_response(responseLaunchJob)
         # Phase response
         responsePhase = DummyResponse(200)
-        responsePhase.set_data(method='GET',
-                               context=None,
-                               body="COMPLETED",
-                               headers=None)
+        responsePhase.set_data(method='GET', body="COMPLETED")
         req = "async/" + jobid + "/phase"
         connHandler.set_response(req, responsePhase)
         # Results response
         responseResultsJob = DummyResponse(200)
         jobDataFile = data_path('job_1.vot')
         jobData = utils.read_file_content(jobDataFile)
-        responseResultsJob.set_data(method='GET',
-                                    context=None,
-                                    body=jobData,
-                                    headers=None)
+        responseResultsJob.set_data(method='GET', body=jobData)
         req = "async/" + jobid + "/results/result"
         connHandler.set_response(req, responseResultsJob)
         sc = SkyCoord(ra=29.0, dec=15.0, unit=(u.degree, u.degree),
@@ -456,10 +444,7 @@ class TestTap:
         responseLaunchJob = DummyResponse(200)
         jobDataFile = data_path('job_1.vot')
         jobData = utils.read_file_content(jobDataFile)
-        responseLaunchJob.set_data(method='POST',
-                                   context=None,
-                                   body=jobData,
-                                   headers=None)
+        responseLaunchJob.set_data(method='POST', body=jobData)
         ra = 19.0
         dec = 20.0
         sc = SkyCoord(ra=ra, dec=dec, unit=(u.degree, u.degree), frame='icrs')
@@ -546,10 +531,7 @@ class TestTap:
         responseLaunchJob = DummyResponse(303)
         # list of list (httplib implementation for headers in response)
         launchResponseHeaders = [['location', 'http://test:1111/tap/async/' + jobid]]
-        responseLaunchJob.set_data(method='POST',
-                                   context=None,
-                                   body=None,
-                                   headers=launchResponseHeaders)
+        responseLaunchJob.set_data(method='POST', headers=launchResponseHeaders)
         ra = 19
         dec = 20
         sc = SkyCoord(ra=ra, dec=dec, unit=(u.degree, u.degree), frame='icrs')
@@ -557,20 +539,14 @@ class TestTap:
         connHandler.set_default_response(responseLaunchJob)
         # Phase response
         responsePhase = DummyResponse(200)
-        responsePhase.set_data(method='GET',
-                               context=None,
-                               body="COMPLETED",
-                               headers=None)
+        responsePhase.set_data(method='GET', body="COMPLETED")
         req = "async/" + jobid + "/phase"
         connHandler.set_response(req, responsePhase)
         # Results response
         responseResultsJob = DummyResponse(200)
         jobDataFile = data_path('job_1.vot')
         jobData = utils.read_file_content(jobDataFile)
-        responseResultsJob.set_data(method='GET',
-                                    context=None,
-                                    body=jobData,
-                                    headers=None)
+        responseResultsJob.set_data(method='GET', body=jobData)
         req = "async/" + jobid + "/results/result"
         connHandler.set_response(req, responseResultsJob)
         job = tap.cone_search(sc, radius, async_job=True)

--- a/astroquery/gaia/tests/test_gaiatap.py
+++ b/astroquery/gaia/tests/test_gaiatap.py
@@ -44,9 +44,7 @@ class TestTap:
     def test_show_message(self):
         connHandler = DummyConnHandler()
 
-        dummy_response = DummyResponse()
-        dummy_response.set_status_code(200)
-        dummy_response.set_message("OK")
+        dummy_response = DummyResponse(200)
 
         message_text = "1653401204784D[type: -100,-1]=Gaia dev is under maintenance"
 
@@ -67,9 +65,7 @@ class TestTap:
         conn_handler = DummyConnHandler()
         # Launch response: we use default response because the query contains
         # decimals
-        dummy_response = DummyResponse()
-        dummy_response.set_status_code(200)
-        dummy_response.set_message("OK")
+        dummy_response = DummyResponse(200)
 
         message_text = "1653401204784D[type: -100,-1]=Gaia dev is under maintenance"
 
@@ -87,9 +83,7 @@ class TestTap:
         tap = GaiaClass(conn_handler, tapplus, show_server_messages=True)
         # Launch response: we use default response because the query contains
         # decimals
-        response_launch_job = DummyResponse()
-        response_launch_job.set_status_code(200)
-        response_launch_job.set_message("OK")
+        response_launch_job = DummyResponse(200)
         job_data_file = data_path('job_1.vot')
         job_data = utils.read_file_content(job_data_file)
         response_launch_job.set_data(method='POST',
@@ -168,9 +162,7 @@ class TestTap:
         tap = GaiaClass(conn_handler, tapplus, show_server_messages=False)
         jobid = '12345'
         # Launch response
-        response_launch_job = DummyResponse()
-        response_launch_job.set_status_code(303)
-        response_launch_job.set_message("OK")
+        response_launch_job = DummyResponse(303)
         # list of list (httplib implementation for headers in response)
         launch_response_headers = [
             ['location', 'http://test:1111/tap/async/' + jobid]
@@ -181,9 +173,7 @@ class TestTap:
                                      headers=launch_response_headers)
         conn_handler.set_default_response(response_launch_job)
         # Phase response
-        response_phase = DummyResponse()
-        response_phase.set_status_code(200)
-        response_phase.set_message("OK")
+        response_phase = DummyResponse(200)
         response_phase.set_data(method='GET',
                                 context=None,
                                 body="COMPLETED",
@@ -191,9 +181,7 @@ class TestTap:
         req = "async/" + jobid + "/phase"
         conn_handler.set_response(req, response_phase)
         # Results response
-        response_results_job = DummyResponse()
-        response_results_job.set_status_code(200)
-        response_results_job.set_message("OK")
+        response_results_job = DummyResponse(200)
         job_data_file = data_path('job_1.vot')
         job_data = utils.read_file_content(job_data_file)
         response_results_job.set_data(method='GET',
@@ -263,9 +251,7 @@ class TestTap:
         tap = GaiaClass(conn_handler, tapplus, show_server_messages=False)
         # Launch response: we use default response because the query contains
         # decimals
-        response_launch_job = DummyResponse()
-        response_launch_job.set_status_code(200)
-        response_launch_job.set_message("OK")
+        response_launch_job = DummyResponse(200)
         job_data_file = data_path('job_1.vot')
         job_data = utils.read_file_content(job_data_file)
         response_launch_job.set_data(method='POST',
@@ -316,9 +302,7 @@ class TestTap:
         tap = GaiaClass(conn_handler, tapplus, show_server_messages=False)
         jobid = '12345'
         # Launch response
-        response_launch_job = DummyResponse()
-        response_launch_job.set_status_code(303)
-        response_launch_job.set_message("OK")
+        response_launch_job = DummyResponse(303)
         # list of list (httplib implementation for headers in response)
         launch_response_headers = [
             ['location', 'http://test:1111/tap/async/' + jobid]
@@ -333,9 +317,7 @@ class TestTap:
         radius = Quantity(1.0, u.deg)
         conn_handler.set_default_response(response_launch_job)
         # Phase response
-        response_phase = DummyResponse()
-        response_phase.set_status_code(200)
-        response_phase.set_message("OK")
+        response_phase = DummyResponse(200)
         response_phase.set_data(method='GET',
                                 context=None,
                                 body="COMPLETED",
@@ -343,9 +325,7 @@ class TestTap:
         req = "async/" + jobid + "/phase"
         conn_handler.set_response(req, response_phase)
         # Results response
-        response_results_job = DummyResponse()
-        response_results_job.set_status_code(200)
-        response_results_job.set_message("OK")
+        response_results_job = DummyResponse(200)
         job_data_file = data_path('job_1.vot')
         job_data = utils.read_file_content(job_data_file)
         response_results_job.set_data(method='GET',
@@ -474,9 +454,7 @@ class TestTap:
         tap = GaiaClass(conn_handler, tapplus, show_server_messages=False)
         jobid = '12345'
         # Launch response
-        response_launch_job = DummyResponse()
-        response_launch_job.set_status_code(303)
-        response_launch_job.set_message("OK")
+        response_launch_job = DummyResponse(303)
         # list of list (httplib implementation for headers in response)
         launch_response_headers = [
             ['location', 'http://test:1111/tap/async/' + jobid]
@@ -487,9 +465,7 @@ class TestTap:
                                      headers=launch_response_headers)
         conn_handler.set_default_response(response_launch_job)
         # Phase response
-        response_phase = DummyResponse()
-        response_phase.set_status_code(200)
-        response_phase.set_message("OK")
+        response_phase = DummyResponse(200)
         response_phase.set_data(method='GET',
                                 context=None,
                                 body="COMPLETED",
@@ -497,9 +473,7 @@ class TestTap:
         req = "async/" + jobid + "/phase"
         conn_handler.set_response(req, response_phase)
         # Results response
-        response_results_job = DummyResponse()
-        response_results_job.set_status_code(200)
-        response_results_job.set_message("OK")
+        response_results_job = DummyResponse(200)
         job_data_file = data_path('job_1.vot')
         job_data = utils.read_file_content(job_data_file)
         response_results_job.set_data(method='GET',

--- a/astroquery/gaia/tests/test_gaiatap.py
+++ b/astroquery/gaia/tests/test_gaiatap.py
@@ -48,10 +48,7 @@ class TestTap:
 
         message_text = "1653401204784D[type: -100,-1]=Gaia dev is under maintenance"
 
-        dummy_response.set_data(method='GET',
-                                context=None,
-                                body=message_text,
-                                headers=None)
+        dummy_response.set_data(method='GET', body=message_text)
         connHandler.set_default_response(dummy_response)
 
         # show_server_messages
@@ -69,10 +66,7 @@ class TestTap:
 
         message_text = "1653401204784D[type: -100,-1]=Gaia dev is under maintenance"
 
-        dummy_response.set_data(method='GET',
-                                context=None,
-                                body=message_text,
-                                headers=None)
+        dummy_response.set_data(method='GET', body=message_text)
         conn_handler.set_default_response(dummy_response)
 
         # show_server_messages
@@ -86,10 +80,7 @@ class TestTap:
         response_launch_job = DummyResponse(200)
         job_data_file = data_path('job_1.vot')
         job_data = utils.read_file_content(job_data_file)
-        response_launch_job.set_data(method='POST',
-                                     context=None,
-                                     body=job_data,
-                                     headers=None)
+        response_launch_job.set_data(method='POST', body=job_data)
         # The query contains decimals: force default response
         conn_handler.set_default_response(response_launch_job)
         sc = SkyCoord(ra=29.0, dec=15.0, unit=(u.degree, u.degree),
@@ -167,27 +158,18 @@ class TestTap:
         launch_response_headers = [
             ['location', 'http://test:1111/tap/async/' + jobid]
         ]
-        response_launch_job.set_data(method='POST',
-                                     context=None,
-                                     body=None,
-                                     headers=launch_response_headers)
+        response_launch_job.set_data(method='POST', headers=launch_response_headers)
         conn_handler.set_default_response(response_launch_job)
         # Phase response
         response_phase = DummyResponse(200)
-        response_phase.set_data(method='GET',
-                                context=None,
-                                body="COMPLETED",
-                                headers=None)
+        response_phase.set_data(method='GET', body="COMPLETED")
         req = "async/" + jobid + "/phase"
         conn_handler.set_response(req, response_phase)
         # Results response
         response_results_job = DummyResponse(200)
         job_data_file = data_path('job_1.vot')
         job_data = utils.read_file_content(job_data_file)
-        response_results_job.set_data(method='GET',
-                                      context=None,
-                                      body=job_data,
-                                      headers=None)
+        response_results_job.set_data(method='GET', body=job_data)
         req = "async/" + jobid + "/results/result"
         conn_handler.set_response(req, response_results_job)
         sc = SkyCoord(ra=29.0, dec=15.0, unit=(u.degree, u.degree),
@@ -254,10 +236,7 @@ class TestTap:
         response_launch_job = DummyResponse(200)
         job_data_file = data_path('job_1.vot')
         job_data = utils.read_file_content(job_data_file)
-        response_launch_job.set_data(method='POST',
-                                     context=None,
-                                     body=job_data,
-                                     headers=None)
+        response_launch_job.set_data(method='POST', body=job_data)
         ra = 19.0
         dec = 20.0
         sc = SkyCoord(ra=ra, dec=dec, unit=(u.degree, u.degree), frame='icrs')
@@ -307,10 +286,7 @@ class TestTap:
         launch_response_headers = [
             ['location', 'http://test:1111/tap/async/' + jobid]
         ]
-        response_launch_job.set_data(method='POST',
-                                     context=None,
-                                     body=None,
-                                     headers=launch_response_headers)
+        response_launch_job.set_data(method='POST', headers=launch_response_headers)
         ra = 19
         dec = 20
         sc = SkyCoord(ra=ra, dec=dec, unit=(u.degree, u.degree), frame='icrs')
@@ -318,20 +294,14 @@ class TestTap:
         conn_handler.set_default_response(response_launch_job)
         # Phase response
         response_phase = DummyResponse(200)
-        response_phase.set_data(method='GET',
-                                context=None,
-                                body="COMPLETED",
-                                headers=None)
+        response_phase.set_data(method='GET', body="COMPLETED")
         req = "async/" + jobid + "/phase"
         conn_handler.set_response(req, response_phase)
         # Results response
         response_results_job = DummyResponse(200)
         job_data_file = data_path('job_1.vot')
         job_data = utils.read_file_content(job_data_file)
-        response_results_job.set_data(method='GET',
-                                      context=None,
-                                      body=job_data,
-                                      headers=None)
+        response_results_job.set_data(method='GET', body=job_data)
         req = "async/" + jobid + "/results/result"
         conn_handler.set_response(req, response_results_job)
         job = tap.cone_search_async(sc, radius)
@@ -459,27 +429,18 @@ class TestTap:
         launch_response_headers = [
             ['location', 'http://test:1111/tap/async/' + jobid]
         ]
-        response_launch_job.set_data(method='POST',
-                                     context=None,
-                                     body=None,
-                                     headers=launch_response_headers)
+        response_launch_job.set_data(method='POST', headers=launch_response_headers)
         conn_handler.set_default_response(response_launch_job)
         # Phase response
         response_phase = DummyResponse(200)
-        response_phase.set_data(method='GET',
-                                context=None,
-                                body="COMPLETED",
-                                headers=None)
+        response_phase.set_data(method='GET', body="COMPLETED")
         req = "async/" + jobid + "/phase"
         conn_handler.set_response(req, response_phase)
         # Results response
         response_results_job = DummyResponse(200)
         job_data_file = data_path('job_1.vot')
         job_data = utils.read_file_content(job_data_file)
-        response_results_job.set_data(method='GET',
-                                      context=None,
-                                      body=job_data,
-                                      headers=None)
+        response_results_job.set_data(method='GET', body=job_data)
         req = "async/" + jobid + "/results/result"
         conn_handler.set_response(req, response_results_job)
         query = ("SELECT crossmatch_positional(",

--- a/astroquery/utils/tap/conn/tests/DummyConn.py
+++ b/astroquery/utils/tap/conn/tests/DummyConn.py
@@ -29,7 +29,7 @@ class DummyConn:
         self.cookie = None
         self.ishttps = False
 
-    def request(self, method, context, body, headers):
+    def request(self, method, context=None, body=None, headers=None):
         self.response.set_data(method, context, body, headers)
 
     def getresponse(self):

--- a/astroquery/utils/tap/conn/tests/DummyResponse.py
+++ b/astroquery/utils/tap/conn/tests/DummyResponse.py
@@ -21,17 +21,17 @@ class DummyResponse:
     classdocs
     '''
 
-    def __init__(self):
+    STATUS_MESSAGES = {200: "OK", 303: "OK", 500: "ERROR"}
+
+    def __init__(self, status_code=None):
         self.reason = ""
-        self.status = 0
+        self.set_status_code(status_code)
         self.index = 0
         self.set_data(None, None, None, None)
 
-    def set_status_code(self, status):
-        self.status = status
-
-    def set_message(self, reason):
-        self.reason = reason
+    def set_status_code(self, status_code):
+        self.status = status_code
+        self.reason = self.STATUS_MESSAGES.get(status_code)
 
     def set_data(self, method, context, body, headers):
         self.method = method

--- a/astroquery/utils/tap/conn/tests/DummyResponse.py
+++ b/astroquery/utils/tap/conn/tests/DummyResponse.py
@@ -33,7 +33,7 @@ class DummyResponse:
         self.status = status_code
         self.reason = self.STATUS_MESSAGES.get(status_code)
 
-    def set_data(self, method, context, body, headers):
+    def set_data(self, method, context=None, body=None, headers=None):
         self.method = method
         self.context = context
         self.body = body

--- a/astroquery/utils/tap/model/tests/test_job.py
+++ b/astroquery/utils/tap/model/tests/test_job.py
@@ -41,9 +41,7 @@ def test_job_get_results(capsys, tmpdir):
     outputFormat = "votable"
     job.jobid = jobid
     job.parameters['format'] = outputFormat
-    responseCheckPhase = DummyResponse()
-    responseCheckPhase.set_status_code(500)
-    responseCheckPhase.set_message("ERROR")
+    responseCheckPhase = DummyResponse(500)
     responseCheckPhase.set_data(method='GET',
                                 context=None,
                                 body='FINISHED',
@@ -57,10 +55,7 @@ def test_job_get_results(capsys, tmpdir):
         job.get_results()
 
     responseCheckPhase.set_status_code(200)
-    responseCheckPhase.set_message("OK")
-    responseGetData = DummyResponse()
-    responseGetData.set_status_code(500)
-    responseGetData.set_message("ERROR")
+    responseGetData = DummyResponse(500)
     jobContentFileName = data_path('result_1.vot')
     jobContent = utils.read_file_content(jobContentFileName)
     responseGetData.set_data(method='GET',
@@ -74,7 +69,6 @@ def test_job_get_results(capsys, tmpdir):
         job.get_results()
 
     responseGetData.set_status_code(200)
-    responseGetData.set_message("OK")
     res = job.get_results()
     assert len(res) == 3
     assert len(res.columns) == 4

--- a/astroquery/utils/tap/model/tests/test_job.py
+++ b/astroquery/utils/tap/model/tests/test_job.py
@@ -42,10 +42,7 @@ def test_job_get_results(capsys, tmpdir):
     job.jobid = jobid
     job.parameters['format'] = outputFormat
     responseCheckPhase = DummyResponse(500)
-    responseCheckPhase.set_data(method='GET',
-                                context=None,
-                                body='FINISHED',
-                                headers=None)
+    responseCheckPhase.set_data(method='GET', body='FINISHED')
     waitRequest = f"async/{jobid}/phase"
     connHandler = DummyConnHandler()
     connHandler.set_response(waitRequest, responseCheckPhase)
@@ -58,10 +55,7 @@ def test_job_get_results(capsys, tmpdir):
     responseGetData = DummyResponse(500)
     jobContentFileName = data_path('result_1.vot')
     jobContent = utils.read_file_content(jobContentFileName)
-    responseGetData.set_data(method='GET',
-                             context=None,
-                             body=jobContent,
-                             headers=None)
+    responseGetData.set_data(method='GET', body=jobContent)
     dataRequest = f"async/{jobid}/results/result"
     connHandler.set_response(dataRequest, responseGetData)
 

--- a/astroquery/utils/tap/tests/test_tap.py
+++ b/astroquery/utils/tap/tests/test_tap.py
@@ -39,10 +39,7 @@ def test_load_tables():
     responseLoadTable = DummyResponse(500)
     tableDataFile = data_path('test_tables.xml')
     tableData = utils.read_file_content(tableDataFile)
-    responseLoadTable.set_data(method='GET',
-                               context=None,
-                               body=tableData,
-                               headers=None)
+    responseLoadTable.set_data(method='GET', body=tableData)
     tableRequest = "tables"
     connHandler.set_response(tableRequest, responseLoadTable)
     with pytest.raises(Exception):
@@ -81,10 +78,7 @@ def test_load_tables_parameters():
     responseLoadTable = DummyResponse(200)
     tableDataFile = data_path('test_tables.xml')
     tableData = utils.read_file_content(tableDataFile)
-    responseLoadTable.set_data(method='GET',
-                               context=None,
-                               body=tableData,
-                               headers=None)
+    responseLoadTable.set_data(method='GET', body=tableData)
     tableRequest = "tables"
     connHandler.set_response(tableRequest, responseLoadTable)
 
@@ -132,10 +126,7 @@ def test_load_table():
     responseLoadTable = DummyResponse(500)
     tableDataFile = data_path('test_table1.xml')
     tableData = utils.read_file_content(tableDataFile)
-    responseLoadTable.set_data(method='GET',
-                               context=None,
-                               body=tableData,
-                               headers=None)
+    responseLoadTable.set_data(method='GET', body=tableData)
     tableSchema = "public"
     tableName = "table1"
     fullQualifiedTableName = f"{tableSchema}.{tableName}"
@@ -163,10 +154,7 @@ def test_launch_sync_job():
     responseLaunchJob = DummyResponse(500)
     jobDataFile = data_path('job_1.vot')
     jobData = utils.read_file_content(jobDataFile)
-    responseLaunchJob.set_data(method='POST',
-                               context=None,
-                               body=jobData,
-                               headers=None)
+    responseLaunchJob.set_data(method='POST', body=jobData)
     query = 'select top 5 * from table'
     dTmp = {"q": query}
     dTmpEncoded = connHandler.url_encode(dTmp)
@@ -229,10 +217,7 @@ def test_launch_sync_job_redirect():
     launchResponseHeaders = [
         ['location', resultsLocation]
     ]
-    responseLaunchJob.set_data(method='POST',
-                               context=None,
-                               body=None,
-                               headers=None)
+    responseLaunchJob.set_data(method='POST')
     query = 'select top 5 * from table'
     dTmp = {"q": query}
     dTmpEncoded = connHandler.url_encode(dTmp)
@@ -252,10 +237,7 @@ def test_launch_sync_job_redirect():
     responseResultsJob = DummyResponse(500)
     jobDataFile = data_path('job_1.vot')
     jobData = utils.read_file_content(jobDataFile)
-    responseResultsJob.set_data(method='GET',
-                                context=None,
-                                body=jobData,
-                                headers=None)
+    responseResultsJob.set_data(method='GET', body=jobData)
     connHandler.set_response(resultsReq, responseResultsJob)
 
     with pytest.raises(Exception):
@@ -271,10 +253,7 @@ def test_launch_sync_job_redirect():
     # Location available
     # Results raises error (500)
     responseResultsJob.set_status_code(200)
-    responseLaunchJob.set_data(method='POST',
-                               context=None,
-                               body=None,
-                               headers=launchResponseHeaders)
+    responseLaunchJob.set_data(method='POST', headers=launchResponseHeaders)
     responseResultsJob.set_status_code(500)
     with pytest.raises(Exception):
         tap.launch_job(query)
@@ -324,10 +303,7 @@ def test_launch_async_job():
     launchResponseHeaders = [
         ['location', f'http://test:1111/tap/async/{jobid}']
     ]
-    responseLaunchJob.set_data(method='POST',
-                               context=None,
-                               body=None,
-                               headers=launchResponseHeaders)
+    responseLaunchJob.set_data(method='POST', headers=launchResponseHeaders)
     query = 'query'
     dictTmp = {
         "REQUEST": "doQuery",
@@ -341,20 +317,14 @@ def test_launch_async_job():
     connHandler.set_response(req, responseLaunchJob)
     # Phase response
     responsePhase = DummyResponse(500)
-    responsePhase.set_data(method='GET',
-                           context=None,
-                           body="COMPLETED",
-                           headers=None)
+    responsePhase.set_data(method='GET', body="COMPLETED")
     req = f"async/{jobid}/phase"
     connHandler.set_response(req, responsePhase)
     # Results response
     responseResultsJob = DummyResponse(500)
     jobDataFile = data_path('job_1.vot')
     jobData = utils.read_file_content(jobDataFile)
-    responseResultsJob.set_data(method='GET',
-                                context=None,
-                                body=jobData,
-                                headers=None)
+    responseResultsJob.set_data(method='GET', body=jobData)
     req = f"async/{jobid}/results/result"
     connHandler.set_response(req, responseResultsJob)
 
@@ -407,10 +377,7 @@ def test_start_job():
     jobid = '12345'
     # Phase POST response
     responsePhase = DummyResponse(200)
-    responsePhase.set_data(method='POST',
-                           context=None,
-                           body=None,
-                           headers=None)
+    responsePhase.set_data(method='POST')
     req = f"async/{jobid}/phase?PHASE=RUN"
     connHandler.set_response(req, responsePhase)
     # Launch response
@@ -419,10 +386,7 @@ def test_start_job():
     launchResponseHeaders = [
         ['location', f'http://test:1111/tap/async/{jobid}']
     ]
-    responseLaunchJob.set_data(method='POST',
-                               context=None,
-                               body=None,
-                               headers=launchResponseHeaders)
+    responseLaunchJob.set_data(method='POST', headers=launchResponseHeaders)
     query = 'query'
     dictTmp = {
         "REQUEST": "doQuery",
@@ -435,20 +399,14 @@ def test_start_job():
     connHandler.set_response(req, responseLaunchJob)
     # Phase response
     responsePhase = DummyResponse(200)
-    responsePhase.set_data(method='GET',
-                           context=None,
-                           body="COMPLETED",
-                           headers=None)
+    responsePhase.set_data(method='GET', body="COMPLETED")
     req = f"async/{jobid}/phase"
     connHandler.set_response(req, responsePhase)
     # Results response
     responseResultsJob = DummyResponse(200)
     jobDataFile = data_path('job_1.vot')
     jobData = utils.read_file_content(jobDataFile)
-    responseResultsJob.set_data(method='GET',
-                                context=None,
-                                body=jobData,
-                                headers=None)
+    responseResultsJob.set_data(method='GET', body=jobData)
     req = f"async/{jobid}/results/result"
     connHandler.set_response(req, responseResultsJob)
 
@@ -476,10 +434,7 @@ def test_abort_job():
     jobid = '12345'
     # Phase POST response
     responsePhase = DummyResponse(200)
-    responsePhase.set_data(method='POST',
-                           context=None,
-                           body=None,
-                           headers=None)
+    responsePhase.set_data(method='POST')
     req = f"async/{jobid}/phase?PHASE=ABORT"
     connHandler.set_response(req, responsePhase)
     # Launch response
@@ -488,10 +443,7 @@ def test_abort_job():
     launchResponseHeaders = [
         ['location', f'http://test:1111/tap/async/{jobid}']
     ]
-    responseLaunchJob.set_data(method='POST',
-                               context=None,
-                               body=None,
-                               headers=launchResponseHeaders)
+    responseLaunchJob.set_data(method='POST', headers=launchResponseHeaders)
     query = 'query'
     dictTmp = {
         "REQUEST": "doQuery",
@@ -524,10 +476,7 @@ def test_job_parameters():
     launchResponseHeaders = [
         ['location', f'http://test:1111/tap/async/{jobid}']
     ]
-    responseLaunchJob.set_data(method='POST',
-                               context=None,
-                               body=None,
-                               headers=launchResponseHeaders)
+    responseLaunchJob.set_data(method='POST', headers=launchResponseHeaders)
     query = 'query'
     dictTmp = {
         "REQUEST": "doQuery",
@@ -540,20 +489,14 @@ def test_job_parameters():
     connHandler.set_response(req, responseLaunchJob)
     # Phase response
     responsePhase = DummyResponse(200)
-    responsePhase.set_data(method='GET',
-                           context=None,
-                           body="COMPLETED",
-                           headers=None)
+    responsePhase.set_data(method='GET', body="COMPLETED")
     req = f"async/{jobid}/phase"
     connHandler.set_response(req, responsePhase)
     # Results response
     responseResultsJob = DummyResponse(200)
     jobDataFile = data_path('job_1.vot')
     jobData = utils.read_file_content(jobDataFile)
-    responseResultsJob.set_data(method='GET',
-                                context=None,
-                                body=jobData,
-                                headers=None)
+    responseResultsJob.set_data(method='GET', body=jobData)
     req = f"async/{jobid}/results/result"
     connHandler.set_response(req, responseResultsJob)
 
@@ -564,18 +507,12 @@ def test_job_parameters():
 
     # parameter response
     responseParameters = DummyResponse(200)
-    responseParameters.set_data(method='GET',
-                                context=None,
-                                body=None,
-                                headers=None)
+    responseParameters.set_data(method='GET')
     req = f"async/{jobid}?param1=value1"
     connHandler.set_response(req, responseParameters)
     # Phase POST response
     responsePhase = DummyResponse(200)
-    responsePhase.set_data(method='POST',
-                           context=None,
-                           body=None,
-                           headers=None)
+    responsePhase.set_data(method='POST')
     req = f"async/{jobid}/phase?PHASE=RUN"
     connHandler.set_response(req, responsePhase)
 
@@ -595,10 +532,7 @@ def test_list_async_jobs():
     response = DummyResponse(500)
     jobDataFile = data_path('jobs_list.xml')
     jobData = utils.read_file_content(jobDataFile)
-    response.set_data(method='GET',
-                      context=None,
-                      body=jobData,
-                      headers=None)
+    response.set_data(method='GET', body=jobData)
     req = "async"
     connHandler.set_response(req, response)
     with pytest.raises(Exception):
@@ -621,10 +555,7 @@ def test_data():
     responseResultsJob = DummyResponse(200)
     jobDataFile = data_path('job_1.vot')
     jobData = utils.read_file_content(jobDataFile)
-    responseResultsJob.set_data(method='GET',
-                                context=None,
-                                body=jobData,
-                                headers=None)
+    responseResultsJob.set_data(method='GET', body=jobData)
     req = "?ID=1%2C2&format=votable"
     connHandler.set_response(req, responseResultsJob)
     req = "?ID=1%2C2"
@@ -660,10 +591,7 @@ def test_datalink():
     responseResultsJob = DummyResponse(200)
     jobDataFile = data_path('job_1.vot')
     jobData = utils.read_file_content(jobDataFile)
-    responseResultsJob.set_data(method='GET',
-                                context=None,
-                                body=jobData,
-                                headers=None)
+    responseResultsJob.set_data(method='GET', body=jobData)
     req = "links?ID=1,2"
     connHandler.set_response(req, responseResultsJob)
 
@@ -828,10 +756,7 @@ def test_update_user_table():
     dummyResponse = DummyResponse(200)
     tableDataFile = data_path('test_table_update.xml')
     tableData = utils.read_file_content(tableDataFile)
-    dummyResponse.set_data(method='GET',
-                           context=None,
-                           body=tableData,
-                           headers=None)
+    dummyResponse.set_data(method='GET', body=tableData)
     tableRequest = f"tables?tables={tableName}"
     connHandler.set_response(tableRequest, dummyResponse)
 
@@ -899,10 +824,7 @@ def test_rename_table():
     dummyResponse = DummyResponse(200)
     tableDataFile = data_path('test_table_rename.xml')
     tableData = utils.read_file_content(tableDataFile)
-    dummyResponse.set_data(method='GET',
-                           context=None,
-                           body=tableData,
-                           headers=None)
+    dummyResponse.set_data(method='GET', body=tableData)
 
     with pytest.raises(Exception):
         tap.rename_table()

--- a/astroquery/utils/tap/tests/test_tap.py
+++ b/astroquery/utils/tap/tests/test_tap.py
@@ -36,9 +36,7 @@ def data_path(filename):
 def test_load_tables():
     connHandler = DummyConnHandler()
     tap = TapPlus("http://test:1111/tap", connhandler=connHandler)
-    responseLoadTable = DummyResponse()
-    responseLoadTable.set_status_code(500)
-    responseLoadTable.set_message("ERROR")
+    responseLoadTable = DummyResponse(500)
     tableDataFile = data_path('test_tables.xml')
     tableData = utils.read_file_content(tableDataFile)
     responseLoadTable.set_data(method='GET',
@@ -51,7 +49,6 @@ def test_load_tables():
         tap.load_tables()
 
     responseLoadTable.set_status_code(200)
-    responseLoadTable.set_message("OK")
     res = tap.load_tables()
     assert len(res) == 2
 
@@ -81,9 +78,7 @@ def test_load_tables():
 def test_load_tables_parameters():
     connHandler = DummyConnHandler()
     tap = TapPlus("http://test:1111/tap", connhandler=connHandler)
-    responseLoadTable = DummyResponse()
-    responseLoadTable.set_status_code(200)
-    responseLoadTable.set_message("OK")
+    responseLoadTable = DummyResponse(200)
     tableDataFile = data_path('test_tables.xml')
     tableData = utils.read_file_content(tableDataFile)
     responseLoadTable.set_data(method='GET',
@@ -134,9 +129,7 @@ def test_load_table():
     with pytest.raises(Exception):
         tap.load_table()
 
-    responseLoadTable = DummyResponse()
-    responseLoadTable.set_status_code(500)
-    responseLoadTable.set_message("ERROR")
+    responseLoadTable = DummyResponse(500)
     tableDataFile = data_path('test_table1.xml')
     tableData = utils.read_file_content(tableDataFile)
     responseLoadTable.set_data(method='GET',
@@ -153,7 +146,6 @@ def test_load_table():
         tap.load_table(fullQualifiedTableName)
 
     responseLoadTable.set_status_code(200)
-    responseLoadTable.set_message("OK")
     table = tap.load_table(fullQualifiedTableName)
     assert table is not None
     assert table.description == 'Table1 desc'
@@ -168,9 +160,7 @@ def test_load_table():
 def test_launch_sync_job():
     connHandler = DummyConnHandler()
     tap = TapPlus("http://test:1111/tap", connhandler=connHandler)
-    responseLaunchJob = DummyResponse()
-    responseLaunchJob.set_status_code(500)
-    responseLaunchJob.set_message("ERROR")
+    responseLaunchJob = DummyResponse(500)
     jobDataFile = data_path('job_1.vot')
     jobData = utils.read_file_content(jobDataFile)
     responseLaunchJob.set_data(method='POST',
@@ -197,7 +187,6 @@ def test_launch_sync_job():
         tap.launch_job(query)
 
     responseLaunchJob.set_status_code(200)
-    responseLaunchJob.set_message("OK")
     job = tap.launch_job(query)
 
     assert job is not None
@@ -233,9 +222,7 @@ def test_launch_sync_job():
 def test_launch_sync_job_redirect():
     connHandler = DummyConnHandler()
     tap = TapPlus("http://test:1111/tap", connhandler=connHandler)
-    responseLaunchJob = DummyResponse()
-    responseLaunchJob.set_status_code(500)
-    responseLaunchJob.set_message("ERROR")
+    responseLaunchJob = DummyResponse(500)
     jobid = '12345'
     resultsReq = f'sync/{jobid}'
     resultsLocation = f'http://test:1111/tap/{resultsReq}'
@@ -262,9 +249,7 @@ def test_launch_sync_job_redirect():
     jobRequest = f"sync?{sortedKey}"
     connHandler.set_response(jobRequest, responseLaunchJob)
     # Results response
-    responseResultsJob = DummyResponse()
-    responseResultsJob.set_status_code(500)
-    responseResultsJob.set_message("ERROR")
+    responseResultsJob = DummyResponse(500)
     jobDataFile = data_path('job_1.vot')
     jobData = utils.read_file_content(jobDataFile)
     responseResultsJob.set_data(method='GET',
@@ -279,7 +264,6 @@ def test_launch_sync_job_redirect():
     # Response is redirect (303)
     # No location available
     responseLaunchJob.set_status_code(303)
-    responseLaunchJob.set_message("OK")
     with pytest.raises(Exception):
         tap.launch_job(query)
 
@@ -287,13 +271,11 @@ def test_launch_sync_job_redirect():
     # Location available
     # Results raises error (500)
     responseResultsJob.set_status_code(200)
-    responseResultsJob.set_message("OK")
     responseLaunchJob.set_data(method='POST',
                                context=None,
                                body=None,
                                headers=launchResponseHeaders)
     responseResultsJob.set_status_code(500)
-    responseResultsJob.set_message("ERROR")
     with pytest.raises(Exception):
         tap.launch_job(query)
 
@@ -301,7 +283,6 @@ def test_launch_sync_job_redirect():
     # Results is 200
     # Location available
     responseResultsJob.set_status_code(200)
-    responseResultsJob.set_message("OK")
     job = tap.launch_job(query)
     assert job is not None
     assert job.async_ is False
@@ -338,9 +319,7 @@ def test_launch_async_job():
     tap = TapPlus("http://test:1111/tap", connhandler=connHandler)
     jobid = '12345'
     # Launch response
-    responseLaunchJob = DummyResponse()
-    responseLaunchJob.set_status_code(500)
-    responseLaunchJob.set_message("ERROR")
+    responseLaunchJob = DummyResponse(500)
     # list of list (httplib implementation for headers in response)
     launchResponseHeaders = [
         ['location', f'http://test:1111/tap/async/{jobid}']
@@ -361,9 +340,7 @@ def test_launch_async_job():
     req = f"async?{sortedKey}"
     connHandler.set_response(req, responseLaunchJob)
     # Phase response
-    responsePhase = DummyResponse()
-    responsePhase.set_status_code(500)
-    responsePhase.set_message("ERROR")
+    responsePhase = DummyResponse(500)
     responsePhase.set_data(method='GET',
                            context=None,
                            body="COMPLETED",
@@ -371,9 +348,7 @@ def test_launch_async_job():
     req = f"async/{jobid}/phase"
     connHandler.set_response(req, responsePhase)
     # Results response
-    responseResultsJob = DummyResponse()
-    responseResultsJob.set_status_code(500)
-    responseResultsJob.set_message("ERROR")
+    responseResultsJob = DummyResponse(500)
     jobDataFile = data_path('job_1.vot')
     jobData = utils.read_file_content(jobDataFile)
     responseResultsJob.set_data(method='GET',
@@ -387,17 +362,14 @@ def test_launch_async_job():
         tap.launch_job_async(query)
 
     responseLaunchJob.set_status_code(303)
-    responseLaunchJob.set_message("OK")
     with pytest.raises(Exception):
         tap.launch_job_async(query)
 
     responsePhase.set_status_code(200)
-    responsePhase.set_message("OK")
     with pytest.raises(Exception):
         tap.launch_job_async(query)
 
     responseResultsJob.set_status_code(200)
-    responseResultsJob.set_message("OK")
     job = tap.launch_job_async(query)
     assert job is not None
     assert job.async_ is True
@@ -434,9 +406,7 @@ def test_start_job():
     tap = TapPlus("http://test:1111/tap", connhandler=connHandler)
     jobid = '12345'
     # Phase POST response
-    responsePhase = DummyResponse()
-    responsePhase.set_status_code(200)
-    responsePhase.set_message("OK")
+    responsePhase = DummyResponse(200)
     responsePhase.set_data(method='POST',
                            context=None,
                            body=None,
@@ -444,9 +414,7 @@ def test_start_job():
     req = f"async/{jobid}/phase?PHASE=RUN"
     connHandler.set_response(req, responsePhase)
     # Launch response
-    responseLaunchJob = DummyResponse()
-    responseLaunchJob.set_status_code(303)
-    responseLaunchJob.set_message("OK")
+    responseLaunchJob = DummyResponse(303)
     # list of list (httplib implementation for headers in response)
     launchResponseHeaders = [
         ['location', f'http://test:1111/tap/async/{jobid}']
@@ -466,9 +434,7 @@ def test_start_job():
     req = f"async?{sortedKey}"
     connHandler.set_response(req, responseLaunchJob)
     # Phase response
-    responsePhase = DummyResponse()
-    responsePhase.set_status_code(200)
-    responsePhase.set_message("OK")
+    responsePhase = DummyResponse(200)
     responsePhase.set_data(method='GET',
                            context=None,
                            body="COMPLETED",
@@ -476,9 +442,7 @@ def test_start_job():
     req = f"async/{jobid}/phase"
     connHandler.set_response(req, responsePhase)
     # Results response
-    responseResultsJob = DummyResponse()
-    responseResultsJob.set_status_code(200)
-    responseResultsJob.set_message("OK")
+    responseResultsJob = DummyResponse(200)
     jobDataFile = data_path('job_1.vot')
     jobData = utils.read_file_content(jobDataFile)
     responseResultsJob.set_data(method='GET',
@@ -489,7 +453,6 @@ def test_start_job():
     connHandler.set_response(req, responseResultsJob)
 
     responseResultsJob.set_status_code(200)
-    responseResultsJob.set_message("OK")
     job = tap.launch_job_async(query, autorun=False)
     assert job is not None
     assert job.get_phase() == 'PENDING'
@@ -512,9 +475,7 @@ def test_abort_job():
     tap = TapPlus("http://test:1111/tap", connhandler=connHandler)
     jobid = '12345'
     # Phase POST response
-    responsePhase = DummyResponse()
-    responsePhase.set_status_code(200)
-    responsePhase.set_message("OK")
+    responsePhase = DummyResponse(200)
     responsePhase.set_data(method='POST',
                            context=None,
                            body=None,
@@ -522,9 +483,7 @@ def test_abort_job():
     req = f"async/{jobid}/phase?PHASE=ABORT"
     connHandler.set_response(req, responsePhase)
     # Launch response
-    responseLaunchJob = DummyResponse()
-    responseLaunchJob.set_status_code(303)
-    responseLaunchJob.set_message("OK")
+    responseLaunchJob = DummyResponse(303)
     # list of list (httplib implementation for headers in response)
     launchResponseHeaders = [
         ['location', f'http://test:1111/tap/async/{jobid}']
@@ -560,9 +519,7 @@ def test_job_parameters():
     tap = TapPlus("http://test:1111/tap", connhandler=connHandler)
     jobid = '12345'
     # Launch response
-    responseLaunchJob = DummyResponse()
-    responseLaunchJob.set_status_code(303)
-    responseLaunchJob.set_message("OK")
+    responseLaunchJob = DummyResponse(303)
     # list of list (httplib implementation for headers in response)
     launchResponseHeaders = [
         ['location', f'http://test:1111/tap/async/{jobid}']
@@ -582,9 +539,7 @@ def test_job_parameters():
     req = f"async?{sortedKey}"
     connHandler.set_response(req, responseLaunchJob)
     # Phase response
-    responsePhase = DummyResponse()
-    responsePhase.set_status_code(200)
-    responsePhase.set_message("OK")
+    responsePhase = DummyResponse(200)
     responsePhase.set_data(method='GET',
                            context=None,
                            body="COMPLETED",
@@ -592,9 +547,7 @@ def test_job_parameters():
     req = f"async/{jobid}/phase"
     connHandler.set_response(req, responsePhase)
     # Results response
-    responseResultsJob = DummyResponse()
-    responseResultsJob.set_status_code(200)
-    responseResultsJob.set_message("OK")
+    responseResultsJob = DummyResponse(200)
     jobDataFile = data_path('job_1.vot')
     jobData = utils.read_file_content(jobDataFile)
     responseResultsJob.set_data(method='GET',
@@ -605,15 +558,12 @@ def test_job_parameters():
     connHandler.set_response(req, responseResultsJob)
 
     responseResultsJob.set_status_code(200)
-    responseResultsJob.set_message("OK")
     job = tap.launch_job_async(query, autorun=False)
     assert job is not None
     assert job.get_phase() == 'PENDING'
 
     # parameter response
-    responseParameters = DummyResponse()
-    responseParameters.set_status_code(200)
-    responseParameters.set_message("OK")
+    responseParameters = DummyResponse(200)
     responseParameters.set_data(method='GET',
                                 context=None,
                                 body=None,
@@ -621,9 +571,7 @@ def test_job_parameters():
     req = f"async/{jobid}?param1=value1"
     connHandler.set_response(req, responseParameters)
     # Phase POST response
-    responsePhase = DummyResponse()
-    responsePhase.set_status_code(200)
-    responsePhase.set_message("OK")
+    responsePhase = DummyResponse(200)
     responsePhase.set_data(method='POST',
                            context=None,
                            body=None,
@@ -644,9 +592,7 @@ def test_job_parameters():
 def test_list_async_jobs():
     connHandler = DummyConnHandler()
     tap = TapPlus("http://test:1111/tap", connhandler=connHandler)
-    response = DummyResponse()
-    response.set_status_code(500)
-    response.set_message("ERROR")
+    response = DummyResponse(500)
     jobDataFile = data_path('jobs_list.xml')
     jobData = utils.read_file_content(jobDataFile)
     response.set_data(method='GET',
@@ -659,7 +605,6 @@ def test_list_async_jobs():
         tap.list_async_jobs()
 
     response.set_status_code(200)
-    response.set_message("OK")
     jobs = tap.list_async_jobs()
     assert len(jobs) == 2
     assert jobs[0].jobid == '12345'
@@ -673,9 +618,7 @@ def test_data():
     tap = TapPlus("http://test:1111/tap",
                   data_context="data",
                   connhandler=connHandler)
-    responseResultsJob = DummyResponse()
-    responseResultsJob.set_status_code(200)
-    responseResultsJob.set_message("OK")
+    responseResultsJob = DummyResponse(200)
     jobDataFile = data_path('job_1.vot')
     jobData = utils.read_file_content(jobDataFile)
     responseResultsJob.set_data(method='GET',
@@ -689,7 +632,6 @@ def test_data():
 
     # error
     responseResultsJob.set_status_code(500)
-    responseResultsJob.set_message("ERROR")
     params_dict = {}
     params_dict['ID'] = "1,2"
     with pytest.raises(Exception):
@@ -697,7 +639,6 @@ def test_data():
 
     # OK
     responseResultsJob.set_status_code(200)
-    responseResultsJob.set_message("OK")
 
     # results
     results = tap.load_data(params_dict)
@@ -716,9 +657,7 @@ def test_datalink():
     tap = TapPlus("http://test:1111/tap",
                   datalink_context="datalink",
                   connhandler=connHandler)
-    responseResultsJob = DummyResponse()
-    responseResultsJob.set_status_code(200)
-    responseResultsJob.set_message("OK")
+    responseResultsJob = DummyResponse(200)
     jobDataFile = data_path('job_1.vot')
     jobData = utils.read_file_content(jobDataFile)
     responseResultsJob.set_data(method='GET',
@@ -730,14 +669,12 @@ def test_datalink():
 
     # error
     responseResultsJob.set_status_code(500)
-    responseResultsJob.set_message("ERROR")
     with pytest.raises(Exception):
         # missing IDS parameter
         tap.get_datalinks(ids=None)
 
     # OK
     responseResultsJob.set_status_code(200)
-    responseResultsJob.set_message("OK")
     # results
     results = tap.get_datalinks("1,2")
     assert len(results) == 3
@@ -888,9 +825,7 @@ def test_update_user_table():
     tableName = 'table'
     connHandler = DummyConnHandler()
     tap = TapPlus("http://test:1111/tap", connhandler=connHandler)
-    dummyResponse = DummyResponse()
-    dummyResponse.set_status_code(200)
-    dummyResponse.set_message("OK")
+    dummyResponse = DummyResponse(200)
     tableDataFile = data_path('test_table_update.xml')
     tableData = utils.read_file_content(tableDataFile)
     dummyResponse.set_data(method='GET',
@@ -920,9 +855,7 @@ def test_update_user_table():
         tap.update_user_table(table_name=tableName, list_of_changes=list_of_changes)
 
     # OK
-    responseEditTable = DummyResponse()
-    responseEditTable.set_status_code(200)
-    responseEditTable.set_message("OK")
+    responseEditTable = DummyResponse(200)
     dictTmp = {
         "ACTION": "edit",
         "NUMTABLES": "1",
@@ -963,9 +896,7 @@ def test_rename_table():
     newColumnNames = {'ra': 'alpha', 'dec': 'delta'}
     connHandler = DummyConnHandler()
     tap = TapPlus("http://test:1111/tap", connhandler=connHandler)
-    dummyResponse = DummyResponse()
-    dummyResponse.set_status_code(200)
-    dummyResponse.set_message("OK")
+    dummyResponse = DummyResponse(200)
     tableDataFile = data_path('test_table_rename.xml')
     tableData = utils.read_file_content(tableDataFile)
     dummyResponse.set_data(method='GET',
@@ -981,9 +912,7 @@ def test_rename_table():
         tap.rename_table(table_name=tableName, new_table_name=None, new_column_names_dict=None)
 
     # Test OK.
-    responseRenameTable = DummyResponse()
-    responseRenameTable.set_status_code(200)
-    responseRenameTable.set_message("OK")
+    responseRenameTable = DummyResponse(200)
     dictArgs = {
         "action": "rename",
         "new_column_names": "ra:alpha,dec:delta",


### PR DESCRIPTION
Making a couple of small changes in the classes that are used for mocking server responses in `esa/jwst` and `gaia` tests made it possible to shorten the tests quite a lot. This makes the current tests simpler to understand and any future tests simpler to write. See the commit messages for details.