### PR TITLE
Remove `*CoordGenerator` classes

### DIFF
--- a/astroquery/heasarc/tests/conftest.py
+++ b/astroquery/heasarc/tests/conftest.py
@@ -4,6 +4,7 @@ import glob
 import hashlib
 import requests
 import pytest
+from astropy.coordinates import SkyCoord
 from ... import log
 
 """
@@ -15,6 +16,10 @@ else
     runs remote test patched so that the test data is stored in a temporary directory.
     advice is given to copy the newly generated test data into the repository
 """
+
+
+# The quasar 3C 273
+skycoord_3C_273 = SkyCoord("12h29m06.70s +02d03m08.7s", frame="icrs")
 
 
 class MockResponse:

--- a/astroquery/heasarc/tests/test_heasarc_remote.py
+++ b/astroquery/heasarc/tests/test_heasarc_remote.py
@@ -4,9 +4,8 @@ import pytest
 import requests
 
 from ...heasarc import Heasarc
-from ...utils import commons
 
-from .conftest import parametrization_local_save_remote, MockResponse
+from .conftest import MockResponse, parametrization_local_save_remote, skycoord_3C_273
 
 
 @parametrization_local_save_remote
@@ -84,9 +83,8 @@ class TestHeasarc:
     def test_query_region_async(self):
         heasarc = Heasarc()
         mission = 'rosmaster'
-        c = commons.coord.SkyCoord('12h29m06.70s +02d03m08.7s', frame='icrs')
-        response = heasarc.query_region_async(c, mission=mission,
-                                              radius='1 degree')
+        response = heasarc.query_region_async(
+            skycoord_3C_273, mission=mission, radius="1 degree")
         assert response is not None
         assert isinstance(response, (requests.models.Response, MockResponse))
 
@@ -94,8 +92,7 @@ class TestHeasarc:
         heasarc = Heasarc()
         mission = 'rosmaster'
 
-        # Define coordinates for '3c273' object
-        c = commons.coord.SkyCoord('12h29m06.70s +02d03m08.7s', frame='icrs')
-        table = heasarc.query_region(c, mission=mission, radius='1 degree')
+        table = heasarc.query_region(
+            skycoord_3C_273, mission=mission, radius="1 degree")
 
         assert len(table) == 63

--- a/astroquery/heasarc/tests/test_heasarc_remote_isdc.py
+++ b/astroquery/heasarc/tests/test_heasarc_remote_isdc.py
@@ -6,8 +6,7 @@ from astropy.time import Time, TimeDelta
 import astropy.units as u
 
 from ...heasarc import Heasarc, Conf
-from ...utils import commons
-from .conftest import parametrization_local_save_remote, MockResponse
+from .conftest import MockResponse, parametrization_local_save_remote, skycoord_3C_273
 
 
 @parametrization_local_save_remote
@@ -191,11 +190,10 @@ class TestHeasarcISDC:
     def test_query_region_async(self):
         heasarc = Heasarc()
         mission = 'integral_rev3_scw'
-        c = commons.coord.SkyCoord('12h29m06.70s +02d03m08.7s', frame='icrs')
 
         with self.isdc_context:
-            response = heasarc.query_region_async(c, mission=mission,
-                                                  radius='1 degree')
+            response = heasarc.query_region_async(
+                skycoord_3C_273, mission=mission, radius="1 degree")
         assert response is not None
         assert isinstance(response, (requests.models.Response, MockResponse))
 
@@ -203,12 +201,8 @@ class TestHeasarcISDC:
         heasarc = Heasarc()
         mission = 'integral_rev3_scw'
 
-        # Define coordinates for '3c273' object
         with self.isdc_context:
-            c = commons.coord.SkyCoord(
-                    '12h29m06.70s +02d03m08.7s',
-                    frame='icrs'
-                )
-            table = heasarc.query_region(c, mission=mission, radius='1 degree')
+            table = heasarc.query_region(
+                skycoord_3C_273, mission=mission, radius="1 degree")
 
         assert len(table) >= 274

--- a/astroquery/image_cutouts/first/tests/test_first.py
+++ b/astroquery/image_cutouts/first/tests/test_first.py
@@ -4,12 +4,15 @@ import os
 import numpy.testing as npt
 import pytest
 import astropy.units as u
+from astropy.coordinates import SkyCoord
 
 from ....utils import commons
 from astroquery.utils.mocks import MockResponse
 from ... import first
 
 DATA_FILES = {'image': 'image.fits'}
