### PR TITLE
Remove `astroquery.utils.commons.radius_to_unit()`

### DIFF
--- a/astroquery/cadc/core.py
+++ b/astroquery/cadc/core.py
@@ -20,6 +20,7 @@ from ..utils import async_to_sync, commons
 from ..query import BaseQuery
 from bs4 import BeautifulSoup
 from astropy import units as u
+from astropy.coordinates import Angle
 import pyvo
 from pyvo.auth import authsession
 
@@ -432,7 +433,7 @@ class CadcClass(BaseQuery):
             raise AttributeError('Missing query_result argument')
 
         parsed_coordinates = commons.parse_coordinates(coordinates).fk5
-        radius_deg = commons.radius_to_unit(radius, unit='degree')
+        radius_deg = Angle(radius).to_value(u.deg)
         ra = parsed_coordinates.ra.degree
         dec = parsed_coordinates.dec.degree
         cutout_params = {'POS': 'CIRCLE {} {} {}'.format(ra, dec, radius_deg)}
@@ -708,7 +709,7 @@ class CadcClass(BaseQuery):
         # and force the coordinates to FK5 (assuming FK5/ICRS are
         # interchangeable) since RA/Dec are used below
         coordinates = commons.parse_coordinates(kwargs['coordinates']).fk5
-        radius_deg = commons.radius_to_unit(kwargs['radius'], unit='degree')
+        radius_deg = Angle(kwargs["radius"]).to_value(u.deg)
         payload = {format: 'VOTable'}
         payload['query'] = \
             "SELECT * from caom2.Observation o join caom2.Plane p " \

--- a/astroquery/esa/jwst/core.py
+++ b/astroquery/esa/jwst/core.py
@@ -20,7 +20,7 @@ from urllib.parse import urlencode
 
 from astropy import log
 from astropy import units
-from astropy.coordinates import SkyCoord
+from astropy.coordinates import Angle, SkyCoord
 from astropy.table import vstack
 from astropy.units import Quantity
 from requests.exceptions import ConnectionError
@@ -438,7 +438,7 @@ class JwstClass(BaseQuery):
 
         if radius is not None:
             radius_quantity = self.__get_quantity_input(value=radius, msg="radius")
