### PR TITLE
ENH: CADC: fix the ability to pass on Path objects as `output_file`

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -56,6 +56,9 @@ cadc
 
 - Deprecated keywords and ``run_query`` method have been removed. [#2389]
 
+- Added the ability to pass longer that filename Path objects as
+  ``output_file``. [#2541]
+
 casda
 ^^^^^
 

--- a/astroquery/cadc/core.py
+++ b/astroquery/cadc/core.py
@@ -11,6 +11,7 @@ from astroquery import log
 import warnings
 import requests
 from numpy import ma
+from pathlib import Path
 from urllib.parse import urlencode
 from urllib.error import HTTPError
 
@@ -587,7 +588,7 @@ class CadcClass(BaseQuery):
             the maximum records to return. defaults to the service default
         uploads :
             Temporary tables to upload and run with the queries
-        output_file : str or file handler
+        output_file : str, Path, or file handler
             File to save the results to
         output_format :
             Format of the output (default is basic). Must be one
@@ -608,10 +609,13 @@ class CadcClass(BaseQuery):
         if output_file:
             if isinstance(output_file, str):
                 fname = output_file
+            elif isinstance(output_file, Path):
+                # Merge this case into the str once astropy is >=5.1
+                fname = str(output_file)
             elif hasattr(output_file, 'name'):
                 fname = output_file.name
             else:
-                raise AttributeError('Not a valid file name or file handler')
+                raise AttributeError('Not a valid file name, Path, or file handler')
             result.write(fname, format=output_format, overwrite=True)
         return result
 

--- a/astroquery/cadc/tests/test_cadctap.py
+++ b/astroquery/cadc/tests/test_cadctap.py
@@ -384,12 +384,14 @@ def test_exec_sync(tmp_path):
 
         assert report_diff_values(table, actual_table, fileobj=sys.stdout)
 
-    # check file handlers, too
-    with open(os.path.join(tmp_path, 'test_open_file_handler.xml'), 'w+b') as open_file:
-        cadc.exec_sync('some query', output_file=open_file)
+    # check file handlers, but skip on windows as it has issues with
+    # context managers and open files
+    if not sys.platform.startswith('win'):
+        with open(os.path.join(tmp_path, 'test_open_file_handler.xml'), 'w+b') as open_file:
+            cadc.exec_sync('some query', output_file=open_file)
 
-    actual = parse(os.path.join(tmp_path, 'test_open_file_handler.xml'))
-    assert report_diff_values(table, actual_table, fileobj=sys.stdout)
+        actual = parse(os.path.join(tmp_path, 'test_open_file_handler.xml'))
+        assert report_diff_values(table, actual_table, fileobj=sys.stdout)
 
 
 @patch('astroquery.cadc.core.CadcClass.exec_sync', Mock())

--- a/astroquery/cadc/tests/test_cadctap.py
+++ b/astroquery/cadc/tests/test_cadctap.py
@@ -10,7 +10,6 @@ from urllib.parse import urlsplit, parse_qs
 from pathlib import Path
 import os
 import sys
-from pathlib import Path
 
 from astropy.table import Table as AstroTable
 from astropy.io.fits.hdu.hdulist import HDUList

--- a/astroquery/cadc/tests/test_cadctap.py
+++ b/astroquery/cadc/tests/test_cadctap.py
@@ -10,15 +10,16 @@ from urllib.parse import urlsplit, parse_qs
 from pathlib import Path
 import os
 import sys
+from pathlib import Path
 
 from astropy.table import Table as AstroTable
 from astropy.io.fits.hdu.hdulist import HDUList
 from astropy.io.votable.tree import VOTableFile, Resource, Table, Field
 from astropy.io.votable import parse
+from astropy.utils.diff import report_diff_values
 from astroquery.utils.commons import parse_coordinates, FileContainer
 from astropy import units as u
 import pytest
-import tempfile
 import requests
 
 from pyvo.auth import securitymethods
@@ -348,7 +349,7 @@ def test_get_image_list():
 
 @patch('astroquery.cadc.core.get_access_url',
        Mock(side_effect=lambda x, y=None: 'https://some.url'))
-def test_exec_sync():
+def test_exec_sync(tmp_path):
     # save results in a file
     # create the VOTable result
     # example from http://docs.astropy.org/en/stable/io/votable/
@@ -369,20 +370,27 @@ def test_exec_sync():
     response = Mock()
     response.to_table.return_value = table.to_table()
     cadc.cadctap.search = Mock(return_value=response)
-    output_file = '{}/test_vooutput.xml'.format(tempfile.tempdir)
-    cadc.exec_sync('some query', output_file=output_file)
 
-    actual = parse(output_file)
-    assert len(votable.resources) == len(actual.resources) == 1
-    assert len(votable.resources[0].tables) ==\
-        len(actual.resources[0].tables) == 1
-    actual_table = actual.resources[0].tables[0]
-    try:
-        # TODO remove when astropy LTS upgraded
-        from astropy.utils.diff import report_diff_values
+    output_files = [os.path.join(tmp_path, 'test_vooutput.xml'),
+                    Path(tmp_path, 'test_path_vooutput.xml')]
+
+    for output_file in output_files:
+        cadc.exec_sync('some query', output_file=output_file)
+
+        actual = parse(output_file)
+        assert len(votable.resources) == len(actual.resources) == 1
+        assert len(votable.resources[0].tables) ==\
+            len(actual.resources[0].tables) == 1
+        actual_table = actual.resources[0].tables[0]
+
         assert report_diff_values(table, actual_table, fileobj=sys.stdout)
-    except ImportError:
-        pass
+
+    # check file handlers, too
+    with open(os.path.join(tmp_path, 'test_open_file_handler.xml'), 'w+b') as open_file:
+        cadc.exec_sync('some query', output_file=open_file)
+
+    actual = parse(os.path.join(tmp_path, 'test_open_file_handler.xml'))
+    assert report_diff_values(table, actual_table, fileobj=sys.stdout)
 
 
 @patch('astroquery.cadc.core.CadcClass.exec_sync', Mock())


### PR DESCRIPTION
fixes #2540 