### PR TITLE
Fix and refactor `esa.hsa` remote tests

### DIFF
--- a/astroquery/esa/hsa/tests/test_hsa_remote.py
+++ b/astroquery/esa/hsa/tests/test_hsa_remote.py
@@ -3,7 +3,6 @@ from pathlib import Path
 import tarfile
 
 import pytest
-from requests.exceptions import ChunkedEncodingError
 
 from ..core import HSAClass
 
@@ -20,16 +19,6 @@ SPIRE_ENDINGS = ["898.xml", "898.jpg", "141.fits.gz", "045.fits.gz", "952.fits.g
 
 @pytest.mark.remote_data
 class TestHSARemote:
-    retries = 2
-
-    def access_archive_with_retries(self, f, params):
-        for _ in range(self.retries):
-            try:
-                res = f(**params)
-                return res
-            except ChunkedEncodingError:
-                pass
-        return None
 
     def test_download_data_observation_pacs(self, tmp_path):
         obs_id = "1342191813"
@@ -41,9 +30,7 @@ class TestHSARemote:
                       'download_dir': tmp_path}
         expected_res = Path(tmp_path, obs_id + ".tar")
         hsa = HSAClass()
-        res = self.access_archive_with_retries(hsa.download_data, parameters)
-        if res is None:
-            pytest.xfail(f"Archive broke the connection {self.retries} times, unable to test")
+        res = hsa.download_data(**parameters)
         assert Path(res) == expected_res
         assert Path(res).is_file()
         with tarfile.open(res) as tar:
@@ -64,9 +51,7 @@ class TestHSARemote:
                       'download_dir': tmp_path}
         expected_res = Path(tmp_path, fname + ".tar")
         hsa = HSAClass()
-        res = self.access_archive_with_retries(hsa.download_data, parameters)
-        if res is None:
-            pytest.xfail(f"Archive broke the connection {self.retries} times, unable to test")
+        res = hsa.download_data(**parameters)
         assert Path(res) == expected_res
         assert Path(res).is_file()
         with tarfile.open(res) as tar:
@@ -86,9 +71,7 @@ class TestHSARemote:
                       'download_dir': tmp_path}
         expected_res = Path(tmp_path, obs_id + ".tgz")
         hsa = HSAClass()
-        res = self.access_archive_with_retries(hsa.download_data, parameters)
-        if res is None:
-            pytest.xfail(f"Archive broke the connection {self.retries} times, unable to test")
+        res = hsa.download_data(**parameters)
         assert Path(res) == expected_res
         assert Path(res).is_file()
         with tarfile.open(res) as tar:
@@ -107,9 +90,7 @@ class TestHSARemote:
                       'download_dir': tmp_path}
         expected_res = Path(tmp_path, obs_id + ".tar")
         hsa = HSAClass()
-        res = self.access_archive_with_retries(hsa.download_data, parameters)
-        if res is None:
-            pytest.xfail(f"Archive broke the connection {self.retries} times, unable to test")
+        res = hsa.download_data(**parameters)
         assert Path(res) == expected_res
         assert Path(res).is_file()
         with tarfile.open(res) as tar:
@@ -127,9 +108,7 @@ class TestHSARemote:
                       'download_dir': tmp_path}
         expected_res = Path(tmp_path, obs_id + ".jpg")
         hsa = HSAClass()
-        res = self.access_archive_with_retries(hsa.download_data, parameters)
-        if res is None:
-            pytest.xfail(f"Archive broke the connection {self.retries} times, unable to test")
+        res = hsa.download_data(**parameters)
         assert Path(res) == expected_res
         assert Path(res).is_file()
 
@@ -144,9 +123,7 @@ class TestHSARemote:
                       'download_dir': tmp_path}
         expected_res = Path(tmp_path, fname + ".jpg")
         hsa = HSAClass()
-        res = self.access_archive_with_retries(hsa.download_data, parameters)
-        if res is None:
-            pytest.xfail(f"Archive broke the connection {self.retries} times, unable to test")
+        res = hsa.download_data(**parameters)
         assert Path(res) == expected_res
         assert Path(res).is_file()
 
@@ -159,9 +136,7 @@ class TestHSARemote:
                       'download_dir': tmp_path}
         expected_res = Path(tmp_path, obs_id + ".tar")
         hsa = HSAClass()