+
+skycoord = SkyCoord(162.530 * u.deg, 30.677 * u.deg, frame="icrs")
 
 
 def data_path(filename):
@@ -42,15 +45,12 @@ def post_mockreturn(method, url, data, timeout, **kwargs):
 
 def test_get_images_async(patch_post, patch_parse_coordinates):
     response = first.core.First.get_images_async(
-        commons.ICRSCoordGenerator(162.530, 30.677, unit=(u.deg, u.deg)),
-        image_size=0.2 * u.deg, get_query_payload=True)
+        skycoord, image_size=0.2 * u.deg, get_query_payload=True)
     npt.assert_approx_equal(response['ImageSize'], 12, significant=3)
-    response = first.core.First.get_images_async(
-        commons.ICRSCoordGenerator(162.530, 30.677, unit=(u.deg, u.deg)))
+    response = first.core.First.get_images_async(skycoord)
     assert response is not None
 
 
 def test_get_images(patch_post, patch_parse_coordinates):
-    image = first.core.First.get_images(
-        commons.ICRSCoordGenerator(162.530, 30.677, unit=(u.deg, u.deg)))
+    image = first.core.First.get_images(skycoord)
     assert image is not None

--- a/astroquery/ipac/irsa/irsa_dust/core.py
+++ b/astroquery/ipac/irsa/irsa_dust/core.py
@@ -1,7 +1,9 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
+
+from astropy.coordinates import Angle, SkyCoord
+from astropy.coordinates.name_resolve import NameResolveError
 from astropy.table import Table, Column
 import astropy.units as u
-from astropy import coordinates
 
 from astroquery.ipac.irsa.irsa_dust import utils
 from astroquery.ipac.irsa.irsa_dust import conf
@@ -336,18 +338,18 @@ class IrsaDustClass(BaseQuery):
                 # If the coordinate is a resolvable name, pass that name
                 # directly to irsa_dust because it can handle it (and that
                 # changes the return value associated metadata)
-                C = commons.ICRSCoord.from_name(coordinate)
+                C = SkyCoord.from_name(coordinate, frame="icrs")
                 payload = {"locstr": coordinate}
-            except coordinates.name_resolve.NameResolveError:
+            except NameResolveError:
                 C = commons.parse_coordinates(coordinate).transform_to('fk5')
                 # check if this is resolvable?
                 payload = {"locstr": "{0} {1}".format(C.ra.deg, C.dec.deg)}
-        elif isinstance(coordinate, coordinates.SkyCoord):
+        elif isinstance(coordinate, SkyCoord):
             C = coordinate.transform_to('fk5')
             payload = {"locstr": "{0} {1}".format(C.ra.deg, C.dec.deg)}
         # check if radius is given with proper units
         if radius is not None:
-            reg_size = coordinates.Angle(radius).deg
+            reg_size = Angle(radius).deg
             # check if radius falls in the acceptable range
             if reg_size < 2 or reg_size > 37.5:
                 raise ValueError("Radius (in any unit) must be in the"

--- a/astroquery/ipac/irsa/tests/test_irsa.py
+++ b/astroquery/ipac/irsa/tests/test_irsa.py
@@ -5,12 +5,11 @@ import re
 import numpy as np
 
 import pytest
+from astropy.coordinates import SkyCoord
 from astropy.table import Table
-import astropy.coordinates as coord
 import astropy.units as u
 
 from astroquery.utils.mocks import MockResponse
-from astroquery.utils import commons
 from astroquery.ipac.irsa import Irsa, conf
 from astroquery.ipac import irsa
 
@@ -19,8 +18,7 @@ DATA_FILES = {'Cone': 'Cone.xml',
               'Polygon': 'Polygon.xml'}
 
 OBJ_LIST = ["m31", "00h42m44.330s +41d16m07.50s",
-            commons.GalacticCoordGenerator(l=121.1743, b=-21.5733,
-                                           unit=(u.deg, u.deg))]
+            SkyCoord(l=121.1743 * u.deg, b=-21.5733 * u.deg, frame="galactic")]
 
 
 def data_path(filename):
@@ -120,9 +118,9 @@ def test_query_region_box(coordinates, patch_get):
     assert isinstance(result, Table)
 
 
