### PR TITLE
Fixing code coverage

### DIFF
--- a/astroquery/mast/tests/test_mast.py
+++ b/astroquery/mast/tests/test_mast.py
@@ -705,6 +705,15 @@ def test_tesscut_get_sector(patch_post):
         mast.Tesscut.get_sectors(objectname='Ceres', moving_target=True, coordinates=coord)
     assert error_str in str(invalid_query.value)
 
+    # Testing invalid queries
+    with pytest.raises(InvalidQueryError) as invalid_query:
+        mast.Tesscut.get_sectors(objectname="M101", product="spooc")
+    assert "Input product must either be SPOC or TICA." in str(invalid_query.value)
+
+    with pytest.raises(InvalidQueryError) as invalid_query:
+        mast.Tesscut.get_sectors(objectname="M101", product="TICA", moving_target=True)
+    assert "Only SPOC is available for moving targets queries." in str(invalid_query.value)
+
 
 def test_tesscut_download_cutouts(patch_post, tmpdir):
 
@@ -754,6 +763,15 @@ def test_tesscut_download_cutouts(patch_post, tmpdir):
                                       path=str(tmpdir))
     assert error_str in str(invalid_query.value)
 
+    # Testing invalid queries
+    with pytest.raises(InvalidQueryError) as invalid_query:
+        mast.Tesscut.download_cutouts(objectname="M101", product="spooc")
+    assert "Input product must either be SPOC or TICA." in str(invalid_query.value)
+
+    with pytest.raises(InvalidQueryError) as invalid_query:
+        mast.Tesscut.download_cutouts(objectname="M101", product="TICA", moving_target=True)
+    assert "Only SPOC is available for moving targets queries." in str(invalid_query.value)
+
 
 def test_tesscut_get_cutouts(patch_post, tmpdir):
 
@@ -787,6 +805,15 @@ def test_tesscut_get_cutouts(patch_post, tmpdir):
                                  coordinates=coord,
                                  size=5)
     assert error_str in str(invalid_query.value)
+
+    # Testing invalid queries
+    with pytest.raises(InvalidQueryError) as invalid_query:
+        mast.Tesscut.get_cutouts(objectname="M101", product="spooc")
+    assert "Input product must either be SPOC or TICA." in str(invalid_query.value)
+
+    with pytest.raises(InvalidQueryError) as invalid_query:
+        mast.Tesscut.get_cutouts(objectname="M101", product="TICA", moving_target=True)
+    assert "Only SPOC is available for moving targets queries." in str(invalid_query.value)
 
 
 ######################


### PR DESCRIPTION
I acccidentall dropped the code coverage below allowed levels for the repo when I merged https://github.com/astropy/astroquery/pull/2668 (mixed up patch vs project failure).

This PR adds tests for the `InvalidQueryError` exceptions in that PR and bumps the coverage back up to acceptable levels.