### PR TITLE
Exclude all test files from code coverage analysis

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -99,13 +99,11 @@ exclude = _astropy_init.py,version.py,astroquery/template_module
 [coverage:run]
 omit =
   astroquery/*_init*
-  astroquery/tests/*
-  astroquery/*/tests/*
+  astroquery/**/tests/*
   astroquery/*setup*
   astroquery/version*
   */astroquery/*_init*
-  */astroquery/tests/*
-  */astroquery/*/tests/*
+  */astroquery/**/tests/*
   */astroquery/*setup*
   */astroquery/version*
 


### PR DESCRIPTION
Currently test directories are only excluded from coverage analysis if they are just under `astroquery` or separated from it by one directory, which means code in e.g. `astroquery/esa/hsa/tests/test_hsa_remote.py` is included in coverage analysis. The updated configuration in this pull request ensures all directories named `tests` are excluded no matter how deep in the directory hierarchy they are. See also https://coverage.readthedocs.io/en/7.2.2/source.html#file-patterns