### PR TITLE
CI: Adding online CI job for windows

### DIFF
--- a/.github/workflows/ci_crontests.yml
+++ b/.github/workflows/ci_crontests.yml
@@ -5,9 +5,6 @@ on:
     # Run this job on release tags, but not on pushes to the main branch
     tags:
     - '*'
-  pull_request:
-    branches:
-    - main
   schedule:
     # run every Monday at 5am UTC
     - cron: '0 5 * * 1'
@@ -19,7 +16,7 @@ jobs:
   tests:
     name: ${{ matrix.name }}
     runs-on: ${{ matrix.os }}
-#    if: github.event_name == 'schedule' && github.repository == 'astropy/astroquery'
+    if: github.event_name == 'schedule' && github.repository == 'astropy/astroquery'
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/ci_crontests.yml
+++ b/.github/workflows/ci_crontests.yml
@@ -5,6 +5,9 @@ on:
     # Run this job on release tags, but not on pushes to the main branch
     tags:
     - '*'
+  pull_request:
+    branches:
+    - main
   schedule:
     # run every Monday at 5am UTC
     - cron: '0 5 * * 1'
@@ -16,19 +19,26 @@ jobs:
   tests:
     name: ${{ matrix.name }}
     runs-on: ${{ matrix.os }}
-    if: github.event_name == 'schedule' && github.repository == 'astropy/astroquery'
+#    if: github.event_name == 'schedule' && github.repository == 'astropy/astroquery'
     strategy:
       fail-fast: false
       matrix:
         include:
-          - name: Python 3.9 with all dependencies with remote data
+          - name: py3.10 all dev deps online
             os: ubuntu-latest
-            python: '3.9'
-            toxenv: py39-test-alldeps-devdeps-online
+            python: '3.10'
+            toxenv: py310-test-alldeps-devdeps-online
             toxargs: -v
             toxposargs: -v --durations=50
 
-          - name: pre-release dependencies with all dependencies
+          - name: Windows py3.9 all deps online
+            os: windows-latest
+            python: '3.9'
+            toxenv: py39-test-alldeps-online
+            toxargs: -v
+            toxposargs: -v --durations=50
+
+          - name: py3.10 pre-release all deps
             os: ubuntu-latest
             python: '3.10'
             toxenv: py310-test-alldeps-predeps


### PR DESCRIPTION
This PR adds another remote-data cron job, this time to run it on windows. I'm not certain that it will smoke out all issues (https://github.com/astropy/astroquery/pull/2526#issuecomment-1245545239), but will be better than nothing.

I'm temporarily running this windows job here, so we can have one run for smoking out issues. Once CI is finished with this (the online jobs will fail), I'll revert back this to be cron only and merge.

Then we start working with the log and fix possible path issues.

cc @eerovaher 