### PR TITLE
BUG: fix for alma timeout 

### DIFF
--- a/astroquery/alma/core.py
+++ b/astroquery/alma/core.py
@@ -641,8 +641,6 @@ class AlmaClass(QueryWithLogin):
             if p.ID == parameter_id:
                 return p.value
 
-        return None
-
     def is_proprietary(self, uid):
         """
         Given an ALMA UID, query the servers to determine whether it is

--- a/astroquery/alma/tests/test_alma_remote.py
+++ b/astroquery/alma/tests/test_alma_remote.py
@@ -185,9 +185,13 @@ class TestAlma:
         download_files_mock = Mock()
         alma.download_files = download_files_mock
         alma.retrieve_data_from_uid([uid])
-
-        comparison = download_files_mock.mock_calls[0][1] == data_info_tar['access_url']
-        assert comparison.all()
+        trimmed_access_url_list = [e for e in data_info_tar['access_url'].data if len(e) > 0]
+        trimmed_access_urls = (trimmed_access_url_list,)
+        mock_calls = download_files_mock.mock_calls[0][1]
+        print(f"\n\nComparing {mock_calls} to {trimmed_access_urls}\n\n")
+        # comparison = download_files_mock.mock_calls[0][1] == data_info_tar['access_url']
+        assert mock_calls == trimmed_access_urls
+        # assert comparison.all()
 
     def test_download_data(self, tmp_path, alma):
         # test only fits files from a program

--- a/astroquery/query.py
+++ b/astroquery/query.py
@@ -293,7 +293,7 @@ class BaseQuery(metaclass=LoginABCMeta):
                 local_filename = local_filename.replace(':', '_')
             local_filepath = os.path.join(savedir or self.cache_location or '.', local_filename)
 
-            response = self._download_file(url, local_filepath, cache=cache,
+            response = self._download_file(url, local_filepath, cache=cache, timeout=timeout,
                                            continuation=continuation, method=method,
                                            allow_redirects=allow_redirects,
                                            auth=auth, **req_kwargs)


### PR DESCRIPTION
Add timeouts and test fixes.

DataLink tests were failing to traverse the ad-hoc DataLink services.  I made some test and code fixes in order to push through the timeout changes.