### PR TITLE
Refactor `gaia/tests/test_gaiatap.py` 

### DIFF
--- a/astroquery/gaia/tests/test_gaiatap.py
+++ b/astroquery/gaia/tests/test_gaiatap.py
@@ -100,251 +100,249 @@ def mock_querier_async():
     return GaiaClass(conn_handler, tapplus, show_server_messages=False)
 
 
-class TestTap:
+def test_show_message():
+    connHandler = DummyConnHandler()
 
-    def test_show_message(self):
-        connHandler = DummyConnHandler()
+    dummy_response = DummyResponse(200)
 
-        dummy_response = DummyResponse(200)
+    message_text = "1653401204784D[type: -100,-1]=Gaia dev is under maintenance"
 
-        message_text = "1653401204784D[type: -100,-1]=Gaia dev is under maintenance"
+    dummy_response.set_data(method='GET', body=message_text)
+    connHandler.set_default_response(dummy_response)
 
-        dummy_response.set_data(method='GET', body=message_text)
-        connHandler.set_default_response(dummy_response)
+    # show_server_messages
+    tableRequest = 'notification?action=GetNotifications'
+    connHandler.set_response(tableRequest, dummy_response)
 
-        # show_server_messages
-        tableRequest = 'notification?action=GetNotifications'
-        connHandler.set_response(tableRequest, dummy_response)
+    tapplus = TapPlus("http://test:1111/tap", connhandler=connHandler)
+    GaiaClass(connHandler, tapplus, show_server_messages=True)
 
-        tapplus = TapPlus("http://test:1111/tap", connhandler=connHandler)
-        GaiaClass(connHandler, tapplus, show_server_messages=True)
+def test_query_object(column_attrs, mock_querier):
+    with pytest.raises(ValueError) as err:
+        mock_querier.query_object(skycoord)
+    assert "Missing required argument: width" in err.value.args[0]
 
-    def test_query_object(self, column_attrs, mock_querier):
-        with pytest.raises(ValueError) as err:
-            mock_querier.query_object(skycoord)
-        assert "Missing required argument: width" in err.value.args[0]
+    width = 12 * u.deg
 
-        width = 12 * u.deg
+    with pytest.raises(ValueError) as err:
+        mock_querier.query_object(skycoord, width=width)
+    assert "Missing required argument: height" in err.value.args[0]
 
-        with pytest.raises(ValueError) as err:
-            mock_querier.query_object(skycoord, width=width)
-        assert "Missing required argument: height" in err.value.args[0]
+    table = mock_querier.query_object(skycoord, width=width, height=10 * u.deg)
+    assert len(table) == 3
+    for colname, attrs in column_attrs.items():
+        assert table[colname].attrs_equal(attrs)
+    # by radius
+    table = mock_querier.query_object(skycoord, radius=1 * u.deg)
+    assert len(table) == 3
+    for colname, attrs in column_attrs.items():
+        assert table[colname].attrs_equal(attrs)
 
-        table = mock_querier.query_object(skycoord, width=width, height=10 * u.deg)
-        assert len(table) == 3
-        for colname, attrs in column_attrs.items():
-            assert table[colname].attrs_equal(attrs)
-        # by radius
-        table = mock_querier.query_object(skycoord, radius=1 * u.deg)
-        assert len(table) == 3
-        for colname, attrs in column_attrs.items():
-            assert table[colname].attrs_equal(attrs)
+def test_query_object_async(column_attrs, mock_querier_async):
+    table = mock_querier_async.query_object_async(
+        skycoord, width=12 * u.deg, height=10 * u.deg
+    )
+    assert len(table) == 3
+    for colname, attrs in column_attrs.items():
+        assert table[colname].attrs_equal(attrs)
+    # by radius
+    table = mock_querier_async.query_object_async(skycoord, radius=1 * u.deg)
+    assert len(table) == 3
+    for colname, attrs in column_attrs.items():
+        assert table[colname].attrs_equal(attrs)
 
-    def test_query_object_async(self, column_attrs, mock_querier_async):
-        table = mock_querier_async.query_object_async(
-            skycoord, width=12 * u.deg, height=10 * u.deg
-        )
-        assert len(table) == 3
-        for colname, attrs in column_attrs.items():
-            assert table[colname].attrs_equal(attrs)
-        # by radius
-        table = mock_querier_async.query_object_async(skycoord, radius=1 * u.deg)
-        assert len(table) == 3
-        for colname, attrs in column_attrs.items():
-            assert table[colname].attrs_equal(attrs)
+def test_cone_search_sync(column_attrs, mock_querier):
+    job = mock_querier.cone_search(skycoord, 1 * u.deg)
+    assert job.async_ is False
+    assert job.get_phase() == "COMPLETED"
+    assert job.failed is False
+    # results
+    results = job.get_results()
+    assert len(results) == 3
+    for colname, attrs in column_attrs.items():
+        assert results[colname].attrs_equal(attrs)
 
