### PR TITLE
Remove unused code from `gaia` test setup

### DIFF
--- a/astroquery/gaia/tests/test_gaiatap.py
+++ b/astroquery/gaia/tests/test_gaiatap.py
@@ -32,7 +32,6 @@ from astropy.coordinates.sky_coordinate import SkyCoord
 import numpy as np
 from astroquery.utils.tap.xmlparser import utils
 from astroquery.utils.tap.core import TapPlus
-from astroquery.utils.tap import taputils
 
 
 job_data = utils.read_file_content(Path(__file__).parent.joinpath("data", "job_1.vot"))
@@ -83,20 +82,6 @@ def mock_querier_async():
     results_response = DummyResponse(200)
     results_response.set_data(method="GET", body=job_data)
     conn_handler.set_response("async/" + jobid + "/results/result", results_response)
-
-    dict_tmp = {
-        "REQUEST": "doQuery",
-        "LANG": "ADQL",
-        "FORMAT": "votable",
-        "tapclient": tapplus.tap_client_id,
-        "PHASE": "RUN",
-        "QUERY": (
-            "SELECT crossmatch_positional('schemaA','tableA','schemaB','tableB',1.0,"
-            "'results')FROM dual;"
-        )
-    }
-    sorted_key = taputils.taputil_create_sorted_dict_key(dict_tmp)
-    conn_handler.set_response("sync?" + sorted_key, launch_response)
 
     return GaiaClass(conn_handler, tapplus, show_server_messages=False)
 


### PR DESCRIPTION
EDIT
Originally this pull request was opened to undo an unintentional change to `gaia` test setup, but it turns out that the affected code block was not needed for the tests at all, so it has been deleted.

ORIGINAL MESSAGE
The commit 897aed03b17583152118d44f7a3b78f22a8a08b6 refactored `gaia` tests, but also unintentionally changed a value in a dictionary. The relevant code before refactoring: https://github.com/astropy/astroquery/blob/a2215fa0604f86cb1a4f006c5cb706375aa0d511/astroquery/gaia/tests/test_gaiatap.py#L323-L336

After refactoring: https://github.com/astropy/astroquery/blob/897aed03b17583152118d44f7a3b78f22a8a08b6/astroquery/gaia/tests/test_gaiatap.py#L91-L94

This pull request fixes the overly eager refactoring by restoring the previous value.