### PR TITLE
Updating tox.ini to recognize the flaky marker

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -72,3 +72,8 @@ requires =
 commands =
     pip freeze
     python setup.py build_sphinx -W
+
+[pytest]
+markers =
+    flaky: mark tests to be rerun
+


### PR DESCRIPTION
Without this change I get a `pytest.PytestUnknownMarkWarning: Unknown pytest.mark.flaky` error when running `tox -e test`.