-    def test_cone_search_sync(self, column_attrs, mock_querier):
-        job = mock_querier.cone_search(skycoord, 1 * u.deg)
-        assert job.async_ is False
-        assert job.get_phase() == "COMPLETED"
-        assert job.failed is False
-        # results
-        results = job.get_results()
-        assert len(results) == 3
-        for colname, attrs in column_attrs.items():
-            assert results[colname].attrs_equal(attrs)
+def test_cone_search_async(column_attrs, mock_querier_async):
+    radius = 1.0 * u.deg
+    job = mock_querier_async.cone_search_async(skycoord, radius)
+    assert job.async_ is True
+    assert job.get_phase() == "COMPLETED"
+    assert job.failed is False
+    # results
+    results = job.get_results()
+    assert len(results) == 3
+    for colname, attrs in column_attrs.items():
+        assert results[colname].attrs_equal(attrs)
 
-    def test_cone_search_async(self, column_attrs, mock_querier_async):
-        radius = 1.0 * u.deg
+    # Regression test for #2093 and #2099 - changing the MAIN_GAIA_TABLE
+    # had no effect.
+    # The preceding tests should have used the default value.
+    assert 'gaiadr2.gaia_source' in job.parameters['query']
+    with conf.set_temp("MAIN_GAIA_TABLE", "name_from_conf"):
         job = mock_querier_async.cone_search_async(skycoord, radius)
-        assert job.async_ is True
-        assert job.get_phase() == "COMPLETED"
-        assert job.failed is False
-        # results
-        results = job.get_results()
-        assert len(results) == 3
-        for colname, attrs in column_attrs.items():
-            assert results[colname].attrs_equal(attrs)
+        assert "name_from_conf" in job.parameters["query"]
+        # Changing the value through the class should overrule conf.
+        mock_querier_async.MAIN_GAIA_TABLE = "name_from_class"
+        job = mock_querier_async.cone_search_async(skycoord, radius)
+        assert "name_from_class" in job.parameters["query"]
 
-        # Regression test for #2093 and #2099 - changing the MAIN_GAIA_TABLE
-        # had no effect.
-        # The preceding tests should have used the default value.
-        assert 'gaiadr2.gaia_source' in job.parameters['query']
-        with conf.set_temp("MAIN_GAIA_TABLE", "name_from_conf"):
-            job = mock_querier_async.cone_search_async(skycoord, radius)
-            assert "name_from_conf" in job.parameters["query"]
-            # Changing the value through the class should overrule conf.
-            mock_querier_async.MAIN_GAIA_TABLE = "name_from_class"
-            job = mock_querier_async.cone_search_async(skycoord, radius)
-            assert "name_from_class" in job.parameters["query"]
+def test_load_data():
+    dummy_handler = DummyTapHandler()
+    tap = GaiaClass(dummy_handler, dummy_handler, show_server_messages=False)
 
-    def test_load_data(self):
-        dummy_handler = DummyTapHandler()
-        tap = GaiaClass(dummy_handler, dummy_handler, show_server_messages=False)
+    ids = "1,2,3,4"
+    retrieval_type = "epoch_photometry"
+    verbose = True
+    output_file = os.path.abspath("output_file")
+    path_to_end_with = os.path.join("gaia", "test", "output_file")
+    if not output_file.endswith(path_to_end_with):
+        output_file = os.path.abspath(path_to_end_with)
 
-        ids = "1,2,3,4"
-        retrieval_type = "epoch_photometry"
-        verbose = True
-        output_file = os.path.abspath("output_file")
-        path_to_end_with = os.path.join("gaia", "test", "output_file")
-        if not output_file.endswith(path_to_end_with):
-            output_file = os.path.abspath(path_to_end_with)
+    tap.load_data(ids=ids,
+                  retrieval_type=retrieval_type,
+                  valid_data=True,
+                  verbose=verbose,
+                  output_file=output_file)
 