-poly1 = [coord.SkyCoord(ra=10.1, dec=10.1, unit=(u.deg, u.deg)),
-         coord.SkyCoord(ra=10.0, dec=10.1, unit=(u.deg, u.deg)),
-         coord.SkyCoord(ra=10.0, dec=10.0, unit=(u.deg, u.deg))]
+poly1 = [SkyCoord(ra=10.1 * u.deg, dec=10.1 * u.deg),
+         SkyCoord(ra=10.0 * u.deg, dec=10.1 * u.deg),
+         SkyCoord(ra=10.0 * u.deg, dec=10.0 * u.deg)]
 poly2 = [(10.1 * u.deg, 10.1 * u.deg), (10.0 * u.deg, 10.1 * u.deg),
          (10.0 * u.deg, 10.0 * u.deg)]
 

--- a/astroquery/ipac/ned/tests/test_ned.py
+++ b/astroquery/ipac/ned/tests/test_ned.py
@@ -221,8 +221,7 @@ def test_query_region_async(monkeypatch, patch_get):
     assert response['search_type'] == "Near Name Search"
     # check with Galactic coordinates
     response = ned.core.Ned.query_region_async(
-        commons.GalacticCoordGenerator(l=-67.02084, b=-29.75447,
-                                       unit=(u.deg, u.deg)),
+        coord.SkyCoord(l=-67.02084 * u.deg, b=-29.75447 * u.deg, frame="galactic"),
         get_query_payload=True)
     assert response['search_type'] == 'Near Position Search'
     npt.assert_approx_equal(

--- a/astroquery/magpis/tests/test_magpis.py
+++ b/astroquery/magpis/tests/test_magpis.py
@@ -5,10 +5,14 @@ import os
 import numpy.testing as npt
 import pytest
 import astropy.units as u
+from astropy.coordinates import SkyCoord
 
 from ...utils import commons
 from astroquery.utils.mocks import MockResponse
 from ... import magpis
+
+
+skycoord = SkyCoord(10.5 * u.deg, 0.0 * u.deg, frame="galactic")
 
 DATA_FILES = {'image': 'image.fits'}
 
@@ -50,23 +54,18 @@ def test_list_surveys():
 
 def test_get_images_async(patch_post, patch_parse_coordinates):
     response = magpis.core.Magpis.get_images_async(
-        commons.GalacticCoordGenerator(10.5, 0.0, unit=(u.deg, u.deg)),
-        image_size=2 * u.deg, survey="gps6epoch3", get_query_payload=True)
+        skycoord, image_size=2 * u.deg, survey="gps6epoch3", get_query_payload=True)
     npt.assert_approx_equal(response['ImageSize'], 120, significant=3)
     assert response['Survey'] == 'gps6epoch3'
-    response = magpis.core.Magpis.get_images_async(
-        commons.GalacticCoordGenerator(10.5, 0.0, unit=(u.deg, u.deg)))
+    response = magpis.core.Magpis.get_images_async(skycoord)
     assert response is not None
 
 
 def test_get_images(patch_post, patch_parse_coordinates):
-    image = magpis.core.Magpis.get_images(
-        commons.GalacticCoordGenerator(10.5, 0.0, unit=(u.deg, u.deg)))
+    image = magpis.core.Magpis.get_images(skycoord)
     assert image is not None
 
 
 @pytest.mark.xfail
 def test_get_images_fail(patch_post, patch_parse_coordinates):
-    magpis.core.Magpis.get_images(
-        commons.GalacticCoordGenerator(10.5, 0.0, unit=(u.deg, u.deg)),
-        survey='Not a survey')
+    magpis.core.Magpis.get_images(skycoord, survey="Not a survey")

--- a/astroquery/nvas/tests/test_nvas.py
+++ b/astroquery/nvas/tests/test_nvas.py
@@ -8,16 +8,15 @@ from contextlib import contextmanager
 import numpy.testing as npt
 import astropy.units as u
 import pytest
+from astropy.coordinates import SkyCoord
 from astropy.io.fits.verify import VerifyWarning
 
 from ...import nvas
 from astroquery.utils.mocks import MockResponse
 from ...utils import commons
 
-COORDS_GAL = commons.GalacticCoordGenerator(
-    l=49.489, b=-0.37, unit=(u.deg, u.deg))  # ARM 2000
-COORDS_ICRS = commons.ICRSCoordGenerator(
-    "12h29m06.69512s +2d03m08.66276s")  # 3C 273
+COORDS_GAL = SkyCoord(l=49.489 * u.deg, b=-0.37 * u.deg, frame="galactic")  # ARM 2000
+COORDS_ICRS = SkyCoord("12h29m06.69512s +2d03m08.66276s", frame="icrs")  # 3C 273
 
 DATA_FILES = {'image': 'image.imfits',
               'image_search': 'image_results.html'}
