### PR TITLE
ENH: get_query_payload to return useful info

### DIFF
--- a/astroquery/alma/core.py
+++ b/astroquery/alma/core.py
@@ -380,11 +380,16 @@ class AlmaClass(QueryWithLogin):
             payload['science_observation'] = science
         if public is not None:
             payload['public_data'] = public
-        if get_query_payload:
-            return payload
 
         query = _gen_sql(payload)
+
+        if get_query_payload:
+            # Return the TAP query payload that goes out to the server rather
+            # than the unprocessed payload dict from the python side
+            return query
+
         result = self.query_tap(query, maxrec=maxrec)
+
         if result is not None:
             result = result.to_table()
         else:

--- a/astroquery/alma/core.py
+++ b/astroquery/alma/core.py
@@ -335,7 +335,7 @@ class AlmaClass(QueryWithLogin):
                                 payload=payload, **kwargs)
 
     def query_async(self, payload, *, public=True, science=True,
-                    legacy_columns=False, get_query_payload=None,
+                    legacy_columns=False, get_query_payload=False,
                     maxrec=None, **kwargs):
         """
         Perform a generic query with user-specified payload

--- a/astroquery/alma/tests/test_alma.py
+++ b/astroquery/alma/tests/test_alma.py
@@ -538,7 +538,7 @@ def test_galactic_query():
     result = alma.query_region(SkyCoord(0*u.deg, 0*u.deg, frame='galactic'),
                                radius=1*u.deg, get_query_payload=True)
 
-    assert result['ra_dec'] == SkyCoord(0*u.deg, 0*u.deg, frame='galactic').icrs.to_string() + ", 1.0"
+    assert "'ICRS',266.405,-28.9362,1.0" in result
 
 
 def test_download_files():


### PR DESCRIPTION
The naming of the kwarg is somewhat misleading, we should aim it to return the payload that is in fact sent out to the server, not an intermediate one in our library yet to be processed further. So in this case the adql query string is more useful than a payload dictionary yet to be process to generate the query string.

