### PR TITLE
Updated pip command for repository install

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -86,7 +86,7 @@ or cloned and installed from source:
     $ # If you do not:
     $ git clone https://github.com/astropy/astroquery.git
     $ cd astroquery
-    $ python setup.py install
+    $ pip install .
 
 Using astroquery
 ----------------

--- a/README.rst
+++ b/README.rst
@@ -75,7 +75,7 @@ To install the 'bleeding edge' version:
 
 .. code-block:: bash
 
-   $ pip install https://github.com/astropy/astroquery/archive/main.zip
+   $ pip install git+https://github.com/astropy/astroquery.git
 
 or cloned and installed from source:
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -74,7 +74,22 @@ The development version can be obtained and installed from github:
     $ # If you do not:
     $ git clone https://github.com/astropy/astroquery.git
     $ cd astroquery
-    $ python setup.py install
+    $ pip install .
+
+
+To install all the optional dependencies (listed below), add the option
+``[all]``. To install dependencies required for running the tests locally
+use ``[test]``, and for documentation build ``[docs]``.
+If you would like to modify the source, you can install
+``astroquery`` in editable mode, which means you don't need to rerun the
+install command after you made the changes.
+
+To install all dependencies, including those required for local testing and
+building the documentation, in editable mode:
+
+..code-block:: bash
+
+    $ pip install -e .[all,test,docs]
 
 
 Requirements

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -87,7 +87,7 @@ install command after you made the changes.
 To install all dependencies, including those required for local testing and
 building the documentation, in editable mode:
 
-..code-block:: bash
+.. code-block:: bash
 
     $ pip install -e .[all,test,docs]
 


### PR DESCRIPTION
Updated the pip command for installing the bleeding edge version of `astroquery`. The command in place was returning an error due to `pip` not finding `astropy_helpers` even after manually installing it.