### PR TITLE
MAINT: sorting missions list for mast for aesthetic convenience

### DIFF
--- a/astroquery/mast/observations.py
+++ b/astroquery/mast/observations.py
@@ -89,6 +89,7 @@ class ObservationsClass(MastQueryWithLogin):
             if facet['text'] == "obs_collection":
                 mission_info = facet['ExtendedProperties']['histObj']
                 missions = list(mission_info.keys())
+                missions.sort()
                 missions.remove('hist')
                 return missions
 

--- a/astroquery/mast/observations.py
+++ b/astroquery/mast/observations.py
@@ -88,8 +88,7 @@ class ObservationsClass(MastQueryWithLogin):
         for facet in hist_data:
             if facet['text'] == "obs_collection":
                 mission_info = facet['ExtendedProperties']['histObj']
-                missions = list(mission_info.keys())
-                missions.sort()
+                missions = sorted(mission_info)
                 missions.remove('hist')
                 return missions
 


### PR DESCRIPTION
This is purely to ensure the returned list is always the same.