### PR TITLE
Fix field name in Horizons.ephemerides docstring

### DIFF
--- a/astroquery/jplhorizons/core.py
+++ b/astroquery/jplhorizons/core.py
@@ -235,7 +235,7 @@ class HorizonsClass(BaseQuery):
         +------------------+-----------------------------------------------+
         | phasecoeff       | comet phase coeff (float, mag/deg, ``PHCOFF``)|
         +------------------+-----------------------------------------------+
-        | datetime         | epoch (str, ``Date__(UT)__HR:MN:SC.fff``)     |
+        | datetime_str     | epoch (str, ``Date__(UT)__HR:MN:SC.fff``)     |
         +------------------+-----------------------------------------------+
         | datetime_jd      | epoch Julian Date (float,                     |
         |                  | ``Date_________JDUT``)                        |


### PR DESCRIPTION
Corrected based on the fields in https://github.com/astropy/astroquery/blob/c5332fa6a41d9ee03f42a1af96a8d7bf62faaeab/astroquery/jplhorizons/__init__.py#L41-L43