### PR TITLE
Remove possible debug print statement?

### DIFF
--- a/astroquery/utils/tap/xmlparser/jobSaxParser.py
+++ b/astroquery/utils/tap/xmlparser/jobSaxParser.py
@@ -120,7 +120,6 @@ class JobSaxParser(xml.sax.ContentHandler):
         elif UWS_OWNERID == nameLower:
             self.__job.ownerid = value
         elif UWS_PHASE == nameLower:
-            print("phase was set")
             self.__job._phase = value
         elif UWS_QUOTE == nameLower:
             self.__job.quote = value


### PR DESCRIPTION
I've noticed this printed phrase whenever doing queries with the `Gaia` class and wondered if it was left in from debugging at some point. Can this be removed? 

In some cases it can lead to distracting output, e.g.,
<img width="314" alt="image" src="https://user-images.githubusercontent.com/583379/196501262-a6b306f1-36cf-418f-b989-b015a9fc3127.png">
