### PR TITLE
MAINT: do the warning ignore in test

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -50,8 +50,6 @@ filterwarnings =
 # utils.commons.parse_coordinates, we should remove its usage:
     ignore:Coordinate string is being interpreted as an ICRS coordinate:astroquery.exceptions.InputWarning
     ignore:Coordinate string is being interpreted as an ICRS coordinate:UserWarning
-# To be removed with a fix for https://github.com/astropy/astroquery/issues/2523
-    ignore::bs4.builder.XMLParsedAsHTMLWarning
 # To be removed with a fix for https://github.com/astropy/astroquery/issues/2242
      ignore::astropy.io.votable.exceptions.E02
 # Warnings from yet to be refactored or to be removed modules


### PR DESCRIPTION
…  to avoid CI issues with older bs4 versions

These workarounds are to be removed once https://github.com/astropy/astroquery/issues/2523 is properly addressed.

This PR is required as a prerequisite for https://github.com/astropy/astroquery/issues/2603 