-        res = self.access_archive_with_retries(hsa.get_observation, parameters)
-        if res is None:
-            pytest.xfail(f"Archive broke the connection {self.retries} times, unable to test")
+        res = hsa.get_observation(**parameters)
         assert Path(res) == expected_res
         assert Path(res).is_file()
         with tarfile.open(res) as tar:
@@ -178,8 +153,6 @@ class TestHSARemote:
                       'download_dir': tmp_path}
         expected_res = Path(tmp_path, obs_id + ".jpg")
         hsa = HSAClass()
-        res = self.access_archive_with_retries(hsa.get_postcard, parameters)
-        if res is None:
-            pytest.xfail(f"Archive broke the connection {self.retries} times, unable to test")
+        res = hsa.get_postcard(**parameters)
         assert Path(res) == expected_res
         assert Path(res).is_file()

--- a/astroquery/esa/hsa/tests/test_hsa_remote.py
+++ b/astroquery/esa/hsa/tests/test_hsa_remote.py
@@ -7,74 +7,61 @@ import pytest
 from ..core import HSAClass
 
 
+pytestmark = pytest.mark.remote_data
+
+
 PACS_ENDINGS = ["571.xml", "571.jpg", "214.fits.gz", "008.fits.gz",
                 "674.fits.gz", "350.fits.gz", "README.pdf"]
 SPIRE_ENDINGS = ["898.xml", "898.jpg", "141.fits.gz", "045.fits.gz", "952.fits.gz",
                  "974.fits.gz", "715.fits.gz", "547.fits.gz", "770.fits.gz",
                  "856.fits.gz", "148.fits.gz", "025.fits.gz", "538.fits.gz",
                  "070.fits.gz", "434.fits.gz", "637.fits.gz", "835.fits.gz",
-                 "372.fits.gz","248.fits.gz", "README.pdf"]
+                 "372.fits.gz", "248.fits.gz", "README.pdf"]
 
 
-@pytest.mark.remote_data
-class TestHSARemote:
+@pytest.mark.parametrize(
+    "method,kwargs,expected_filename,expected_endings",
+    [("download_data", {}, "1342191813.tar", PACS_ENDINGS),
+     ("download_data", {"filename": "output_file"}, "output_file.tar", PACS_ENDINGS),
+     ("download_data", {"compress": "true"}, "1342191813.tgz", PACS_ENDINGS),
+     ("download_data", {"observation_id": "1342191188", "instrument_name": "SPIRE", "product_level": "LEVEL2", },
+      "1342191188.tar", SPIRE_ENDINGS),
+     ("get_observation", {}, "1342191813.tar", PACS_ENDINGS)])
+def test_download_data_observation(
+    method, kwargs, expected_filename, expected_endings, tmp_path
+):
+    parameters = {"observation_id": "1342191813",
+                  'instrument_name': "PACS",
+                  'product_level': 'LEVEL3',
+                  'cache': False,
+                  'download_dir': tmp_path}
+    parameters.update(kwargs)
+    if method == "download_data":
+        res = HSAClass().download_data(**parameters, retrieval_type="OBSERVATION")
+    elif method == "get_observation":
+        res = HSAClass().get_observation(**parameters)
+    assert Path(res) == tmp_path / expected_filename
+    assert Path(res).is_file()
+    with tarfile.open(res) as tar:
+        names = tar.getnames()
+    assert len(names) == len(expected_endings)
+    for name, ending in zip(names, expected_endings):
+        assert name.endswith(ending)
 
