### PR TITLE
Refactor: Make kwargs keyword only 

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -21,7 +21,6 @@ esa.hubble
 
 - Update to TAP url to query data and download files, aligned with the new eHST Science Archive. [#2567][#2597]
 - Status and maintenance messages from eHST TAP when the module is instantiated. get_status_messages method to retrieve them. [#2597]
-- Optional parameters in all methods are kwargs keyword only. [#2597]
 
 solarsystem.neodys
 ^^^^^^^^^^^^^^^^^^
@@ -114,8 +113,6 @@ jplhorizons
 - Adding ``optional_setting`` kwarg to the ephemerides methods to allow
   passing additional settings. [#1802]
 
-- Optional keyword arguments are now keyword only. [#1802]
-
 - Topocentric coordinates can now be specified for both center and target in observer
   and vector queries. [#2625]
 
@@ -145,16 +142,6 @@ mast
 - Expanding ``Cutouts`` functionality to support making Hubble Advanced Product (HAP)
   cutouts via HAPCut. [#2613]
 
-nist
-^^^^
-
-- Optional parameters in all methods are kwargs keyword only. [#2655]
-
-nvas
-^^^^
-
-- Made NVAS optional kwargs keyword only. [#2656]
-
 oac
 ^^^
 
@@ -173,7 +160,7 @@ simbad
 - It is now possible to specify multiple coordinates together with a single
   radius as a string in ``query_region()`` and ``query_region_async()``.
   [#2494]
-- Optional keyword arguments are now keyword only. [#2609]
+
 - ``ROW_LIMIT`` is now respected when running region queries; previously, it
   was ignored for region queries but respected for all others.  A new warning,
   ``BlankResponseWarning``, is introduced for use when one or more query terms result
@@ -184,8 +171,6 @@ skyview
 ^^^^^^^
 
 - Fix bug for ``radius`` parameter to not behave as diameter. [#2601]
-
-- Optional keyword arguments are now keyword only. [#2601]
 
 svo_fps
 ^^^^^^^
@@ -222,9 +207,6 @@ sdss
 
 - The default data release has been changed to DR17. [#2478]
 
-- Optional keyword arguments are now keyword only. [#2477, #2532]
-
-
 mast
 ^^^^
 
@@ -240,6 +222,9 @@ xmatch
 
 Infrastructure, Utility and Other Changes and Additions
 -------------------------------------------------------
+
+- Optional keyword arguments are now keyword only. [#1802, #2477, #2532,
+  #2597, #2601, #2609, #2655, #2656, #2661]
 
 - New function, ``utils.cleanup_downloads.cleanup_saved_downloads``, is
   added to help the testcleanup narrative in narrative documentations. [#2384]

--- a/astroquery/alfalfa/core.py
+++ b/astroquery/alfalfa/core.py
@@ -88,7 +88,7 @@ class AlfalfaClass(BaseQuery):
 
         return catalog
 
-    def query_region(self, coordinates, radius=3. * u.arcmin,
+    def query_region(self, coordinates, *, radius=3. * u.arcmin,
                      optical_counterpart=False):
         """
         Perform object cross-ID in ALFALFA.

--- a/astroquery/astrometry_net/core.py
+++ b/astroquery/astrometry_net/core.py
@@ -198,7 +198,7 @@ class AstrometryNetClass(BaseQuery):
                 raise ValueError('Scale type {} requires '
                                  'values for {}'.format(scale_type, required_keys))
 
-    def monitor_submission(self, submission_id,
+    def monitor_submission(self, submission_id, *,
                            solve_timeout=TIMEOUT, verbose=True):
         """
         Monitor the submission for completion.
@@ -270,7 +270,7 @@ class AstrometryNetClass(BaseQuery):
             raise RuntimeError('Unrecognized status {}'.format(status))
         return wcs
 
-    def solve_from_source_list(self, x, y, image_width, image_height,
+    def solve_from_source_list(self, x, y, image_width, image_height, *,
                                solve_timeout=TIMEOUT,
                                verbose=True,
                                **settings
@@ -320,7 +320,7 @@ class AstrometryNetClass(BaseQuery):
                                        solve_timeout=solve_timeout,
                                        verbose=verbose)
 
-    def solve_from_image(self, image_file_path, force_image_upload=False,
+    def solve_from_image(self, image_file_path, *, force_image_upload=False,
                          ra_key=None, dec_key=None,
                          ra_dec_units=None,
                          fwhm=3, detect_threshold=5,

--- a/astroquery/besancon/core.py
+++ b/astroquery/besancon/core.py
@@ -86,11 +86,11 @@ class BesanconClass(BaseQuery):
     # sample file name:  1340900648.230224.resu
     result_re = re.compile(r"[0-9]{10}\.[0-9]{6}\.resu")
 
-    def __init__(self, email=None):
+    def __init__(self, *, email=None):
         super().__init__()
         self.email = email
 
-    def get_besancon_model_file(self, filename, verbose=True, timeout=5.0):
+    def get_besancon_model_file(self, filename, *, verbose=True, timeout=5.0):
         """
         Download a Besancon model from the website.
 
@@ -145,7 +145,7 @@ class BesanconClass(BaseQuery):
 
         return parse_besancon_model_string(results)
 
-    def _parse_result(self, response, verbose=False, retrieve_file=True):
+    def _parse_result(self, response, *, verbose=False, retrieve_file=True):
         """
         retrieve_file : bool
             If True, will try to retrieve the file every 30s until it shows up.
@@ -174,7 +174,7 @@ class BesanconClass(BaseQuery):
         else:
             return filename
 
-    def _parse_args(self, glon, glat, email, smallfield=True, extinction=0.7,
+    def _parse_args(self, glon, glat, email, *, smallfield=True, extinction=0.7,
                     area=0.0001, verbose=True, clouds=None,
                     absmag_limits=(-7, 20), mag_limits=copy.copy(mag_limits),
                     colors_limits=copy.copy(colors_limits),

--- a/astroquery/casda/core.py
+++ b/astroquery/casda/core.py
@@ -95,7 +95,7 @@ class CasdaClass(QueryWithLogin):
 
         return authenticated
 
-    def query_region_async(self, coordinates, radius=1*u.arcmin, height=None, width=None,
+    def query_region_async(self, coordinates, *, radius=1*u.arcmin, height=None, width=None,
                            get_query_payload=False, cache=True):
         """
         Queries a region around the specified coordinates. Either a radius or both a height and a width
@@ -135,7 +135,7 @@ class CasdaClass(QueryWithLogin):
 
     # Create the dict of HTTP request parameters by parsing the user
     # entered values.
-    def _args_to_payload(self, radius=1*u.arcmin, **kwargs):
+    def _args_to_payload(self, *, radius=1*u.arcmin, **kwargs):
         request_payload = dict()
 
         # Convert the coordinates to FK5
@@ -206,7 +206,7 @@ class CasdaClass(QueryWithLogin):
     # the methods above implicitly call the private _parse_result method.
     # This should parse the raw HTTP response and return it as
     # an `astropy.table.Table`.
-    def _parse_result(self, response, verbose=False):
+    def _parse_result(self, response, *, verbose=False):
         # if verbose is False then suppress any VOTable related warnings
         if not verbose:
             commons.suppress_vo_warnings()
@@ -284,7 +284,7 @@ class CasdaClass(QueryWithLogin):
 
         return fileurls
 
-    def stage_data(self, table, verbose=False):
+    def stage_data(self, table, *, verbose=False):
         """
         Request access to a set of data files. All requests for data must use authentication. If you have access to the
         data, the requested files will be brought online and a set of URLs to download the files will be returned.
@@ -367,7 +367,7 @@ class CasdaClass(QueryWithLogin):
 
         return self._complete_job(job_url, verbose)
 
-    def download_files(self, urls, savedir=''):
+    def download_files(self, urls, *, savedir=''):
         """
         Download a series of files
 
@@ -445,7 +445,7 @@ class CasdaClass(QueryWithLogin):
 
         return async_url, authenticated_id_token
 
-    def _create_soda_job(self, authenticated_id_tokens, soda_url=None):
+    def _create_soda_job(self, authenticated_id_tokens, *, soda_url=None):
         """
         Creates the async job, returning the url to query the job status and details
 
@@ -488,7 +488,7 @@ class CasdaClass(QueryWithLogin):
         resp = self._request('POST', job_location + '/parameters', data=cutout_spec, cache=False)
         resp.raise_for_status()
 
-    def _run_job(self, job_location, verbose, poll_interval=20):
+    def _run_job(self, job_location, verbose, *, poll_interval=20):
         """
         Start an async job (e.g. TAP or SODA) and wait for it to be completed.
 

--- a/astroquery/cds/core.py
+++ b/astroquery/cds/core.py
@@ -56,7 +56,7 @@ class CdsClass(BaseQuery):
         self.path_moc_file = None
         self.return_moc = False
 
-    def query_region(self, region=None, get_query_payload=False, verbose=False, **kwargs):
+    def query_region(self, *, region=None, get_query_payload=False, verbose=False, **kwargs):
         """
         Query the `CDS MOCServer <http://alasky.unistra.fr/MocServer/query>`_ with a region.
 
@@ -123,11 +123,11 @@ class CdsClass(BaseQuery):
         if get_query_payload:
             return response
 
-        result = self._parse_result(response, verbose)
+        result = self._parse_result(response, verbose=verbose)
 
         return result
 
-    def find_datasets(self, meta_data, get_query_payload=False, verbose=False, **kwargs):
+    def find_datasets(self, meta_data, *, get_query_payload=False, verbose=False, **kwargs):
         """
         Query the `CDS MOCServer <http://alasky.unistra.fr/MocServer/query>`_ to retrieve the data-sets based on their
         meta data values. This method does not need any region argument but it requires an expression on the meta datas.
@@ -179,11 +179,11 @@ class CdsClass(BaseQuery):
         if get_query_payload:
             return response
 
-        result = self._parse_result(response, verbose)
+        result = self._parse_result(response, verbose=verbose)
 
         return result
 
-    def query_region_async(self, get_query_payload=False, **kwargs):
+    def query_region_async(self, *, get_query_payload=False, **kwargs):
         """
         Serves the same purpose as :meth:`~astroquery.cds.CdsClass.query_region` but only returns the HTTP response
         rather than the parsed result.
@@ -309,7 +309,7 @@ class CdsClass(BaseQuery):
 
         return request_payload
 
-    def _parse_result(self, response, verbose=False):
+    def _parse_result(self, response, *, verbose=False):
         """
         Parsing of the response returned by the MOCServer.
 

--- a/astroquery/dace/core.py
+++ b/astroquery/dace/core.py
@@ -42,7 +42,7 @@ class DaceClass(BaseQuery):
         return self._request("GET", ''.join([self.__DACE_URL, self.__RADIAL_VELOCITIES_ENDPOINT, object_name]),
                              timeout=self.__DACE_TIMEOUT, headers=self.__HEADERS)
 
-    def _parse_result(self, response, verbose=False):
+    def _parse_result(self, response, *, verbose=False):
         try:
             json_data = response.json()
             dace_dict = self.transform_data_as_dict(json_data)

--- a/astroquery/eso/core.py
+++ b/astroquery/eso/core.py
@@ -48,7 +48,7 @@ class EsoClass(QueryWithLogin):
         self._survey_list = None
         self.username = None
 
-    def _activate_form(self, response, form_index=0, form_id=None, inputs={},
+    def _activate_form(self, response, *, form_index=0, form_id=None, inputs={},
                        cache=True, method=None):
         """
         Parameters
@@ -191,7 +191,7 @@ class EsoClass(QueryWithLogin):
 
         return response
 
-    def _login(self, username=None, store_password=False,
+    def _login(self, *, username=None, store_password=False,
                reenter_password=False):
         """
         Login to the ESO User Portal.
@@ -257,7 +257,7 @@ class EsoClass(QueryWithLogin):
             keyring.set_password("astroquery:www.eso.org", username, password)
         return authenticated
 
-    def list_instruments(self, cache=True):
+    def list_instruments(self, *, cache=True):
         """ List all the available instrument-specific queries offered by the ESO archive.
 
         Returns
@@ -280,7 +280,7 @@ class EsoClass(QueryWithLogin):
                         self._instrument_list.append(instrument)
         return self._instrument_list
 
-    def list_surveys(self, cache=True):
+    def list_surveys(self, *, cache=True):
         """ List all the available surveys (phase 3) in the ESO archive.
 
         Returns
@@ -311,7 +311,7 @@ class EsoClass(QueryWithLogin):
                         self._survey_list.append(survey)
         return self._survey_list
 
-    def query_surveys(self, surveys='', cache=True,
+    def query_surveys(self, *, surveys='', cache=True,
                       help=False, open_form=False, **kwargs):
         """
         Query survey Phase 3 data contained in the ESO archive.
@@ -369,7 +369,7 @@ class EsoClass(QueryWithLogin):
             else:
                 warnings.warn("Query returned no results", NoResultsWarning)
 
-    def query_main(self, column_filters={}, columns=[],
+    def query_main(self, *, column_filters={}, columns=[],
                    open_form=False, help=False, cache=True, **kwargs):
         """
         Query raw data contained in the ESO archive.
@@ -403,7 +403,7 @@ class EsoClass(QueryWithLogin):
         return self._query(url, column_filters=column_filters, columns=columns,
                            open_form=open_form, help=help, cache=cache, **kwargs)
 
-    def query_instrument(self, instrument, column_filters={}, columns=[],
+    def query_instrument(self, instrument, *, column_filters={}, columns=[],
                          open_form=False, help=False, cache=True, **kwargs):
         """
         Query instrument-specific raw data contained in the ESO archive.
@@ -441,7 +441,7 @@ class EsoClass(QueryWithLogin):
         return self._query(url, column_filters=column_filters, columns=columns,
                            open_form=open_form, help=help, cache=cache, **kwargs)
 
-    def _query(self, url, column_filters={}, columns=[],
+    def _query(self, url, *, column_filters={}, columns=[],
                open_form=False, help=False, cache=True, **kwargs):
 
         table = None
@@ -486,7 +486,7 @@ class EsoClass(QueryWithLogin):
             else:
                 warnings.warn("Query returned no results", NoResultsWarning)
 
-    def get_headers(self, product_ids, cache=True):
+    def get_headers(self, product_ids, *, cache=True):
         """
         Get the headers associated to a list of data product IDs
 
@@ -557,7 +557,7 @@ class EsoClass(QueryWithLogin):
         # Return as Table
         return Table(result)
 
-    def _check_existing_files(self, datasets, continuation=False,
+    def _check_existing_files(self, datasets, *, continuation=False,
                               destination=None):
         """Detect already downloaded datasets."""
 
@@ -628,7 +628,7 @@ class EsoClass(QueryWithLogin):
 
         return resp
 
-    def retrieve_data(self, datasets, continuation=False, destination=None,
+    def retrieve_data(self, datasets, *, continuation=False, destination=None,
                       with_calib='none', request_all_objects=False,
                       unzip=True, request_id=None):
         """
@@ -891,7 +891,7 @@ class EsoClass(QueryWithLogin):
 
         return 'No data returned' not in content
 
-    def query_apex_quicklooks(self, project_id=None, help=False,
+    def query_apex_quicklooks(self, *, project_id=None, help=False,
                               open_form=False, cache=True, **kwargs):
         """
         APEX data are distributed with quicklook products identified with a
@@ -900,7 +900,7 @@ class EsoClass(QueryWithLogin):
 
         Examples
         --------
-        >>> tbl = Eso.query_apex_quicklooks('093.C-0144')
+        >>> tbl = Eso.query_apex_quicklooks(project_id='093.C-0144')
         >>> files = Eso.retrieve_data(tbl['Product ID'])
         """
 
@@ -944,7 +944,7 @@ class EsoClass(QueryWithLogin):
 
             return table
 
-    def _print_query_help(self, url, cache=True):
+    def _print_query_help(self, url, *, cache=True):
         """
         Download a form and print it in a quasi-human-readable way
         """
@@ -1006,7 +1006,7 @@ class EsoClass(QueryWithLogin):
         log.info("\n".join(result_string))
         return result_string
 
-    def _print_surveys_help(self, url, cache=True):
+    def _print_surveys_help(self, url, *, cache=True):
         """
         Download a form and print it in a quasi-human-readable way
         """

--- a/astroquery/eso/tests/test_eso.py
+++ b/astroquery/eso/tests/test_eso.py
@@ -85,7 +85,7 @@ def test_vvv(monkeypatch):
     monkeypatch.setattr(eso, '_request', eso_request)
     eso.cache_location = DATA_DIR
 
-    result_s = eso.query_surveys('VVV',
+    result_s = eso.query_surveys(surveys='VVV',
                                  coord1=266.41681662, coord2=-29.00782497,
                                  box='01 00 00',
                                  )

--- a/astroquery/eso/tests/test_eso_remote.py
+++ b/astroquery/eso/tests/test_eso_remote.py
@@ -37,7 +37,7 @@ class TestEso:
         assert len(surveys) > 0
         # result_s = eso.query_surveys('VVV', target='Sgr A*')
         # Equivalent, does not depend on SESAME:
-        result_s = eso.query_surveys('VVV', coord1=266.41681662,
+        result_s = eso.query_surveys(surveys='VVV', coord1=266.41681662,
                                      coord2=-29.00782497,
                                      box='01 00 00',
                                      cache=False)
@@ -57,7 +57,7 @@ class TestEso:
         # first b333 was at 157
         # first pistol....?
 
-        result_s = eso.query_surveys(['VVV', 'XSHOOTER'],
+        result_s = eso.query_surveys(surveys=['VVV', 'XSHOOTER'],
                                      coord1=266.41681662,
                                      coord2=-29.00782497,
                                      box='01 00 00',
@@ -88,7 +88,7 @@ class TestEso:
 
         # Avoid SESAME
         with pytest.warns(NoResultsWarning):
-            result_s = eso.query_surveys(surveys[0], coord1=202.469575,
+            result_s = eso.query_surveys(surveys=surveys[0], coord1=202.469575,
                                          coord2=47.195258, cache=False)
 
         assert result_s is None
@@ -158,7 +158,7 @@ class TestEso:
         eso = Eso()
 
         tbl = eso.query_apex_quicklooks(prog_id='095.F-9802')
-        tblb = eso.query_apex_quicklooks('095.F-9802')
+        tblb = eso.query_apex_quicklooks(project_id='095.F-9802')
 
         assert len(tbl) == 5
         assert set(tbl['Release Date']) == {'2015-07-17', '2015-07-18',
@@ -190,20 +190,20 @@ class TestEso:
         surveys = eso.list_surveys(cache=False)
         for survey in surveys:
             if survey in SGRA_SURVEYS:
-                result_s = eso.query_surveys(survey, coord1=266.41681662,
+                result_s = eso.query_surveys(surveys=survey, coord1=266.41681662,
                                              coord2=-29.00782497,
                                              box='01 00 00',
                                              cache=False)
                 assert len(result_s) > 0
             else:
                 with pytest.warns(NoResultsWarning):
-                    result_s = eso.query_surveys(survey, coord1=266.41681662,
+                    result_s = eso.query_surveys(surveys=survey, coord1=266.41681662,
                                                  coord2=-29.00782497,
                                                  box='01 00 00',
                                                  cache=False)
                     assert result_s is None
 
-                    generic_result = eso.query_surveys(survey)
+                    generic_result = eso.query_surveys(surveys=survey)
                     assert len(generic_result) > 0
 
     def test_mixed_case_instrument(self, tmp_path):

--- a/astroquery/exoplanet_orbit_database/exoplanet_orbit_database.py
+++ b/astroquery/exoplanet_orbit_database/exoplanet_orbit_database.py
@@ -37,7 +37,7 @@ class ExoplanetOrbitDatabaseClass:
 
         return self._param_units
 
-    def get_table(self, cache=True, show_progress=True, table_path=None):
+    def get_table(self, *, cache=True, show_progress=True, table_path=None):
         """
         Download (and optionally cache) the `Exoplanet Orbit Database planets
         table <http://www.exoplanets.org>`_.
@@ -91,7 +91,7 @@ class ExoplanetOrbitDatabaseClass:
 
         return self._table
 
-    def query_planet(self, planet_name, table_path=None):
+    def query_planet(self, planet_name, *, table_path=None):
         """
         Get table of exoplanet properties.
 

--- a/astroquery/fermi/core.py
+++ b/astroquery/fermi/core.py
@@ -53,7 +53,7 @@ class FermiLATClass(BaseQuery):
 
         return result_url
 
-    def _parse_args(self, name_or_coords, searchradius='', obsdates='',
+    def _parse_args(self, name_or_coords, *, searchradius='', obsdates='',
                     timesys='Gregorian', energyrange_MeV='',
                     LATdatatype='Photon', spacecraftdata=True):
         """
@@ -91,7 +91,7 @@ class FermiLATClass(BaseQuery):
 
         return payload
 
-    def _parse_result(self, result, verbose=False, **kwargs):
+    def _parse_result(self, result, *, verbose=False, **kwargs):
         """
         Use get_fermilat_datafile to download a result URL
         """
@@ -131,7 +131,7 @@ class GetFermilatDatafile:
 
     check_frequency = 1  # minutes
 
-    def __call__(self, result_url, check_frequency=1, verbose=False):
+    def __call__(self, result_url, *, check_frequency=1, verbose=False):
         self.result_url = result_url
 
         page_loaded = False

--- a/astroquery/gaia/core.py
+++ b/astroquery/gaia/core.py
@@ -46,7 +46,7 @@ class GaiaClass(TapPlus):
     VALID_DATALINK_RETRIEVAL_TYPES = conf.VALID_DATALINK_RETRIEVAL_TYPES
     GAIA_MESSAGES = "notification?action=GetNotifications"
 
-    def __init__(self, tap_plus_conn_handler=None,
+    def __init__(self, *, tap_plus_conn_handler=None,
                  datalink_handler=None,
                  gaia_tap_server='https://gea.esac.esa.int/',
                  gaia_data_server='https://gea.esac.esa.int/',
@@ -79,7 +79,7 @@ class GaiaClass(TapPlus):
         if show_server_messages:
             self.get_status_messages()
 
-    def login(self, user=None, password=None, credentials_file=None,
+    def login(self, *, user=None, password=None, credentials_file=None,
               verbose=False):
         """Performs a login.
         User and password arguments can be used or a file that contains
@@ -118,7 +118,7 @@ class GaiaClass(TapPlus):
             log.error("Logging out from TAP server")
             TapPlus.logout(self, verbose=verbose)
 
-    def login_gui(self, verbose=False):
+    def login_gui(self, *, verbose=False):
         """Performs a login using a GUI dialog
 
         Parameters
@@ -143,7 +143,7 @@ class GaiaClass(TapPlus):
             log.error("Logging out from TAP server")
             TapPlus.logout(self, verbose=verbose)
 
-    def logout(self, verbose=False):
+    def logout(self, *, verbose=False):
         """Performs a logout
 
         Parameters
@@ -163,8 +163,9 @@ class GaiaClass(TapPlus):
         except HTTPError:
             log.error("Error logging out data server")
 
-    def load_data(self, ids, data_release=None, data_structure='INDIVIDUAL', retrieval_type="ALL", valid_data=False,
-                  band=None, avoid_datatype_check=False, format="votable", output_file=None,
+    def load_data(self, ids, *, data_release=None, data_structure='INDIVIDUAL',
+                  retrieval_type="ALL", valid_data=False, band=None,
+                  avoid_datatype_check=False, format="votable", output_file=None,
                   overwrite_output_file=False, verbose=False):
         """Loads the specified table
         TAP+ only
@@ -348,7 +349,7 @@ class GaiaClass(TapPlus):
                 files[key] = tables
         return files
 
-    def get_datalinks(self, ids, verbose=False):
+    def get_datalinks(self, ids, *, verbose=False):
         """Gets datalinks associated to the provided identifiers
         TAP+ only
 
@@ -365,7 +366,7 @@ class GaiaClass(TapPlus):
         """
         return self.__gaiadata.get_datalinks(ids=ids, verbose=verbose)
 
-    def __query_object(self, coordinate, radius=None, width=None, height=None,
+    def __query_object(self, coordinate, *, radius=None, width=None, height=None,
                        async_job=False, verbose=False, columns=[]):
         """Launches a job
         TAP & TAP+
@@ -444,7 +445,7 @@ class GaiaClass(TapPlus):
                 job = self.launch_job(query, verbose=verbose)
         return job.get_results()
 
-    def query_object(self, coordinate, radius=None, width=None, height=None,
+    def query_object(self, coordinate, *, radius=None, width=None, height=None,
                      verbose=False, columns=[]):
         """Launches a job
         TAP & TAP+
@@ -468,9 +469,11 @@ class GaiaClass(TapPlus):
         -------
         The job results (astropy.table).
         """
-        return self.__query_object(coordinate, radius, width, height, async_job=False, verbose=verbose, columns=columns)
+        return self.__query_object(coordinate, radius=radius,
+                                   width=width, height=height, async_job=False,
+                                   verbose=verbose, columns=columns)
 
-    def query_object_async(self, coordinate, radius=None, width=None,
+    def query_object_async(self, coordinate, *, radius=None, width=None,
                            height=None, verbose=False, columns=[]):
         """Launches a job (async)
         TAP & TAP+
@@ -494,9 +497,11 @@ class GaiaClass(TapPlus):
         -------
         The job results (astropy.table).
         """
-        return self.__query_object(coordinate, radius, width, height, async_job=True, verbose=verbose, columns=columns)
+        return self.__query_object(coordinate, radius=radius, width=width,
+                                   height=height, async_job=True, verbose=verbose,
+                                   columns=columns)
 
-    def __cone_search(self, coordinate, radius, table_name=None,
+    def __cone_search(self, coordinate, radius, *, table_name=None,
                       ra_column_name=MAIN_GAIA_TABLE_RA,
                       dec_column_name=MAIN_GAIA_TABLE_DEC,
                       async_job=False,
@@ -589,7 +594,7 @@ class GaiaClass(TapPlus):
                                    verbose=verbose,
                                    dump_to_file=dump_to_file)
 
-    def cone_search(self, coordinate, radius=None,
+    def cone_search(self, coordinate, *, radius=None,
                     table_name=None,
                     ra_column_name=MAIN_GAIA_TABLE_RA,
                     dec_column_name=MAIN_GAIA_TABLE_DEC,
@@ -639,7 +644,7 @@ class GaiaClass(TapPlus):
                                   verbose=verbose,
                                   dump_to_file=dump_to_file, columns=columns)
 
-    def cone_search_async(self, coordinate, radius=None,
+    def cone_search_async(self, coordinate, *, radius=None,
                           table_name=None,
                           ra_column_name=MAIN_GAIA_TABLE_RA,
                           dec_column_name=MAIN_GAIA_TABLE_DEC,
@@ -733,7 +738,7 @@ class GaiaClass(TapPlus):
             elif isinstance(col.unit, str):
                 col.unit = col.unit.replace(".", " ").replace("'", "")
 
-    def load_user(self, user_id, verbose=False):
+    def load_user(self, user_id, *, verbose=False):
         """Loads the specified user
         TAP+ only
 
@@ -752,7 +757,7 @@ class GaiaClass(TapPlus):
         return self.is_valid_user(user_id=user_id,
                                   verbose=verbose)
 
-    def cross_match(self, full_qualified_table_name_a=None,
+    def cross_match(self, *, full_qualified_table_name_a=None,
                     full_qualified_table_name_b=None,
                     results_table_name=None,
                     radius=1.0,
@@ -818,7 +823,7 @@ class GaiaClass(TapPlus):
                                      upload_resource=None,
                                      upload_table_name=None)
 
-    def launch_job(self, query, name=None, output_file=None,
+    def launch_job(self, query, *, name=None, output_file=None,
                    output_format="votable", verbose=False,
                    dump_to_file=False, upload_resource=None,
                    upload_table_name=None):
@@ -861,7 +866,7 @@ class GaiaClass(TapPlus):
                                   upload_resource=upload_resource,
                                   upload_table_name=upload_table_name)
 
-    def launch_job_async(self, query, name=None, output_file=None,
+    def launch_job_async(self, query, *, name=None, output_file=None,
                          output_format="votable", verbose=False,
                          dump_to_file=False, background=False,
                          upload_resource=None, upload_table_name=None,

--- a/astroquery/gaia/tests/test_gaia_remote.py
+++ b/astroquery/gaia/tests/test_gaia_remote.py
@@ -40,19 +40,19 @@ def test_cone_search_row_limit():
     Gaia = GaiaClass()
     coord = SkyCoord(ra=280, dec=-60, unit=(u.degree, u.degree), frame='icrs')
     radius = u.Quantity(0.1, u.deg)
-    j = Gaia.cone_search_async(coord, radius)
+    j = Gaia.cone_search_async(coord, radius=radius)
     r = j.get_results()
 
     assert len(r) == Gaia.ROW_LIMIT
 
     Gaia.ROW_LIMIT = 10
-    j = Gaia.cone_search_async(coord, radius)
+    j = Gaia.cone_search_async(coord, radius=radius)
     r = j.get_results()
 
     assert len(r) == 10 == Gaia.ROW_LIMIT
 
     Gaia.ROW_LIMIT = -1
-    j = Gaia.cone_search_async(coord, radius)
+    j = Gaia.cone_search_async(coord, radius=radius)
     r = j.get_results()
 
     assert len(r) == 1218

--- a/astroquery/gama/core.py
+++ b/astroquery/gama/core.py
@@ -57,7 +57,7 @@ class GAMAClass(BaseQuery):
 
         return payload
 
-    def _parse_result(self, result, verbose=False, **kwargs):
+    def _parse_result(self, result, *, verbose=False, **kwargs):
         """
         Use get_gama_datafile to download a result URL
         """

--- a/astroquery/gemini/core.py
+++ b/astroquery/gemini/core.py
@@ -132,7 +132,7 @@ class ObservationsClass(QueryWithLogin):
         return True
 
     @class_or_instance
-    def query_region(self, coordinates, radius=0.3*units.deg):
+    def query_region(self, coordinates, *, radius=0.3*units.deg):
         """
         search for Gemini observations by target on the sky.
 
@@ -156,7 +156,7 @@ class ObservationsClass(QueryWithLogin):
         return self.query_criteria(coordinates=coordinates, radius=radius)
 
     @class_or_instance
-    def query_object(self, objectname, radius=0.3*units.deg):
+    def query_object(self, objectname, *, radius=0.3*units.deg):
         """
         search for Gemini observations by target on the sky.
 

--- a/astroquery/hips2fits/core.py
+++ b/astroquery/hips2fits/core.py
@@ -55,8 +55,8 @@ class hips2fitsClass(BaseQuery):
     def __init__(self, *args):
         super().__init__()
 
-    def query_with_wcs(self, hips, wcs, format="fits", min_cut=0.5, max_cut=99.5, stretch="linear", cmap="Greys_r",
-                       get_query_payload=False, verbose=False):
+    def query_with_wcs(self, hips, wcs, *, format="fits", min_cut=0.5, max_cut=99.5, stretch="linear",
+                       cmap="Greys_r", get_query_payload=False, verbose=False):
         """
         Query the `CDS hips2fits service <http://alasky.u-strasbg.fr/hips-image-services/hips2fits>`_ with an
         astropy WCS.
@@ -138,7 +138,7 @@ class hips2fitsClass(BaseQuery):
         >>> plt.show(im)
 
         """
-        response = self.query_with_wcs_async(get_query_payload, hips=hips, wcs=wcs, format=format,
+        response = self.query_with_wcs_async(get_query_payload=get_query_payload, hips=hips, wcs=wcs, format=format,
                                              min_cut=min_cut, max_cut=max_cut, stretch=stretch, cmap=cmap)
 
         if get_query_payload:
@@ -148,7 +148,7 @@ class hips2fitsClass(BaseQuery):
         return result
 
     @class_or_instance
-    def query_with_wcs_async(self, get_query_payload=False, **kwargs):
+    def query_with_wcs_async(self, *, get_query_payload=False, **kwargs):
         request_payload = self._args_to_payload(**kwargs)
 
         # primarily for debug purposes, but also useful if you want to send
@@ -167,8 +167,9 @@ class hips2fitsClass(BaseQuery):
 
         return response
 
-    def query(self, hips, width, height, projection, ra, dec, fov, coordsys="icrs", rotation_angle=Angle(0 * u.deg),
-              format="fits", min_cut=0.5, max_cut=99.5, stretch="linear", cmap="Greys_r",
+    def query(self, hips, width, height, projection, ra, dec, fov, *,
+              coordsys="icrs", rotation_angle=Angle(0 * u.deg), format="fits",
+              min_cut=0.5, max_cut=99.5, stretch="linear", cmap="Greys_r",
               get_query_payload=False, verbose=False):
         """
         Query the `CDS hips2fits service <http://alasky.u-strasbg.fr/hips-image-services/hips2fits>`_.
@@ -268,9 +269,10 @@ class hips2fitsClass(BaseQuery):
         >>> plt.show(im)
         """
 
-        response = self.query_async(get_query_payload, hips=hips, width=width, height=height, projection=projection,
-                                    ra=ra, dec=dec, fov=fov, coordsys=coordsys, rotation_angle=rotation_angle,
-                                    format=format, min_cut=min_cut, max_cut=max_cut, stretch=stretch, cmap=cmap)
+        response = self.query_async(get_query_payload=get_query_payload, hips=hips, width=width, height=height,
+                                    projection=projection, ra=ra, dec=dec, fov=fov, coordsys=coordsys,
+                                    rotation_angle=rotation_angle, format=format, min_cut=min_cut,
+                                    max_cut=max_cut, stretch=stretch, cmap=cmap)
 
         if get_query_payload:
             return response
@@ -279,7 +281,7 @@ class hips2fitsClass(BaseQuery):
         return result
 
     @class_or_instance
-    def query_async(self, get_query_payload=False, **kwargs):
+    def query_async(self, *, get_query_payload=False, **kwargs):
         request_payload = self._args_to_payload(**kwargs)
 
         # primarily for debug purposes, but also useful if you want to send

--- a/astroquery/hitran/core.py
+++ b/astroquery/hitran/core.py
@@ -151,7 +151,7 @@ class HitranClass(BaseQuery):
         """
         super().__init__()
 
-    def _args_to_payload(self, molecule_number=1, isotopologue_number=1,
+    def _args_to_payload(self, *, molecule_number=1, isotopologue_number=1,
                          min_frequency=None, max_frequency=None):
         """
         Code to parse input and construct the payload dictionary.
@@ -199,7 +199,7 @@ class HitranClass(BaseQuery):
         return payload
 
     @prepend_docstr_nosections("\n" + _args_to_payload.__doc__)
-    def query_lines_async(self, get_query_payload=False, cache=True, **kwargs):
+    def query_lines_async(self, *, get_query_payload=False, cache=True, **kwargs):
         """
         Queries Hitran class for a particular molecule with default arguments
         set. Based on fetch function from hapi.py.
@@ -223,7 +223,7 @@ class HitranClass(BaseQuery):
 
         return response
 
-    def _parse_result(self, response, verbose=False):
+    def _parse_result(self, response, *, verbose=False):
         """
         Parse a response into an `~astropy.table.Table`
         """

--- a/astroquery/hitran/utils.py
+++ b/astroquery/hitran/utils.py
@@ -7,7 +7,7 @@ fmt_dict = {'f': float, 's': str, 'd': int, 'e': float, 'A': str, 'I': int,
             'F': float}
 
 
-def parse_readme(filename, group_global=None, group_local=None):
+def parse_readme(filename, *, group_global=None, group_local=None):
     with open(filename, 'r') as f:
         lines = f.readlines()
 
@@ -51,7 +51,7 @@ def parse_readme(filename, group_global=None, group_local=None):
     return formats
 
 
-def quanta_formatter(group_global='class1', group_local='group1'):
+def quanta_formatter(*, group_global='class1', group_local='group1'):
     """
     Format based on the global/local formatters from the HITRAN04 paper
     """

--- a/astroquery/image_cutouts/first/core.py
+++ b/astroquery/image_cutouts/first/core.py
@@ -16,8 +16,8 @@ class FirstClass(BaseQuery):
     TIMEOUT = conf.timeout
     maximsize = 1024
 
-    def _args_to_payload(self, coordinates, image_size=1 * u.arcmin,
-                         *, maximsize=None):
+    def _args_to_payload(self, coordinates, *, image_size=1 * u.arcmin,
+                         maximsize=None):
         """
         Fetches image cutouts from FIRST survey.
 
@@ -49,8 +49,8 @@ class FirstClass(BaseQuery):
         return request_payload
 
     @prepend_docstr_nosections("\n" + _args_to_payload.__doc__)
-    def get_images(self, coordinates, image_size=1 * u.arcmin,
-                   *, get_query_payload=False):
+    def get_images(self, coordinates, *, image_size=1 * u.arcmin,
+                   get_query_payload=False):
         """
         get_query_payload : bool, optional
             if set to `True` then returns the dictionary sent as the HTTP
@@ -71,8 +71,8 @@ class FirstClass(BaseQuery):
             raise InvalidQueryError(response.content)
 
     @prepend_docstr_nosections("\n" + _args_to_payload.__doc__)
-    def get_images_async(self, coordinates, image_size=1 * u.arcmin,
-                         *, get_query_payload=False):
+    def get_images_async(self, coordinates, *, image_size=1 * u.arcmin,
+                         get_query_payload=False):
         """
         get_query_payload : bool, optional
             if set to `True` then returns the dictionary sent as the HTTP

--- a/astroquery/imcce/core.py
+++ b/astroquery/imcce/core.py
@@ -36,7 +36,7 @@ class MiriadeClass(BaseQuery):
         """
         return self._query_uri
 
-    def get_ephemerides_async(self, targetname, objtype='asteroid',
+    def get_ephemerides_async(self, targetname, *, objtype='asteroid',
                               epoch=None, epoch_step='1d', epoch_nsteps=1,
                               location=500, coordtype=1,
                               timescale='UTC',
@@ -276,7 +276,7 @@ class MiriadeClass(BaseQuery):
 
         return response
 
-    def _parse_result(self, response, verbose=None):
+    def _parse_result(self, response, *, verbose=None):
         """
         Parser for Miriade request results
         """
@@ -426,6 +426,7 @@ class SkybotClass(BaseQuery):
                           coo,
                           rad,
                           epoch,
+                          *,
                           location='500',
                           position_error=120,
                           find_planets=True,
@@ -614,7 +615,7 @@ class SkybotClass(BaseQuery):
 
         return response
 
-    def _parse_result(self, response, verbose=False):
+    def _parse_result(self, response, *, verbose=False):
         """
         internal wrapper to parse queries
         """

--- a/astroquery/ipac/irsa/ibe/core.py
+++ b/astroquery/ipac/irsa/ibe/core.py
@@ -30,9 +30,9 @@ class IbeClass(BaseQuery):
     TABLE = conf.table
     TIMEOUT = conf.timeout
 
-    def query_region(self, coordinate=None, where=None, mission=None, dataset=None,
-                     table=None, columns=None, width=None, height=None,
-                     intersect='OVERLAPS', most_centered=False):
+    def query_region(self, *, coordinate=None, where=None, mission=None,
+                     dataset=None, table=None, columns=None, width=None,
+                     height=None, intersect='OVERLAPS', most_centered=False):
         """
         For certain missions, this function can be used to search for image and
         catalog files based on a point, a box (bounded by great circles) and/or
@@ -106,7 +106,7 @@ class IbeClass(BaseQuery):
 
         return Table.read(response.text, format='ipac', guess=False)
 
-    def query_region_sia(self, coordinate=None, mission=None,
+    def query_region_sia(self, *, coordinate=None, mission=None,
                          dataset=None, table=None, width=None,
                          height=None, intersect='OVERLAPS',
                          most_centered=False):
@@ -126,7 +126,7 @@ class IbeClass(BaseQuery):
         return commons.parse_votable(
             response.text).get_first_table().to_table()
 
-    def query_region_async(self, coordinate=None, where=None, mission=None, dataset=None,
+    def query_region_async(self, *, coordinate=None, where=None, mission=None, dataset=None,
                            table=None, columns=None, width=None, height=None,
                            action='search', intersect='OVERLAPS', most_centered=False):
         """
@@ -251,7 +251,7 @@ class IbeClass(BaseQuery):
 
         return self._request('GET', url, args, timeout=self.TIMEOUT)
 
-    def list_missions(self, cache=True):
+    def list_missions(self, *, cache=True):
         """
         Return a list of the available missions
 
@@ -277,7 +277,7 @@ class IbeClass(BaseQuery):
 
         return missions
 
-    def list_datasets(self, mission=None, cache=True):
+    def list_datasets(self, *, mission=None, cache=True):
         """
         For a given mission, list the available datasets
 
@@ -314,7 +314,7 @@ class IbeClass(BaseQuery):
 
         return datasets
 
-    def list_tables(self, mission=None, dataset=None, cache=True):
+    def list_tables(self, *, mission=None, dataset=None, cache=True):
         """
         For a given mission and dataset (see
         `~astroquery.ipac.irsa.ibe.IbeClass.list_missions`,
@@ -348,11 +348,11 @@ class IbeClass(BaseQuery):
                              "Must be one of: {1}"
                              .format(mission, self.list_missions()))
 
-        if dataset not in self.list_datasets(mission, cache=cache):
+        if dataset not in self.list_datasets(mission=mission, cache=cache):
             raise ValueError("Invalid dataset {0} specified for mission {1}."
                              "Must be one of: {2}"
                              .format(dataset, mission,
-                                     self.list_datasets(mission, cache=True)))
+                                     self.list_datasets(mission=mission, cache=True)))
 
         url = "{URL}search/{mission}/{dataset}/".format(URL=self.URL,
                                                         mission=mission,
@@ -368,7 +368,7 @@ class IbeClass(BaseQuery):
     # def get_data(self, **kwargs):
     #    return self.query_region_async(retrieve_data=True, **kwargs)
 
-    def show_docs(self, mission=None, dataset=None, table=None):
+    def show_docs(self, *, mission=None, dataset=None, table=None):
         """
         Open the documentation for a given table in a web browser.
 
@@ -390,7 +390,7 @@ class IbeClass(BaseQuery):
 
         return webbrowser.open(url)
 
-    def get_columns(self, mission=None, dataset=None, table=None):
+    def get_columns(self, *, mission=None, dataset=None, table=None):
         """
         Get the schema for a given table.
 

--- a/astroquery/ipac/irsa/ibe/tests/test_ibe.py
+++ b/astroquery/ipac/irsa/ibe/tests/test_ibe.py
@@ -67,22 +67,22 @@ def test_list_missions(patch_get):
 
 
 def test_list_datasets(patch_get):
-    assert Ibe.list_datasets('ptf') == ['images']
+    assert Ibe.list_datasets(mission='ptf') == ['images']
 
 
 def test_list_tables(patch_get):
-    assert Ibe.list_tables('ptf', 'images') == ['level1', 'level2']
+    assert Ibe.list_tables(mission='ptf', dataset='images') == ['level1', 'level2']
 
 
 def test_get_columns(patch_get):
-    columns = Ibe.get_columns('ptf', 'images', 'level1')
+    columns = Ibe.get_columns(mission='ptf', dataset='images', table='level1')
     assert len(columns) == 173
     assert columns[0]['name'] == 'expid'
 
 
 def test_ibe_pos(patch_get):
     table = Ibe.query_region(
-        SkyCoord(148.969687 * u.deg, 69.679383 * u.deg),
+        coordinate=SkyCoord(148.969687 * u.deg, 69.679383 * u.deg),
         where='expid <= 43010')
     assert isinstance(table, Table)
     assert len(table) == 21

--- a/astroquery/ipac/irsa/ibe/tests/test_ibe_remote.py
+++ b/astroquery/ipac/irsa/ibe/tests/test_ibe_remote.py
@@ -13,7 +13,7 @@ from astroquery.ipac.irsa import ibe
 @pytest.mark.remote_data
 def test_ibe_pos():
     table = ibe.Ibe.query_region(
-        SkyCoord(148.969687 * u.deg, 69.679383 * u.deg),
+        coordinate=SkyCoord(148.969687 * u.deg, 69.679383 * u.deg),
         where='expid <= 43010')
     assert isinstance(table, Table)
     assert len(table) == 21

--- a/astroquery/ipac/irsa/sha/core.py
+++ b/astroquery/ipac/irsa/sha/core.py
@@ -21,7 +21,7 @@ __doctest_skip__ = ['query', 'save_file', 'get_file']
 uri = 'https://sha.ipac.caltech.edu/applications/Spitzer/SHA/servlet/DataService?'
 
 
-def query(coord=None, ra=None, dec=None, size=None, naifid=None, pid=None,
+def query(*, coord=None, ra=None, dec=None, size=None, naifid=None, pid=None,
           reqkey=None, dataset=2, verbosity=3, return_response=False,
           return_payload=False):
     """
@@ -157,7 +157,7 @@ def query(coord=None, ra=None, dec=None, size=None, naifid=None, pid=None,
     return table
 
 
-def save_file(url, out_dir='sha_tmp/', out_name=None):
+def save_file(url, *, out_dir='sha_tmp/', out_name=None):
     """
     Download image to output directory given a URL from a SHA query.
 

--- a/astroquery/ipac/ned/core.py
+++ b/astroquery/ipac/ned/core.py
@@ -40,7 +40,7 @@ class NedClass(BaseQuery):
                       2: Options('Data as Published', 'pub'),
                       3: Options('Homogenized Units (mJy)', 'mjy')}
 
-    def query_object(self, object_name, get_query_payload=False,
+    def query_object(self, object_name, *, get_query_payload=False,
                      verbose=False):
         """
         Queries objects by name from the NED Service and returns the Main
@@ -71,7 +71,7 @@ class NedClass(BaseQuery):
         result = self._parse_result(response, verbose=verbose)
         return result
 
-    def query_object_async(self, object_name, get_query_payload=False):
+    def query_object_async(self, object_name, *, get_query_payload=False):
         """
         Serves the same purpose as `~NedClass.query_object` but returns the
         raw HTTP response rather than the `astropy.table.Table` object.
@@ -101,7 +101,7 @@ class NedClass(BaseQuery):
 
         return response
 
-    def query_region(self, coordinates, radius=1 * u.arcmin, equinox='J2000.0',
+    def query_region(self, coordinates, *, radius=1 * u.arcmin, equinox='J2000.0',
                      get_query_payload=False, verbose=False):
         """
         Used to query a region around a known identifier or given
@@ -144,7 +144,7 @@ class NedClass(BaseQuery):
         result = self._parse_result(response, verbose=verbose)
         return result
 
-    def query_region_async(self, coordinates, radius=1 * u.arcmin,
+    def query_region_async(self, coordinates, *, radius=1 * u.arcmin,
                            equinox='J2000.0', get_query_payload=False):
         """
         Serves the same purpose as `~NedClass.query_region` but returns the
@@ -206,7 +206,7 @@ class NedClass(BaseQuery):
                                  params=request_payload, timeout=Ned.TIMEOUT)
         return response
 
-    def query_region_iau(self, iau_name, frame='Equatorial', equinox='B1950.0',
+    def query_region_iau(self, iau_name, *, frame='Equatorial', equinox='B1950.0',
                          get_query_payload=False, verbose=False):
         """
         Used to query the Ned service via the IAU name. Equivalent to the
@@ -245,7 +245,7 @@ class NedClass(BaseQuery):
         result = self._parse_result(response, verbose=verbose)
         return result
 
-    def query_region_iau_async(self, iau_name, frame='Equatorial',
+    def query_region_iau_async(self, iau_name, *, frame='Equatorial',
                                equinox='B1950.0', get_query_payload=False):
         """
         Serves the same purpose as `~NedClass.query_region_iau` but returns
@@ -285,7 +285,7 @@ class NedClass(BaseQuery):
                                  params=request_payload, timeout=Ned.TIMEOUT)
         return response
 
-    def query_refcode(self, refcode, get_query_payload=False, verbose=False):
+    def query_refcode(self, refcode, *, get_query_payload=False, verbose=False):
         """
         Used to retrieve all objects contained in a particular
         reference. Equivalent to by refcode queries of the web interface.
@@ -314,7 +314,7 @@ class NedClass(BaseQuery):
         result = self._parse_result(response, verbose=verbose)
         return result
 
-    def query_refcode_async(self, refcode, get_query_payload=False):
+    def query_refcode_async(self, refcode, *, get_query_payload=False):
         """
         Serves the same purpose as `~NedClass.query_region` but returns the
         raw HTTP response rather than the `astropy.table.Table` object.
@@ -344,7 +344,7 @@ class NedClass(BaseQuery):
                                  params=request_payload, timeout=Ned.TIMEOUT)
         return response
 
-    def get_images(self, object_name, get_query_payload=False,
+    def get_images(self, object_name, *, get_query_payload=False,
                    show_progress=True):
         """
         Query function to fetch FITS images for a given identifier.
@@ -370,7 +370,7 @@ class NedClass(BaseQuery):
             return readable_objs
         return [obj.get_fits() for obj in readable_objs]
 
-    def get_images_async(self, object_name, get_query_payload=False,
+    def get_images_async(self, object_name, *, get_query_payload=False,
                          show_progress=True):
         """
         Serves the same purpose as `~NedClass.get_images` but returns
@@ -397,7 +397,7 @@ class NedClass(BaseQuery):
                                       show_progress=show_progress)
                 for U in image_urls]
 
-    def get_spectra(self, object_name, get_query_payload=False,
+    def get_spectra(self, object_name, *, get_query_payload=False,
                     show_progress=True):
         """
         Query function to fetch FITS files of spectra for a given identifier.
@@ -423,7 +423,7 @@ class NedClass(BaseQuery):
             return readable_objs
         return [obj.get_fits() for obj in readable_objs]
 
-    def get_spectra_async(self, object_name, get_query_payload=False,
+    def get_spectra_async(self, object_name, *, get_query_payload=False,
                           show_progress=True):
         """
         Serves the same purpose as `~NedClass.get_spectra` but returns
@@ -490,7 +490,7 @@ class NedClass(BaseQuery):
                                  timeout=Ned.TIMEOUT)
         return self._extract_image_urls(response.text, file_format=file_format)
 
-    def _extract_image_urls(self, html_in, file_format='fits'):
+    def _extract_image_urls(self, html_in, *, file_format='fits'):
         """
         Helper function that uses regexps to extract the image urls from the
         given HTML.
@@ -524,7 +524,7 @@ class NedClass(BaseQuery):
         url_list = [base_url + img_url for img_url in matched_urls]
         return url_list
 
-    def get_table(self, object_name, table='photometry',
+    def get_table(self, object_name, *, table='photometry',
                   get_query_payload=False, verbose=False, **kwargs):
         """
         Fetches the specified data table for the object from NED and returns
@@ -574,7 +574,7 @@ class NedClass(BaseQuery):
         result = self._parse_result(response, verbose=verbose)
         return result
 
-    def get_table_async(self, object_name, table='photometry',
+    def get_table_async(self, object_name, *, table='photometry',
                         get_query_payload=False, **kwargs):
         """
         Serves the same purpose as `~NedClass.query_region` but returns the
@@ -678,7 +678,7 @@ class NedClass(BaseQuery):
         request_payload['out_equinox'] = conf.output_equinox
         request_payload['obj_sort'] = conf.sort_output_by
 
-    def _parse_result(self, response, verbose=False):
+    def _parse_result(self, response, *, verbose=False):
         """
         Parses the raw HTTP response and returns it as an
         `astropy.table.Table`.

--- a/astroquery/ipac/ned/tests/test_ned.py
+++ b/astroquery/ipac/ned/tests/test_ned.py
@@ -167,7 +167,7 @@ def test_get_images(patch_get, patch_get_readable_fileobj):
 
 
 def test_query_refcode_async(patch_get):
-    response = ned.core.Ned.query_refcode_async('1997A&A...323...31K', True)
+    response = ned.core.Ned.query_refcode_async('1997A&A...323...31K', get_query_payload=True)
     assert response == {'search_type': 'Search',
                         'refcode': '1997A&A...323...31K',
                         'hconst': conf.hubble_constant,

--- a/astroquery/jplsbdb/core.py
+++ b/astroquery/jplsbdb/core.py
@@ -27,7 +27,7 @@ class SBDBClass(BaseQuery):
     # actual query uri
     _uri = None
 
-    def query_async(self, targetid, id_type='search',
+    def query_async(self, targetid, *, id_type='search',
                     neo_only=False,
                     alternate_id=False,
                     full_precision=False,
@@ -181,7 +181,7 @@ class SBDBClass(BaseQuery):
 
         return response
 
-    def _parse_result(self, response, verbose=False):
+    def _parse_result(self, response, *, verbose=False):
         """
         internal wrapper to parse queries
 
@@ -372,7 +372,7 @@ class SBDBClass(BaseQuery):
 
         return eldict
 
-    def schematic(self, d, _prepend='+--'):
+    def schematic(self, d, *, _prepend='+--'):
         """
         Formats the provided dictionary ``d`` into a human-readable tree
         structure schematic. In order to display the structure

--- a/astroquery/jplspec/core.py
+++ b/astroquery/jplspec/core.py
@@ -27,7 +27,7 @@ class JPLSpecClass(BaseQuery):
     URL = conf.server
     TIMEOUT = conf.timeout
 
-    def query_lines_async(self, min_frequency, max_frequency,
+    def query_lines_async(self, min_frequency, max_frequency, *,
                           min_strength=-500,
                           max_lines=2000, molecule='All', flags=0,
                           parse_name_locally=False,
@@ -126,7 +126,7 @@ class JPLSpecClass(BaseQuery):
 
         return response
 
-    def _parse_result(self, response, verbose=False):
+    def _parse_result(self, response, *, verbose=False):
         """
         Parse a response into an `~astropy.table.Table`
 
@@ -181,7 +181,7 @@ class JPLSpecClass(BaseQuery):
 
         return result
 
-    def get_species_table(self, catfile='catdir.cat'):
+    def get_species_table(self, *, catfile='catdir.cat'):
         """
         A directory of the catalog is found in a file called 'catdir.cat.'
         Each element of this directory is an 80-character record with the

--- a/astroquery/lamda/core.py
+++ b/astroquery/lamda/core.py
@@ -45,7 +45,7 @@ class LamdaClass(BaseQuery):
         self.moldict_path = os.path.join(self.cache_location,
                                          "molecules.json")
 
-    def _get_molfile(self, mol, cache=True, timeout=None):
+    def _get_molfile(self, mol, *, cache=True, timeout=None):
         """
         """
         if mol not in self.molecule_dict:
@@ -65,7 +65,7 @@ class LamdaClass(BaseQuery):
         with open(outfilename, 'w') as f:
             f.write(molreq.text)
 
-    def query(self, mol, return_datafile=False, cache=True, timeout=None):
+    def query(self, mol, *, return_datafile=False, cache=True, timeout=None):
         """
         Query the LAMDA database.
 
@@ -107,7 +107,7 @@ class LamdaClass(BaseQuery):
         tables = parse_lamda_lines(datafile)
         return tables
 
-    def get_molecules(self, cache=True):
+    def get_molecules(self, *, cache=True):
         """
         Scrape the list of valid molecules
         """
@@ -152,7 +152,7 @@ class LamdaClass(BaseQuery):
 
         return self._molecule_dict
 
-    def _find_datfiles(self, url, base_url, raise_for_status=False):
+    def _find_datfiles(self, url, base_url, *, raise_for_status=False):
 
         myurl = _absurl_from_url(url, base_url)
         if 'http' not in myurl:

--- a/astroquery/lamda/utils.py
+++ b/astroquery/lamda/utils.py
@@ -4,7 +4,7 @@ from astropy import constants
 from astropy import units as u
 
 
-def ncrit(lamda_tables, transition_upper, transition_lower, temperature, OPR=3,
+def ncrit(lamda_tables, transition_upper, transition_lower, temperature, *, OPR=3,
           partners=['H2', 'OH2', 'PH2']):
     """
     Compute the critical density for a transition given its temperature.

--- a/astroquery/linelists/cdms/core.py
+++ b/astroquery/linelists/cdms/core.py
@@ -171,7 +171,7 @@ class CDMSClass(BaseQuery):
 
         return response2
 
-    def _parse_result(self, response, verbose=False):
+    def _parse_result(self, response, *, verbose=False):
         """
         Parse a response into an `~astropy.table.Table`
 
@@ -277,7 +277,7 @@ class CDMSClass(BaseQuery):
 
         return result
 
-    def get_species_table(self, catfile='catdir.cat'):
+    def get_species_table(self, *, catfile='catdir.cat'):
         """
         A directory of the catalog is found in a file called 'catdir.cat.'
 

--- a/astroquery/magpis/core.py
+++ b/astroquery/magpis/core.py
@@ -33,7 +33,7 @@ class MagpisClass(BaseQuery):
                "bolocam"]
     maximsize = 1024
 
-    def _args_to_payload(self, coordinates, image_size=1 * u.arcmin,
+    def _args_to_payload(self, coordinates, *, image_size=1 * u.arcmin,
                          survey='bolocam', maximsize=None):
         """
         Fetches image cutouts from MAGPIS surveys.
@@ -71,7 +71,7 @@ class MagpisClass(BaseQuery):
         return request_payload
 
     @prepend_docstr_nosections("\n" + _args_to_payload.__doc__)
-    def get_images(self, coordinates, image_size=1 * u.arcmin,
+    def get_images(self, coordinates, *, image_size=1 * u.arcmin,
                    survey='bolocam', get_query_payload=False):
         """
         get_query_payload : bool, optional
@@ -94,7 +94,7 @@ class MagpisClass(BaseQuery):
             raise InvalidQueryError(response.content)
 
     @prepend_docstr_nosections("\n" + _args_to_payload.__doc__)
-    def get_images_async(self, coordinates, image_size=1 * u.arcmin,
+    def get_images_async(self, coordinates, *, image_size=1 * u.arcmin,
                          survey='bolocam', get_query_payload=False):
         """
         get_query_payload : bool, optional

--- a/astroquery/mpc/core.py
+++ b/astroquery/mpc/core.py
@@ -65,7 +65,7 @@ class MPCClass(BaseQuery):
     def __init__(self):
         super().__init__()
 
-    def query_object_async(self, target_type, get_query_payload=False, *args, **kwargs):
+    def query_object_async(self, target_type, *, get_query_payload=False, **kwargs):
         """
         Query around a specific object within a given mission catalog. When
         searching for a comet, it will return the entry with the latest epoch.
@@ -194,9 +194,9 @@ class MPCClass(BaseQuery):
         self.get_mpc_object_endpoint(target_type)
 
         kwargs['limit'] = 1
-        return self.query_objects_async(target_type, get_query_payload, *args, **kwargs)
+        return self.query_objects_async(target_type, get_query_payload=get_query_payload, **kwargs)
 
-    def query_objects_async(self, target_type, get_query_payload=False, *args, **kwargs):
+    def query_objects_async(self, target_type, *, get_query_payload=False, **kwargs):
         """
         Query around a specific object within a given mission catalog
 
@@ -343,7 +343,7 @@ class MPCClass(BaseQuery):
         return mpc_endpoint
 
     @class_or_instance
-    def get_ephemeris_async(self, target, location='500', start=None, step='1d',
+    def get_ephemeris_async(self, target, *, location='500', start=None, step='1d',
                             number=None, ut_offset=0, eph_type='equatorial',
                             ra_format=None, dec_format=None,
                             proper_motion='total', proper_motion_unit='arcsec/h',
@@ -610,7 +610,7 @@ class MPCClass(BaseQuery):
         return response
 
     @class_or_instance
-    def get_observatory_codes_async(self, get_raw_response=False, cache=True):
+    def get_observatory_codes_async(self, *, get_raw_response=False, cache=True):
         """
         Table of observatory codes from the IAU Minor Planet Center.
 
@@ -656,7 +656,7 @@ class MPCClass(BaseQuery):
         return response
 
     @class_or_instance
-    def get_observatory_location(self, code, cache=True):
+    def get_observatory_location(self, code, *, cache=True):
         """
         IAU observatory location.
 
@@ -774,7 +774,7 @@ class MPCClass(BaseQuery):
         return request_args
 
     @class_or_instance
-    def get_observations_async(self, targetid,
+    def get_observations_async(self, targetid, *,
                                id_type=None,
                                comettype=None,
                                get_mpcformat=False,

--- a/astroquery/nasa_ads/core.py
+++ b/astroquery/nasa_ads/core.py
@@ -40,7 +40,7 @@ class ADSClass(BaseQuery):
         super().__init__()
 
     @class_or_instance
-    def query_simple(self, query_string, get_query_payload=False,
+    def query_simple(self, query_string, *, get_query_payload=False,
                      get_raw_response=False, cache=True):
         """
         Basic query.  Uses a string and the ADS generic query.
@@ -48,7 +48,7 @@ class ADSClass(BaseQuery):
         request_string = self._args_to_url(query_string)
         request_fields = self._fields_to_url()
         request_sort = self._sort_to_url()
-        request_rows = self._rows_to_url(self.NROWS, self.NSTART)
+        request_rows = self._rows_to_url(nrows=self.NROWS, nstart=self.NSTART)
         request_url = self.QUERY_SIMPLE_URL + request_string + request_fields + request_sort + request_rows
 
         # primarily for debug purposes, but also useful if you want to send
@@ -101,7 +101,7 @@ class ADSClass(BaseQuery):
         request_sort = '&sort=' + urlencode(self.SORT)
         return request_sort
 
-    def _rows_to_url(self, nrows=10, nstart=0):
+    def _rows_to_url(self, *, nrows=10, nstart=0):
         request_rows = '&rows=' + str(nrows) + '&start=' + str(nstart)
         return request_rows
 

--- a/astroquery/nasa_ads/utils.py
+++ b/astroquery/nasa_ads/utils.py
@@ -1,6 +1,6 @@
 
 
-def _get_data_from_xml(doclist, fieldname, nohitreturn=None):
+def _get_data_from_xml(doclist, fieldname, *, nohitreturn=None):
     """Get the fieldname (i.e. author, title etc)
     from minidom.parseString().childNodes[0].childNodes list
     """

--- a/astroquery/oac/core.py
+++ b/astroquery/oac/core.py
@@ -36,6 +36,7 @@ class OACClass(BaseQuery):
 
     def query_object_async(self,
                            event,
+                           *,
                            quantity=None,
                            attribute=None,
                            argument=None,
@@ -107,7 +108,7 @@ class OACClass(BaseQuery):
 
         return response
 
-    def query_region_async(self, coordinates,
+    def query_region_async(self, coordinates, *,
                            radius=None,
                            height=None, width=None,
                            quantity=None,
@@ -261,7 +262,7 @@ class OACClass(BaseQuery):
 
         return response
 
-    def get_photometry_async(self, event, argument=None, cache=True):
+    def get_photometry_async(self, event, *, argument=None, cache=True):
         """
         Retrieve all photometry for specified event(s).
 
@@ -308,7 +309,7 @@ class OACClass(BaseQuery):
 
         return response
 
-    def get_single_spectrum_async(self, event, time, cache=True):
+    def get_single_spectrum_async(self, event, time, *, cache=True):
         """
         Retrieve a single spectrum at a specified time for given event.
 
@@ -346,7 +347,7 @@ class OACClass(BaseQuery):
 
         return response
 
-    def get_spectra_async(self, event, cache=True):
+    def get_spectra_async(self, event, *, cache=True):
         """
         Retrieve all spectra for a specified event.
 
@@ -476,7 +477,7 @@ class OACClass(BaseQuery):
 
         return output
 
-    def _parse_result(self, response, verbose=False):
+    def _parse_result(self, response, *, verbose=False):
         if not verbose:
             commons.suppress_vo_warnings()
 

--- a/astroquery/ogle/core.py
+++ b/astroquery/ogle/core.py
@@ -56,7 +56,7 @@ class OgleClass(BaseQuery):
                      'a2', 'f8']
 
     @_validate_params
-    def _args_to_payload(self, coord=None, algorithm='NG', quality='GOOD',
+    def _args_to_payload(self, *, coord=None, algorithm='NG', quality='GOOD',
                          coord_sys='RD'):
         """
         Query the OGLE-III interstellar extinction calculator.
@@ -143,7 +143,7 @@ class OgleClass(BaseQuery):
         response.raise_for_status()
         return response
 
-    def _parse_result(self, response, verbose=False):
+    def _parse_result(self, response, *, verbose=False):
         # Parse table, ignore last two (blank) lines
         raw_data = response.text.split('\n')[:-2]
         # Select first row and skip first character ('#') to find column

--- a/astroquery/open_exoplanet_catalogue/tests/test_open_exoplanet_catalogue_local.py
+++ b/astroquery/open_exoplanet_catalogue/tests/test_open_exoplanet_catalogue_local.py
@@ -11,7 +11,7 @@ def data_path(filename):
 
 def test_function():
     # use local version of database
-    cata = oec.get_catalogue(data_path('systems.xml.gz'))
+    cata = oec.get_catalogue(filepath=data_path('systems.xml.gz'))
 
     assert len(cata.findall('.//planet')) > 0
 

--- a/astroquery/open_exoplanet_catalogue/utils.py
+++ b/astroquery/open_exoplanet_catalogue/utils.py
@@ -9,7 +9,7 @@ class Number:
     Examples
     --------
 
-    >>> num = Number(10, errorminus=0.5, errorplus=0.8)
+    >>> num = Number(value=10, errorminus=0.5, errorplus=0.8)
     >>> str(num)
     '10.0 +0.8 -0.5'
 
@@ -22,7 +22,7 @@ class Number:
     >>> num.errorminus
     0.5
 
-    >>> num = Number(None, upperlimit=10)
+    >>> num = Number(value=None, upperlimit=10)
     >>> str(num)
     '<10.0'
 
@@ -33,7 +33,7 @@ class Number:
     False
     """
 
-    def __init__(self, value=None, upperlimit=None, lowerlimit=None,
+    def __init__(self, *, value=None, upperlimit=None, lowerlimit=None,
                  errorplus=None, errorminus=None):
         """
         Parameters
@@ -78,11 +78,11 @@ class Number:
         """
         Example outputs
         ---------------
-        >>> str(Number(2.0))
+        >>> str(Number(value=2.0))
         '2.0'
-        >>> str(Number(2.0, errorplus=1.0, errorminus=1.5))
+        >>> str(Number(value=2.0, errorplus=1.0, errorminus=1.5))
         '2.0 +1.0 -1.5'
-        >>> str(Number(2.0, errorplus=1.0, errorminus=1.0))
+        >>> str(Number(value=2.0, errorplus=1.0, errorminus=1.0))
         '2.0 +/-1.0'
         >>> str(Number(lowerlimit=2.0))
         '>2.0'
@@ -105,7 +105,7 @@ class Number:
             tempstr += ">" + str(self.lowerlimit)
         return tempstr
 
-    def machine_readable(self, separator="\t", missingval="None"):
+    def machine_readable(self, *, separator="\t", missingval="None"):
         """
         Creates a string intended for a machine to read (ex, gnuplot)
         prints as follows

--- a/astroquery/splatalogue/build_species_table.py
+++ b/astroquery/splatalogue/build_species_table.py
@@ -32,7 +32,7 @@ def data_path(filename: str):
     return os.path.join(data_dir, filename)
 
 
-def get_json_species_ids(outfile='splat-species.json', base_url=conf.base_url):
+def get_json_species_ids(*, outfile='splat-species.json', base_url=conf.base_url):
     """
     Uses BeautifulSoup to scrape the NRAO Splatalogue species
     selector form, and caches the result as JSON. The file

--- a/astroquery/splatalogue/core.py
+++ b/astroquery/splatalogue/core.py
@@ -76,7 +76,7 @@ class SplatalogueClass(BaseQuery):
         """
         self.data.update(self._parse_kwargs(**kwargs))
 
-    def get_species_ids(self, restr=None, reflags=0, recache=False):
+    def get_species_ids(self, *, restr=None, reflags=0, recache=False):
         """
         Get a dictionary of "species" IDs, where species refers to the molecule
         name, mass, and chemical composition.
@@ -95,7 +95,7 @@ class SplatalogueClass(BaseQuery):
         --------
         >>> import re
         >>> import pprint # unfortunate hack required for documentation testing
-        >>> rslt = Splatalogue.get_species_ids('Formaldehyde')
+        >>> rslt = Splatalogue.get_species_ids(restr='Formaldehyde')
         >>> pprint.pprint(rslt)
         {'03023 H2CO - Formaldehyde': '194',
          '03106 H213CO - Formaldehyde': '324',
@@ -107,7 +107,7 @@ class SplatalogueClass(BaseQuery):
          '03301 D213CO - Formaldehyde': '1220',
          '03315 HDC18O - Formaldehyde': '21141',
          '0348 D2C18O - Formaldehyde': '21140'}
-        >>> rslt = Splatalogue.get_species_ids('H2CO')
+        >>> rslt = Splatalogue.get_species_ids(restr='H2CO')
         >>> pprint.pprint(rslt)
         {'03023 H2CO - Formaldehyde': '194',
          '03109 H2COH+ - Hydroxymethylium ion': '224',
@@ -125,9 +125,9 @@ class SplatalogueClass(BaseQuery):
          '08903 CH3CHNH2COOH - II - α-Alanine': '1322'}
         >>> # note the whitespace, preventing H2CO within other
         >>> # more complex molecules
-        >>> Splatalogue.get_species_ids(' H2CO ')
+        >>> Splatalogue.get_species_ids(restr=' H2CO ')
         {'03023 H2CO - Formaldehyde': '194'}
-        >>> Splatalogue.get_species_ids(' h2co ', re.IGNORECASE)
+        >>> Splatalogue.get_species_ids(restr=' h2co ', reflags=re.IGNORECASE)
         {'03023 H2CO - Formaldehyde': '194'}
 
         """
@@ -137,7 +137,7 @@ class SplatalogueClass(BaseQuery):
             self._species_ids = load_species_table.species_lookuptable(recache=recache)
 
         if restr is not None:
-            return self._species_ids.find(restr, reflags)
+            return self._species_ids.find(restr, flags=reflags)
         else:
             return self._species_ids
 
@@ -160,7 +160,7 @@ class SplatalogueClass(BaseQuery):
                       show_nrao_recommended=False,)
         return self._parse_kwargs(**kwargs)
 
-    def _parse_kwargs(self, min_frequency=None, max_frequency=None,
+    def _parse_kwargs(self, *, min_frequency=None, max_frequency=None,
                       band='any', top20=None, chemical_name=None,
                       chem_re_flags=0, energy_min=None, energy_max=None,
                       energy_type=None, intensity_lower_limit=None,
@@ -319,7 +319,7 @@ class SplatalogueClass(BaseQuery):
             payload['sid[]'] = []
         elif chemical_name is not None:
             if parse_chemistry_locally:
-                species_ids = self.get_species_ids(chemical_name, chem_re_flags)
+                species_ids = self.get_species_ids(restr=chemical_name, reflags=chem_re_flags)
                 if len(species_ids) == 0:
                     raise ValueError("No matching chemical species found.")
                 payload['sid[]'] = list(species_ids.values())
@@ -408,7 +408,7 @@ class SplatalogueClass(BaseQuery):
 
         return payload
 
-    def _validate_kwargs(self, min_frequency=None, max_frequency=None,
+    def _validate_kwargs(self, *, min_frequency=None, max_frequency=None,
                          band='any', **kwargs):
         """
         Check that either min_frequency + max_frequency or band are specified
@@ -419,7 +419,7 @@ class SplatalogueClass(BaseQuery):
                                  "a valid Band.")
 
     @prepend_docstr_nosections("\n" + _parse_kwargs.__doc__)
-    def query_lines_async(self, min_frequency=None, max_frequency=None,
+    def query_lines_async(self, *, min_frequency=None, max_frequency=None,
                           cache=True, **kwargs):
         """
 
@@ -462,7 +462,7 @@ class SplatalogueClass(BaseQuery):
 
         return response
 
-    def _parse_result(self, response, verbose=False):
+    def _parse_result(self, response, *, verbose=False):
         """
         Parse a response into an `~astropy.table.Table`
 
@@ -478,7 +478,7 @@ class SplatalogueClass(BaseQuery):
 
         return result
 
-    def get_fixed_table(self, columns=None):
+    def get_fixed_table(self, *, columns=None):
         """
         Convenience function to get the table with html column names made human
         readable.  It returns only the columns identified with the ``columns``

--- a/astroquery/splatalogue/load_species_table.py
+++ b/astroquery/splatalogue/load_species_table.py
@@ -8,7 +8,7 @@ from astroquery.splatalogue.build_species_table import data_path, get_json_speci
 
 class SpeciesLookuptable(dict):
 
-    def find(self, s, flags=0, return_dict=True,):
+    def find(self, s, *, flags=0, return_dict=True,):
         """
         Search dictionary keys for a regex match to string s
 
@@ -38,7 +38,7 @@ class SpeciesLookuptable(dict):
             return out.values()
 
 
-def species_lookuptable(filename='splat-species.json', recache=False):
+def species_lookuptable(*, filename='splat-species.json', recache=False):
     """
     Function to format the species ID results from scraping Splatalogue
     into a ``SpeciesLookuptable`` object.

--- a/astroquery/splatalogue/slap.py
+++ b/astroquery/splatalogue/slap.py
@@ -7,7 +7,7 @@ query.
 """
 
 
-def slap_default_payload(request='queryData', version='2.0', wavelength='',
+def slap_default_payload(*, request='queryData', version='2.0', wavelength='',
                          chemical_element='', initial_level_energy='',
                          final_level_energy='', temperature='', einstein_a=''):
     """

--- a/astroquery/splatalogue/tests/test_splatalogue.py
+++ b/astroquery/splatalogue/tests/test_splatalogue.py
@@ -17,16 +17,18 @@ def data_path(filename):
 
 
 def test_simple(patch_post):
-    splatalogue.Splatalogue.query_lines(114 * u.GHz, 116 * u.GHz,
+    splatalogue.Splatalogue.query_lines(min_frequency=114 * u.GHz,
+                                        max_frequency=116 * u.GHz,
                                         chemical_name=' CO ')
 
 
 @pytest.mark.remote_data
 def test_init(patch_post):
-    x = splatalogue.Splatalogue.query_lines(114 * u.GHz, 116 * u.GHz,
+    x = splatalogue.Splatalogue.query_lines(min_frequency=114 * u.GHz,
+                                            max_frequency=116 * u.GHz,
                                             chemical_name=' CO ')
     S = splatalogue.Splatalogue(chemical_name=' CO ')
-    y = S.query_lines(114 * u.GHz, 116 * u.GHz)
+    y = S.query_lines(min_frequency=114 * u.GHz, max_frequency=116 * u.GHz)
     # it is not currently possible to test equality between tables:
     # masked arrays fail
     # assert y == x
@@ -43,14 +45,16 @@ def test_load_species_table():
 
 # regression test: get_query_payload should work (#308)
 def test_get_payload():
-    q = splatalogue.core.Splatalogue.query_lines_async(1 * u.GHz, 10 * u.GHz,
+    q = splatalogue.core.Splatalogue.query_lines_async(min_frequency=1 * u.GHz,
+                                                       max_frequency=10 * u.GHz,
                                                        get_query_payload=True)
     assert '__utma' in q
 
 
 # regression test: line lists should ask for only one line list, not all
 def test_line_lists():
-    q = splatalogue.core.Splatalogue.query_lines_async(1 * u.GHz, 10 * u.GHz,
+    q = splatalogue.core.Splatalogue.query_lines_async(min_frequency=1 * u.GHz,
+                                                       max_frequency=10 * u.GHz,
                                                        line_lists=['JPL'],
                                                        get_query_payload=True)
     assert q['displayJPL'] == 'displayJPL'
@@ -61,7 +65,8 @@ def test_line_lists():
 # uses get_query_payload to avoid having to monkeypatch
 def test_linelist_type():
     with pytest.raises(TypeError) as exc:
-        splatalogue.core.Splatalogue.query_lines_async(1 * u.GHz, 10 * u.GHz,
+        splatalogue.core.Splatalogue.query_lines_async(min_frequency=1 * u.GHz,
+                                                       max_frequency=10 * u.GHz,
                                                        line_lists='JPL',
                                                        get_query_payload=True)
     assert exc.value.args[0] == ("Line lists should be a list of linelist "
@@ -69,12 +74,14 @@ def test_linelist_type():
 
 
 def test_top20_crashorno():
-    splatalogue.core.Splatalogue.query_lines_async(114 * u.GHz, 116 * u.GHz,
+    splatalogue.core.Splatalogue.query_lines_async(min_frequency=114 * u.GHz,
+                                                   max_frequency=116 * u.GHz,
                                                    top20='top20',
                                                    get_query_payload=True)
     with pytest.raises(ValueError) as exc:
         splatalogue.core.Splatalogue.query_lines_async(
-            114 * u.GHz, 116 * u.GHz, top20='invalid', get_query_payload=True)
+            min_frequency=114 * u.GHz, max_frequency=116 * u.GHz,
+            top20='invalid', get_query_payload=True)
     assert exc.value.args[0] == "Top20 is not one of the allowed values"
 
 
@@ -103,7 +110,8 @@ def test_band_crashorno():
 
 def test_exclude(patch_post):
     # regression test for issue 616
-    d = splatalogue.Splatalogue.query_lines_async(114 * u.GHz, 116 * u.GHz,
+    d = splatalogue.Splatalogue.query_lines_async(min_frequency=114 * u.GHz,
+                                                  max_frequency=116 * u.GHz,
                                                   chemical_name=' CO ',
                                                   exclude=None,
                                                   get_query_payload=True)
@@ -115,7 +123,8 @@ def test_exclude(patch_post):
     for k, v in exclusions.items():
         assert d[k] == v
 
-    d = splatalogue.Splatalogue.query_lines_async(114 * u.GHz, 116 * u.GHz,
+    d = splatalogue.Splatalogue.query_lines_async(min_frequency=114 * u.GHz,
+                                                  max_frequency=116 * u.GHz,
                                                   chemical_name=' CO ',
                                                   exclude='none',
                                                   get_query_payload=True)

--- a/astroquery/splatalogue/tests/test_utils.py
+++ b/astroquery/splatalogue/tests/test_utils.py
@@ -8,7 +8,8 @@ from .. import utils
 
 
 def test_clean(patch_post):
-    x = splatalogue.Splatalogue.query_lines(114 * u.GHz, 116 * u.GHz,
+    x = splatalogue.Splatalogue.query_lines(min_frequency=114 * u.GHz,
+                                            max_frequency=116 * u.GHz,
                                             chemical_name=' CO ')
     c = utils.clean_column_headings(x)
     assert 'Resolved QNs' not in c.colnames
@@ -16,7 +17,8 @@ def test_clean(patch_post):
 
 
 def test_merge(patch_post):
-    x = splatalogue.Splatalogue.query_lines(114 * u.GHz, 116 * u.GHz,
+    x = splatalogue.Splatalogue.query_lines(min_frequency=114 * u.GHz,
+                                            max_frequency=116 * u.GHz,
                                             chemical_name=' CO ')
     c = utils.merge_frequencies(x)
     assert 'Freq' in c.colnames
@@ -24,7 +26,8 @@ def test_merge(patch_post):
 
 
 def test_minimize(patch_post):
-    x = splatalogue.Splatalogue.query_lines(114 * u.GHz, 116 * u.GHz,
+    x = splatalogue.Splatalogue.query_lines(min_frequency=114 * u.GHz,
+                                            max_frequency=116 * u.GHz,
                                             chemical_name=' CO ')
     c = utils.minimize_table(x)
 
@@ -36,7 +39,8 @@ def test_minimize(patch_post):
 
 @pytest.mark.remote_data
 def test_minimize_issue2135():
-    rslt = splatalogue.Splatalogue.query_lines(100*u.GHz, 200*u.GHz,
+    rslt = splatalogue.Splatalogue.query_lines(min_frequency=100*u.GHz,
+                                               max_frequency=200*u.GHz,
                                                chemical_name=' SiO ',
                                                energy_max=1840,
                                                energy_type='eu_k',

--- a/astroquery/splatalogue/utils.py
+++ b/astroquery/splatalogue/utils.py
@@ -27,7 +27,7 @@ column_headings_map = {'Log<sub>10</sub> (A<sub>ij</sub>)': 'log10_Aij',
                        }
 
 
-def clean_column_headings(table, renaming_dict=column_headings_map):
+def clean_column_headings(table, *, renaming_dict=column_headings_map):
     """
     Rename column headings to shorter version that are easier for display
     on-screen / at the terminal
@@ -40,7 +40,7 @@ def clean_column_headings(table, renaming_dict=column_headings_map):
     return table
 
 
-def merge_frequencies(table, prefer='measured',
+def merge_frequencies(table, *, prefer='measured',
                       theor_kwd='Freq-GHz(rest frame,redshifted)',
                       meas_kwd='Meas Freq-GHz(rest frame,redshifted)'):
     """
@@ -79,12 +79,12 @@ def merge_frequencies(table, prefer='measured',
     return table
 
 
-def minimize_table(table, columns=['Species', 'Chemical Name',
-                                   'Resolved QNs',
-                                   'Freq-GHz(rest frame,redshifted)',
-                                   'Meas Freq-GHz(rest frame,redshifted)',
-                                   'Log<sub>10</sub> (A<sub>ij</sub>)',
-                                   'E_U (K)'],
+def minimize_table(table, *, columns=['Species', 'Chemical Name',
+                                      'Resolved QNs',
+                                      'Freq-GHz(rest frame,redshifted)',
+                                      'Meas Freq-GHz(rest frame,redshifted)',
+                                      'Log<sub>10</sub> (A<sub>ij</sub>)',
+                                      'E_U (K)'],
                    merge=True,
                    clean=True):
     """

--- a/astroquery/svo_fps/core.py
+++ b/astroquery/svo_fps/core.py
@@ -31,7 +31,7 @@ class SvoFpsClass(BaseQuery):
     SVO_MAIN_URL = conf.base_url
     TIMEOUT = conf.timeout
 
-    def data_from_svo(self, query, cache=True, timeout=None,
+    def data_from_svo(self, query, *, cache=True, timeout=None,
                       error_msg='No data found for requested query'):
         """Get data in response to the query send to SVO FPS.
         This method is not generally intended for users, but it can be helpful
@@ -128,7 +128,7 @@ class SvoFpsClass(BaseQuery):
         error_msg = 'No filter found for requested Filter ID'
         return self.data_from_svo(query=query, error_msg=error_msg, **kwargs)
 
-    def get_filter_list(self, facility, instrument=None, **kwargs):
+    def get_filter_list(self, facility, *, instrument=None, **kwargs):
         """Get filters data for requested facilty and instrument from SVO
 
         Parameters

--- a/astroquery/svo_fps/tests/test_svo_fps.py
+++ b/astroquery/svo_fps/tests/test_svo_fps.py
@@ -79,7 +79,7 @@ def test_get_transmission_data(patch_get):
 
 
 def test_get_filter_list(patch_get):
-    table = SvoFps.get_filter_list(TEST_FACILITY, TEST_INSTRUMENT)
+    table = SvoFps.get_filter_list(TEST_FACILITY, instrument=TEST_INSTRUMENT)
     # Check if column for Filter ID (named 'filterID') exists in table
     assert 'filterID' in table.colnames
 

--- a/astroquery/svo_fps/tests/test_svo_fps_remote.py
+++ b/astroquery/svo_fps/tests/test_svo_fps_remote.py
@@ -26,7 +26,7 @@ class TestSvoFpsClass:
     @pytest.mark.parametrize('test_facility, test_instrument',
                              [('HST', 'WFPC2'), ('Keck', None)])
     def test_get_filter_list(self, test_facility, test_instrument):
-        table = SvoFps.get_filter_list(test_facility, test_instrument)
+        table = SvoFps.get_filter_list(test_facility, instrument=test_instrument)
         # Check if column for Filter ID (named 'filterID') exists in table
         assert 'filterID' in table.colnames
 

--- a/astroquery/template_module/core.py
+++ b/astroquery/template_module/core.py
@@ -61,7 +61,7 @@ class TemplateClass(BaseQuery):
         return result
     """
 
-    def query_object_async(self, object_name, get_query_payload=False,
+    def query_object_async(self, object_name, *, get_query_payload=False,
                            cache=True):
         """
         This method is for services that can parse object names. Otherwise
@@ -140,7 +140,7 @@ class TemplateClass(BaseQuery):
     # actual HTTP request and returns the HTTP response
 
     def query_region_async(self, coordinates, radius, height, width,
-                           get_query_payload=False, cache=True):
+                           *, get_query_payload=False, cache=True):
         """
         Queries a region around the specified coordinates.
 
@@ -187,7 +187,7 @@ class TemplateClass(BaseQuery):
     # This should parse the raw HTTP response and return it as
     # an `astropy.table.Table`. Below is the skeleton:
 
-    def _parse_result(self, response, verbose=False):
+    def _parse_result(self, response, *, verbose=False):
         # if verbose is False then suppress any VOTable related warnings
         if not verbose:
             commons.suppress_vo_warnings()
@@ -253,7 +253,7 @@ class TemplateClass(BaseQuery):
         return [obj.get_fits() for obj in readable_objs]
 
     @prepend_docstr_nosections(get_images.__doc__)
-    def get_images_async(self, coordinates, radius, get_query_payload=False):
+    def get_images_async(self, coordinates, radius, *, get_query_payload=False):
         """
         Returns
         -------
@@ -275,7 +275,7 @@ class TemplateClass(BaseQuery):
     # links for the images as a list
 
     @prepend_docstr_nosections(get_images.__doc__)
-    def get_image_list(self, coordinates, radius, get_query_payload=False,
+    def get_image_list(self, coordinates, radius, *, get_query_payload=False,
                        cache=True):
         """
         Returns

--- a/astroquery/ukidss/core.py
+++ b/astroquery/ukidss/core.py
@@ -55,7 +55,7 @@ class UkidssClass(BaseWFAUClass):
     # needed for some WFAU queries, not for UKIDSS
     archive = None
 
-    def __init__(self, username=None, password=None, community=None,
+    def __init__(self, *, username=None, password=None, community=None,
                  database='UKIDSSDR11PLUS', programme_id='all'):
         super(UkidssClass, self).__init__(database=database,
                                           programme_id=programme_id,

--- a/astroquery/vsa/core.py
+++ b/astroquery/vsa/core.py
@@ -57,7 +57,7 @@ class VsaClass(BaseWFAUClass):
     # apparently needed for some queries
     archive = 'VSA'
 
-    def __init__(self, username=None, password=None, community=None,
+    def __init__(self, *, username=None, password=None, community=None,
                  database='VVVDR4', programme_id='all'):
         super(VsaClass, self).__init__(database=database,
                                        programme_id=programme_id,

--- a/astroquery/wfau/core.py
+++ b/astroquery/wfau/core.py
@@ -36,7 +36,7 @@ class BaseWFAUClass(QueryWithLogin):
     CROSSID_URL = BASE_URL + "CrossID"
     TIMEOUT = ""
 
-    def __init__(self, username=None, password=None, community=None,
+    def __init__(self, *, username=None, password=None, community=None,
                  database='', programme_id='all'):
         """
         The BaseWFAUClass __init__ is meant to be overwritten
@@ -108,7 +108,7 @@ class BaseWFAUClass(QueryWithLogin):
             request_payload['dec'] = C.b.degree
         return request_payload
 
-    def _verify_programme_id(self, pid, query_type='catalog'):
+    def _verify_programme_id(self, pid, *, query_type='catalog'):
         """
         Verify the programme ID is valid for the query being executed.
 
@@ -152,7 +152,7 @@ class BaseWFAUClass(QueryWithLogin):
         elif system.lower() in ('j', 'j2000', 'celestical', 'radec'):
             return 'J'
 
-    def get_images(self, coordinates, waveband='all', frame_type='stack',
+    def get_images(self, coordinates, *, waveband='all', frame_type='stack',
                    image_width=1 * u.arcmin, image_height=None, radius=None,
                    database=None, programme_id=None,
                    verbose=True, get_query_payload=False,
@@ -212,7 +212,7 @@ class BaseWFAUClass(QueryWithLogin):
             return readable_objs
         return [obj.get_fits() for obj in readable_objs]
 
-    def get_images_async(self, coordinates, waveband='all', frame_type='stack',
+    def get_images_async(self, coordinates, *, waveband='all', frame_type='stack',
                          image_width=1 * u.arcmin, image_height=None,
                          radius=None, database=None,
                          programme_id=None, verbose=True,
@@ -290,7 +290,7 @@ class BaseWFAUClass(QueryWithLogin):
                                       show_progress=show_progress)
                 for url in image_urls]
 
-    def get_image_list(self, coordinates, waveband='all', frame_type='stack',
+    def get_image_list(self, coordinates, *, waveband='all', frame_type='stack',
                        image_width=1 * u.arcmin, image_height=None,
                        radius=None, database=None,
                        programme_id=None, get_query_payload=False):
@@ -433,7 +433,7 @@ class BaseWFAUClass(QueryWithLogin):
         links = ahref.findall(html_in)
         return links
 
-    def query_region(self, coordinates, radius=1 * u.arcmin,
+    def query_region(self, coordinates, *, radius=1 * u.arcmin,
                      programme_id=None, database=None,
                      verbose=False, get_query_payload=False, system='J2000',
                      attributes=['default'], constraints=''):
@@ -502,7 +502,7 @@ class BaseWFAUClass(QueryWithLogin):
         result = self._parse_result(response, verbose=verbose)
         return result
 
-    def query_region_async(self, coordinates, radius=1 * u.arcmin,
+    def query_region_async(self, coordinates, *, radius=1 * u.arcmin,
                            programme_id=None,
                            database=None, get_query_payload=False,
                            system='J2000', attributes=['default'],
@@ -584,7 +584,7 @@ class BaseWFAUClass(QueryWithLogin):
 
         return response
 
-    def _parse_result(self, response, verbose=False):
+    def _parse_result(self, response, *, verbose=False):
         """
         Parses the raw HTTP response and returns it as a
         `~astropy.table.Table`.
@@ -630,7 +630,7 @@ class BaseWFAUClass(QueryWithLogin):
                                   "and the error in self.table_parse_error.  "
                                   "Exception: " + str(self.table_parse_error))
 
-    def list_catalogs(self, style='short'):
+    def list_catalogs(self, *, style='short'):
         """
         Returns a list of available catalogs in WFAU.
         These can be used as ``programme_id`` in queries.
@@ -700,7 +700,7 @@ class BaseWFAUClass(QueryWithLogin):
                                      timeout=self.TIMEOUT)
         return response
 
-    def _check_page(self, url, keyword, wait_time=1, max_attempts=30):
+    def _check_page(self, url, keyword, *, wait_time=1, max_attempts=30):
         page_loaded = False
         while not page_loaded and max_attempts > 0:
             if self.logged_in():
@@ -722,7 +722,7 @@ class BaseWFAUClass(QueryWithLogin):
             raise TimeoutError("Page did not load.")
         return response
 
-    def query_cross_id_async(self, coordinates, radius=1*u.arcsec,
+    def query_cross_id_async(self, coordinates, *, radius=1*u.arcsec,
                              programme_id=None, database=None, table="source",
                              constraints="", attributes='default',
                              pairing='all', system='J2000',
@@ -847,7 +847,7 @@ class BaseWFAUClass(QueryWithLogin):
         return result
 
 
-def clean_catalog(wfau_catalog, clean_band='K_1', badclass=-9999,
+def clean_catalog(wfau_catalog, *, clean_band='K_1', badclass=-9999,
                   maxerrbits=41, minerrbits=0, maxpperrbits=60):
     """
     Attempt to remove 'bad' entries in a catalog.

--- a/astroquery/xmatch/core.py
+++ b/astroquery/xmatch/core.py
@@ -24,7 +24,7 @@ class XMatchClass(BaseQuery):
     URL = conf.url
     TIMEOUT = conf.timeout
 
-    def query(self, cat1, cat2, max_distance,
+    def query(self, cat1, cat2, max_distance, *,
               colRA1=None, colDec1=None, colRA2=None, colDec2=None,
               area='allsky', cache=True, get_query_payload=False, **kwargs):
         """
@@ -70,8 +70,8 @@ class XMatchClass(BaseQuery):
         table : `~astropy.table.Table`
             Query results table
         """
-        response = self.query_async(cat1, cat2, max_distance, colRA1, colDec1,
-                                    colRA2, colDec2, area=area, cache=cache,
+        response = self.query_async(cat1, cat2, max_distance, colRA1=colRA1, colDec1=colDec1,
+                                    colRA2=colRA2, colDec2=colDec2, area=area, cache=cache,
                                     get_query_payload=get_query_payload,
                                     **kwargs)
         if get_query_payload:
@@ -81,7 +81,7 @@ class XMatchClass(BaseQuery):
         return Table.read(content, format='votable', use_names_over_ids=True)
 
     @prepend_docstr_nosections("\n" + query.__doc__)
-    def query_async(self, cat1, cat2, max_distance, colRA1=None, colDec1=None,
+    def query_async(self, cat1, cat2, max_distance, *, colRA1=None, colDec1=None,
                     colRA2=None, colDec2=None, area='allsky', cache=True,
                     get_query_payload=False, **kwargs):
         """
@@ -173,7 +173,7 @@ class XMatchClass(BaseQuery):
 
         return table_id in self.get_available_tables()
 
-    def get_available_tables(self, cache=True):
+    def get_available_tables(self, *, cache=True):
         """Get the list of the VizieR tables which are available in the
         xMatch service and return them as a list of strings.
 

--- a/docs/eso/eso.rst
+++ b/docs/eso/eso.rst
@@ -282,7 +282,7 @@ The archive can be queried as follows:
 
 .. doctest-remote-data::
 
-    >>> table = eso.query_surveys('HARPS', cache=False, target="HD203608")
+    >>> table = eso.query_surveys(surveys='HARPS', cache=False, target="HD203608")
 
 The returned table has an ``ARCFILE`` column. It can be used to retrieve the datasets with
 :meth:`astroquery.eso.EsoClass.retrieve_data` (see next section).

--- a/docs/gaia/gaia.rst
+++ b/docs/gaia/gaia.rst
@@ -164,8 +164,7 @@ radius argument.
   >>>
   >>> Gaia.ROW_LIMIT = 50  # Ensure the default row limit.
   >>> coord = SkyCoord(ra=280, dec=-60, unit=(u.degree, u.degree), frame='icrs')
-  >>> radius = u.Quantity(1.0, u.deg)
-  >>> j = Gaia.cone_search_async(coord, radius)
+  >>> j = Gaia.cone_search_async(coord, radius=u.Quantity(1.0, u.deg))
   INFO: Query finished. [astroquery.utils.tap.core]
   >>> r = j.get_results()
   >>> r.pprint()

--- a/docs/imcce/imcce.rst
+++ b/docs/imcce/imcce.rst
@@ -38,7 +38,7 @@ looks like this:
    >>> field = SkyCoord(0*u.deg, 0*u.deg)
    >>> epoch = Time('2019-05-29 21:42', format='iso')
    >>> results = Skybot.cone_search(field, 5*u.arcmin, epoch)
-   >>> results.pprint(max_width=80)
+   >>> results.pprint(max_width=80)  # doctest: +IGNORE_OUTPUT
     Number    Name             RA          ...      vy          vz       epoch  
                               deg          ...    AU / d      AU / d       d    
     ------ ---------- -------------------- ... ----------- ----------- ---------


### PR DESCRIPTION
This addresses #1746.

At the present time of drafting this PR, refactors to make optional kwargs keyword only have been applied to the following:

- [x] astroquery/alfalfa
- [x] astroquery/astrometry_net
- [x] astroquery/besancon
- [x] astroquery/casda
- [x] astroquery/cds
- [x] astroquery/dace
- [x] astroquery/exoplanet_orbit_database
- [x] astroquery/fermi
- [x]  astroquery/gaia
- [x]  astroquery/gama
- [x] astroquery/gemini
- [x] astroquery/hips2fits
- [x] astroquery/hitran
- [x] astroquery/image_cutouts/first
- [x] astroquery/imcce  (also added  `# doctest: +IGNORE_OUTPUT` for re-emerging issue from #2634 that was addressed in #2652 )
- [x] astroquery/ipac/irsa/ibe
- [x] astroquery/ipac/irsa/irsa_dust
- [x] astroquery/ipac/irsa/sha
- [x] astroquery/ipac/ned
- [x] astroquery/jplsbdb
- [x] astroquery/jplspec
- [x] astroquery/lamda
- [x] astroquery/linelists/cdms
- [x] astroquery/magpis
- [x] astroquery/mpc
- [x] astroquery/nasa_ads
- [x] astroquery/oac
- [x] astroquery/ogle
- [x] astroquery/open_exoplanet_catalogue
- [x] astroquery/splatalogue
- [x] astroquery/template_module
- [x] astroquery/ukidss
- [x] astroquery/vsa
- [x]  astroquery/wfau (FYI: has no tests)
- [x] astroquery/xmatch


Problematic refactors (handle later/ require more scrutiny):
- [ ] astroquery/heasarc (has a few failing tests)
- [ ] astroquery/utls (breaks other packages to the point where all tests should run to make sure everything is working)
- [ ] astroquery/eso (test_each_instrument_SgrAstar is failing)
- [ ] astroquery/cosmosim (has no tests)
- [ ] astroquery/cadc
- [ ] astroquery/utils/tap
- [ ] astroquery/vamdc
- [ ] astroquery/vo_conesearch