### PR TITLE
Fixed failing PANSTARRS `Catalog` queries

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -144,6 +144,8 @@ mast
 
 - Expanding ``Cutouts`` functionality to support TICA HLSPs now available through 
   ``TesscutClass``. [##2668]
+
+- Resolved issue making PANSTARRS catalog queries when columns and sorting is specified. [#2727]
   
 nist
 ^^^^

--- a/astroquery/mast/collections.py
+++ b/astroquery/mast/collections.py
@@ -162,7 +162,11 @@ class CatalogsClass(MastQueryWithLogin):
         for prop, value in kwargs.items():
             params[prop] = value
 
-        return self._current_connection.service_request_async(service, params, pagesize=pagesize, page=page)
+        # Parameters will be passed as JSON objects only when accessing the PANSTARRS API
+        use_json = True if catalog.lower() == 'panstarrs' else False
+
+        return self._current_connection.service_request_async(service, params, pagesize=pagesize, page=page,
+                                                              use_json=use_json)
 
     @class_or_instance
     def query_object_async(self, objectname, *, radius=0.2*u.deg, catalog="Hsc",
@@ -313,7 +317,11 @@ class CatalogsClass(MastQueryWithLogin):
                 raise InvalidQueryError("At least one non-positional criterion must be supplied.")
             params["filters"] = filters
 
-        return self._current_connection.service_request_async(service, params, pagesize=pagesize, page=page)
+        # Parameters will be passed as JSON objects only when accessing the PANSTARRS API
+        use_json = True if catalog.lower() == 'panstarrs' else False
+
+        return self._current_connection.service_request_async(service, params, pagesize=pagesize, page=page,
+                                                              use_json=use_json)
 
     @class_or_instance
     def query_hsc_matchid_async(self, match, *, version=3, pagesize=None, page=None):

--- a/astroquery/mast/collections.py
+++ b/astroquery/mast/collections.py
@@ -163,7 +163,7 @@ class CatalogsClass(MastQueryWithLogin):
             params[prop] = value
 
         # Parameters will be passed as JSON objects only when accessing the PANSTARRS API
-        use_json = True if catalog.lower() == 'panstarrs' else False
+        use_json = catalog.lower() == 'panstarrs'
 
         return self._current_connection.service_request_async(service, params, pagesize=pagesize, page=page,
                                                               use_json=use_json)
@@ -318,7 +318,7 @@ class CatalogsClass(MastQueryWithLogin):
             params["filters"] = filters
 
         # Parameters will be passed as JSON objects only when accessing the PANSTARRS API
-        use_json = True if catalog.lower() == 'panstarrs' else False
+        use_json = catalog.lower() == 'panstarrs'
 
         return self._current_connection.service_request_async(service, params, pagesize=pagesize, page=page,
                                                               use_json=use_json)

--- a/astroquery/mast/services.py
+++ b/astroquery/mast/services.py
@@ -288,7 +288,27 @@ class ServiceAPI(BaseQuery):
             catalogs_request.extend(self._build_catalogs_params(params))
         else:
             headers['Content-Type'] = 'application/json'
-            catalogs_request = params
+
+            # Parameter syntax needs to be updated only for PANSTARRS catalog queries
+            if service.lower() == 'panstarrs':
+                catalogs_request.extend(self._build_catalogs_params(params))
+
+                # After parameter syntax is updated, revert back to dictionary
+                # so params can be passed as a JSON dictionary
+                params_dict = {}
+                for key, val in catalogs_request:
+                    params_dict.setdefault(key, []).append(val)
+                catalogs_request = params_dict
+
+                # Removing single-element lists. Single values will live on their own (except for `sort_by`)
+                for key in catalogs_request.keys():
+                    if (key != 'sort_by') & (len(catalogs_request[key]) == 1):
+                        catalogs_request[key] = catalogs_request[key][0]
+
+            # Otherwise, catalogs_request can remain as the original params dict
+            else:
+                catalogs_request = params
+
         response = self._request('POST', request_url, data=catalogs_request, headers=headers, use_json=use_json)
         return response
 

--- a/astroquery/mast/tests/test_mast_remote.py
+++ b/astroquery/mast/tests/test_mast_remote.py
@@ -691,6 +691,17 @@ class TestMast:
         assert isinstance(result, Table)
         assert 'PSO J254.2861-04.1091' in result['objName']
 
+        result = mast.Catalogs.query_criteria(coordinates="158.47924 -7.30962",
+                                              radius=0.01,
+                                              catalog="PANSTARRS",
+                                              table="mean",
+                                              data_release="dr2",
+                                              nStackDetections=[("gte", "1")],
+                                              columns=["objName", "distance"],
+                                              sort_by=[("asc", "distance")])
+        assert isinstance(result, Table)
+        assert result['distance'][0] <= result['distance'][1]
+
     def test_catalogs_query_hsc_matchid_async(self):
         catalogData = mast.Catalogs.query_object("M10",
                                                  radius=.001,


### PR DESCRIPTION
### Summary
Resolves https://github.com/astropy/astroquery/issues/2709 and https://github.com/astropy/astroquery/issues/2716. Users were reporting issues where PANSTARRS queries were failing when columns were specified, or any column sorting was requested with a sorting direction. 

The solution I found was:
* To pass the parameters as JSON when making requests to the PANSTARRS API (see changes in `collections.py`) 
* Call upon `_build_catalogs_params` when `use_json` is true for PANSTARRS queries (see changes in `services.py`). This call updates the syntax of the parameters being passed so that users can use criteria decorators (e.g. `sort_by=[("asc", "distance")]`), but setting `use_json` to true would prevent these decorators from passing because the synax wasnt being updated (params was left as the original `params` dictionary so it can be converted to a JSON object in the request). This didn't seem to be a problem before, but now that the PANSTARRS API needs the parameters to be passed as JSON dictionaries, this call needed to be made for both `use_json` = False AND True. Notice how none of the [`MastMissions` examples](https://astroquery.readthedocs.io/en/latest/mast/mast.html#mission-searches) have criteria decorators. This is because `use_json` is True so the params are passed in a dictionary without updating the syntax. That's something we can improve upon MastMissions the way I've done here with PANSTARRS, but is out of scope of this PR, so I'll make a separate issue about it. 

------
### Task list
- [x] Resolve 422 Unprocessable Entity error in PANSTARRS Catalog queries
- [x] Add a unit test to catch potential errors from queries like this in the future
- [x] `CHANGELOG` entry

------
### Screenshots

When sorting direction is specified, `(direction, criteria)` tuples can be passed as a single tuple or list of tuples: 

<img width="613" alt="image" src="https://user-images.githubusercontent.com/32107699/236328873-9cfa6049-8db3-43b0-be03-b088db275b29.png">

<img width="635" alt="image" src="https://user-images.githubusercontent.com/32107699/236329039-668f476e-0e67-4871-82b4-6e808f3202d8.png">

The changes in this PR do not break non-PANSTARRS queries to the Catalogs API: 

<img width="1001" alt="image" src="https://user-images.githubusercontent.com/32107699/236330098-e0cc7905-cab9-4291-a46e-d30552d026cf.png">

The changes in this PR do not break non-PANSTARRS queries that request specific columns and/or sorting: 

<img width="941" alt="image" src="https://user-images.githubusercontent.com/32107699/236508830-090fa78c-74ed-4b52-85c6-6879d151bf87.png">

Below are screenshots (taken May 4, 2023) showing the results of the queries that reported errors, after fix:

#2709:

<img width="995" alt="image" src="https://user-images.githubusercontent.com/32107699/236295888-05e3111b-6fb5-488e-ac2c-8df96c0f75cb.png">

#2716:

<img width="998" alt="image" src="https://user-images.githubusercontent.com/32107699/236327391-0ddd5e5d-6904-4a79-bee8-744c43e3f3ac.png">

