### PR TITLE
MAINT: fix tox v4 compatibility

### DIFF
--- a/.github/workflows/ci_devtests.yml
+++ b/.github/workflows/ci_devtests.yml
@@ -13,6 +13,7 @@ on:
   schedule:
     # run every Monday at 5am UTC
     - cron: '0 5 * * 1'
+  workflow_dispatch:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/.github/workflows/ci_tests.yml
+++ b/.github/workflows/ci_tests.yml
@@ -13,6 +13,7 @@ on:
   schedule:
     # run every Monday at 5am UTC
     - cron: '0 5 * * 1'
+  workflow_dispatch:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/tox.ini
+++ b/tox.ini
@@ -7,13 +7,12 @@ envlist =
 requires =
     setuptools >= 30.3.0
     pip >= 19.3.1
-    tox-pypi-filter >= 0.12
 isolated_build = true
 
 [testenv]
 
 # Pass through the following environment variables which are needed for the CI
-passenv = HOME WINDIR CI
+passenv = HOME,WINDIR,CI
 
 # Run the tests in a temporary directory to make sure that we don't import
 # astropy from the source tree


### PR DESCRIPTION
This should fix the CI failure we started to see recently, as well as allows workflow dispatch for all the workflows (it would have been useful to dispatch on main, rather than to restart the last run (that was fully passing atm, but now is failing and thus overwriting the logs)