### PR TITLE
MAINT: remove unused and otherwise unsupported dependency

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -40,7 +40,6 @@ deps =
     oldestdeps: beautifulsoup4==4.8
     oldestdeps-alldeps: mocpy==0.9
 
-    cov: codecov
     online: pytest-rerunfailures
 
 extras =


### PR DESCRIPTION
codecov has been removed from pypi, and apparently we haven't even used it.