### PR TITLE
CI: moving cronjob to Friday

### DIFF
--- a/.github/workflows/ci_crontests.yml
+++ b/.github/workflows/ci_crontests.yml
@@ -6,8 +6,8 @@ on:
     tags:
     - '*'
   schedule:
-    # run every Monday at 5am UTC
-    - cron: '0 5 * * 1'
+    # run every Friday at 23:00 UTC
+    - cron: '0 23 * * 5'
   workflow_dispatch:
 
 permissions:


### PR DESCRIPTION
where upstream services are most unlikely to have planned downtime. I went with Friday night UT as it may avoid planed server downtime of alma, while I assume that it's just as unlikely for any planned jobs at ESA.

To close https://github.com/astropy/astroquery/issues/2643

