### PR TITLE
CI: remote tests should run for release tags and manual trigger

### DIFF
--- a/.github/workflows/ci_crontests.yml
+++ b/.github/workflows/ci_crontests.yml
@@ -17,7 +17,7 @@ jobs:
   tests:
     name: ${{ matrix.name }}
     runs-on: ${{ matrix.os }}
-    if: github.event_name == 'schedule' && github.repository == 'astropy/astroquery'
+    if: github.repository == 'astropy/astroquery'
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
The `on` section should already filter when the workflow is running, this extra conditional prevented the manual trigger (as well as running on the tag)

This should close, will manually close it after merge #https://github.com/astropy/astroquery/issues/2545