-        tap.load_data(ids=ids,
-                      retrieval_type=retrieval_type,
-                      valid_data=True,
-                      verbose=verbose,
-                      output_file=output_file)
+    parameters = {
+        "params_dict": {
+            "VALID_DATA": "true",
+            "ID": ids,
+            "FORMAT": "votable",
+            "RETRIEVAL_TYPE": retrieval_type,
+            "DATA_STRUCTURE": "INDIVIDUAL",
+            "USE_ZIP_ALWAYS": "true",
+        },
+        "output_file": dummy_handler._DummyTapHandler__parameters["output_file"],
+        "verbose": verbose,
+    }
+    dummy_handler.check_call('load_data', parameters)
 
-        parameters = {
-            "params_dict": {
-                "VALID_DATA": "true",
-                "ID": ids,
-                "FORMAT": "votable",
-                "RETRIEVAL_TYPE": retrieval_type,
-                "DATA_STRUCTURE": "INDIVIDUAL",
-                "USE_ZIP_ALWAYS": "true",
-            },
-            "output_file": dummy_handler._DummyTapHandler__parameters["output_file"],
-            "verbose": verbose,
-        }
-        dummy_handler.check_call('load_data', parameters)
+def test_get_datalinks():
+    dummy_handler = DummyTapHandler()
+    tap = GaiaClass(dummy_handler, dummy_handler, show_server_messages=False)
+    ids = ["1", "2", "3", "4"]
+    verbose = True
+    tap.get_datalinks(ids, verbose)
+    dummy_handler.check_call("get_datalinks", {"ids": ids, "verbose": verbose})
 
