### PR TITLE
MAINT: adding py311 testing

### DIFF
--- a/.github/workflows/ci_crontests.yml
+++ b/.github/workflows/ci_crontests.yml
@@ -22,10 +22,10 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - name: py3.10 all dev deps online
+          - name: py3.11 all dev deps online
             os: ubuntu-latest
-            python: '3.10'
-            toxenv: py310-test-alldeps-devdeps-online
+            python: '3.11'
+            toxenv: py311-test-alldeps-devdeps-online
             toxargs: -v
             toxposargs: -v --durations=50
 
@@ -36,10 +36,10 @@ jobs:
             toxargs: -v
             toxposargs: -v --durations=50
 
-          - name: py3.10 pre-release all deps
+          - name: py3.11 pre-release all deps
             os: ubuntu-latest
-            python: '3.10'
-            toxenv: py310-test-alldeps-predeps
+            python: '3.11'
+            toxenv: py311-test-alldeps-predeps
             toxargs: -v
             toxposargs: -v
 

--- a/.github/workflows/ci_devtests.yml
+++ b/.github/workflows/ci_devtests.yml
@@ -32,8 +32,8 @@ jobs:
         include:
           - name: dev dependencies with all dependencies with coverage
             os: ubuntu-latest
-            python: '3.10'
-            toxenv: py310-test-alldeps-devdeps-cov
+            python: '3.11'
+            toxenv: py311-test-alldeps-devdeps-cov
             toxargs: -v
 
     steps:

--- a/astroquery/esa/hubble/tests/test_esa_hubble_remote.py
+++ b/astroquery/esa/hubble/tests/test_esa_hubble_remote.py
@@ -12,11 +12,11 @@ European Space Agency (ESA)
 import tempfile
 
 import os
+import numpy as np
 
 import pytest
 from astroquery.esa.hubble import ESAHubble
 from astropy import coordinates
-import random
 
 esa_hubble = ESAHubble()
 
@@ -58,7 +58,7 @@ class TestEsaHubbleRemoteData:
 
     def test_download_product(self):
         result = esa_hubble.query_tap(query=self.hst_query)
-        observation_id = random.choice(result['observation_id'])
+        observation_id = np.random.choice((result['observation_id']))
         temp_file = self.temp_folder.name + "/" + observation_id + ".tar"
         esa_hubble.download_product(observation_id=observation_id,
                                     filename=temp_file)
@@ -67,7 +67,7 @@ class TestEsaHubbleRemoteData:
     def test_get_artifact(self):
         result = esa_hubble.query_tap(query=self.top_artifact_query)
         assert "artifact_id" in result.keys()
-        artifact_id = random.choice(result["artifact_id"])
+        artifact_id = np.random.choice(result["artifact_id"])
         temp_file = self.temp_folder.name + "/" + artifact_id + ".gz"
         esa_hubble.get_artifact(artifact_id=artifact_id, filename=temp_file)
         assert os.path.exists(temp_file)

--- a/setup.cfg
+++ b/setup.cfg
@@ -39,6 +39,8 @@ filterwarnings =
 #   These are temporary measures, all of these should be fixed:
 #   -----------------------------------------------------------
     ignore:distutils Version classes are deprecated:DeprecationWarning
+# Remove along with astropy-helpers, once we switch to a new versioning scheme
+    ignore:Use setlocale:DeprecationWarning
 # Upstream issues in many packages, not clear whether we can do anything about these in astroquery
     ignore:unclosed <socket.socket:ResourceWarning
     ignore:unclosed <ssl.SSLSocket:ResourceWarning

--- a/setup.cfg
+++ b/setup.cfg
@@ -41,6 +41,8 @@ filterwarnings =
     ignore:distutils Version classes are deprecated:DeprecationWarning
 # Remove along with astropy-helpers, once we switch to a new versioning scheme
     ignore:Use setlocale:DeprecationWarning
+# Remove with fix for https://github.com/astropy/astroquery/issues/2628
+    ignore:\'cgi\' is deprecated and:DeprecationWarning
 # Upstream issues in many packages, not clear whether we can do anything about these in astroquery
     ignore:unclosed <socket.socket:ResourceWarning
     ignore:unclosed <ssl.SSLSocket:ResourceWarning

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 envlist =
-    py{37,38,39,310}-test{,-alldeps,-oldestdeps,-devdeps,-predeps}{,-online}{,-cov}
+    py{37,38,39,310,311}-test{,-alldeps,-oldestdeps,-devdeps,-predeps}{,-online}{,-cov}
     codestyle
     linkcheck
     build_docs


### PR DESCRIPTION


Python 3.11 is the last nail in astropy-helpers' coffin, we need to switch over to a new versioning numbering scheme. 