### PR TITLE
Remove all uses of `cgi`

### DIFF
--- a/astroquery/esa/hsa/core.py
+++ b/astroquery/esa/hsa/core.py
@@ -1,9 +1,9 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 
-import cgi
 import os
 import re
 import shutil
+from email.message import Message
 from pathlib import Path
 
 from astropy import units as u
@@ -113,10 +113,9 @@ class HSAClass(BaseQuery):
                 error = "Please set either 'obervation_id' or 'filename' for the output"
                 raise ValueError(error)
 
-        _, res_params = cgi.parse_header(response.headers['Content-Disposition'])
-
-        r_filename = res_params["filename"]
-        suffixes = Path(r_filename).suffixes
+        message = Message()
+        message["content-type"] = response.headers["Content-Disposition"]
+        suffixes = Path(message.get_param("filename")).suffixes
 
         if len(suffixes) > 1 and suffixes[-1] == ".jpg":
             filename += suffixes[-1]
@@ -205,10 +204,9 @@ class HSAClass(BaseQuery):
 
         response.raise_for_status()
 
-        _, res_params = cgi.parse_header(response.headers['Content-Disposition'])
-
-        r_filename = res_params["filename"]
-        suffixes = Path(r_filename).suffixes
+        message = Message()
+        message["content-type"] = response.headers["Content-Disposition"]
+        suffixes = Path(message.get_param("filename")).suffixes
 
         if filename is None:
             filename = observation_id

--- a/astroquery/esa/iso/core.py
+++ b/astroquery/esa/iso/core.py
@@ -12,7 +12,7 @@ import re
 from astroquery.utils.tap.core import TapPlus
 from astroquery.query import BaseQuery
 import shutil
-import cgi
+from email.message import Message
 from requests import HTTPError
 from pathlib import Path
 
@@ -122,9 +122,9 @@ class ISOClass(BaseQuery):
         response.raise_for_status()
 
         # Get original extension
-        _, params = cgi.parse_header(response.headers['Content-Disposition'])
-        r_filename = params["filename"]
-        suffixes = Path(r_filename).suffixes
+        message = Message()
+        message["content-type"] = response.headers["Content-Disposition"]
+        suffixes = Path(message.get_param("filename")).suffixes
 
         if filename is None:
             filename = tdt

--- a/astroquery/esa/xmm_newton/core.py
+++ b/astroquery/esa/xmm_newton/core.py
@@ -13,11 +13,11 @@ Created on 3 Sept 2019
 """
 import re
 import shutil
-import cgi
 from pathlib import Path
 import tarfile
 import os
 import configparser
+from email.message import Message
 
 from astropy.io import fits
 from astroquery import log
@@ -296,7 +296,9 @@ class XMMNewtonClass(BaseQuery):
         response = self._request('HEAD', link, save=False, cache=cache)
         # Get original extension
         if 'Content-Type' in response.headers and 'text' not in response.headers['Content-Type']:
-            _, params = cgi.parse_header(response.headers['Content-Disposition'])
+            message = Message()
+            message["content-type"] = response.headers["Content-Disposition"]
+            params = dict(message.get_params()[1:])
         elif response.status_code == 401:
             error = "Data protected by proprietary rights. Please check your credentials"
             raise LoginError(error)

--- a/setup.cfg
+++ b/setup.cfg
@@ -41,8 +41,6 @@ filterwarnings =
     ignore:distutils Version classes are deprecated:DeprecationWarning
 # Remove along with astropy-helpers, once we switch to a new versioning scheme
     ignore:Use setlocale:DeprecationWarning
-# Remove with fix for https://github.com/astropy/astroquery/issues/2628
-    ignore:\'cgi\' is deprecated and:DeprecationWarning
 # Upstream issues in many packages, not clear whether we can do anything about these in astroquery
     ignore:unclosed <socket.socket:ResourceWarning
     ignore:unclosed <ssl.SSLSocket:ResourceWarning


### PR DESCRIPTION
The `cgi` module from the Python standard library is deprecated as of Python 3.11, see [PEP 594](https://peps.python.org/pep-0594/). This pull request replaces all uses of `cgi` in `astroquery`  following the example provided in the PEP.

Closes #2628