-            radius_deg = commons.radius_to_unit(radius_quantity, unit='deg')
+            radius_deg = Angle(radius_quantity).to_value(units.deg)
 
         query = (f"SELECT DISTANCE(POINT('ICRS',"
                  f"{str(conf.JWST_MAIN_TABLE_RA)},"

--- a/astroquery/esasky/core.py
+++ b/astroquery/esasky/core.py
@@ -10,11 +10,11 @@ from io import BytesIO
 from zipfile import ZipFile
 from pathlib import Path
 
+from astropy import units as u
 from astropy.coordinates import Angle
 from astropy.io import fits
 from astropy.utils.console import ProgressBar
 from astroquery import log
-import astropy.units
 from requests import HTTPError
 from requests import ConnectionError
 
@@ -51,7 +51,7 @@ class ESASkyClass(BaseQuery):
     __ACCESS_URL_STRING = "access_url"
     __USE_INTERSECT_STRING = "useIntersectPolygonInsteadOfContainsPoint"
     __ZERO_ARCMIN_STRING = "0 arcmin"
-    __MIN_RADIUS_CATALOG_DEG = Angle(5*astropy.units.arcsec).to_value(astropy.units.deg)
+    __MIN_RADIUS_CATALOG_DEG = Angle(5 * u.arcsec).to_value(u.deg)
 
     __HERSCHEL_STRING = 'herschel'
     __HST_STRING = 'hst'
@@ -114,7 +114,7 @@ class ESASkyClass(BaseQuery):
         if not verbose:
             with warnings.catch_warnings():
                 commons.suppress_vo_warnings()
-                warnings.filterwarnings("ignore", category=astropy.units.core.UnitsWarning)
+                warnings.filterwarnings("ignore", category=u.UnitsWarning)
                 job = self._tap.launch_job(query=query, output_file=output_file, output_format=output_format,
                                            verbose=False, dump_to_file=output_file is not None)
         else:
@@ -1347,8 +1347,7 @@ class ESASkyClass(BaseQuery):
         return spectra
 
     def _sanitize_input_radius(self, radius):
-        if (isinstance(radius, str) or isinstance(radius,
-                                                  astropy.units.Quantity)):
+        if isinstance(radius, (str, u.Quantity)):
             return radius
         else:
             raise ValueError("Radius must be either a string or "
@@ -1554,7 +1553,7 @@ class ESASkyClass(BaseQuery):
         if verbose:
             return fits.open(path)
         with warnings.catch_warnings():
-            warnings.filterwarnings("ignore", category=astropy.io.fits.verify.VerifyWarning)
+            warnings.filterwarnings("ignore", category=fits.verify.VerifyWarning)
             return fits.open(path)
 
     def _ends_with_fits_like_extentsion(self, name):
@@ -1709,7 +1708,7 @@ class ESASkyClass(BaseQuery):
     def _build_region_query(self, coordinates, radius, row_limit, json):
         ra = coordinates.transform_to('icrs').ra.deg
         dec = coordinates.transform_to('icrs').dec.deg
-        radius_deg = Angle(radius).to_value(astropy.units.deg)
+        radius_deg = Angle(radius).to_value(u.deg)
 
         select_query = "SELECT "
         if row_limit > 0:

--- a/astroquery/gaia/core.py
+++ b/astroquery/gaia/core.py
@@ -20,6 +20,7 @@ import shutil
 from collections.abc import Iterable
 
 from astropy import units
+from astropy.coordinates import Angle
 from astropy.units import Quantity
 from astropy.io import votable
 from astropy.io import fits
@@ -544,8 +545,7 @@ class GaiaClass(TapPlus):
         raHours, dec = commons.coord_to_radec(coord)
         ra = raHours * 15.0  # Converts to degrees
         if radius is not None:
-            radiusQuantity = self.__getQuantityInput(radius, "radius")
-            radiusDeg = commons.radius_to_unit(radiusQuantity, unit='deg')
+            radiusDeg = Angle(self.__getQuantityInput(radius, "radius")).to_value(u.deg)
 
         if columns:
             columns = ','.join(map(str, columns))

--- a/astroquery/utils/commons.py
+++ b/astroquery/utils/commons.py
@@ -17,7 +17,7 @@ from astropy.utils import minversion
 import astropy.utils.data as aud
 from astropy.io import fits, votable
 
-from astropy.coordinates import Angle, BaseCoordinateFrame, SkyCoord
+from astropy.coordinates import BaseCoordinateFrame, SkyCoord
 
 from ..exceptions import TimeoutError, InputWarning
 
@@ -37,30 +37,6 @@ ASTROPY_LT_4_3 = not minversion('astropy', '4.3')
 ASTROPY_LT_5_0 = not minversion('astropy', '5.0')
 
 ASTROPY_LT_5_1 = not minversion('astropy', '5.1')
-
-
-def radius_to_unit(radius, unit='degree'):
-    """
-    Helper function: Parse a radius, then return its value in degrees
-
-    Parameters
-    ----------
-    radius : str or `~astropy.units.Quantity`
-        The radius of a region
-
-    Returns
-    -------
-    Floating point scalar value of radius in degrees
-    """
-    rad = Angle(radius)
-
-    if isinstance(unit, str):
-        if hasattr(rad, unit):
-            return getattr(rad, unit)
-        elif hasattr(rad, f"{unit}s"):
-            return getattr(rad, f"{unit}s")
-
-    return rad.to(unit).value
 
 
 def parse_coordinates(coordinates):

--- a/astroquery/utils/tests/test_utils.py
+++ b/astroquery/utils/tests/test_utils.py
@@ -438,11 +438,3 @@ def test_filecontainer_get(patch_getreadablefileobj):
 def test_is_coordinate(coordinates, expected):
     out = commons._is_coordinate(coordinates)
     assert out == expected
-
-
-@pytest.mark.parametrize(('radius'),
-                         [0.01*u.deg, '0.01 deg', 0.01*u.arcmin]
-                         )
-def test_radius_to_unit(radius):
-    c = commons.radius_to_unit(radius)
-    assert c is not None

--- a/astroquery/vo_conesearch/core.py
+++ b/astroquery/vo_conesearch/core.py
@@ -6,7 +6,7 @@ from io import BytesIO
 from numbers import Number
 
 from astropy import units as u
-from astropy.coordinates import (BaseCoordinateFrame, ICRS, SkyCoord,
+from astropy.coordinates import (Angle, BaseCoordinateFrame, ICRS, SkyCoord,
                                  Longitude, Latitude)
 from astropy.io.votable import table
 
@@ -227,12 +227,7 @@ def _validate_coord(coordinates):
 
 def _validate_sr(radius):
     """Validate search radius and return value in deg."""
-    if isinstance(radius, Number):
-        sr = radius
-    else:
-        sr = commons.radius_to_unit(radius)
-
-    return sr
+    return radius if isinstance(radius, Number) else Angle(radius).to_value(u.deg)
 
 
 def _validate_verb(verb):


### PR DESCRIPTION
`radius_to_unit(radius, unit)` is equivalent to `astropy.coordinates.Angle(radius).to_value(unit)` except that if `unit` is not specified then it defaults to degrees. The convenience of not having to specify degrees is not worth obscuring the simple `Angle.to_value()` call, so this pull request removes the function.

Contributes towards #2429