### PR TITLE
Remove needless argument checks from `gaia`

### DIFF
--- a/astroquery/gaia/core.py
+++ b/astroquery/gaia/core.py
@@ -218,10 +218,6 @@ class GaiaClass(TapPlus):
         -------
         A table object
         """
-
-        if retrieval_type is None:
-            raise ValueError("Missing mandatory argument 'retrieval_type'")
-
         now = datetime.now()
         now_formatted = now.strftime("%Y%m%d_%H%M%S")
         temp_dirname = "temp_" + now_formatted
@@ -238,9 +234,6 @@ class GaiaClass(TapPlus):
                                  f"overwrite output file.")
 
         path = os.path.dirname(output_file)
-
-        if ids is None:
-            raise ValueError("Missing mandatory argument 'ids'")
 
         if avoid_datatype_check is False:
             # we need to check params
@@ -757,9 +750,9 @@ class GaiaClass(TapPlus):
         return self.is_valid_user(user_id=user_id,
                                   verbose=verbose)
 
-    def cross_match(self, *, full_qualified_table_name_a=None,
-                    full_qualified_table_name_b=None,
-                    results_table_name=None,
+    def cross_match(self, *, full_qualified_table_name_a,
+                    full_qualified_table_name_b,
+                    results_table_name,
                     radius=1.0,
                     background=False,
                     verbose=False):
@@ -785,12 +778,6 @@ class GaiaClass(TapPlus):
         -------
         Boolean indicating if the specified user is valid
         """
-        if full_qualified_table_name_a is None:
-            raise ValueError("Table name A argument is mandatory")
-        if full_qualified_table_name_b is None:
-            raise ValueError("Table name B argument is mandatory")
-        if results_table_name is None:
-            raise ValueError("Results table name argument is mandatory")
         if radius < 0.1 or radius > 10.0:
             raise ValueError(f"Invalid radius value. Found {radius}, valid range is: 0.1 to 10.0")
 

--- a/astroquery/gaia/tests/test_gaiatap.py
+++ b/astroquery/gaia/tests/test_gaiatap.py
@@ -245,13 +245,13 @@ def test_cross_match_invalid_radius(cross_match_kwargs, radius):
 
 
 @pytest.mark.parametrize(
-    "missing_kwarg,msg",
-    [("full_qualified_table_name_a", "Table name A"),
-     ("full_qualified_table_name_b", "Table name B"),
-     ("results_table_name", "Results table name")])
-def test_cross_match_missing_mandatory_kwarg(cross_match_kwargs, missing_kwarg, msg):
+    "missing_kwarg",
+    ["full_qualified_table_name_a", "full_qualified_table_name_b", "results_table_name"])
+def test_cross_match_missing_mandatory_kwarg(cross_match_kwargs, missing_kwarg):
     del cross_match_kwargs[missing_kwarg]
-    with pytest.raises(ValueError, match=rf"^{msg} argument is mandatory$"):
+    with pytest.raises(
+        TypeError, match=rf"missing 1 required keyword-only argument: '{missing_kwarg}'$"
+    ):
         GAIA_QUERIER.cross_match(**cross_match_kwargs)
 
 


### PR DESCRIPTION
`astroquery.gaia.GaiaClass` contained a handful of needless argument checks:

- In `load_data()` separately checking for `retrieval_type` being `None` (its default value is `"ALL"`) is not needed because the value is checked later on, unless `avoid_datatype_check` is explicitly set to `True`: https://github.com/astropy/astroquery/blob/03c8420cfee3d6c6654abfb63f85fdcc3d0cd686/astroquery/gaia/core.py#L245-L250
- In `load_data()` checking for `ids` being `None` only makes a difference if `None` is the explicitly specified value, but any other possible invalid value would pass this check, so it is not very useful.
- In `cross_match()` several arguments were given default values and the code then checked if any of those arguments had the default value. It is better to not specify the default value at all and to let Python itself ensure that the mandatory argument values are specified. This is not only simpler but also ensures that the error message contains the correct argument name, and if multiple arguments are missing then Python's error message makes that clear too.