### PR TITLE
Remove deprecated function `send_request()`

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -168,6 +168,8 @@ Infrastructure, Utility and Other Changes and Additions
 - Removal of the non-functional ``noirlab`` module because the current module
   is incompatible with the new upstream API. [#2579]
 
+- Removed deprecated function ``utils.commons.send_request()``. [#2583]
+
 
 0.4.6 (2022-03-22)
 ==================

--- a/astroquery/utils/__init__.py
+++ b/astroquery/utils/__init__.py
@@ -6,7 +6,7 @@ functions that will ultimately be merged into `astropy.utils`.
 from .progressbar import chunk_report, chunk_read
 from .download_file_list import download_list_of_fitsfiles
 from .class_or_instance import class_or_instance
-from .commons import (send_request, parse_coordinates, TableList, suppress_vo_warnings,
+from .commons import (parse_coordinates, TableList, suppress_vo_warnings,
                       validate_email, ASTROPY_LT_4_1, ASTROPY_LT_4_3, ASTROPY_LT_5_0,
                       ASTROPY_LT_5_1)
 from .process_asyncs import async_to_sync
@@ -17,7 +17,6 @@ from .cleanup_downloads import cleanup_saved_downloads
 __all__ = ['chunk_report', 'chunk_read',
            'download_list_of_fitsfiles',
            'class_or_instance',
-           'send_request',
            'parse_coordinates',
            'TableList',
            'suppress_vo_warnings',

--- a/astroquery/utils/commons.py
+++ b/astroquery/utils/commons.py
@@ -11,25 +11,21 @@ import socket
 from io import BytesIO, StringIO
 from urllib.error import URLError
 
-import requests
-
 import astropy.units as u
 from collections import OrderedDict
-from astropy.utils import deprecated, minversion
+from astropy.utils import minversion
 import astropy.utils.data as aud
 from astropy.io import fits, votable
 
 from astropy.coordinates import Angle, BaseCoordinateFrame, SkyCoord
 
 from ..exceptions import TimeoutError, InputWarning
-from .. import version
 
 
 CoordClasses = (SkyCoord, BaseCoordinateFrame)
 
 
-__all__ = ['send_request',
-           'parse_coordinates',
+__all__ = ['parse_coordinates',
            'TableList',
            'suppress_vo_warnings',
            'validate_email',
@@ -45,62 +41,6 @@ ASTROPY_LT_5_0 = not minversion('astropy', '5.0')
 ASTROPY_LT_5_1 = not minversion('astropy', '5.1dev197')
 # Update the line above once 5.1 is released
 # ASTROPY_LT_5_1 = not minversion('astropy', '5.1')
-
-
-@deprecated('0.4.4', alternative='astroquery.query.BaseQuery._request')
-def send_request(url, data, timeout, request_type='POST', headers={},
-                 **kwargs):
-    """
-    A utility function that post HTTP requests to remote server
-    and returns the HTTP response.
-
-    Parameters
-    ----------
-    url : str
-        The URL of the remote server
-    data : dict
-        A dictionary representing the payload to be posted via the HTTP request
-    timeout : int, quantity_like
-        Time limit for establishing successful connection with remote server
-    request_type : str
-        options are 'POST' (default) and 'GET'. Determines whether to perform
-        an HTTP POST or an HTTP GET request
-    headers : dict
-        POST or GET headers.  user-agent will be set to
-        astropy:astroquery.version
-
-    Returns
-    -------
-    response : `requests.Response`
-        Response object returned by the remote server
-    """
-    headers['User-Agent'] = ('astropy:astroquery.{vers}'
-                             .format(vers=version.version))
-
-    if hasattr(timeout, "unit"):
-        warnings.warn("Converting timeout to seconds and truncating "
-                      "to integer.", InputWarning)
-        timeout = int(timeout.to(u.s).value)
-
-    try:
-        if request_type == 'GET':
-            response = requests.get(url, params=data, timeout=timeout,
-                                    headers=headers, **kwargs)
-        elif request_type == 'POST':
-            response = requests.post(url, data=data, timeout=timeout,
-                                     headers=headers, **kwargs)
-        else:
-            raise ValueError("request_type must be either 'GET' or 'POST'.")
-
-        response.raise_for_status()
-
-        return response
-
-    except requests.exceptions.Timeout:
-        raise TimeoutError("Query timed out, time elapsed {time}s".
-                           format(time=timeout))
-    except requests.exceptions.RequestException as ex:
-        raise Exception("Query failed: {0}\n".format(ex))
 
 
 def radius_to_unit(radius, unit='degree'):

--- a/astroquery/xmatch/tests/test_xmatch.py
+++ b/astroquery/xmatch/tests/test_xmatch.py
@@ -7,7 +7,6 @@ from astropy.io import ascii
 from astropy.table import Table
 from astropy.units import arcsec
 
-from ...utils import commons
 from astroquery.utils.mocks import MockResponse
 from ...xmatch import XMatch
 
@@ -75,11 +74,6 @@ def test_xmatch_is_avail_table(monkeypatch):
 def test_xmatch_query_local(monkeypatch):
     xm = XMatch()
     monkeypatch.setattr(xm, '_request', request_mockreturn)
-    monkeypatch.setattr(
-        commons,
-        'send_request',
-        lambda url, data, timeout, request_type='POST', headers={}, **kwargs:
-            request_mockreturn(request_type, url, data, **kwargs))
     with open(DATA_DIR / "posList.csv") as pos_list:
         response = xm.query_async(
             cat1=pos_list, cat2='vizier:II/246/out', max_distance=5 * arcsec,
@@ -96,11 +90,6 @@ def test_xmatch_query_local(monkeypatch):
 def test_xmatch_query_cat1_table_local(monkeypatch):
     xm = XMatch()
     monkeypatch.setattr(xm, '_request', request_mockreturn)
-    monkeypatch.setattr(
-        commons,
-        'send_request',
-        lambda url, data, timeout, request_type='POST', headers={}, **kwargs:
-            request_mockreturn(request_type, url, data, **kwargs))
     with open(DATA_DIR / "posList.csv") as pos_list:
         input_table = Table.read(pos_list.readlines(),
                                  format='ascii.csv',


### PR DESCRIPTION
Removed code deprecated in 910791c46388138dfd81061dee00a682c55ed532 more than a year ago. 
Also removed tests and monkeypatched test functions in xmatch which were not doing anything. 