@@ -84,8 +83,8 @@ def deparse_coordinates(cstr):
 @pytest.mark.parametrize(('coordinates'), [COORDS_GAL, COORDS_ICRS])
 def test_parse_coordinates(coordinates):
     out_str = nvas.core._parse_coordinates(coordinates)
-    new_coords = commons.ICRSCoordGenerator(
-        deparse_coordinates(out_str), unit=(u.hour, u.deg))
+    new_coords = SkyCoord(
+        deparse_coordinates(out_str), unit=(u.hour, u.deg), frame="icrs")
     # if all goes well new_coords and coordinates have same ra and dec
     npt.assert_approx_equal(new_coords.ra.degree,
                             coordinates.transform_to('fk5').ra.degree,

--- a/astroquery/sdss/tests/test_sdss.py
+++ b/astroquery/sdss/tests/test_sdss.py
@@ -10,7 +10,7 @@ import warnings
 
 import astropy.units as u
 from astropy.io import fits
-from astropy.coordinates import Angle
+from astropy.coordinates import Angle, SkyCoord
 from astropy.table import Column, Table
 from astropy.utils.exceptions import AstropyWarning
 import pytest
@@ -105,7 +105,7 @@ def data_path(filename):
 
 
 # Test Case: A Seyfert 1 galaxy
-coords = commons.ICRSCoordGenerator('0h8m05.63s +14d50m23.3s')
+coords = SkyCoord("0h8m05.63s +14d50m23.3s", frame="icrs")
 
 # Test Case: list of coordinates
 coords_list = [coords, coords]

--- a/astroquery/simbad/tests/test_simbad.py
+++ b/astroquery/simbad/tests/test_simbad.py
@@ -4,6 +4,7 @@ import re
 
 import pytest
 import astropy.units as u
+from astropy.coordinates import SkyCoord
 from astropy.table import Table
 import numpy as np
 
@@ -14,13 +15,10 @@ from ...query import AstroQuery
 from ...exceptions import TableParseError
 from .test_simbad_remote import multicoords
 
-GALACTIC_COORDS = commons.GalacticCoordGenerator(l=-67.02084, b=-29.75447,
-                                                 unit=(u.deg, u.deg))
-ICRS_COORDS = commons.ICRSCoordGenerator("05h35m17.3s -05h23m28s")
-FK4_COORDS = commons.FK4CoordGenerator(ra=84.90759, dec=-80.89403,
-                                       unit=(u.deg, u.deg))
-FK5_COORDS = commons.FK5CoordGenerator(ra=83.82207, dec=-80.86667,
-                                       unit=(u.deg, u.deg))
+GALACTIC_COORDS = SkyCoord(l=-67.02084 * u.deg, b=-29.75447 * u.deg, frame="galactic")
+ICRS_COORDS = SkyCoord("05h35m17.3s -05h23m28s", frame="icrs")
+FK4_COORDS = SkyCoord(ra=84.90759 * u.deg, dec=-80.89403 * u.deg, frame="fk4")
+FK5_COORDS = SkyCoord(ra=83.82207 * u.deg, dec=-80.86667 * u.deg, frame="fk5")
 
 DATA_FILES = {
     'id': 'query_id.data',

--- a/astroquery/skyview/tests/test_skyview.py
+++ b/astroquery/skyview/tests/test_skyview.py
@@ -3,16 +3,15 @@ import os.path
 import types
 
 import pytest
-from astropy import coordinates
+from astropy.coordinates import SkyCoord
+from astropy.coordinates.name_resolve import NameResolveError
 from astropy import units as u
 
-from ...utils import commons
 from astroquery.utils.mocks import MockResponse
 from ...skyview import SkyView
 
-objcoords = {'Eta Carinae': coordinates.SkyCoord(ra=161.264775 * u.deg,
-                                                 dec=-59.6844306 * u.deg,
-                                                 frame='icrs'), }
+objcoords = {"Eta Carinae": SkyCoord(ra=161.264775 * u.deg, dec=-59.6844306 * u.deg,
+                                     frame="icrs")}
 
 
 @pytest.fixture
@@ -23,14 +22,12 @@ def patch_fromname(request):
     except AttributeError:  # pytest < 3
         mp = request.getfuncargvalue("monkeypatch")
 
-    def fromname(self, name):
+    def fromname(self, name, frame=None):
         if isinstance(name, str):
             return objcoords[name]
         else:
-            raise coordinates.name_resolve.NameResolveError
-    mp.setattr(commons.ICRSCoord,
-               'from_name',
-               types.MethodType(fromname, commons.ICRSCoord))
+            raise NameResolveError
+    mp.setattr(SkyCoord, "from_name", types.MethodType(fromname, SkyCoord))
 
 
 class MockResponseSkyView(MockResponse):

--- a/astroquery/ukidss/tests/test_ukidss.py
+++ b/astroquery/ukidss/tests/test_ukidss.py
@@ -4,6 +4,7 @@ import requests
 from contextlib import contextmanager
 
 import pytest
+from astropy.coordinates import SkyCoord
 from astropy.table import Table
 import astropy.units as u
 
@@ -18,6 +19,10 @@ DATA_FILES = {"vo_results": "vo_results.html",
               "votable": "votable.xml",
               "error": "error.html"
               }
+
+
+galactic_skycoord = SkyCoord(l=10.625 * u.deg, b=-0.38 * u.deg, frame="galactic")
+icrs_skycoord = SkyCoord(ra=83.633083 * u.deg, dec=22.0145 * u.deg, frame="icrs")
 
 
 def data_path(filename):
@@ -87,28 +92,20 @@ def get_mockreturn(method='GET', url='default_url',
 
 def test_get_images(patch_get, patch_get_readable_fileobj):
     image = ukidss.core.Ukidss.get_images(
-        commons.ICRSCoordGenerator(ra=83.633083, dec=22.0145,
-                                   unit=(u.deg, u.deg)),
-        frame_type='interleave', programme_id="GCS", waveband="K",
+        icrs_skycoord, frame_type="interleave", programme_id="GCS", waveband="K",
         radius=20 * u.arcmin)
     assert image is not None
 
 
 def test_get_images_async_1():
     payload = ukidss.core.Ukidss.get_images_async(
-        commons.ICRSCoordGenerator(ra=83.633083, dec=22.0145,
-                                   unit=(u.deg, u.deg)),
-        radius=20 * u.arcmin, get_query_payload=True,
-        programme_id='GPS')
+        icrs_skycoord, radius=20 * u.arcmin, get_query_payload=True, programme_id="GPS")
 
     assert 'xsize' not in payload
     assert 'ysize' not in payload
 
     payload = ukidss.core.Ukidss.get_images_async(
-        commons.ICRSCoordGenerator(ra=83.633083, dec=22.0145,
-                                   unit=(u.deg, u.deg)),
-        get_query_payload=True,
-        programme_id='GPS')
+        icrs_skycoord, get_query_payload=True, programme_id="GPS")
     assert payload['xsize'] == payload['ysize']
     assert payload['xsize'] == 1
 
@@ -117,20 +114,14 @@ def test_get_images_async_1():
 
 def test_get_images_async_2(patch_get, patch_get_readable_fileobj):
 
-    image_urls = ukidss.core.Ukidss.get_images_async(
-        commons.ICRSCoordGenerator(ra=83.633083, dec=22.0145,
-                                   unit=(u.deg, u.deg)),
-        programme_id='GPS')
+    image_urls = ukidss.core.Ukidss.get_images_async(icrs_skycoord, programme_id="GPS")
 
     assert len(image_urls) == 1
 
 
 def test_get_image_list(patch_get, patch_get_readable_fileobj):
     urls = ukidss.core.Ukidss.get_image_list(
-        commons.ICRSCoordGenerator(ra=83.633083, dec=22.0145,
-                                   unit=(u.deg, u.deg)),
-        frame_type='all', waveband='all',
-        programme_id='GPS')
+        icrs_skycoord, frame_type="all", waveband="all", programme_id="GPS")
     print(urls)
     assert len(urls) == 1
 
