### PR TITLE
Restore rectangle search

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -217,8 +217,8 @@ gaia
 sdss
 ^^^^
 
-- ``query_region()`` now does a cone search around the specified
-  coordinates. [#2477]
+- ``query_region()`` can perform cone search or a rectangular
+  search around the specified coordinates. [#2477, #2663]
 
 - The default data release has been changed to DR17. [#2478]
 

--- a/astroquery/sdss/core.py
+++ b/astroquery/sdss/core.py
@@ -339,10 +339,10 @@ class SDSSClass(BaseQuery):
 
         if width is not None:
             if isinstance(width, Angle):
-                width = width.to_value(u.arcmin)
+                width = width.to_value(u.degree)
             else:
                 try:
-                    width = Angle(width).to_value(u.arcmin)
+                    width = Angle(width).to_value(u.degree)
                 except ValueError:
                     raise TypeError("width should be either Quantity or "
                                     "convertible to float.")
@@ -350,10 +350,10 @@ class SDSSClass(BaseQuery):
                 height = width
             else:
                 if isinstance(height, Angle):
-                    height = height.to_value(u.arcmin)
+                    height = height.to_value(u.degree)
                 else:
                     try:
-                        height = Angle(height).to_value(u.arcmin)
+                        height = Angle(height).to_value(u.degree)
                     except ValueError:
                         raise TypeError("height should be either Quantity or "
                                         "convertible to float.")
@@ -378,16 +378,8 @@ class SDSSClass(BaseQuery):
             for n, target in enumerate(coordinates):
                 # Query for a rectangle
                 target = commons.parse_coordinates(target).transform_to('fk5')
+                rectangles.append(self._rectangle_sql(target.ra.degree, target.dec.degree, width, height=height))
 
-                ra = target.ra.degree
-                dec = target.dec.degree
-                dra = Angle(width).to('degree').value / 2.0
-                ddec = Angle(height).to('degree').value / 2.0
-                rectangles.append('((p.ra BETWEEN {0:g} AND {1:g}) '
-                                  'AND (p.dec BETWEEN {2:g} AND {3:g}))'.format(ra - dra,
-                                                                                ra + dra,
-                                                                                dec - ddec,
-                                                                                dec + ddec))
             rect = ' OR '.join(rectangles)
             if 'WHERE' in sql_query:
                 sql_query += f' AND ({rect})'

--- a/astroquery/sdss/core.py
+++ b/astroquery/sdss/core.py
@@ -66,7 +66,7 @@ class SDSSClass(BaseQuery):
 
         This query returns the nearest `primary object`_.
 
-        Note that there is a server-side limit of 3 arcmin on `radius`.
+        Note that there is a server-side limit of 3 arcmin on ``radius``.
 
         .. _`primary object`: https://www.sdss.org/dr17/help/glossary/#surveyprimary
 
@@ -129,10 +129,10 @@ class SDSSClass(BaseQuery):
         Raises
         ------
         TypeError
-            If the `radius` keyword could not be parsed as an angle.
+            If the ``radius`` keyword could not be parsed as an angle.
         ValueError
-            If the `radius` exceeds 3 arcmin, or if the sizes of
-            `coordinates` and `obj_names` do not match.
+            If the ``radius`` exceeds 3 arcmin, or if the sizes of
+            ``coordinates`` and ``obj_names`` do not match.
 
         Returns
         -------
@@ -208,16 +208,16 @@ class SDSSClass(BaseQuery):
                            spectro=False, field_help=False, get_query_payload=False,
                            data_release=conf.default_release, cache=True):
         """
-        Used to query a region around given coordinates. Either `radius` or
+        Used to query a region around given coordinates. Either ``radius`` or
         `width` must be specified.
 
-        When called with keyword `radius`, a radial or "cone" search is
+        When called with keyword ``radius``, a radial or "cone" search is
         performed, centered on each of the given coordinates. In this mode, internally,
         this function is equivalent to the object cross-ID (`query_crossid`),
         with slightly different parameters.  Note that in this mode there is a server-side
-        limit of 3 arcmin on `radius`.
+        limit of 3 arcmin on ``radius``.
 
-        When called with keyword `width`, and optionally a different `height`,
+        When called with keyword ``width``, and optionally a different ``height``,
         a rectangular search is performed, centered on each of the given
         coordinates. In this mode, internally, this function is equivalent to
         a general SQL query (`query_sql`).
@@ -286,6 +286,15 @@ class SDSSClass(BaseQuery):
         cache : bool, optional
             If ``True`` use the request caching mechanism.
 
+        Raises
+        ------
+        TypeError
+            If the ``radius``, ``width`` or ``height`` keywords could not be parsed as an angle.
+        ValueError
+            If both ``radius`` and ``width`` are set (or neither),
+            or if the ``radius`` exceeds 3 arcmin,
+            or if the sizes of ``coordinates`` and ``obj_names`` do not match.
+
         Examples
         --------
         >>> from astroquery.sdss import SDSS
@@ -307,17 +316,6 @@ class SDSSClass(BaseQuery):
             The result of the query as a `~astropy.table.Table` object.
 
         """
-        # Move Raises section here, since async_to_sync does not appear to like it.
-        #
-        # Raises
-        # ------
-        # TypeError
-        #     If the `radius`, `width` or `height` keywords could not be parsed as an angle.
-        # ValueError
-        #     If both `radius` and `width are set (or neither),
-        #     or if the `radius` exceeds 3 arcmin,
-        #     or if the sizes of `coordinates` and `obj_names` do not match.
-
         # Allow field_help requests to pass without requiring a radius or width.
         if field_help and radius is None and width is None:
             radius = 2.0 * u.arcsec
@@ -1279,7 +1277,7 @@ class SDSSClass(BaseQuery):
 
     def _rectangle_sql(self, ra, dec, width, height=None, cosdec=False):
         """
-        Generate SQL for a rectangular query centered on `ra`, `dec`.
+        Generate SQL for a rectangular query centered on ``ra``, ``dec``.
 
         This assumes that RA is defined on the range ``[0, 360)``, and Dec on
         ``[-90, 90]``.
@@ -1293,9 +1291,11 @@ class SDSSClass(BaseQuery):
         width : float
             Width of rectangle in degrees.
         height : float, optional
-            Height of rectangle in degrees. If not specified, `width` is used.
+            Height of rectangle in degrees. If not specified, ``width`` is used.
         cosdec : bool, optional
             If ``True`` apply ``cos(dec)`` correction to the rectangle.
+            Otherwise, rectangles become increasingly triangle-like
+            near the poles.
 
         Returns
         -------
@@ -1312,8 +1312,6 @@ class SDSSClass(BaseQuery):
         d1 = dec + dd
         if d1 > 90.0:
             d1 = 90.0
-        if d1 < d0:
-            d0, d1 = d1, d0
         ra_wrap = False
         r0 = ra - dr
         if r0 < 0:

--- a/astroquery/sdss/core.py
+++ b/astroquery/sdss/core.py
@@ -126,11 +126,6 @@ class SDSSClass(BaseQuery):
         cache : bool, optional
             If ``True`` use the request caching mechanism.
 
-        Returns
-        -------
-        result : `~astropy.table.Table`
-            The result of the query as a `~astropy.table.Table` object.
-
         Raises
         ------
         TypeError
@@ -138,6 +133,12 @@ class SDSSClass(BaseQuery):
         ValueError
             If the `radius` exceeds 3 arcmin, or if the sizes of
             `coordinates` and `obj_names` do not match.
+
+        Returns
+        -------
+        result : `~astropy.table.Table`
+            The result of the query as a `~astropy.table.Table` object.
+
         """
 
         if isinstance(radius, Angle):
@@ -285,11 +286,6 @@ class SDSSClass(BaseQuery):
         cache : bool, optional
             If ``True`` use the request caching mechanism.
 
-        Returns
-        -------
-        result : `~astropy.table.Table`
-            The result of the query as a `~astropy.table.Table` object.
-
         Raises
         ------
         TypeError
@@ -313,6 +309,12 @@ class SDSSClass(BaseQuery):
         2.02344596595 14.8398237229 1237652943176138867 1739   301      3   315
         2.02344596303 14.8398237521 1237652943176138868 1739   301      3   315
         2.02344772021 14.8398201105 1237653651835781243 1904   301      3   163
+
+        Returns
+        -------
+        result : `~astropy.table.Table`
+            The result of the query as a `~astropy.table.Table` object.
+
         """
         # Allow field_help requests to pass without requiring a radius or width.
         if field_help and radius is None and width is None:
@@ -445,11 +447,6 @@ class SDSSClass(BaseQuery):
         cache : bool, optional
             If ``True`` use the request caching mechanism.
 
-        Returns
-        -------
-        result : `~astropy.table.Table`
-            The result of the query as an `~astropy.table.Table` object.
-
         Examples
         --------
         >>> from astroquery.sdss import SDSS
@@ -463,6 +460,12 @@ class SDSSClass(BaseQuery):
         47.1604269095 5.48241410994  2340 53733     332 2634697104106219520
         48.6634992214 6.69459110287  2340 53733     553 2634757852123654144
         48.0759195428 6.18757403485  2340 53733     506 2634744932862027776
+
+        Returns
+        -------
+        result : `~astropy.table.Table`
+            The result of the query as an `~astropy.table.Table` object.
+
         """
 
         if plate is None and mjd is None and fiberID is None:
@@ -524,11 +527,6 @@ class SDSSClass(BaseQuery):
         cache : bool, optional
             If ``True`` use the request caching mechanism.
 
-        Returns
-        -------
-        result : `~astropy.table.Table`
-            The result of the query as a `~astropy.table.Table` object.
-
         Examples
         --------
         >>> from astroquery.sdss import SDSS
@@ -541,6 +539,12 @@ class SDSSClass(BaseQuery):
         22.2574304026 8.43175488904 1237670017262485671 5714   301      6    21
         23.3724928784 8.32576993103 1237670017262944491 5714   301      6    28
         25.4801226435 8.27642390025 1237670017263927330 5714   301      6    43
+
+        Returns
+        -------
+        result : `~astropy.table.Table`
+            The result of the query as a `~astropy.table.Table` object.
+
         """
 
         if run is None and camcol is None and field is None:
@@ -585,11 +589,6 @@ class SDSSClass(BaseQuery):
         cache : bool, optional
             If ``True`` use the request caching mechanism.
 
-        Returns
-        -------
-        result : `~astropy.table.Table`
-            The result of the query as a `~astropy.table.Table` object.
-
         Examples
         --------
         >>> from astroquery.sdss import SDSS
@@ -610,6 +609,13 @@ class SDSSClass(BaseQuery):
         0.3000027 156.25024 7.6586271 1237658425162858683
         0.3000027 256.99461 25.566255 1237661387086693265
          0.300003 175.65125  34.37548 1237665128003731630
+
+
+        Returns
+        -------
+        result : `~astropy.table.Table`
+            The result of the query as a `~astropy.table.Table` object.
+
         """
 
         request_payload = dict(cmd=self.__sanitize_query(sql_query),
@@ -677,14 +683,6 @@ class SDSSClass(BaseQuery):
         show_progress : bool, optional
             If False, do not display download progress.
 
-        Returns
-        -------
-        list : list
-            A list of context-managers that yield readable file-like objects.
-            The function returns the spectra for only one of ``matches``, or
-            ``coordinates`` and ``radius``, or ``plate``, ``mjd`` and
-            ``fiberID``.
-
         Examples
         --------
         Using results from a call to `query_region`:
@@ -702,6 +700,14 @@ class SDSSClass(BaseQuery):
         Fetch the spectra from all fibers on plate 751 with mjd 52251:
 
         >>> specs = SDSS.get_spectra(plate=751, mjd=52251)
+
+        Returns
+        -------
+        list : list
+            A list of context-managers that yield readable file-like objects.
+            The function returns the spectra for only one of ``matches``, or
+            ``coordinates`` and ``radius``, or ``plate``, ``mjd`` and
+            ``fiberID``.
 
         """
 
@@ -846,10 +852,6 @@ class SDSSClass(BaseQuery):
         show_progress : bool, optional
             If False, do not display download progress.
 
-        Returns
-        -------
-        list : List of `~astropy.io.fits.HDUList` objects.
-
         Examples
         --------
         Using results from a call to `query_region`:
@@ -871,6 +873,10 @@ class SDSSClass(BaseQuery):
         Fetch only images from run 1904, camcol 3 and field 164:
 
         >>> imgs = SDSS.get_images(run=1904, camcol=3, field=164)
+
+        Returns
+        -------
+        list : List of `~astropy.io.fits.HDUList` objects.
 
         """
         if not matches:
@@ -977,15 +983,16 @@ class SDSSClass(BaseQuery):
         show_progress : bool, optional
             If False, do not display download progress.
 
-        Returns
-        -------
-        list : List of `~astropy.io.fits.HDUList` objects.
-
         Examples
         --------
         >>> qso = SDSS.get_spectral_template(kind='qso')
         >>> Astar = SDSS.get_spectral_template(kind='star_A')
         >>> Fstar = SDSS.get_spectral_template(kind='star_F')
+
+        Returns
+        -------
+        list : List of `~astropy.io.fits.HDUList` objects.
+
         """
 
         if kind == 'all':

--- a/astroquery/sdss/core.py
+++ b/astroquery/sdss/core.py
@@ -142,7 +142,6 @@ class SDSSClass(BaseQuery):
         #     If the `radius` exceeds 3 arcmin, or if the sizes of
         #     `coordinates` and `obj_names` do not match.
 
-
         if isinstance(radius, Angle):
             radius = radius.to_value(u.arcmin)
         else:

--- a/astroquery/sdss/core.py
+++ b/astroquery/sdss/core.py
@@ -140,6 +140,7 @@ class SDSSClass(BaseQuery):
             The result of the query as a `~astropy.table.Table` object.
 
         """
+
         if isinstance(radius, Angle):
             radius = radius.to_value(u.arcmin)
         else:

--- a/astroquery/sdss/core.py
+++ b/astroquery/sdss/core.py
@@ -384,10 +384,10 @@ class SDSSClass(BaseQuery):
                 rectangles.append(self._rectangle_sql(target.ra.degree, target.dec.degree, width, height=height))
 
             rect = ' OR '.join(rectangles)
-            if 'WHERE' in sql_query:
-                sql_query += f' AND ({rect})'
-            else:
-                sql_query += f' WHERE ({rect})'
+
+            # self._args_to_payload only returns a WHERE if e.g. plate, mjd, fiber
+            # are set, which will not happen in this function.
+            sql_query += f' WHERE ({rect})'
 
             return self.query_sql_async(sql_query, timeout=timeout,
                                         data_release=data_release,

--- a/astroquery/sdss/core.py
+++ b/astroquery/sdss/core.py
@@ -209,7 +209,7 @@ class SDSSClass(BaseQuery):
                            data_release=conf.default_release, cache=True):
         """
         Used to query a region around given coordinates. Either ``radius`` or
-        `width` must be specified.
+        ``width`` must be specified.
 
         When called with keyword ``radius``, a radial or "cone" search is
         performed, centered on each of the given coordinates. In this mode, internally,
@@ -252,7 +252,7 @@ class SDSSClass(BaseQuery):
             The string must be parsable by `~astropy.coordinates.Angle`. The
             appropriate `~astropy.units.Quantity` object from
             `astropy.units` may also be used. If not specified, it will be
-            set to the same value as `width`.
+            set to the same value as ``width``.
         timeout : float, optional
             Time limit (in seconds) for establishing successful connection with
             remote server.  Defaults to `SDSSClass.TIMEOUT`.

--- a/astroquery/sdss/core.py
+++ b/astroquery/sdss/core.py
@@ -126,22 +126,20 @@ class SDSSClass(BaseQuery):
         cache : bool, optional
             If ``True`` use the request caching mechanism.
 
+        Raises
+        ------
+        TypeError
+            If the `radius` keyword could not be parsed as an angle.
+        ValueError
+            If the `radius` exceeds 3 arcmin, or if the sizes of
+            `coordinates` and `obj_names` do not match.
+
         Returns
         -------
         result : `~astropy.table.Table`
             The result of the query as a `~astropy.table.Table` object.
 
         """
-        # Move Raises section here, since async_to_sync does not appear to like it.
-        #
-        # Raises
-        # ------
-        # TypeError
-        #     If the `radius` keyword could not be parsed as an angle.
-        # ValueError
-        #     If the `radius` exceeds 3 arcmin, or if the sizes of
-        #     `coordinates` and `obj_names` do not match.
-
         if isinstance(radius, Angle):
             radius = radius.to_value(u.arcmin)
         else:
@@ -1314,6 +1312,8 @@ class SDSSClass(BaseQuery):
         d1 = dec + dd
         if d1 > 90.0:
             d1 = 90.0
+        if d1 < d0:
+            d0, d1 = d1, d0
         ra_wrap = False
         r0 = ra - dr
         if r0 < 0:

--- a/astroquery/sdss/core.py
+++ b/astroquery/sdss/core.py
@@ -373,8 +373,10 @@ class SDSSClass(BaseQuery):
             else:
                 sql_query = sql_query.replace(' ON p.objID = x.objID ORDER BY x.up_id', '')
 
-            if (not isinstance(coordinates, (list, Column, commons.CoordClasses)) and not coordinates.isscalar):
+            if (not isinstance(coordinates, list) and not isinstance(coordinates, Column)
+                    and not (isinstance(coordinates, commons.CoordClasses) and not coordinates.isscalar)):
                 coordinates = [coordinates]
+
             rectangles = list()
             for n, target in enumerate(coordinates):
                 # Query for a rectangle

--- a/astroquery/sdss/core.py
+++ b/astroquery/sdss/core.py
@@ -126,20 +126,22 @@ class SDSSClass(BaseQuery):
         cache : bool, optional
             If ``True`` use the request caching mechanism.
 
-        Raises
-        ------
-        TypeError
-            If the `radius` keyword could not be parsed as an angle.
-        ValueError
-            If the `radius` exceeds 3 arcmin, or if the sizes of
-            `coordinates` and `obj_names` do not match.
-
         Returns
         -------
         result : `~astropy.table.Table`
             The result of the query as a `~astropy.table.Table` object.
 
         """
+        # Move Raises section here, since async_to_sync does not appear to like it.
+        #
+        # Raises
+        # ------
+        # TypeError
+        #     If the `radius` keyword could not be parsed as an angle.
+        # ValueError
+        #     If the `radius` exceeds 3 arcmin, or if the sizes of
+        #     `coordinates` and `obj_names` do not match.
+
 
         if isinstance(radius, Angle):
             radius = radius.to_value(u.arcmin)
@@ -286,15 +288,6 @@ class SDSSClass(BaseQuery):
         cache : bool, optional
             If ``True`` use the request caching mechanism.
 
-        Raises
-        ------
-        TypeError
-            If the `radius`, `width` or `height` keywords could not be parsed as an angle.
-        ValueError
-            If both `radius` and `width are set (or neither),
-            or if the `radius` exceeds 3 arcmin,
-            or if the sizes of `coordinates` and `obj_names` do not match.
-
         Examples
         --------
         >>> from astroquery.sdss import SDSS
@@ -316,6 +309,17 @@ class SDSSClass(BaseQuery):
             The result of the query as a `~astropy.table.Table` object.
 
         """
+        # Move Raises section here, since async_to_sync does not appear to like it.
+        #
+        # Raises
+        # ------
+        # TypeError
+        #     If the `radius`, `width` or `height` keywords could not be parsed as an angle.
+        # ValueError
+        #     If both `radius` and `width are set (or neither),
+        #     or if the `radius` exceeds 3 arcmin,
+        #     or if the sizes of `coordinates` and `obj_names` do not match.
+
         # Allow field_help requests to pass without requiring a radius or width.
         if field_help and radius is None and width is None:
             radius = 2.0 * u.arcsec

--- a/astroquery/sdss/core.py
+++ b/astroquery/sdss/core.py
@@ -221,7 +221,10 @@ class SDSSClass(BaseQuery):
         When called with keyword ``width``, and optionally a different ``height``,
         a rectangular search is performed, centered on each of the given
         coordinates. In this mode, internally, this function is equivalent to
-        a general SQL query (`query_sql`).
+        a general SQL query (`query_sql`). The shape of the rectangle is
+        not corrected for declination (*i.e.* no :math:`\cos \delta` correction);
+        conceptually, this means that the rectangle will become increasingly
+        trapezoidal-shaped at high declination.
 
         In both radial and rectangular modes, this function returns all objects
         within the search area; this could potentially include duplicate observations

--- a/astroquery/sdss/core.py
+++ b/astroquery/sdss/core.py
@@ -209,7 +209,8 @@ class SDSSClass(BaseQuery):
                            fields=None, photoobj_fields=None, specobj_fields=None, obj_names=None,
                            spectro=False, field_help=False, get_query_payload=False,
                            data_release=conf.default_release, cache=True):
-        """Used to query a region around given coordinates. Either `radius` or
+        """
+        Used to query a region around given coordinates. Either `radius` or
         `width` must be specified.
 
         When called with keyword `radius`, a radial or "cone" search is
@@ -1279,7 +1280,8 @@ class SDSSClass(BaseQuery):
         return url
 
     def _rectangle_sql(self, ra, dec, width, height=None, cosdec=False):
-        """Generate SQL for a rectangular query centered on `ra`, `dec`.
+        """
+        Generate SQL for a rectangular query centered on `ra`, `dec`.
 
         This assumes that RA is defined on the range ``[0, 360)``, and Dec on
         ``[-90, 90]``.

--- a/astroquery/sdss/core.py
+++ b/astroquery/sdss/core.py
@@ -208,7 +208,7 @@ class SDSSClass(BaseQuery):
                            fields=None, photoobj_fields=None, specobj_fields=None, obj_names=None,
                            spectro=False, field_help=False, get_query_payload=False,
                            data_release=conf.default_release, cache=True):
-        """
+        r"""
         Used to query a region around given coordinates. Either ``radius`` or
         ``width`` must be specified.
 

--- a/astroquery/sdss/core.py
+++ b/astroquery/sdss/core.py
@@ -314,10 +314,14 @@ class SDSSClass(BaseQuery):
         2.02344596303 14.8398237521 1237652943176138868 1739   301      3   315
         2.02344772021 14.8398201105 1237653651835781243 1904   301      3   163
         """
+        # Allow field_help requests to pass without requiring a radius or width.
+        if field_help and radius is None and width is None:
+            radius = 2.0 * u.arcsec
+
         if radius is None and width is None:
-            raise ValueError("One or the other of radius or width must be selected!")
+            raise ValueError("Either radius or width must be selected!")
         if radius is not None and width is not None:
-            raise ValueError("One or the other of radius or width must be selected!")
+            raise ValueError("Either radius or width must be selected!")
 
         if radius is not None:
             request_payload, files = self.query_crossid_async(coordinates=coordinates,

--- a/astroquery/sdss/core.py
+++ b/astroquery/sdss/core.py
@@ -363,8 +363,7 @@ class SDSSClass(BaseQuery):
             else:
                 sql_query = sql_query.replace(' ON p.objID = x.objID ORDER BY x.up_id', '')
 
-            if (not isinstance(coordinates, (list, Column, commons.CoordClasses))
-                and not coordinates.isscalar):
+            if (not isinstance(coordinates, (list, Column, commons.CoordClasses)) and not coordinates.isscalar):
                 coordinates = [coordinates]
             rectangles = list()
             for n, target in enumerate(coordinates):

--- a/astroquery/sdss/core.py
+++ b/astroquery/sdss/core.py
@@ -363,10 +363,8 @@ class SDSSClass(BaseQuery):
             else:
                 sql_query = sql_query.replace(' ON p.objID = x.objID ORDER BY x.up_id', '')
 
-            if (not isinstance(coordinates, list) and
-                not isinstance(coordinates, Column) and
-                not (isinstance(coordinates, commons.CoordClasses) and
-                     not coordinates.isscalar)):
+            if (not isinstance(coordinates, (list, Column, commons.CoordClasses))
+                and not coordinates.isscalar):
                 coordinates = [coordinates]
             rectangles = list()
             for n, target in enumerate(coordinates):
@@ -375,9 +373,13 @@ class SDSSClass(BaseQuery):
 
                 ra = target.ra.degree
                 dec = target.dec.degree
-                dra = coord.Angle(width).to('degree').value / 2.0
-                ddec = coord.Angle(height).to('degree').value / 2.0
-                rectangles.append('((p.ra BETWEEN {0:g} AND {1:g}) AND (p.dec BETWEEN {2:g} AND {3:g}))'.format(ra - dra, ra + dra, dec - ddec, dec + ddec))
+                dra = Angle(width).to('degree').value / 2.0
+                ddec = Angle(height).to('degree').value / 2.0
+                rectangles.append('((p.ra BETWEEN {0:g} AND {1:g}) '
+                                  'AND (p.dec BETWEEN {2:g} AND {3:g}))'.format(ra - dra,
+                                                                                ra + dra,
+                                                                                dec - ddec,
+                                                                                dec + ddec))
             rect = ' OR '.join(rectangles)
             if 'WHERE' in sql_query:
                 sql_query += f' AND ({rect})'

--- a/astroquery/sdss/core.py
+++ b/astroquery/sdss/core.py
@@ -295,7 +295,8 @@ class SDSSClass(BaseQuery):
         TypeError
             If the `radius`, `width` or `height` keywords could not be parsed as an angle.
         ValueError
-            If both `radius` and `width or set, or if the `radius` exceeds 3 arcmin,
+            If both `radius` and `width are set (or neither),
+            or if the `radius` exceeds 3 arcmin,
             or if the sizes of `coordinates` and `obj_names` do not match.
 
         Examples
@@ -313,6 +314,8 @@ class SDSSClass(BaseQuery):
         2.02344596303 14.8398237521 1237652943176138868 1739   301      3   315
         2.02344772021 14.8398201105 1237653651835781243 1904   301      3   163
         """
+        if radius is None and width is None:
+            ValueError("One or the other of radius or width must be selected!")
         if radius is not None and width is not None:
             raise ValueError("One or the other of radius or width must be selected!")
 

--- a/astroquery/sdss/core.py
+++ b/astroquery/sdss/core.py
@@ -315,7 +315,7 @@ class SDSSClass(BaseQuery):
         2.02344772021 14.8398201105 1237653651835781243 1904   301      3   163
         """
         if radius is None and width is None:
-            ValueError("One or the other of radius or width must be selected!")
+            raise ValueError("One or the other of radius or width must be selected!")
         if radius is not None and width is not None:
             raise ValueError("One or the other of radius or width must be selected!")
 

--- a/astroquery/sdss/tests/test_sdss.py
+++ b/astroquery/sdss/tests/test_sdss.py
@@ -602,3 +602,11 @@ def test_rectangle_sql():
     assert sql == '(((p.ra >= 357.5) OR (p.ra <= 0.5)) AND (p.dec BETWEEN -0.5 AND 0.5))'
     sql = sdss.SDSS._rectangle_sql(5, 0, 1)
     assert sql == '((p.ra BETWEEN 4.5 AND 5.5) AND (p.dec BETWEEN -0.5 AND 0.5))'
+    sql = sdss.SDSS._rectangle_sql(5, 89.75, 1)
+    assert sql == '((p.ra BETWEEN 4.5 AND 5.5) AND (p.dec BETWEEN 89.25 AND 90))'
+    sql = sdss.SDSS._rectangle_sql(5, -89.75, 1)
+    assert sql == '((p.ra BETWEEN 4.5 AND 5.5) AND (p.dec BETWEEN -90 AND -89.25))'
+    sql = sdss.SDSS._rectangle_sql(5, 5, 1, height=2)
+    assert sql == '((p.ra BETWEEN 4.5 AND 5.5) AND (p.dec BETWEEN 4 AND 6))'
+    sql = sdss.SDSS._rectangle_sql(5, -5, 1, height=2)
+    assert sql == '((p.ra BETWEEN 4.5 AND 5.5) AND (p.dec BETWEEN -6 AND -4))'

--- a/astroquery/sdss/tests/test_sdss.py
+++ b/astroquery/sdss/tests/test_sdss.py
@@ -316,7 +316,7 @@ def test_list_coordinates_with_height(patch_request, width, height):
                 warnings.filterwarnings("ignore", category=AstropyWarning,
                                         message=r'OverflowError converting.*')
             data = Table.read(data_path(DATA_FILES['images_id']),
-                                format='ascii.csv', comment='#')
+                              format='ascii.csv', comment='#')
 
             data['objid'] = data['objid'].astype(np.int64)
 

--- a/astroquery/sdss/tests/test_sdss.py
+++ b/astroquery/sdss/tests/test_sdss.py
@@ -428,6 +428,60 @@ def test_list_coordinates_region_payload(patch_request, dr):
     assert query_payload['uquery'] == expect
     assert query_payload['format'] == 'csv'
     assert query_payload['photoScope'] == 'allObj'
+    if dr > 11:
+        assert query_payload['searchtool'] == 'CrossID'
+
+
+@pytest.mark.parametrize("dr", dr_list)
+def test_list_coordinates_region_payload_rectangle(patch_request, dr):
+    expect = (" SELECT\r "
+              "p.ra, p.dec, p.objid, p.run, p.rerun, p.camcol, p.field "
+              "FROM PhotoObjAll AS p "
+              "WHERE (((p.ra BETWEEN 2.02319 AND 2.02374) AND (p.dec BETWEEN 14.8395 AND 14.8401)) "
+              "OR ((p.ra BETWEEN 2.02319 AND 2.02374) AND (p.dec BETWEEN 14.8395 AND 14.8401)))")
+    query_payload = sdss.SDSS.query_region(coords_list, width=Angle('2 arcsec'),
+                                           get_query_payload=True,
+                                           data_release=dr)
+    assert query_payload['cmd'] == expect
+    assert query_payload['format'] == 'csv'
+    if dr > 11:
+        assert query_payload['searchtool'] == 'SQL'
+
+
+@pytest.mark.parametrize("dr", dr_list)
+def test_list_coordinates_region_spectro_payload_rectangle(patch_request, dr):
+    expect = (" SELECT\r "
+              "p.ra, p.dec, p.objid, p.run, p.rerun, p.camcol, p.field, "
+              "s.z, s.plate, s.mjd, s.fiberID, s.specobjid, s.run2d "
+              "FROM PhotoObjAll AS p "
+              "JOIN SpecObjAll AS s ON p.objID = s.bestObjID "
+              "WHERE (((p.ra BETWEEN 2.02319 AND 2.02374) AND (p.dec BETWEEN 14.8395 AND 14.8401)) "
+              "OR ((p.ra BETWEEN 2.02319 AND 2.02374) AND (p.dec BETWEEN 14.8395 AND 14.8401)))")
+    query_payload = sdss.SDSS.query_region(coords_list, width=Angle('2 arcsec'),
+                                           spectro=True,
+                                           get_query_payload=True,
+                                           data_release=dr)
+    assert query_payload['cmd'] == expect
+    assert query_payload['format'] == 'csv'
+    if dr > 11:
+        assert query_payload['searchtool'] == 'SQL'
+
+
+@pytest.mark.parametrize("dr", dr_list)
+def test_coordinate_region_payload_rectangle(patch_request, dr):
+    expect = (" SELECT\r "
+              "p.ra, p.dec, p.objid, p.run, p.rerun, p.camcol, p.field "
+              "FROM PhotoObjAll AS p "
+              "WHERE ((((p.ra >= 359.999) OR (p.ra <= 0.00152171)) AND (p.dec BETWEEN 14.8356 AND 14.844)))")
+    query_payload = sdss.SDSS.query_region(SkyCoord("0h0m00.03s +14d50m23.3s", frame="icrs"),
+                                           width=Angle('10 arcsec'),
+                                           height=Angle('30 arcsec'),
+                                           get_query_payload=True,
+                                           data_release=dr)
+    assert query_payload['cmd'] == expect
+    assert query_payload['format'] == 'csv'
+    if dr > 11:
+        assert query_payload['searchtool'] == 'SQL'
 
 
 @pytest.mark.parametrize("dr", dr_list)

--- a/astroquery/sdss/tests/test_sdss.py
+++ b/astroquery/sdss/tests/test_sdss.py
@@ -598,4 +598,7 @@ def test_field_help_region(patch_request):
 def test_rectangle_sql():
     sql = sdss.SDSS._rectangle_sql(0, 0, 1)
     assert sql == '(((p.ra >= 359.5) OR (p.ra <= 0.5)) AND (p.dec BETWEEN -0.5 AND 0.5))'
-    # assert sql == '((p.ra BETWEEN -0.5 AND 0.5) AND (p.dec BETWEEN -0.5 AND 0.5))
+    sql = sdss.SDSS._rectangle_sql(359, 0, 3, height=1)
+    assert sql == '(((p.ra >= 357.5) OR (p.ra <= 0.5)) AND (p.dec BETWEEN -0.5 AND 0.5))'
+    sql = sdss.SDSS._rectangle_sql(5, 0, 1)
+    assert sql == '((p.ra BETWEEN 4.5 AND 5.5) AND (p.dec BETWEEN -0.5 AND 0.5))'

--- a/astroquery/sdss/tests/test_sdss.py
+++ b/astroquery/sdss/tests/test_sdss.py
@@ -593,3 +593,9 @@ def test_field_help_region(patch_request):
 
     assert len(non_existing_field) == 2
     assert set(non_existing_field.keys()) == set(('photoobj_all', 'specobj_all'))
+
+
+def test_rectangle_sql():
+    sql = sdss.SDSS._rectangle_sql(0, 0, 1)
+    assert sql == '(((p.ra >= 359.5) OR (p.ra <= 0.5)) AND (p.dec BETWEEN -0.5 AND 0.5))
+    # assert sql == '((p.ra BETWEEN -0.5 AND 0.5) AND (p.dec BETWEEN -0.5 AND 0.5))

--- a/astroquery/sdss/tests/test_sdss.py
+++ b/astroquery/sdss/tests/test_sdss.py
@@ -597,5 +597,5 @@ def test_field_help_region(patch_request):
 
 def test_rectangle_sql():
     sql = sdss.SDSS._rectangle_sql(0, 0, 1)
-    assert sql == '(((p.ra >= 359.5) OR (p.ra <= 0.5)) AND (p.dec BETWEEN -0.5 AND 0.5))
+    assert sql == '(((p.ra >= 359.5) OR (p.ra <= 0.5)) AND (p.dec BETWEEN -0.5 AND 0.5))'
     # assert sql == '((p.ra BETWEEN -0.5 AND 0.5) AND (p.dec BETWEEN -0.5 AND 0.5))

--- a/astroquery/sdss/tests/test_sdss.py
+++ b/astroquery/sdss/tests/test_sdss.py
@@ -270,6 +270,7 @@ def test_sdss_photoobj(patch_request, dr):
         compare_xid_data(xid, data)
         url_tester(dr)
 
+
 @pytest.mark.parametrize("dr", dr_list)
 @pytest.mark.parametrize("radius", [None, Angle('2 arcsec')])
 @pytest.mark.parametrize("width", [None, Angle('2 arcsec')])
@@ -286,7 +287,7 @@ def test_list_coordinates(patch_request, dr, radius, width):
                 warnings.filterwarnings("ignore", category=AstropyWarning,
                                         message=r'OverflowError converting.*')
             data = Table.read(data_path(DATA_FILES['images_id']),
-                            format='ascii.csv', comment='#')
+                              format='ascii.csv', comment='#')
 
             data['objid'] = data['objid'].astype(np.int64)
 

--- a/astroquery/sdss/tests/test_sdss.py
+++ b/astroquery/sdss/tests/test_sdss.py
@@ -164,7 +164,7 @@ def image_tester(images, filetype):
 @pytest.mark.parametrize("dr", dr_list)
 def test_sdss_spectrum(patch_request, patch_get_readable_fileobj, dr,
                        coords=coords):
-    xid = sdss.SDSS.query_region(coords, data_release=dr, spectro=True)
+    xid = sdss.SDSS.query_region(coords, radius=Angle('2 arcsec'), data_release=dr, spectro=True)
     url_tester_crossid(dr)
     sp = sdss.SDSS.get_spectra(matches=xid, data_release=dr)
     image_tester(sp, 'spectra')
@@ -213,7 +213,7 @@ def test_sdss_sql(patch_request, patch_get_readable_fileobj, dr):
 @pytest.mark.parametrize("dr", dr_list)
 def test_sdss_image_from_query_region(patch_request, patch_get_readable_fileobj,
                                       dr, coords=coords):
-    xid = sdss.SDSS.query_region(coords, data_release=dr)
+    xid = sdss.SDSS.query_region(coords, radius=Angle('2 arcsec'), data_release=dr)
     url_tester_crossid(dr)
     # TODO test what img is
     img = sdss.SDSS.get_images(matches=xid)
@@ -273,7 +273,7 @@ def test_sdss_photoobj(patch_request, dr):
 
 @pytest.mark.parametrize("dr", dr_list)
 def test_list_coordinates(patch_request, dr):
-    xid = sdss.SDSS.query_region(coords_list, data_release=dr)
+    xid = sdss.SDSS.query_region(coords_list, radius=Angle('2 arcsec'), data_release=dr)
 
     with warnings.catch_warnings():
         if sys.platform.startswith('win'):
@@ -290,7 +290,7 @@ def test_list_coordinates(patch_request, dr):
 
 @pytest.mark.parametrize("dr", dr_list)
 def test_column_coordinates(patch_request, dr):
-    xid = sdss.SDSS.query_region(coords_column, data_release=dr)
+    xid = sdss.SDSS.query_region(coords_column, radius=Angle('2 arcsec'), data_release=dr)
 
     with warnings.catch_warnings():
         if sys.platform.startswith('win'):
@@ -307,7 +307,7 @@ def test_column_coordinates(patch_request, dr):
 
 def test_query_timeout(patch_request_slow, coord=coords):
     with pytest.raises(TimeoutError):
-        sdss.SDSS.query_region(coords, timeout=1)
+        sdss.SDSS.query_region(coords, radius=Angle('2 arcsec'), timeout=1)
 
 
 def test_spectra_timeout(patch_request, patch_get_readable_fileobj_slow):
@@ -387,7 +387,7 @@ def test_list_coordinates_region_payload(patch_request, dr):
               "p.ra, p.dec, p.objid, p.run, p.rerun, p.camcol, p.field "
               "FROM #upload u JOIN #x x ON x.up_id = u.up_id JOIN PhotoObjAll AS p ON p.objID = x.objID "
               "ORDER BY x.up_id")
-    query_payload = sdss.SDSS.query_region(coords_list, radius=Angle('3 arcsec'),
+    query_payload = sdss.SDSS.query_region(coords_list, radius=Angle('2 arcsec'),
                                            get_query_payload=True,
                                            data_release=dr)
     assert query_payload['uquery'] == expect
@@ -401,7 +401,7 @@ def test_column_coordinates_region_payload(patch_request, dr):
               "p.ra, p.dec, p.objid, p.run, p.rerun, p.camcol, p.field "
               "FROM #upload u JOIN #x x ON x.up_id = u.up_id JOIN PhotoObjAll AS p ON p.objID = x.objID "
               "ORDER BY x.up_id")
-    query_payload = sdss.SDSS.query_region(coords_column, radius=Angle('3 arcsec'),
+    query_payload = sdss.SDSS.query_region(coords_column, radius=Angle('2 arcsec'),
                                            get_query_payload=True,
                                            data_release=dr)
     assert query_payload['uquery'] == expect
@@ -417,7 +417,7 @@ def test_column_coordinates_region_spectro_payload(patch_request, dr):
               "FROM #upload u JOIN #x x ON x.up_id = u.up_id JOIN PhotoObjAll AS p ON p.objID = x.objID "
               "JOIN SpecObjAll AS s ON p.objID = s.bestObjID "
               "ORDER BY x.up_id")
-    query_payload = sdss.SDSS.query_region(coords_column, radius=Angle('3 arcsec'),
+    query_payload = sdss.SDSS.query_region(coords_column, radius=Angle('2 arcsec'),
                                            spectro=True,
                                            get_query_payload=True,
                                            data_release=dr)
@@ -432,7 +432,7 @@ def test_column_coordinates_region_payload_custom_fields(patch_request, dr):
               "p.r, p.psfMag_r "
               "FROM #upload u JOIN #x x ON x.up_id = u.up_id JOIN PhotoObjAll AS p ON p.objID = x.objID "
               "ORDER BY x.up_id")
-    query_payload = sdss.SDSS.query_region(coords_column, radius=Angle('3 arcsec'),
+    query_payload = sdss.SDSS.query_region(coords_column, radius=Angle('2 arcsec'),
                                            get_query_payload=True,
                                            fields=['r', 'psfMag_r'],
                                            data_release=dr)
@@ -579,10 +579,10 @@ def test_field_help_region(patch_request):
     assert isinstance(valid_field, dict)
     assert 'photoobj_all' in valid_field
 
-    existing_p_field = sdss.SDSS.query_region(coords,
+    existing_p_field = sdss.SDSS.query_region(coords, radius=Angle('2 arcsec'),
                                               field_help='psfMag_r')
 
-    existing_s_field = sdss.SDSS.query_region(coords,
+    existing_s_field = sdss.SDSS.query_region(coords, radius=Angle('2 arcsec'),
                                               field_help='spectroSynFlux_r')
 
     with pytest.warns(UserWarning, match="nonexist isn't a valid 'photobj_field' or 'specobj_field'"):

--- a/astroquery/sdss/tests/test_sdss.py
+++ b/astroquery/sdss/tests/test_sdss.py
@@ -387,7 +387,7 @@ def test_list_coordinates_region_payload(patch_request, dr):
               "p.ra, p.dec, p.objid, p.run, p.rerun, p.camcol, p.field "
               "FROM #upload u JOIN #x x ON x.up_id = u.up_id JOIN PhotoObjAll AS p ON p.objID = x.objID "
               "ORDER BY x.up_id")
-    query_payload = sdss.SDSS.query_region(coords_list,
+    query_payload = sdss.SDSS.query_region(coords_list, radius=Angle('3 arcsec'),
                                            get_query_payload=True,
                                            data_release=dr)
     assert query_payload['uquery'] == expect
@@ -401,7 +401,7 @@ def test_column_coordinates_region_payload(patch_request, dr):
               "p.ra, p.dec, p.objid, p.run, p.rerun, p.camcol, p.field "
               "FROM #upload u JOIN #x x ON x.up_id = u.up_id JOIN PhotoObjAll AS p ON p.objID = x.objID "
               "ORDER BY x.up_id")
-    query_payload = sdss.SDSS.query_region(coords_column,
+    query_payload = sdss.SDSS.query_region(coords_column, radius=Angle('3 arcsec'),
                                            get_query_payload=True,
                                            data_release=dr)
     assert query_payload['uquery'] == expect
@@ -417,7 +417,8 @@ def test_column_coordinates_region_spectro_payload(patch_request, dr):
               "FROM #upload u JOIN #x x ON x.up_id = u.up_id JOIN PhotoObjAll AS p ON p.objID = x.objID "
               "JOIN SpecObjAll AS s ON p.objID = s.bestObjID "
               "ORDER BY x.up_id")
-    query_payload = sdss.SDSS.query_region(coords_column, spectro=True,
+    query_payload = sdss.SDSS.query_region(coords_column, radius=Angle('3 arcsec'),
+                                           spectro=True,
                                            get_query_payload=True,
                                            data_release=dr)
     assert query_payload['uquery'] == expect
@@ -431,7 +432,7 @@ def test_column_coordinates_region_payload_custom_fields(patch_request, dr):
               "p.r, p.psfMag_r "
               "FROM #upload u JOIN #x x ON x.up_id = u.up_id JOIN PhotoObjAll AS p ON p.objID = x.objID "
               "ORDER BY x.up_id")
-    query_payload = sdss.SDSS.query_region(coords_column,
+    query_payload = sdss.SDSS.query_region(coords_column, radius=Angle('3 arcsec'),
                                            get_query_payload=True,
                                            fields=['r', 'psfMag_r'],
                                            data_release=dr)

--- a/astroquery/sdss/tests/test_sdss_remote.py
+++ b/astroquery/sdss/tests/test_sdss_remote.py
@@ -3,6 +3,7 @@ import numpy as np
 from numpy.testing import assert_allclose
 import pytest
 
+import astropy.units as u
 from astropy.coordinates import SkyCoord
 from astropy.table import Table
 from astropy.utils.exceptions import AstropyUserWarning
@@ -36,7 +37,7 @@ class TestSDSSRemote:
         This test *must* be run before `test_sdss_image` because that query
         caches!
         """
-        xid = sdss.SDSS.query_region(self.coords)
+        xid = sdss.SDSS.query_region(self.coords, width=2.0 * u.arcsec)
         assert len(xid) == 18
         try:
             with pytest.raises(TimeoutError):
@@ -51,9 +52,9 @@ class TestSDSSRemote:
     def test_sdss_spectrum(self, dr):
         if dr in dr_warn_list:
             with pytest.warns(AstropyUserWarning, match='Field info are not available for this data release'):
-                xid = sdss.SDSS.query_region(self.coords, spectro=True, data_release=dr)
+                xid = sdss.SDSS.query_region(self.coords, width=2.0 * u.arcsec, spectro=True, data_release=dr)
         else:
-            xid = sdss.SDSS.query_region(self.coords, spectro=True, data_release=dr)
+            xid = sdss.SDSS.query_region(self.coords, width=2.0 * u.arcsec, spectro=True, data_release=dr)
 
         assert isinstance(xid, Table)
         sdss.SDSS.get_spectra(matches=xid, data_release=dr)
@@ -85,7 +86,7 @@ class TestSDSSRemote:
         assert isinstance(xid, Table)
 
     def test_sdss_image(self):
-        xid = sdss.SDSS.query_region(self.coords)
+        xid = sdss.SDSS.query_region(self.coords, width=2.0 * u.arcsec)
         assert isinstance(xid, Table)
         sdss.SDSS.get_images(matches=xid)
 
@@ -170,14 +171,14 @@ class TestSDSSRemote:
 
     def test_query_non_default_field(self):
         # A regression test for #469
-        query1 = sdss.SDSS.query_region(self.coords, fields=['r', 'psfMag_r'])
+        query1 = sdss.SDSS.query_region(self.coords, width=2.0 * u.arcsec, fields=['r', 'psfMag_r'])
 
-        query2 = sdss.SDSS.query_region(self.coords, fields=['ra', 'dec', 'r'])
+        query2 = sdss.SDSS.query_region(self.coords, width=2.0 * u.arcsec, fields=['ra', 'dec', 'r'])
         assert isinstance(query1, Table)
         assert isinstance(query2, Table)
 
-        assert query1.colnames == ['objID', 'r', 'psfMag_r']
-        assert query2.colnames == ['objID', 'ra', 'dec', 'r']
+        assert query1.colnames == ['r', 'psfMag_r']
+        assert query2.colnames == ['ra', 'dec', 'r']
 
     @pytest.mark.parametrize("dr", dr_list)
     def test_query_crossid(self, dr):

--- a/docs/sdss/sdss.rst
+++ b/docs/sdss/sdss.rst
@@ -20,7 +20,7 @@ Getting started
 This example shows how to perform an individual object cross-ID with SDSS.
 We'll start with the position of a source found in another survey, and search
 within a 5 arcsecond radius (a "cone search") for optical counterparts in SDSS.
-Note use of the keyword argument spectro, which requires matches to have
+Note use of the keyword argument ``spectro``, which requires matches to have
 spectroscopy, not just photometry:
 
 .. doctest-remote-data::
@@ -61,7 +61,7 @@ that does *not* correct for the geometry at high declination, also known as
 the :math:`\cos \delta` correction.  At high declination, these rectangles
 would appear much more like trapezoids. However, this is the more intuitive
 interpretation of "this range of RA, that range of Dec" that many people use.
-Finally though, the constructed rectangles *do* account for RA wrap-around,
+Finally, though, the constructed rectangles *do* account for RA wrap-around,
 so an appropriate region of the celestial sphere is searched, even if the
 central coordinate is very close to RA = 0.
 

--- a/docs/sdss/sdss.rst
+++ b/docs/sdss/sdss.rst
@@ -28,7 +28,7 @@ photometry:
     >>> from astroquery.sdss import SDSS
     >>> from astropy import coordinates as coords
     >>> pos = coords.SkyCoord('0h8m05.63s +14d50m23.3s', frame='icrs')
-    >>> xid = SDSS.query_region(pos, spectro=True)
+    >>> xid = SDSS.query_region(pos, radius='5 arcsec', spectro=True)
     >>> print(xid)
            ra              dec        ...     specobjid      run2d
     ---------------- ---------------- ... ------------------ -----

--- a/docs/sdss/sdss.rst
+++ b/docs/sdss/sdss.rst
@@ -17,11 +17,11 @@ images, are also included in DR17.  Users may select alternate DR's.
 Getting started
 ===============
 
-This example shows how to perform an object cross-ID with SDSS. We'll start
-with the position of a source found in another survey, and search within a 5
-arcsecond radius for optical counterparts in SDSS. Note use of the keyword
-argument spectro, which requires matches to have spectroscopy, not just
-photometry:
+This example shows how to perform an individual object cross-ID with SDSS.
+We'll start with the position of a source found in another survey, and search
+within a 5 arcsecond radius (a "cone search") for optical counterparts in SDSS.
+Note use of the keyword argument spectro, which requires matches to have
+spectroscopy, not just photometry:
 
 .. doctest-remote-data::
 
@@ -35,6 +35,38 @@ photometry:
     2.02344596573482 14.8398237551311 ... 845594848269461504    26
 
 The result is an astropy.Table.
+
+Searching regions and multiple objects
+======================================
+
+You can use `~astroquery.sdss.SDSSClass.query_region` to search multiple
+locations; the input coordinates can be a single `astropy.coordinates` object
+or a `list` or `~astropy.table.Column` of coordinates.
+However, it is important to specify exactly what kind of search is
+desired.  When `~astroquery.sdss.SDSSClass.query_region` is invoked with the
+``radius`` keyword, a circle around each point is searched. This is also
+called a "cone search".  When invoked in this mode,
+`~astroquery.sdss.SDSSClass.query_region` is equivalent to
+`~astroquery.sdss.SDSSClass.query_crossid`. Because of this equivalence, there
+is a strict limit of 3 arcmin on the value of ``radius`` which is imposed
+by the SDSS servers.
+
+`~astroquery.sdss.SDSSClass.query_region` can also be used to search a
+rectangular region centered on a coordinate or each coordinate in a list.
+This mode is invoked with the ``width`` keyword, which is the width in
+right ascension. Optionally, the ``height`` keyword can be used to specify
+a different range of declination.  With these parameters,
+`~astroquery.sdss.SDSSClass.query_region` constructs a rectangle in RA, dec
+that does *not* correct for the geometry at high declination, also known as
+the :math:`\cos \delta` correction.  At high declination, these rectangles
+would appear much more like trapezoids. However, this is the more intuitive
+interpretation of "this range of RA, that range of Dec" that many people use.
+Finally though, the constructed rectangles *do* account for RA wrap-around,
+so an appropriate region of the celestial sphere is searched, even if the
+central coordinate is very close to RA = 0.
+
+Finally note that either ``radius`` or ``width`` must be specified.
+Specifying neither or both will raise an exception.
 
 Downloading data
 ================


### PR DESCRIPTION
This PR closes #2659. Rectangle searches are passed as a SQL query to `query_sql()`.

- [X] Fix any existing broken tests.
- [x] Enable tests with rectangular search.
- [x] Test calling `query_region()` with either `radius` or `width`; not neither, not both.
- [x] Decide what defaults should be: *e.g.* what *should* happen if neither `radius` nor `width` are specified?
- [x] Decide on a definition of "rectangle": `cos(dec)` or not.
- [x] Verify that documentation is clear.
- [x] Change log, etc.

Other notes:

* I rearranged some of the documentation sections, even in functions unrelated to this change, because they did not strictly follow numpydoc standards.
* But it turns out that breaks `async_to_sync`, so I'll undo that for the purposes of this PR.