-    def test_get_datalinks(self):
-        dummy_handler = DummyTapHandler()
-        tap = GaiaClass(dummy_handler, dummy_handler, show_server_messages=False)
-        ids = ["1", "2", "3", "4"]
-        verbose = True
-        tap.get_datalinks(ids, verbose)
-        dummy_handler.check_call("get_datalinks", {"ids": ids, "verbose": verbose})
-
-    def test_xmatch(self, mock_querier_async):
-        # missing table A
-        with pytest.raises(ValueError) as err:
-            mock_querier_async.cross_match(
-                full_qualified_table_name_b='schemaB.tableB',
-                results_table_name='results',
-            )
-        assert "Table name A argument is mandatory" in err.value.args[0]
-        # missing schema A
-        with pytest.raises(ValueError) as err:
-            mock_querier_async.cross_match(
-                full_qualified_table_name_a='tableA',
-                full_qualified_table_name_b='schemaB.tableB',
-                results_table_name='results',
-            )
-        assert "Not found schema name in full qualified table A: 'tableA'" \
-               in err.value.args[0]
-        # missing table B
-        with pytest.raises(ValueError) as err:
-            mock_querier_async.cross_match(
-                full_qualified_table_name_a='schemaA.tableA',
-                results_table_name='results',
-            )
-        assert "Table name B argument is mandatory" in err.value.args[0]
-        # missing schema B
-        with pytest.raises(ValueError) as err:
-            mock_querier_async.cross_match(
-                full_qualified_table_name_a='schemaA.tableA',
-                full_qualified_table_name_b='tableB',
-                results_table_name='results',
-            )
-        assert "Not found schema name in full qualified table B: 'tableB'" \
-               in err.value.args[0]
-        # missing results table
-        with pytest.raises(ValueError) as err:
-            mock_querier_async.cross_match(
-                full_qualified_table_name_a='schemaA.tableA',
-                full_qualified_table_name_b='schemaB.tableB',
-            )
-        assert "Results table name argument is mandatory" in err.value.args[0]
-        # wrong results table (with schema)
-        with pytest.raises(ValueError) as err:
-            mock_querier_async.cross_match(
-                full_qualified_table_name_a='schemaA.tableA',
-                full_qualified_table_name_b='schemaB.tableB',
-                results_table_name='schema.results',
-            )
-        assert "Please, do not specify schema for 'results_table_name'" \
-               in err.value.args[0]
-        # radius < 0.1
-        with pytest.raises(ValueError) as err:
-            mock_querier_async.cross_match(
-                full_qualified_table_name_a='schemaA.tableA',
-                full_qualified_table_name_b='schemaB.tableB',
-                results_table_name='results',
-                radius=0.01,
-            )
-        assert "Invalid radius value. Found 0.01, valid range is: 0.1 to 10.0" \
-               in err.value.args[0]
-        # radius > 10.0
-        with pytest.raises(ValueError) as err:
-            mock_querier_async.cross_match(
-                full_qualified_table_name_a='schemaA.tableA',
-                full_qualified_table_name_b='schemaB.tableB',
-                results_table_name='results',
-                radius=10.1
-            )
-        assert "Invalid radius value. Found 10.1, valid range is: 0.1 to 10.0" \
-               in err.value.args[0]
-        job = mock_querier_async.cross_match(
-            full_qualified_table_name_a='schemaA.tableA',
+def test_xmatch(mock_querier_async):
+    # missing table A
+    with pytest.raises(ValueError) as err:
+        mock_querier_async.cross_match(
             full_qualified_table_name_b='schemaB.tableB',
             results_table_name='results',
         )
-        assert job.async_ is True
-        assert job.get_phase() == "COMPLETED"
-        assert job.failed is False
-        job = mock_querier_async.cross_match(
+    assert "Table name A argument is mandatory" in err.value.args[0]
+    # missing schema A
+    with pytest.raises(ValueError) as err:
+        mock_querier_async.cross_match(
+            full_qualified_table_name_a='tableA',
+            full_qualified_table_name_b='schemaB.tableB',
+            results_table_name='results',
+        )
+    assert "Not found schema name in full qualified table A: 'tableA'" \
+           in err.value.args[0]
+    # missing table B
+    with pytest.raises(ValueError) as err:
+        mock_querier_async.cross_match(
+            full_qualified_table_name_a='schemaA.tableA',
+            results_table_name='results',
+        )
+    assert "Table name B argument is mandatory" in err.value.args[0]
+    # missing schema B
+    with pytest.raises(ValueError) as err:
+        mock_querier_async.cross_match(
+            full_qualified_table_name_a='schemaA.tableA',
+            full_qualified_table_name_b='tableB',
+            results_table_name='results',
+        )
+    assert "Not found schema name in full qualified table B: 'tableB'" \
+           in err.value.args[0]
+    # missing results table
+    with pytest.raises(ValueError) as err:
+        mock_querier_async.cross_match(
+            full_qualified_table_name_a='schemaA.tableA',
+            full_qualified_table_name_b='schemaB.tableB',
+        )
+    assert "Results table name argument is mandatory" in err.value.args[0]
+    # wrong results table (with schema)
+    with pytest.raises(ValueError) as err:
+        mock_querier_async.cross_match(
+            full_qualified_table_name_a='schemaA.tableA',
+            full_qualified_table_name_b='schemaB.tableB',
+            results_table_name='schema.results',
+        )
+    assert "Please, do not specify schema for 'results_table_name'" \
+           in err.value.args[0]
+    # radius < 0.1
+    with pytest.raises(ValueError) as err:
+        mock_querier_async.cross_match(
             full_qualified_table_name_a='schemaA.tableA',
             full_qualified_table_name_b='schemaB.tableB',
             results_table_name='results',
-            background=True,
+            radius=0.01,
         )
-        assert job.async_ is True
-        assert job.get_phase() == "EXECUTING"
-        assert job.failed is False
+    assert "Invalid radius value. Found 0.01, valid range is: 0.1 to 10.0" \
+           in err.value.args[0]
+    # radius > 10.0
+    with pytest.raises(ValueError) as err:
+        mock_querier_async.cross_match(
+            full_qualified_table_name_a='schemaA.tableA',
+            full_qualified_table_name_b='schemaB.tableB',
+            results_table_name='results',
+            radius=10.1
+        )
+    assert "Invalid radius value. Found 10.1, valid range is: 0.1 to 10.0" \
+           in err.value.args[0]
+    job = mock_querier_async.cross_match(
+        full_qualified_table_name_a='schemaA.tableA',
+        full_qualified_table_name_b='schemaB.tableB',
+        results_table_name='results',
+    )
+    assert job.async_ is True
+    assert job.get_phase() == "COMPLETED"
+    assert job.failed is False
+    job = mock_querier_async.cross_match(
+        full_qualified_table_name_a='schemaA.tableA',
+        full_qualified_table_name_b='schemaB.tableB',
+        results_table_name='results',
+        background=True,
+    )
+    assert job.async_ is True
+    assert job.get_phase() == "EXECUTING"
+    assert job.failed is False
 
-    @patch.object(TapPlus, 'login')
-    def test_login(self, mock_login):
-        conn_handler = DummyConnHandler()
-        tapplus = TapPlus("http://test:1111/tap", connhandler=conn_handler)
-        tap = GaiaClass(conn_handler, tapplus, show_server_messages=False)
-        tap.login("user", "password")
-        assert (mock_login.call_count == 2)
-        mock_login.side_effect = HTTPError("Login error")
-        tap.login("user", "password")
-        assert (mock_login.call_count == 3)
+@patch.object(TapPlus, 'login')
+def test_login(mock_login):
+    conn_handler = DummyConnHandler()
+    tapplus = TapPlus("http://test:1111/tap", connhandler=conn_handler)
+    tap = GaiaClass(conn_handler, tapplus, show_server_messages=False)
+    tap.login("user", "password")
+    assert (mock_login.call_count == 2)
+    mock_login.side_effect = HTTPError("Login error")
+    tap.login("user", "password")
+    assert (mock_login.call_count == 3)
 
-    @patch.object(TapPlus, 'login_gui')
-    @patch.object(TapPlus, 'login')
-    def test_login_gui(self, mock_login_gui, mock_login):
-        conn_handler = DummyConnHandler()
-        tapplus = TapPlus("http://test:1111/tap", connhandler=conn_handler)
-        tap = GaiaClass(conn_handler, tapplus, show_server_messages=False)
-        tap.login_gui()
-        assert (mock_login_gui.call_count == 1)
-        mock_login_gui.side_effect = HTTPError("Login error")
-        tap.login("user", "password")
-        assert (mock_login.call_count == 1)
+@patch.object(TapPlus, 'login_gui')
+@patch.object(TapPlus, 'login')
+def test_login_gui(mock_login_gui, mock_login):
+    conn_handler = DummyConnHandler()
+    tapplus = TapPlus("http://test:1111/tap", connhandler=conn_handler)
+    tap = GaiaClass(conn_handler, tapplus, show_server_messages=False)
+    tap.login_gui()
+    assert (mock_login_gui.call_count == 1)
+    mock_login_gui.side_effect = HTTPError("Login error")
+    tap.login("user", "password")
+    assert (mock_login.call_count == 1)
 
-    @patch.object(TapPlus, 'logout')
-    def test_logout(self, mock_logout):
-        conn_handler = DummyConnHandler()
-        tapplus = TapPlus("http://test:1111/tap", connhandler=conn_handler)
-        tap = GaiaClass(conn_handler, tapplus, show_server_messages=False)
-        tap.logout()
-        assert (mock_logout.call_count == 2)
-        mock_logout.side_effect = HTTPError("Login error")
-        tap.logout()
-        assert (mock_logout.call_count == 3)
+@patch.object(TapPlus, 'logout')
+def test_logout(mock_logout):
+    conn_handler = DummyConnHandler()
+    tapplus = TapPlus("http://test:1111/tap", connhandler=conn_handler)
+    tap = GaiaClass(conn_handler, tapplus, show_server_messages=False)
+    tap.logout()
+    assert (mock_logout.call_count == 2)
+    mock_logout.side_effect = HTTPError("Login error")
+    tap.logout()
+    assert (mock_logout.call_count == 3)

--- a/astroquery/gaia/tests/test_gaiatap.py
+++ b/astroquery/gaia/tests/test_gaiatap.py
@@ -30,6 +30,7 @@ from astroquery.utils.tap.conn.tests.DummyResponse import DummyResponse
 import astropy.units as u
 from astropy.coordinates.sky_coordinate import SkyCoord
 import numpy as np
+from astroquery.utils import ASTROPY_LT_4_1
 from astroquery.utils.tap.xmlparser import utils
 from astroquery.utils.tap.core import TapPlus, TAP_CLIENT_ID
 from astroquery.utils.tap import taputils
@@ -49,7 +50,8 @@ def column_attrs():
         "table1_oid": np.int32
     }
     columns = {k: Column(name=k, description=k, dtype=v) for k, v in dtypes.items()}
-    columns["source_id"].meta = {"_votable_string_dtype": "char"}
+    if not ASTROPY_LT_4_1:
+        columns["source_id"].meta = {"_votable_string_dtype": "char"}
     return columns
 
 

--- a/astroquery/gaia/tests/test_gaiatap.py
+++ b/astroquery/gaia/tests/test_gaiatap.py
@@ -18,6 +18,7 @@ import os
 from unittest.mock import patch
 
 import pytest
+from astropy.table import Column
 from requests import HTTPError
 
 from astroquery.gaia import conf
@@ -39,6 +40,19 @@ def data_path(filename):
     return os.path.join(data_dir, filename)
 
 
+@pytest.fixture(scope="module")
+def column_attrs():
+    dtypes = {
+        "alpha": np.float64,
+        "delta": np.float64,
+        "source_id": object,
+        "table1_oid": np.int32
+    }
+    columns = {k: Column(name=k, description=k, dtype=v) for k, v in dtypes.items()}
+    columns["source_id"].meta = {"_votable_string_dtype": "char"}
+    return columns
+
+
 class TestTap:
 
     def test_show_message(self):
@@ -58,7 +72,7 @@ class TestTap:
         tapplus = TapPlus("http://test:1111/tap", connhandler=connHandler)
         GaiaClass(connHandler, tapplus, show_server_messages=True)
 
-    def test_query_object(self):
+    def test_query_object(self, column_attrs):
         conn_handler = DummyConnHandler()
         tapplus = TapPlus("http://test:1111/tap", connhandler=conn_handler)
         tap = GaiaClass(conn_handler, tapplus, show_server_messages=False)
@@ -87,54 +101,18 @@ class TestTap:
         assert len(table) == 3, \
             "Wrong job results (num rows). Expected: %d, found %d" % \
             (3, len(table))
-        self.__check_results_column(table,
-                                    'alpha',
-                                    'alpha',
-                                    None,
-                                    np.float64)
-        self.__check_results_column(table,
-                                    'delta',
-                                    'delta',
-                                    None,
-                                    np.float64)
-        self.__check_results_column(table,
-                                    'source_id',
-                                    'source_id',
-                                    None,
-                                    object)
-        self.__check_results_column(table,
-                                    'table1_oid',
-                                    'table1_oid',
-                                    None,
-                                    np.int32)
+        for colname, attrs in column_attrs.items():
+            assert table[colname].attrs_equal(attrs)
         # by radius
         radius = Quantity(1, u.deg)
         table = tap.query_object(sc, radius=radius)
         assert len(table) == 3, \
             "Wrong job results (num rows). Expected: %d, found %d" % \
             (3, len(table))
-        self.__check_results_column(table,
-                                    'alpha',
-                                    'alpha',
-                                    None,
-                                    np.float64)
-        self.__check_results_column(table,
-                                    'delta',
-                                    'delta',
-                                    None,
-                                    np.float64)
-        self.__check_results_column(table,
-                                    'source_id',
-                                    'source_id',
-                                    None,
-                                    object)
-        self.__check_results_column(table,
-                                    'table1_oid',
-                                    'table1_oid',
-                                    None,
-                                    np.int32)
+        for colname, attrs in column_attrs.items():
+            assert table[colname].attrs_equal(attrs)
 
-    def test_query_object_async(self):
+    def test_query_object_async(self, column_attrs):
         conn_handler = DummyConnHandler()
         tapplus = TapPlus("http://test:1111/tap", connhandler=conn_handler)
         tap = GaiaClass(conn_handler, tapplus, show_server_messages=False)
@@ -167,54 +145,18 @@ class TestTap:
         assert len(table) == 3, \
             "Wrong job results (num rows). Expected: %d, found %d" % \
             (3, len(table))
-        self.__check_results_column(table,
-                                    'alpha',
-                                    'alpha',
-                                    None,
-                                    np.float64)
-        self.__check_results_column(table,
-                                    'delta',
-                                    'delta',
-                                    None,
-                                    np.float64)
-        self.__check_results_column(table,
-                                    'source_id',
-                                    'source_id',
-                                    None,
-                                    object)
-        self.__check_results_column(table,
-                                    'table1_oid',
-                                    'table1_oid',
-                                    None,
-                                    np.int32)
+        for colname, attrs in column_attrs.items():
+            assert table[colname].attrs_equal(attrs)
         # by radius
         radius = Quantity(1, u.deg)
         table = tap.query_object_async(sc, radius=radius)
         assert len(table) == 3, \
             "Wrong job results (num rows). Expected: %d, found %d" % \
             (3, len(table))
-        self.__check_results_column(table,
-                                    'alpha',
-                                    'alpha',
-                                    None,
-                                    np.float64)
-        self.__check_results_column(table,
-                                    'delta',
-                                    'delta',
-                                    None,
-                                    np.float64)
-        self.__check_results_column(table,
-                                    'source_id',
-                                    'source_id',
-                                    None,
-                                    object)
-        self.__check_results_column(table,
-                                    'table1_oid',
-                                    'table1_oid',
-                                    None,
-                                    np.int32)
+        for colname, attrs in column_attrs.items():
+            assert table[colname].attrs_equal(attrs)
 
-    def test_cone_search_sync(self):
+    def test_cone_search_sync(self, column_attrs):
         conn_handler = DummyConnHandler()
         tapplus = TapPlus("http://test:1111/tap", connhandler=conn_handler)
         tap = GaiaClass(conn_handler, tapplus, show_server_messages=False)
@@ -241,28 +183,10 @@ class TestTap:
         assert len(results) == 3, \
             "Wrong job results (num rows). Expected: %d, found %d" % \
             (3, len(results))
-        self.__check_results_column(results,
-                                    'alpha',
-                                    'alpha',
-                                    None,
-                                    np.float64)
-        self.__check_results_column(results,
-                                    'delta',
-                                    'delta',
-                                    None,
-                                    np.float64)
-        self.__check_results_column(results,
-                                    'source_id',
-                                    'source_id',
-                                    None,
-                                    object)
-        self.__check_results_column(results,
-                                    'table1_oid',
-                                    'table1_oid',
-                                    None,
-                                    np.int32)
+        for colname, attrs in column_attrs.items():
+            assert results[colname].attrs_equal(attrs)
 
-    def test_cone_search_async(self):
+    def test_cone_search_async(self, column_attrs):
         conn_handler = DummyConnHandler()
         tapplus = TapPlus("http://test:1111/tap", connhandler=conn_handler)
         tap = GaiaClass(conn_handler, tapplus, show_server_messages=False)
@@ -303,26 +227,8 @@ class TestTap:
         assert len(results) == 3, \
             "Wrong job results (num rows). Expected: %d, found %d" % \
             (3, len(results))
-        self.__check_results_column(results,
-                                    'alpha',
-                                    'alpha',
-                                    None,
-                                    np.float64)
-        self.__check_results_column(results,
-                                    'delta',
-                                    'delta',
-                                    None,
-                                    np.float64)
-        self.__check_results_column(results,
-                                    'source_id',
-                                    'source_id',
-                                    None,
-                                    object)
-        self.__check_results_column(results,
-                                    'table1_oid',
-                                    'table1_oid',
-                                    None,
-                                    np.int32)
+        for colname, attrs in column_attrs.items():
+            assert results[colname].attrs_equal(attrs)
 
         # Regression test for #2093 and #2099 - changing the MAIN_GAIA_TABLE
         # had no effect.
@@ -338,22 +244,6 @@ class TestTap:
         assert 'name_from_class' in job.parameters['query']
         # Cleanup.
         conf.reset('MAIN_GAIA_TABLE')
-
-    def __check_results_column(self, results, column_name, description, unit,
-                               data_type):
-        c = results[column_name]
-        assert c.description == description, \
-            "Wrong description for results column '%s'. " % \
-            "Expected: '%s', found '%s'" % \
-            (column_name, description, c.description)
-        assert c.unit == unit, \
-            "Wrong unit for results column '%s'. " % \
-            "Expected: '%s', found '%s'" % \
-            (column_name, unit, c.unit)
-        assert c.dtype == data_type, \
-            "Wrong dataType for results column '%s'. " % \
-            "Expected: '%s', found '%s'" % \
-            (column_name, data_type, c.dtype)
 
     def test_load_data(self):
         dummy_handler = DummyTapHandler()

--- a/astroquery/gaia/tests/test_gaiatap.py
+++ b/astroquery/gaia/tests/test_gaiatap.py
@@ -131,16 +131,12 @@ class TestTap:
         assert "Missing required argument: height" in err.value.args[0]
 
         table = mock_querier.query_object(skycoord, width=width, height=10 * u.deg)
-        assert len(table) == 3, \
-            "Wrong job results (num rows). Expected: %d, found %d" % \
-            (3, len(table))
+        assert len(table) == 3
         for colname, attrs in column_attrs.items():
             assert table[colname].attrs_equal(attrs)
         # by radius
         table = mock_querier.query_object(skycoord, radius=1 * u.deg)
-        assert len(table) == 3, \
-            "Wrong job results (num rows). Expected: %d, found %d" % \
-            (3, len(table))
+        assert len(table) == 3
         for colname, attrs in column_attrs.items():
             assert table[colname].attrs_equal(attrs)
 
@@ -148,47 +144,35 @@ class TestTap:
         table = mock_querier_async.query_object_async(
             skycoord, width=12 * u.deg, height=10 * u.deg
         )
-        assert len(table) == 3, \
-            "Wrong job results (num rows). Expected: %d, found %d" % \
-            (3, len(table))
+        assert len(table) == 3
         for colname, attrs in column_attrs.items():
             assert table[colname].attrs_equal(attrs)
         # by radius
         table = mock_querier_async.query_object_async(skycoord, radius=1 * u.deg)
-        assert len(table) == 3, \
-            "Wrong job results (num rows). Expected: %d, found %d" % \
-            (3, len(table))
+        assert len(table) == 3
         for colname, attrs in column_attrs.items():
             assert table[colname].attrs_equal(attrs)
 
     def test_cone_search_sync(self, column_attrs, mock_querier):
         job = mock_querier.cone_search(skycoord, 1 * u.deg)
-        assert job.async_ is False, "Expected a synchronous job"
-        assert job.get_phase() == 'COMPLETED', \
-            "Wrong job phase. Expected: %s, found %s" % \
-            ('COMPLETED', job.get_phase())
-        assert job.failed is False, "Wrong job status (set Failed = True)"
+        assert job.async_ is False
+        assert job.get_phase() == "COMPLETED"
+        assert job.failed is False
         # results
         results = job.get_results()
-        assert len(results) == 3, \
-            "Wrong job results (num rows). Expected: %d, found %d" % \
-            (3, len(results))
+        assert len(results) == 3
         for colname, attrs in column_attrs.items():
             assert results[colname].attrs_equal(attrs)
 
     def test_cone_search_async(self, column_attrs, mock_querier_async):
         radius = 1.0 * u.deg
         job = mock_querier_async.cone_search_async(skycoord, radius)
-        assert job.async_ is True, "Expected an asynchronous job"
-        assert job.get_phase() == 'COMPLETED', \
-            "Wrong job phase. Expected: %s, found %s" % \
-            ('COMPLETED', job.get_phase())
-        assert job.failed is False, "Wrong job status (set Failed = True)"
+        assert job.async_ is True
+        assert job.get_phase() == "COMPLETED"
+        assert job.failed is False
         # results
         results = job.get_results()
-        assert len(results) == 3, \
-            "Wrong job results (num rows). Expected: %d, found %d" % \
-            (3, len(results))
+        assert len(results) == 3
         for colname, attrs in column_attrs.items():
             assert results[colname].attrs_equal(attrs)
 
@@ -318,22 +302,18 @@ class TestTap:
             full_qualified_table_name_b='schemaB.tableB',
             results_table_name='results',
         )