@@ -144,27 +135,19 @@ def test_extract_urls():
 
 def test_query_region(patch_get, patch_get_readable_fileobj):
     table = ukidss.core.Ukidss.query_region(
-        commons.GalacticCoordGenerator(l=10.625, b=-0.38,
-                                       unit=(u.deg, u.deg)),
-        radius=6 * u.arcsec,
-        programme_id='GPS')
+        galactic_skycoord, radius=6 * u.arcsec, programme_id="GPS")
     assert isinstance(table, Table)
     assert len(table) > 0
 
 
 def test_query_region_async(patch_get):
     response = ukidss.core.Ukidss.query_region_async(
-        commons.GalacticCoordGenerator(l=10.625, b=-0.38,
-                                       unit=(u.deg, u.deg)),
-        radius=6 * u.arcsec, get_query_payload=True,
+        galactic_skycoord, radius=6 * u.arcsec, get_query_payload=True,
         programme_id='GPS')
 
     assert response['radius'] == 0.1
     response = ukidss.core.Ukidss.query_region_async(
-        commons.GalacticCoordGenerator(l=10.625, b=-0.38,
-                                       unit=(u.deg, u.deg)),
-        radius=6 * u.arcsec,
-        programme_id='GPS')
+        galactic_skycoord, radius=6 * u.arcsec, programme_id="GPS")
     assert response is not None
 
 

