### PR TITLE
CI: testing declared minimum version for all dependencies

### DIFF
--- a/.github/workflows/ci_tests.yml
+++ b/.github/workflows/ci_tests.yml
@@ -35,10 +35,10 @@ jobs:
             python: 3.x
             toxenv: codestyle
 
-          - name: oldest dependencies
+          - name: oldest version for all dependencies
             os: ubuntu-latest
             python: 3.7
-            toxenv: py37-test-oldestdeps
+            toxenv: py37-test-oldestdeps-alldeps
             toxargs: -v
 
           - name: Python 3.8 with all optional dependencies (MacOS X)

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -103,7 +103,10 @@ full functionality of the `~astroquery.cds` module:
 
 * `astropy-healpix <http://astropy-healpix.readthedocs.io/en/latest/>`_
 * `regions <https://astropy-regions.readthedocs.io/en/latest/>`_
-* `mocpy <https://cds-astro.github.io/mocpy/>`_ >= 0.5.2
+* `mocpy <https://cds-astro.github.io/mocpy/>`_ >= 0.9
+
+For the `~astroquery.vamdc` module:
+
 * `vamdclib <https://github.com/VAMDC/vamdclib/>`_  install version from
   personal fork: ``pip install git+https://github.com/keflavich/vamdclib-1.git``
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -51,7 +51,7 @@ filterwarnings =
     ignore:Coordinate string is being interpreted as an ICRS coordinate:astroquery.exceptions.InputWarning
     ignore:Coordinate string is being interpreted as an ICRS coordinate:UserWarning
 # To be removed with a fix for https://github.com/astropy/astroquery/issues/2242
-     ignore::astropy.io.votable.exceptions.E02
+    ignore::astropy.io.votable.exceptions.E02
 # Warnings from yet to be refactored or to be removed modules
     ignore:Experimental. ALFALFA:UserWarning
     ignore:Experimental. Fermi-LAT:UserWarning
@@ -159,10 +159,10 @@ python_requires = >=3.7
 install_requires=
    numpy>=1.18
    astropy>=4.2.1
-   requests>=2.4.3
-   beautifulsoup4>=4.3.2
+   requests>=2.19
+   beautifulsoup4>=4.8
    html5lib>=0.999
-   keyring>=4.0
+   keyring>=15.0
    pyvo>=1.1
 tests_require =
    pytest-doctestplus>=0.10.1
@@ -172,8 +172,6 @@ tests_require =
 test=
    pytest-astropy
    matplotlib
-   jinja2
-   flask
    pytest-dependency
    pytest-rerunfailures
 docs=
@@ -181,7 +179,7 @@ docs=
    sphinx-astropy>=1.5
    scipy
 all=
-   mocpy>=0.5.2
+   mocpy>=0.9
    astropy-healpix
    boto3
    regions

--- a/tox.ini
+++ b/tox.ini
@@ -35,6 +35,12 @@ deps =
     oldestdeps: numpy==1.18
     oldestdeps: matplotlib==3.3.*
     oldestdeps: pyvo==1.1
+    oldestdeps: pytest-doctestplus==0.10.1
+    oldestdeps: requests==2.19
+    oldestdeps: keyring==15.0
+    oldestdeps: beautifulsoup4==4.8
+    oldestdeps-alldeps: mocpy==0.9
+
     cov: codecov
     online: pytest-rerunfailures
 


### PR DESCRIPTION
This is to close #2603 and close #2302 