### PR TITLE
MAINT: add testpaths to config 

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -27,6 +27,7 @@ show-response = 1
 [tool:pytest]
 minversion = 6.0
 norecursedirs = build docs/_build docs/gallery-examples astroquery/irsa astroquery/nasa_exoplanet_archive astroquery/ned astroquery/ibe astroquery/irsa_dust astroquery/sha
+testpaths = astroquery docs
 doctest_plus = enabled
 astropy_header = true
 text_file_format = rst


### PR DESCRIPTION
This is to make it extra easy to run pytest. E.g. now a smile `pytest` should pick up the relevant directories for test collection.