-    @pytest.mark.parametrize(
-        "method,kwargs,expected_filename,expected_endings",
-        [
-            ("download_data", {}, "1342191813.tar", PACS_ENDINGS),
-            ("download_data", {"filename": "output_file"}, "output_file.tar", PACS_ENDINGS),
-            ("download_data", {"compress": "true"}, "1342191813.tgz", PACS_ENDINGS),
-            (
-                "download_data",
-                {
-                    "observation_id": "1342191188",
-                    "instrument_name": "SPIRE",
-                    "product_level": "LEVEL2",
-                },
-                "1342191188.tar",
-                SPIRE_ENDINGS,
-            ),
-            ("get_observation", {}, "1342191813.tar", PACS_ENDINGS),
-        ],
-    )
-    def test_download_data_observation(
-        self, method, kwargs, expected_filename, expected_endings, tmp_path
-    ):
-        parameters = {"observation_id": "1342191813",
-                      'instrument_name': "PACS",
-                      'product_level': 'LEVEL3',
-                      'cache': False,
-                      'download_dir': tmp_path}
-        parameters.update(kwargs)
-        if method == "download_data":
-            res = HSAClass().download_data(**parameters, retrieval_type="OBSERVATION")
-        elif method == "get_observation":
-            res = HSAClass().get_observation(**parameters)
-        assert Path(res) == tmp_path / expected_filename
-        assert Path(res).is_file()
-        with tarfile.open(res) as tar:
-            names = tar.getnames()
-        assert len(names) == len(expected_endings)
-        for name, ending in zip(names, expected_endings):
-            assert name.endswith(ending)
 
-    @pytest.mark.parametrize(
-        "method,kwargs,expected_filename",
-        [
-            ("download_data", {}, "1342191813.jpg"),
-            ("download_data", {"filename": "output_file"}, "output_file.jpg"),
-            ("get_postcard", {}, "1342191813.jpg"),
-        ],
-    )
-    def test_download_data_postcard(self, method, kwargs, expected_filename, tmp_path):
-        parameters = {"observation_id": "1342191813",
-                      'instrument_name': "PACS",
-                      'cache': False,
-                      'download_dir': tmp_path}
-        if method == "download_data":
-            res = HSAClass().download_data(**parameters, **kwargs, retrieval_type="POSTCARD")
-        elif method == "get_postcard":
-            res = HSAClass().get_postcard(**parameters, **kwargs)
-        assert Path(res) == tmp_path / expected_filename
-        assert Path(res).is_file()
+@pytest.mark.parametrize(
+    "method,kwargs,expected_filename",
+    [("download_data", {}, "1342191813.jpg"),
+     ("download_data", {"filename": "output_file"}, "output_file.jpg"),
+     ("get_postcard", {}, "1342191813.jpg")])
+def test_download_data_postcard(method, kwargs, expected_filename, tmp_path):
+    parameters = {"observation_id": "1342191813",
+                  'instrument_name': "PACS",
+                  'cache': False,
+                  'download_dir': tmp_path}
+    if method == "download_data":
+        res = HSAClass().download_data(**parameters, **kwargs, retrieval_type="POSTCARD")
+    elif method == "get_postcard":
+        res = HSAClass().get_postcard(**parameters, **kwargs)
+    assert Path(res) == tmp_path / expected_filename
+    assert Path(res).is_file()

--- a/astroquery/esa/hsa/tests/test_hsa_remote.py
+++ b/astroquery/esa/hsa/tests/test_hsa_remote.py
@@ -7,7 +7,6 @@ import pytest
 from ..core import HSAClass
 
 
