### PR TITLE
Fixing CI hiccups from `astroquery.mast` unit test 

### DIFF
--- a/astroquery/mast/tests/test_mast.py
+++ b/astroquery/mast/tests/test_mast.py
@@ -302,7 +302,7 @@ def test_mast_service_request(patch_post):
 def test_resolve_object(patch_post):
     m103_loc = mast.Mast.resolve_object("M103")
     print(m103_loc)
-    assert m103_loc.separation(SkyCoord("23.34086 60.658", unit='deg')).value == 0
+    assert round(m103_loc.separation(SkyCoord("23.34086 60.658", unit='deg')).value, 10) == 0
 
 
 def test_login_logout(patch_post):


### PR DESCRIPTION
### Summary

The dev dependency test was failing due to an error in the computation of the offset between the resolved object and its sky coordinates from the literature. It was infinitesimally small, something like 10**-15, so I rounded it to the neares 10**-10.

### Task List
- [x] Rounded value to nearest 10th decimal place to fix systematic error in offset computation (`astroquery/mast/test_mast.py`)