### PR TITLE
Colorize `pytest` output

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -33,7 +33,7 @@ astropy_header = true
 text_file_format = rst
 xfail_strict = true
 remote_data_strict = true
-addopts = --doctest-rst
+addopts = --color=yes --doctest-rst
 filterwarnings =
     error
 ##  These are temporary measures, all of these should be fixed:


### PR DESCRIPTION
`pytest` is now explicitly told to colorize its output. This also applies to the CI tests on GitHub.

See also astropy/astropy#13629