### PR TITLE
NIST Vectorizing

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -144,6 +144,12 @@ mast
 
 - Expanding ``Cutouts`` functionality to support TICA HLSPs now available through 
   ``TesscutClass``. [##2668]
+  
+nist
+^^^^
+
+- Vectoized ``linename`` option to query multiple spectral lines with one call
+  of ``Nist.query``. [#2678]
 
 oac
 ^^^

--- a/astroquery/nist/core.py
+++ b/astroquery/nist/core.py
@@ -63,8 +63,8 @@ class NistClass(BaseQuery):
             The lower wavelength for the spectrum in appropriate units.
         maxwav : `astropy.units.Quantity` object
             The upper wavelength for the spectrum in appropriate units.
-        linename : str, optional
-            The spectrum to fetch. Defaults to "H I"
+        linename : str or iterable of str, optional
+            The spectrum/spectra to fetch. Defaults to "H I"
         energy_level_unit : str, optional
             The energy level units must be one of the following:
             'R', 'Rydberg', 'rydberg', 'cm', 'cm-1', 'EV', 'eV',
@@ -85,7 +85,8 @@ class NistClass(BaseQuery):
 
         """
         request_payload = {}
-        request_payload["spectra"] = kwargs['linename']
+        linename = kwargs["linename"]
+        request_payload["spectra"] = linename if isinstance(linename, str) else "; ".join(linename)
         (min_wav, max_wav, wav_unit) = _parse_wavelength(args[0], args[1])
         request_payload["low_wl"] = min_wav
         request_payload["upp_wl"] = max_wav

--- a/astroquery/nist/tests/test_nist.py
+++ b/astroquery/nist/tests/test_nist.py
@@ -45,6 +45,9 @@ def test_query_async(patch_get):
                                           linename="H I", get_query_payload=True)
     assert response['spectra'] == "H I"
     assert response['unit'] == nist.core.Nist.unit_code['nm']
+    response = nist.core.Nist.query_async(4000 * u.nm, 7000 * u.nm,
+                                          linename=["H I", "Fe I"], get_query_payload=True)
+    assert response["spectra"] == "H I; Fe I"
     response = nist.core.Nist.query_async(4000 * u.nm, 7000 * u.nm, linename="H I")
     assert response is not None
 

--- a/docs/nist/nist.rst
+++ b/docs/nist/nist.rst
@@ -18,8 +18,10 @@ nanometer, or angstrom or the like. For example, to use a lower wavelength
 value of 4000 Angstroms, you should use ```4000 * u.AA``` and if you want the
 same in nanometers, just use ```400 * u.nm```. Of course there are several optional
 parameters you can also specify. For instance use the ``linename`` parameter to
-specify the spectrum you wish to fetch. By default this is set to "H I", but
-you can set it to several other values like "Na;Mg", etc. Lets now see a simple example.
+specify the spectrum you wish to fetch.
+``linename`` also accepts multiple line strings in an iterable (e.g. ``["Na", "H I"]``)
+or you can specify multiple lines as a single string value separated with a
+semicolon (e.g. ``"Na;Mg"``). Now let's see a simple example:
 
 .. doctest-remote-data::
 


### PR DESCRIPTION
Is this what yall had in mind for #682 ?
I'm not too sure since I can't access the fb post.
Tried to explore what Vizier was doing.
Figured I'd try to start off small (why I chose NIST).
These changes allow for querying multiple linenames with one request i.e...

     >>> from astroquery.nist import Nist
     >>> import astropy.units as u
     >>> table = Nist.query(4000 * u.AA, 7000 * u.AA, linename=["H I", "Fe I", "V I"])

There might be more that could be done for NIST but `linename`  was the main place I thought this could be applied.
Maybe could also be applied to `energy_level_unit`, idk though that might make the responses messy.