### PR TITLE
CI: fix RTD build 

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -1,12 +1,11 @@
 version: 2
 
 build:
-  os: "ubuntu-20.04"
+  os: "ubuntu-22.04"
   tools:
-    python: "mambaforge-4.10"
-
-conda:
-  environment: docs/rtd_environment.yaml
+    python: "3.10"
+  apt_packages:
+    - graphviz
 
 sphinx:
   builder: html
@@ -22,7 +21,6 @@ python:
       path: .
       extra_requirements:
         - docs
-        - all
 
 # Don't build any extra formats
 formats: []


### PR DESCRIPTION
to use newer python and properly install grapviz, follow-up to the quick fix of #2730 