### PR TITLE
Refactors: Make kwargs keyword only for remaining packages

### DIFF
--- a/astroquery/vo_conesearch/validator/inspect.py
+++ b/astroquery/vo_conesearch/validator/inspect.py
@@ -39,7 +39,7 @@ class ConeSearchResults:
         Show download progress bars.
 
     """
-    def __init__(self, cache=False, verbose=True):
+    def __init__(self, *, cache=False, verbose=True):
         self.dbtypes = ['good', 'warn', 'exception', 'error']
         self.dbs = {}
         self.catkeys = {}
@@ -49,7 +49,7 @@ class ConeSearchResults:
                 'conesearch_' + typ, cache=cache, verbose=verbose)
             self.catkeys[typ] = self.dbs[typ].list_catalogs()
 
-    def tally(self, fout=None):
+    def tally(self, *, fout=None):
         """
         Tally databases.
 
@@ -74,7 +74,7 @@ class ConeSearchResults:
             str_list.append('total: {0} catalog(s)\n'.format(n_tot))
             fout.write('\n'.join(str_list))
 
-    def list_cats(self, typ, fout=None, ignore_noncrit=False):
+    def list_cats(self, typ, *, fout=None, ignore_noncrit=False):
         """
         List catalogs in given database.
 
@@ -131,7 +131,7 @@ class ConeSearchResults:
         if len(str_list) > 0:
             fout.write('\n'.join(str_list))
 
-    def print_cat(self, key, fout=None):
+    def print_cat(self, key, *, fout=None):
         """
         Display a single catalog of given key.
 

--- a/astroquery/vo_conesearch/validator/tstquery.py
+++ b/astroquery/vo_conesearch/validator/tstquery.py
@@ -22,7 +22,7 @@ from astropy.utils.exceptions import AstropyUserWarning
 __all__ = ['parse_cs']
 
 
-def parse_cs(ivoid, cap_index=1):
+def parse_cs(ivoid, *, cap_index=1):
     """Return test query pars as dict for given IVO ID and capability index."""
 
     # Production server.

--- a/astroquery/vo_conesearch/validator/validate.py
+++ b/astroquery/vo_conesearch/validator/validate.py
@@ -32,7 +32,7 @@ __all__ = ['check_conesearch_sites']
 
 
 @timefunc(num_tries=1)
-def check_conesearch_sites(destdir=os.curdir, verbose=True, parallel=True,
+def check_conesearch_sites(*, destdir=os.curdir, verbose=True, parallel=True,
                            url_list='default'):
     """
     Validate Cone Search Services.
@@ -155,7 +155,7 @@ def check_conesearch_sites(destdir=os.curdir, verbose=True, parallel=True,
             continue
 
         # Use testQuery to return non-empty VO table with max verbosity.
-        testquery_pars = parse_cs(cur_cat['ivoid'], cur_cat['cap_index'])
+        testquery_pars = parse_cs(cur_cat['ivoid'], cap_index=cur_cat['cap_index'])
         cs_pars_arr = ['{}={}'.format(key, testquery_pars[key])
                        for key in testquery_pars]
         cs_pars_arr += ['VERB=3']

--- a/astroquery/vo_conesearch/vo_async.py
+++ b/astroquery/vo_conesearch/vo_async.py
@@ -49,7 +49,7 @@ class AsyncBase:
         except AttributeError:
             return getattr(self.future, what)
 
-    def get(self, timeout=None):
+    def get(self, *, timeout=None):
         """Get result, if available, then shut down thread.
 
         Parameters

--- a/astroquery/vo_conesearch/vos_catalog.py
+++ b/astroquery/vo_conesearch/vos_catalog.py
@@ -300,14 +300,14 @@ class VOSDatabase(VOSBase):
         """
         return self._match_pattern(list(self._catalogs), pattern, sort)
 
-    def list_catalogs_by_url(self, pattern=None, sort=True):
+    def list_catalogs_by_url(self, *, pattern=None, sort=True):
         """Like :meth:`list_catalogs` but using access URL."""
         out_arr = self._match_pattern(list(self._url_keys), pattern, sort)
 
         # Discard URL that maps to nothing
         return [a for a in out_arr if len(self._url_keys[a]) > 0]
 
-    def add_catalog(self, name, cat, allow_duplicate_url=False):
+    def add_catalog(self, name, cat, *, allow_duplicate_url=False):
         """
         Add a catalog to database.
 
@@ -440,7 +440,7 @@ class VOSDatabase(VOSBase):
 
         return db
 
-    def to_json(self, filename, overwrite=False):
+    def to_json(self, filename, *, overwrite=False):
         """
         Write database content to a JSON file.
 
@@ -527,7 +527,7 @@ class VOSDatabase(VOSBase):
         return cls(tree)
 
     @classmethod
-    def from_registry(cls, registry_url, timeout=60, **kwargs):
+    def from_registry(cls, registry_url, *, timeout=60, **kwargs):
         """
         Create a database of VO services from VO registry URL.
 
@@ -628,7 +628,7 @@ class VOSDatabase(VOSBase):
         return db
 
 
-def get_remote_catalog_db(dbname, cache=True, verbose=True):
+def get_remote_catalog_db(dbname, *, cache=True, verbose=True):
     """
     Get a database of VO services (which is a JSON file) from a remote
     location.
@@ -700,7 +700,7 @@ def _get_catalogs(service_type, catalog_db, **kwargs):
     return catalogs
 
 
-def _vo_service_request(url, pedantic, kwargs, cache=True, verbose=False):
+def _vo_service_request(url, pedantic, kwargs, *, cache=True, verbose=False):
     """
     This is called by :func:`call_vo_service`.
 


### PR DESCRIPTION
This PR is to address the remaining packages requiring refactors to make kwargs keyword only (#1746).

From the list in #1746 
- [x]  astroquery/vo_conesearch (in this PR)
- [x] astroquery/cadc (#2671)
- [x] astroquery/heasarc (#2671)
~~- [ ] astroquery/vamdc~~ (deprecated since 0.4.2 ??? If I am understanding correctly)
- [ ] astroquery/cosmosim (has no tests other than docs which are all skipped. I can make refactors but if stuff breaks I won't know) 
P.S. Thought about forking branch from #600 but probably requires more work than I think, might look into it in the future.
- [ ] ~~astroquery/mast (can try to address #2665 later)~~ (Seems to be a broader issue effecting more than Mast)

Hoping for some feedback on vamdc and cosmosim as I'm a little confused as to what's going on there or what you'll think is the best way to proceed. 