### PR TITLE
DOC: removing links legacy notebooks

### DIFF
--- a/docs/alma/alma.rst
+++ b/docs/alma/alma.rst
@@ -4,15 +4,6 @@
 ALMA Queries (`astroquery.alma`)
 ********************************
 
-Example Notebooks
-=================
-A series of example notebooks can be found here:
-
- * `What has ALMA observed toward all Messier objects? (an example of querying many sources) <http://nbviewer.jupyter.org/gist/keflavich/e798e10e3bf9a93d1453>`_
- * `ALMA finder chart of the Cartwheel galaxy and public Cycle 1 data quicklooks <http://nbviewer.jupyter.org/gist/keflavich/d5af22578094853e2d24>`_
- * `Finder charts toward many sources with different backgrounds <http://nbviewer.jupyter.org/gist/keflavich/2ef877ec90d774645fee>`_
- * `Finder chart and downloaded data from Cycle 0 observations of Sombrero Galaxy <http://nbviewer.jupyter.org/gist/keflavich/9934c9412d8f58299962>`_
-
 Getting started
 ===============
 


### PR DESCRIPTION
 as none of these works as either the covered functionality has been long removed or the API has been refactored.