-
 PACS_ENDINGS = ["571.xml", "571.jpg", "214.fits.gz", "008.fits.gz",
                 "674.fits.gz", "350.fits.gz", "README.pdf"]
 SPIRE_ENDINGS = ["898.xml", "898.jpg", "141.fits.gz", "045.fits.gz", "952.fits.gz",
@@ -20,139 +19,62 @@ SPIRE_ENDINGS = ["898.xml", "898.jpg", "141.fits.gz", "045.fits.gz", "952.fits.g
 @pytest.mark.remote_data
 class TestHSARemote:
 
-    def test_download_data_observation_pacs(self, tmp_path):
-        obs_id = "1342191813"
-        parameters = {'retrieval_type': "OBSERVATION",
-                      'observation_id': obs_id,
+    @pytest.mark.parametrize(
+        "method,kwargs,expected_filename,expected_endings",
+        [
+            ("download_data", {}, "1342191813.tar", PACS_ENDINGS),
+            ("download_data", {"filename": "output_file"}, "output_file.tar", PACS_ENDINGS),
+            ("download_data", {"compress": "true"}, "1342191813.tgz", PACS_ENDINGS),
+            (
+                "download_data",
+                {
+                    "observation_id": "1342191188",
+                    "instrument_name": "SPIRE",
+                    "product_level": "LEVEL2",
+                },
+                "1342191188.tar",
+                SPIRE_ENDINGS,
+            ),
+            ("get_observation", {}, "1342191813.tar", PACS_ENDINGS),
+        ],
+    )
+    def test_download_data_observation(
+        self, method, kwargs, expected_filename, expected_endings, tmp_path
+    ):
+        parameters = {"observation_id": "1342191813",
                       'instrument_name': "PACS",
                       'product_level': 'LEVEL3',
                       'cache': False,
                       'download_dir': tmp_path}
-        expected_res = Path(tmp_path, obs_id + ".tar")
-        hsa = HSAClass()
-        res = hsa.download_data(**parameters)
-        assert Path(res) == expected_res
+        parameters.update(kwargs)
+        if method == "download_data":
+            res = HSAClass().download_data(**parameters, retrieval_type="OBSERVATION")
+        elif method == "get_observation":
+            res = HSAClass().get_observation(**parameters)
+        assert Path(res) == tmp_path / expected_filename
         assert Path(res).is_file()
         with tarfile.open(res) as tar:
             names = tar.getnames()
-        assert len(names) == len(PACS_ENDINGS)
-        for name, ending in zip(names, PACS_ENDINGS):
+        assert len(names) == len(expected_endings)
+        for name, ending in zip(names, expected_endings):
             assert name.endswith(ending)
 
-    def test_download_data_observation_pacs_filename(self, tmp_path):
-        obs_id = "1342191813"
-        fname = "output_file"
-        parameters = {'retrieval_type': "OBSERVATION",
-                      'observation_id': obs_id,
-                      'instrument_name': "PACS",
-                      'product_level': 'LEVEL3',
-                      'filename': fname,
-                      'cache': False,
-                      'download_dir': tmp_path}
-        expected_res = Path(tmp_path, fname + ".tar")
-        hsa = HSAClass()
-        res = hsa.download_data(**parameters)
-        assert Path(res) == expected_res
-        assert Path(res).is_file()
-        with tarfile.open(res) as tar:
-            names = tar.getnames()
-        assert len(names) == len(PACS_ENDINGS)
-        for name, ending in zip(names, PACS_ENDINGS):
-            assert name.endswith(ending)
-
-    def test_download_data_observation_pacs_compressed(self, tmp_path):
-        obs_id = "1342191813"
-        parameters = {'retrieval_type': "OBSERVATION",
-                      'observation_id': obs_id,
-                      'instrument_name': "PACS",
-                      'product_level': 'LEVEL3',
-                      'compress': 'true',
-                      'cache': False,
-                      'download_dir': tmp_path}
-        expected_res = Path(tmp_path, obs_id + ".tgz")
-        hsa = HSAClass()
-        res = hsa.download_data(**parameters)
-        assert Path(res) == expected_res
-        assert Path(res).is_file()
-        with tarfile.open(res) as tar:
-            names = tar.getnames()
-        assert len(names) == len(PACS_ENDINGS)
-        for name, ending in zip(names, PACS_ENDINGS):
-            assert name.endswith(ending)
-
-    def test_download_data_observation_spire(self, tmp_path):
-        obs_id = "1342191188"
-        parameters = {'retrieval_type': "OBSERVATION",
-                      'observation_id': obs_id,
-                      'instrument_name': "SPIRE",
-                      'product_level': 'LEVEL2',
-                      'cache': False,
-                      'download_dir': tmp_path}
-        expected_res = Path(tmp_path, obs_id + ".tar")
-        hsa = HSAClass()
-        res = hsa.download_data(**parameters)
-        assert Path(res) == expected_res
-        assert Path(res).is_file()
-        with tarfile.open(res) as tar:
-            names = tar.getnames()
-        assert len(names) == len(SPIRE_ENDINGS)
-        for name, ending in zip(names, SPIRE_ENDINGS):
-            assert name.endswith(ending)
-
-    def test_download_data_postcard_pacs(self, tmp_path):
-        obs_id = "1342191813"
-        parameters = {'retrieval_type': "POSTCARD",
-                      'observation_id': obs_id,
+    @pytest.mark.parametrize(
+        "method,kwargs,expected_filename",
+        [
+            ("download_data", {}, "1342191813.jpg"),
+            ("download_data", {"filename": "output_file"}, "output_file.jpg"),
+            ("get_postcard", {}, "1342191813.jpg"),
+        ],
+    )
+    def test_download_data_postcard(self, method, kwargs, expected_filename, tmp_path):
+        parameters = {"observation_id": "1342191813",
                       'instrument_name': "PACS",
                       'cache': False,
                       'download_dir': tmp_path}
-        expected_res = Path(tmp_path, obs_id + ".jpg")
-        hsa = HSAClass()
-        res = hsa.download_data(**parameters)
-        assert Path(res) == expected_res
-        assert Path(res).is_file()
-
-    def test_download_data_postcard_pacs_filename(self, tmp_path):
-        obs_id = "1342191813"
-        fname = "output_file"
-        parameters = {'retrieval_type': "POSTCARD",
-                      'observation_id': obs_id,
-                      'instrument_name': "PACS",
-                      'filename': fname,
-                      'cache': False,
-                      'download_dir': tmp_path}
-        expected_res = Path(tmp_path, fname + ".jpg")
-        hsa = HSAClass()
-        res = hsa.download_data(**parameters)
-        assert Path(res) == expected_res
-        assert Path(res).is_file()
-
-    def test_get_observation(self, tmp_path):
-        obs_id = "1342191813"
-        parameters = {'observation_id': obs_id,
-                      'instrument_name': "PACS",
-                      'product_level': 'LEVEL3',
-                      'cache': False,
-                      'download_dir': tmp_path}
-        expected_res = Path(tmp_path, obs_id + ".tar")
-        hsa = HSAClass()
-        res = hsa.get_observation(**parameters)
-        assert Path(res) == expected_res
-        assert Path(res).is_file()
-        with tarfile.open(res) as tar:
-            names = tar.getnames()
-        assert len(names) == len(PACS_ENDINGS)
-        for name, ending in zip(names, PACS_ENDINGS):
-            assert name.endswith(ending)
-
-    def test_get_postcard(self, tmp_path):
-        obs_id = "1342191813"
-        parameters = {'observation_id': obs_id,
-                      'instrument_name': "PACS",
-                      'cache': False,
-                      'download_dir': tmp_path}
-        expected_res = Path(tmp_path, obs_id + ".jpg")
-        hsa = HSAClass()
-        res = hsa.get_postcard(**parameters)
-        assert Path(res) == expected_res
+        if method == "download_data":
+            res = HSAClass().download_data(**parameters, **kwargs, retrieval_type="POSTCARD")
+        elif method == "get_postcard":
+            res = HSAClass().get_postcard(**parameters, **kwargs)
+        assert Path(res) == tmp_path / expected_filename
         assert Path(res).is_file()

--- a/astroquery/esa/hsa/tests/test_hsa_remote.py
+++ b/astroquery/esa/hsa/tests/test_hsa_remote.py
@@ -27,9 +27,7 @@ SPIRE_ENDINGS = ["898.xml", "898.jpg", "141.fits.gz", "045.fits.gz", "952.fits.g
      ("download_data", {"observation_id": "1342191188", "instrument_name": "SPIRE", "product_level": "LEVEL2", },
       "1342191188.tar", SPIRE_ENDINGS),
      ("get_observation", {}, "1342191813.tar", PACS_ENDINGS)])
-def test_download_data_observation(
-    method, kwargs, expected_filename, expected_endings, tmp_path
-):
+def test_download_data_observation(method, kwargs, expected_filename, expected_endings, tmp_path):
     parameters = {"observation_id": "1342191813",
                   'instrument_name': "PACS",
                   'product_level': 'LEVEL3',

--- a/astroquery/esa/hsa/tests/test_hsa_remote.py
+++ b/astroquery/esa/hsa/tests/test_hsa_remote.py
@@ -7,10 +7,15 @@ from requests.exceptions import ChunkedEncodingError
 
 from ..core import HSAClass
 
-spire_chksum = [10233, 10762, 9019, 10869, 3944, 11328, 3921, 10999, 10959,
-                11342, 10974, 3944, 11335, 11323, 11078, 11321, 11089, 11314, 11108, 6281]
 
-pacs_chksum = [10208, 10755, 8917, 10028, 3924, 3935, 6291]
+
+PACS_ENDINGS = ["571.xml", "571.jpg", "214.fits.gz", "008.fits.gz",
+                "674.fits.gz", "350.fits.gz", "README.pdf"]
+SPIRE_ENDINGS = ["898.xml", "898.jpg", "141.fits.gz", "045.fits.gz", "952.fits.gz",
+                 "974.fits.gz", "715.fits.gz", "547.fits.gz", "770.fits.gz",
+                 "856.fits.gz", "148.fits.gz", "025.fits.gz", "538.fits.gz",
+                 "070.fits.gz", "434.fits.gz", "637.fits.gz", "835.fits.gz",
+                 "372.fits.gz","248.fits.gz", "README.pdf"]
 
 
 @pytest.mark.remote_data
@@ -42,8 +47,10 @@ class TestHSARemote:
         assert Path(res) == expected_res
         assert Path(res).is_file()
         with tarfile.open(res) as tar:
-            chksum = [m.chksum for m in tar.getmembers()]
-        assert chksum.sort() == pacs_chksum.sort()
+            names = tar.getnames()
+        assert len(names) == len(PACS_ENDINGS)
+        for name, ending in zip(names, PACS_ENDINGS):
+            assert name.endswith(ending)
 
     def test_download_data_observation_pacs_filename(self, tmp_path):
         obs_id = "1342191813"
@@ -63,8 +70,10 @@ class TestHSARemote:
         assert Path(res) == expected_res
         assert Path(res).is_file()
         with tarfile.open(res) as tar:
-            chksum = [m.chksum for m in tar.getmembers()]
-        assert chksum.sort() == pacs_chksum.sort()
+            names = tar.getnames()
+        assert len(names) == len(PACS_ENDINGS)
+        for name, ending in zip(names, PACS_ENDINGS):
+            assert name.endswith(ending)
 
     def test_download_data_observation_pacs_compressed(self, tmp_path):
         obs_id = "1342191813"
@@ -83,8 +92,10 @@ class TestHSARemote:
         assert Path(res) == expected_res
         assert Path(res).is_file()
         with tarfile.open(res) as tar:
-            chksum = [m.chksum for m in tar.getmembers()]
-        assert chksum.sort() == pacs_chksum.sort()
+            names = tar.getnames()
+        assert len(names) == len(PACS_ENDINGS)
+        for name, ending in zip(names, PACS_ENDINGS):
+            assert name.endswith(ending)
 
     def test_download_data_observation_spire(self, tmp_path):
         obs_id = "1342191188"
@@ -102,8 +113,10 @@ class TestHSARemote:
         assert Path(res) == expected_res
         assert Path(res).is_file()
         with tarfile.open(res) as tar:
-            chksum = [m.chksum for m in tar.getmembers()]
-        assert chksum.sort() == spire_chksum.sort()
+            names = tar.getnames()
+        assert len(names) == len(SPIRE_ENDINGS)
+        for name, ending in zip(names, SPIRE_ENDINGS):
+            assert name.endswith(ending)
 
     def test_download_data_postcard_pacs(self, tmp_path):
         obs_id = "1342191813"
@@ -152,8 +165,10 @@ class TestHSARemote:
         assert Path(res) == expected_res
         assert Path(res).is_file()
         with tarfile.open(res) as tar:
-            chksum = [m.chksum for m in tar.getmembers()]
-        assert chksum.sort() == pacs_chksum.sort()
+            names = tar.getnames()
+        assert len(names) == len(PACS_ENDINGS)
+        for name, ending in zip(names, PACS_ENDINGS):
+            assert name.endswith(ending)
 
     def test_get_postcard(self, tmp_path):
         obs_id = "1342191813"


### PR DESCRIPTION
Currently many `esa.hsa` remote tests are meant to compare two sorted lists, but the lists are sorted with [`list.sort()`](https://docs.python.org/3/library/stdtypes.html#list.sort) in the assert statement: https://github.com/astropy/astroquery/blob/a4716fd1db5d0b7162e9d4e879135c36b451dcdf/astroquery/esa/hsa/tests/test_hsa_remote.py#L46
`list.sort()` sorts the list in place, meaning its return value is `None`:
```python
>>> print([1, 2, 3].sort())
None
```
The tests are therefore asserting that `None == None` regardless of the content of the lists. When fixing the tests it became apparent that the checksums are not reproducible, so I changed the tests to verify the filename endings in the tar-files instead.

I also decided to refactor the remote test file. See the commit messages for details.