### PR TITLE
ENH: exposing error returned in a VOTable

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -148,6 +148,12 @@ svo_fps
 - The default wavelength range used by ``get_filter_index()`` was far too
   large. The user must now always specify both upper and lower limits. [#2509]
 
+xmatch
+^^^^^^
+
+- The reason for the query errors, as parsed from the returned VOTable is now
+  exposed as part of the traceback. [#2608]
+
 gaia
 ^^^^
 

--- a/astroquery/xmatch/tests/test_xmatch_remote.py
+++ b/astroquery/xmatch/tests/test_xmatch_remote.py
@@ -17,6 +17,7 @@ try:
 except ImportError:
     pass
 
+from astroquery.exceptions import InvalidQueryError
 from ...xmatch import XMatch
 
 
@@ -111,3 +112,13 @@ class TestXMatch:
         except ReadTimeout:
             pytest.xfail("xmatch query timed out.")
         assert len(table) == 185
+
+    def test_xmatch_invalid_query(self, xmatch):
+        input_table = Table.read(DATA_DIR / "posList.csv", format="ascii.csv")
+        # columns in input table and kwargs are not matching
+
+        with pytest.raises(InvalidQueryError) as err:
+            xmatch.query(input_table, cat2='vizier:II/246/out', max_distance=5 * arcsec,
+                colRA1='ra', colDec1='DEC')
+
+            assert 'Column name "DEC" not found in table metadata' in str(err)


### PR DESCRIPTION
The vagueness of the HTTPError `400 Client Error: Mauvaise Requête` came up a few times, this PR exposes the actual reason for the query error as it is returned as a VOTable.

This is to close #1465