--- a/astroquery/vizier/tests/conftest.py
+++ b/astroquery/vizier/tests/conftest.py
@@ -1,0 +1,9 @@
+# Licensed under a 3-clause BSD style license - see LICENSE.rst
+
+from astropy import units as u
+from astropy.coordinates import SkyCoord
+
+
+scalar_skycoord = SkyCoord(ra=299.590 * u.deg, dec=35.201 * u.deg, frame="icrs")
+vector_skycoord = SkyCoord(
+    ra=[299.590, 299.90] * u.deg, dec=[35.201, 35.201] * u.deg, frame="icrs")

--- a/astroquery/vizier/tests/test_vizier.py
+++ b/astroquery/vizier/tests/test_vizier.py
@@ -3,12 +3,14 @@ import os
 import requests
 from numpy import testing as npt
 import pytest
+from astropy.coordinates import SkyCoord
 from astropy.table import Table
 import astropy.units as u
 
 from ... import vizier
 from ...utils import commons
 from astroquery.utils.mocks import MockResponse
+from .conftest import scalar_skycoord, vector_skycoord
 
 
 VO_DATA = {'HIP,NOMAD,UCAC': "viz.xml",
@@ -58,8 +60,7 @@ def post_mockreturn(self, method, url, data=None, timeout=10, files=None,
 
 
 def parse_objname(obj):
-    d = {'AFGL 2591': commons.ICRSCoordGenerator(307.35388 * u.deg,
-                                                 40.18858 * u.deg)}
+    d = {"AFGL 2591": SkyCoord(307.35388 * u.deg, 40.18858 * u.deg, frame="icrs")}
     return d[obj]
 
 
@@ -119,19 +120,14 @@ def test_parse_result(filepath, objlen):
 
 
 def test_query_region_async(patch_post):
-    target = commons.ICRSCoordGenerator(ra=299.590, dec=35.201,
-                                        unit=(u.deg, u.deg))
     response = vizier.core.Vizier.query_region_async(
-        target, radius=5 * u.deg, catalog=["HIP", "NOMAD", "UCAC"])
+        scalar_skycoord, radius=5 * u.deg, catalog=["HIP", "NOMAD", "UCAC"])
     assert response is not None
 
 
 def test_query_region(patch_post):
-    target = commons.ICRSCoordGenerator(ra=299.590, dec=35.201,
-                                        unit=(u.deg, u.deg))
-    result = vizier.core.Vizier.query_region(target,
-                                             radius=5 * u.deg,
-                                             catalog=["HIP", "NOMAD", "UCAC"])
+    result = vizier.core.Vizier.query_region(
+        scalar_skycoord, radius=5 * u.deg, catalog=["HIP", "NOMAD", "UCAC"])
 
     assert isinstance(result, commons.TableList)
 
@@ -143,12 +139,8 @@ def test_query_regions(patch_post):
     for the multi-object query.  There is no test for parsing
     that return (yet - but see test_multicoord in remote_data)
     """
-    targets = commons.ICRSCoordGenerator(ra=[299.590, 299.90],
-                                         dec=[35.201, 35.201],
-                                         unit=(u.deg, u.deg))
-    vizier.core.Vizier.query_region(targets,
-                                    radius=5 * u.deg,
-                                    catalog=["HIP", "NOMAD", "UCAC"])
+    vizier.core.Vizier.query_region(
+        vector_skycoord, radius=5 * u.deg, catalog=["HIP", "NOMAD", "UCAC"])
 
 
 def test_query_object_async(patch_post):


### PR DESCRIPTION
`astroquery.utils.commons` defined a few classes which allowed constructing `astropy.coordinates.SkyCoord` instances without having to specify the `frame` keyword at the cost of having to specify the correct class instead. They provided little value, and all the code that used them now uses `SkyCoord` directly.

Contributes towards #2096 and #2429.