### PR TITLE
BUG: Vizier fix non-VO return_type and minor maintenance

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -435,7 +435,10 @@ vizier
 
 - It is now possible to specify 'galatic' centers in region queries to
   have box queries oriented along the galactic axes. [#2152]
+
 - Optional keyword arguments are now keyword only. [#2610]
+
+- Fix parsing vizier_tsvfile returns. [#2611]
 
 
 Infrastructure, Utility and Other Changes and Additions

--- a/astroquery/vizier/core.py
+++ b/astroquery/vizier/core.py
@@ -45,7 +45,7 @@ class VizierClass(BaseQuery):
         schema.Or([_str_schema], _str_schema, None),
         error="catalog must be a list of strings or a single string")
 
-    def __init__(self, columns=["*"], column_filters={}, catalog=None,
+    def __init__(self, *, columns=["*"], column_filters={}, catalog=None,
                  keywords=None, ucd="", timeout=conf.timeout,
                  vizier_server=conf.server, row_limit=conf.row_limit):
         """
@@ -178,7 +178,7 @@ class VizierClass(BaseQuery):
     def keywords(self):
         self._keywords = None
 
-    def find_catalogs(self, keywords, include_obsolete=False, verbose=False,
+    def find_catalogs(self, keywords, *, include_obsolete=False, verbose=False,
                       max_catalogs=None, return_type='votable'):
         """
         Search Vizier for catalogs based on a set of keywords, e.g. author name
@@ -244,7 +244,7 @@ class VizierClass(BaseQuery):
 
         return result
 
-    def get_catalogs_async(self, catalog, verbose=False, return_type='votable',
+    def get_catalogs_async(self, catalog, *, verbose=False, return_type='votable',
                            get_query_payload=False):
         """
         Query the Vizier service for a specific catalog

--- a/astroquery/vizier/core.py
+++ b/astroquery/vizier/core.py
@@ -677,7 +677,7 @@ class VizierClass(BaseQuery):
         """
         if response.content[:5] == b'<?xml':
             try:
-                return parse_vizier_votable(
+                return _parse_vizier_votable(
                     response.content, verbose=verbose, invalid=invalid,
                     get_catalog_names=get_catalog_names)
             except Exception as ex:
@@ -691,7 +691,7 @@ class VizierClass(BaseQuery):
                                       "self.parsed_result.\n Exception: " +
                                       str(self.table_parse_error))
         elif response.content[:5] == b'#\n#  ':
-            return parse_vizier_tsvfile(response.content, verbose=verbose)
+            return _parse_vizier_tsvfile(response.content, verbose=verbose)
         elif response.content[:6] == b'SIMPLE':
             return fits.open(BytesIO(response.content),
                              ignore_missing_end=True)
@@ -710,7 +710,7 @@ class VizierClass(BaseQuery):
         return self._valid_keyword_dict
 
 
-def parse_vizier_tsvfile(data, *, verbose=False):
+def _parse_vizier_tsvfile(data, *, verbose=False):
     """
     Parse a Vizier-generated list of tsv data tables into a list of astropy
     Tables.
@@ -731,8 +731,8 @@ def parse_vizier_tsvfile(data, *, verbose=False):
     return tables
 
 
-def parse_vizier_votable(data, *, verbose=False, invalid='warn',
-                         get_catalog_names=False):
+def _parse_vizier_votable(data, *, verbose=False, invalid='warn',
+                          get_catalog_names=False):
     """
     Given a votable as string, parse it into dict or tables
     """

--- a/astroquery/vizier/core.py
+++ b/astroquery/vizier/core.py
@@ -717,12 +717,12 @@ def parse_vizier_tsvfile(data, *, verbose=False):
 
     Parameters
     ----------
-    data : ascii str
-        An ascii string containing the vizier-formatted list of tables
+    data : response content bytes
+       Bytes containing the vizier-formatted list of tables
     """
 
     # http://stackoverflow.com/questions/4664850/find-all-occurrences-of-a-substring-in-python
-    split_indices = [m.start() for m in re.finditer('\n\n#', data)]
+    split_indices = [m.start() for m in re.finditer(b'\n\n#', data)]
     # we want to slice out chunks of the file each time
     split_limits = zip(split_indices[:-1], split_indices[1:])
     tables = [ascii.read(BytesIO(data[a:b]), format='fast_tab', delimiter='\t',

--- a/astroquery/vizier/tests/test_vizier_remote.py
+++ b/astroquery/vizier/tests/test_vizier_remote.py
@@ -49,9 +49,10 @@ class TestVizierRemote:
         assert "-c=G" in payload
 
     def test_query_Vizier_instance(self):
-        v = vizier.core.Vizier(
-            columns=['_RAJ2000', 'DEJ2000', 'B-V', 'Vmag', 'Plx'],
-            column_filters={"Vmag": ">10"}, keywords=["optical", "xry"])
+        with pytest.warns(UserWarning, match="xry : No such keyword"):
+            v = vizier.core.Vizier(
+                columns=['_RAJ2000', 'DEJ2000', 'B-V', 'Vmag', 'Plx'],
+                column_filters={"Vmag": ">10"}, keywords=["optical", "xry"])
 
         result = v.query_object("HD 226868", catalog=["NOMAD", "UCAC"])
         assert isinstance(result, commons.TableList)
@@ -64,7 +65,7 @@ class TestVizierRemote:
         # catalogs include Bmag's
         v = vizier.core.Vizier(
             columns=['_RAJ2000', 'DEJ2000', 'B-V', 'Vmag', 'Plx'],
-            column_filters={"Vmag": ">10"}, keywords=["optical", "xry"])
+            column_filters={"Vmag": ">10"}, keywords=["optical", "X-ray"])
 
         result = v.query_object("HD 226868", catalog=["NOMAD", "UCAC"])
         for table in result:
@@ -97,7 +98,8 @@ class TestVizierRemote:
             keywords=['Radio', 'IR'], row_limit=5000)
         C = SkyCoord(359.61687 * u.deg, -0.242457 * u.deg, frame="galactic")
 
-        V.query_region(C, radius=2 * u.arcmin)
+        with pytest.warns(UserWarning, match="VOTABLE parsing raised exception"):
+            V.query_region(C, radius=2 * u.arcmin)
 
     def test_multicoord(self):
 

--- a/astroquery/vizier/tests/test_vizier_remote.py
+++ b/astroquery/vizier/tests/test_vizier_remote.py
@@ -133,3 +133,10 @@ class TestVizierRemote:
         assert len(result) >= 628
         # important part: we're testing that UCD is parsed and some catalogs are ruled out
         assert len(ucdresult) < len(result)
+
+    def test_asu_tsv_return_type(self):
+        V = vizier.core.Vizier()
+        result = V.query_object("HD 226868", catalog=["NOMAD", "UCAC"], return_type='asu-tsv', cache=False)
+
+        assert isinstance(result, list)
+        assert len(result) == 3

--- a/docs/vizier/vizier.rst
+++ b/docs/vizier/vizier.rst
@@ -230,7 +230,6 @@ on the Vizier class.
 
     >>> v = Vizier(columns=['_RAJ2000', '_DEJ2000','B-V', 'Vmag', 'Plx'],
     ...            column_filters={"Vmag":">10"}, keywords=["optical", "xry"])
-
     WARNING: xry : No such keyword [astroquery.vizier.core]
 
 Note that whenever an unknown keyword is specified, a warning is emitted and


### PR DESCRIPTION
This is to close https://github.com/astropy/astroquery/issues/1630

(However, I'm not sure why we have `return_type` as a thing, after all we parse it into astropy tables rather than expose as a raw return)


The fix itself is trivial, so this PR also includes the fixes for the failing remote tests