-        assert job.async_ is True, "Expected an asynchronous job"
-        assert job.get_phase() == 'COMPLETED', \
-            "Wrong job phase. Expected: %s, found %s" % \
-            ('COMPLETED', job.get_phase())
-        assert job.failed is False, "Wrong job status (set Failed = True)"
+        assert job.async_ is True
+        assert job.get_phase() == "COMPLETED"
+        assert job.failed is False
         job = mock_querier_async.cross_match(
             full_qualified_table_name_a='schemaA.tableA',
             full_qualified_table_name_b='schemaB.tableB',
             results_table_name='results',
             background=True,
         )
-        assert job.async_ is True, "Expected an asynchronous job"
-        assert job.get_phase() == 'EXECUTING', \
-            "Wrong job phase. Expected: %s, found %s" % \
-            ('EXECUTING', job.get_phase())
-        assert job.failed is False, "Wrong job status (set Failed = True)"
+        assert job.async_ is True
+        assert job.get_phase() == "EXECUTING"
+        assert job.failed is False
 
     @patch.object(TapPlus, 'login')
     def test_login(self, mock_login):

--- a/astroquery/gaia/tests/test_gaiatap.py
+++ b/astroquery/gaia/tests/test_gaiatap.py
@@ -60,21 +60,8 @@ class TestTap:
 
     def test_query_object(self):
         conn_handler = DummyConnHandler()
-        # Launch response: we use default response because the query contains
-        # decimals
-        dummy_response = DummyResponse(200)
-
-        message_text = "1653401204784D[type: -100,-1]=Gaia dev is under maintenance"
-
-        dummy_response.set_data(method='GET', body=message_text)
-        conn_handler.set_default_response(dummy_response)
-
-        # show_server_messages
-        tableRequest = 'notification?action=GetNotifications'
-        conn_handler.set_response(tableRequest, dummy_response)
-
         tapplus = TapPlus("http://test:1111/tap", connhandler=conn_handler)
-        tap = GaiaClass(conn_handler, tapplus, show_server_messages=True)
+        tap = GaiaClass(conn_handler, tapplus, show_server_messages=False)
         # Launch response: we use default response because the query contains
         # decimals
         response_launch_job = DummyResponse(200)


### PR DESCRIPTION
It was possible to shorten the `gaia` non-remote tests quite a lot without losing any test coverage. The refactored code is much less verbose and much easier to read. See the commit messages for more details.