### PR TITLE
MAINT: fixing some remote failures from 202212

### DIFF
--- a/astroquery/cds/tests/test_mocserver_remote.py
+++ b/astroquery/cds/tests/test_mocserver_remote.py
@@ -1,7 +1,6 @@
 # -*- coding: utf-8 -*
 
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
-import sys
 import pytest
 
 from astropy import coordinates
@@ -9,26 +8,28 @@ from astropy.table import Table
 
 try:
     from mocpy import MOC
+    HAS_MOCPY = True
 except ImportError:
-    pass
+    HAS_MOCPY = False
 
 try:
     from regions import CircleSkyRegion
+    HAS_REGIONS = True
 except ImportError:
-    pass
+    HAS_REGIONS = False
 
 from ..core import cds
 
 
 @pytest.mark.remote_data
+@pytest.mark.skipif(not HAS_MOCPY, reason='mocpy is required')
 class TestMOCServerRemote:
     """
     Tests requiring regions
     """
 
     # test of MAXREC payload
-    @pytest.mark.skipif('regions' not in sys.modules,
-                        reason="requires astropy-regions")
+    @pytest.mark.skipif(not HAS_REGIONS, reason='regions is required')
     @pytest.mark.parametrize('max_rec', [3, 10, 25, 100])
     def test_max_rec_param(self, max_rec):
         center = coordinates.SkyCoord(ra=10.8, dec=32.2, unit="deg")
@@ -42,8 +43,7 @@ class TestMOCServerRemote:
         assert max_rec == len(result)
 
     # test of field_l when retrieving dataset records
-    @pytest.mark.skipif('regions' not in sys.modules,
-                        reason="requires astropy-regions")
+    @pytest.mark.skipif(not HAS_REGIONS, reason='regions is required')
     @pytest.mark.parametrize('field_l', [['ID'],
                                          ['ID', 'moc_sky_fraction'],
                                          ['data_ucd', 'vizier_popularity', 'ID'],
@@ -65,8 +65,6 @@ class TestMOCServerRemote:
     """
 
     # test of moc_order payload
-    @pytest.mark.skipif('mocpy' not in sys.modules,
-                        reason="requires MOCPy")
     @pytest.mark.parametrize('moc_order', [5, 10])
     def test_moc_order_param(self, moc_order, tmp_cwd):
 

--- a/astroquery/esa/xmm_newton/tests/test_xmm_newton_remote.py
+++ b/astroquery/esa/xmm_newton/tests/test_xmm_newton_remote.py
@@ -190,7 +190,7 @@ class TestXMMNewtonRemote:
                                                radius))
         assert report_diff_values(slew_source, table)
 
-    def test_download_proprietary_data_incorrect_credentials(self):
+    def test_download_proprietary_data_incorrect_credentials(self, tmp_cwd):
         parameters = {'observation_id': "0762470101",
                       'prop': 'True',
                       'credentials_file': "astroquery/esa/xmm_newton/tests/data/dummy_config.ini",
@@ -204,7 +204,7 @@ class TestXMMNewtonRemote:
         with pytest.raises(LoginError):
             xsa.download_data(**parameters)
 
-    def test_download_proprietary_data_without_credentials(self):
+    def test_download_proprietary_data_without_credentials(self, tmp_cwd):
         parameters = {'observation_id': "0883780101",
                       'level': "PPS",
                       'name': 'OBSMLI',

--- a/astroquery/tests/test_cache.py
+++ b/astroquery/tests/test_cache.py
@@ -1,5 +1,6 @@
 import requests
 import os
+import pytest
 
 from time import mktime
 from datetime import datetime
@@ -14,6 +15,10 @@ URL2 = "http://fakeurl.ac.uk"
 
 TEXT1 = "Penguin"
 TEXT2 = "Walrus"
+
+pytest.skip(reason='request function mocking is buggy here, skipping tests until '
+            'https://github.com/astropy/astroquery/issues/2632 is resolved',
+            allow_module_level=True)
 
 
 def set_response(resp_text, resp_status=200):


### PR DESCRIPTION
Some super minor fixes, plus this PR disables the cache tests (see #2632) which should result a significant drop in the number of failing remote tests. 

Let's aim to merge this quickly, so we can see updated results from the cron job.