### PR TITLE
Adding error handling examples to mast docs

### DIFF
--- a/docs/mast/mast.rst
+++ b/docs/mast/mast.rst
@@ -1454,6 +1454,20 @@ The basic MAST query function returns query results as an `~astropy.table.Table`
    Length = 77 rows
 
 
+The 'params' parameter for the `~astroquery.mast.MastClass.service_request` method requires a key-value pair
+format, with the key name inside quotation marks. Keys without quotes will produce the following error.
+
+.. doctest-remote-data::
+
+   >>> service = 'Mast.Caom.Cone'
+   >>> params = {ra:184.3,
+   ...           dec:54.5,
+   ...           radius:0.2}
+   >>> observations = Mast.service_request(service, params)
+   ...
+   NameError: name 'ra' is not defined
+   
+
 If the output is not the MAST json result type it cannot be properly parsed into a `~astropy.table.Table`.
 In this case, the async method should be used to get the raw http response, which can then be manually parsed.
 

--- a/docs/mast/mast.rst
+++ b/docs/mast/mast.rst
@@ -81,6 +81,16 @@ Radius is an optional parameter and the default is 0.2 degrees.
       science    SPITZER_SHA    SSC Pipeline ...    nan 19000016510      0.0
       science    SPITZER_SHA    SSC Pipeline ...    nan 19000016510      0.0
 
+Optional parameters must be labeled. For example the query above will produce
+an error if the "radius" field is not specified.
+
+.. doctest-skip::
+   >>> from astroquery.mast import Observations
+   ...
+   >>> obs_table = Observations.query_object("M8",".02 deg")
+   >>> print(obs_table[:10])  # doctest: +IGNORE_OUTPUT
+   TypeError: query_object_async() takes 2 positional arguments but 3 were given
+
 
 Observation Criteria Queries
 ----------------------------
@@ -210,6 +220,18 @@ To get a table of metadata associated with observation or product lists use the
             obsID Product Group ID ...         Long integer, e.g. 2007590987
    obs_collection          Mission ... HST, HLA, SWIFT, GALEX, Kepler, K2...
 
+The `~astroquery.mast.ObservationsClass.get_metadata` function only accepts the strings 
+"observations" or "products" as a parameter. Any other string or spelling will result 
+in an error.
+
+.. doctest-skip::
+   
+   >>> from astroquery.mast import Observations
+   ...
+   >>> meta_table = Observations.get_metadata("observation")
+   >>> print(meta_table[:5])  # doctest: +IGNORE_OUTPUT
+   InvalidQueryError: Unknown query type.
+   
 
 Downloading Data
 ================

--- a/docs/mast/mast.rst
+++ b/docs/mast/mast.rst
@@ -914,6 +914,14 @@ Given an HSC Match ID, return all catalog results.
    410574498 63980492 ...   -1.10056e-005 1.56577e-009 1.56577e-009 1.10056e-005
    410574497 63980492 ...   -1.10056e-005 1.56577e-009 1.56577e-009 1.10056e-005
 
+"MatchID" is case sensitive in this case, and will produce an error with different
+capitalization.
+
+.. doctest-skip::
+
+   >>> matchid = catalog_data[0]["matchid"]
+   KeyError: 'matchid'
+
 HSC spectra accessed through this class as well. `~astroquery.mast.CatalogsClass.get_hsc_spectra`
 does not take any arguments, and simply loads all HSC spectra.
 
@@ -1017,6 +1025,13 @@ not explicitly called for TICA.
      0  PRIMARY       1 PrimaryHDU      56   ()
      1  PIXELS        1 BinTableHDU    280   1196R x 12C   [D, E, J, 25J, 25E, 25E, 25E, 25E, J, E, E, 38A]
      2  APERTURE      1 ImageHDU        81   (5, 5)   int32
+
+The SkyCoord constructor requires the 'unit' parameter. Unspecified units will result in an error.
+
+.. doctest-skip::
+
+   >>> cutout_coord = SkyCoord(107.18696, -70.50919)
+   UnitTypeError: Longitude instances require units equivalent to 'rad', but no unit was given.
 
 For users with time-sensitive targets who would like cutouts from the latest observations, 
 we recommend requesting for the TICA product. Using the same target from the example above, 

--- a/docs/mast/mast.rst
+++ b/docs/mast/mast.rst
@@ -85,10 +85,8 @@ Optional parameters must be labeled. For example the query above will produce
 an error if the "radius" field is not specified.
 
 .. doctest-skip::
-   >>> from astroquery.mast import Observations
-   ...
+
    >>> obs_table = Observations.query_object("M8",".02 deg")
-   >>> print(obs_table[:10])  # doctest: +IGNORE_OUTPUT
    TypeError: query_object_async() takes 2 positional arguments but 3 were given
 
 
@@ -226,10 +224,7 @@ in an error.
 
 .. doctest-skip::
    
-   >>> from astroquery.mast import Observations
-   ...
    >>> meta_table = Observations.get_metadata("observation")
-   >>> print(meta_table[:5])  # doctest: +IGNORE_OUTPUT
    InvalidQueryError: Unknown query type.
    
 
@@ -419,12 +414,6 @@ in an error.
 
 .. doctest-skip::
 
-   >>> from astroquery.mast import Observations
-   ...
-   >>> single_obs = Observations.query_criteria(obs_collection="IUE",obs_id="lwp13058")
-   >>> data_products = Observations.get_product_list(single_obs)
-   ...
-   >>> product = data_products[0]["dataURI"]
    >>> result = Observations.download_products(product)   # doctest: +IGNORE_OUTPUT
    RemoteServiceError: Error converting data type varchar to bigint.
 

--- a/docs/mast/mast.rst
+++ b/docs/mast/mast.rst
@@ -1093,16 +1093,15 @@ simply with either the objectname or coordinates.
      2  APERTURE      1 ImageHDU        97   (2136, 2078)   int32
 
 Note that the moving targets functionality does not currently support TICA, so the product
-parameter will always default to SPOC.
+parameter will result in an error when set to 'TICA'.
 
 .. doctest-remote-data::
 
    >>> from astroquery.mast import Tesscut
    ...
    >>> hdulist = Tesscut.get_cutouts(objectname="Eleonora", product='tica', moving_target=True, size=5, sector=6)
-   WARNING: InputWarning: Only SPOC is available for moving targets queries. Defaulting to SPOC. [astroquery.mast.cutouts]
-   >>> hdulist[0][0].header['FFI_TYPE']  # doctest: +IGNORE_OUTPUT
-   'SPOC'
+   ...
+   InvalidQueryError: Only SPOC is available for moving targets queries.
 
 The `~astroquery.mast.TesscutClass.download_cutouts` function takes a product type ("TICA" or "SPOC", but defaults to "SPOC"),
 coordinate, cutout size (in pixels or an angular quantity), or object name (e.g. "M104" or "TIC 32449963") and moving target

--- a/docs/mast/mast.rst
+++ b/docs/mast/mast.rst
@@ -854,7 +854,7 @@ parameters will result in an error.
 
    >>> from astroquery.mast import Catalogs
    ...
-   >>> catalog_data = Catalogs.query_criteria(catalog="Ctl",
+   >>> catalog_data = Catalogs.query_criteria(catalog="Tic",
    ...                                        objectname='M101', radius=1)
    ...
    InvalidQueryError: At least one non-positional criterion must be supplied.
@@ -922,14 +922,6 @@ Given an HSC Match ID, return all catalog results.
    410574498 63980492 ...   -1.10056e-005 1.56577e-009 1.56577e-009 1.10056e-005
    410574497 63980492 ...   -1.10056e-005 1.56577e-009 1.56577e-009 1.10056e-005
 
-"MatchID" is case sensitive in this case, and will produce an error with different
-capitalization.
-
-.. doctest-remote-data::
-
-   >>> matchid = catalog_data[0]["matchid"]
-   ...
-   KeyError: 'matchid'
 
 HSC spectra accessed through this class as well. `~astroquery.mast.CatalogsClass.get_hsc_spectra`
 does not take any arguments, and simply loads all HSC spectra.
@@ -1450,9 +1442,9 @@ The basic MAST query function returns query results as an `~astropy.table.Table`
    Length = 77 rows
 
 
-Many mast services, specifically JWST and Catalog services, require the two principal keywords, columns and filters,
+Many mast services, specifically JWST and Catalog services, require the two principal keywords, 'columns' and 'filters',
 to list parameters. Positional services will also require right ascension and declination parameters, either in
-addition to columns and filters or on their own. For example, the Cone search service only requires the 'ra' and
+addition to columns and filters or on their own. For example, the cone search service only requires the 'ra' and
 'dec' parameters. Using the wrong service parameters will result in an error. Read the
 `MAST API services documentation <https://mast.stsci.edu/api/v0/_services.html>`__ for more information on valid 
 service parameters.

--- a/docs/mast/mast.rst
+++ b/docs/mast/mast.rst
@@ -413,6 +413,27 @@ which can be changed with the ``local_path`` keyword argument.
    >>> print(result)
    ('COMPLETE', None, None)
 
+The `~astroquery.mast.ObservationsClass.download_file` and `~astroquery.mast.ObservationsClass.download_products` 
+methods are not interchangeable. Using the incorrect method for either single files or product lists will result
+in an error.
+
+.. doctest-skip::
+
+   >>> from astroquery.mast import Observations
+   ...
+   >>> single_obs = Observations.query_criteria(obs_collection="IUE",obs_id="lwp13058")
+   >>> data_products = Observations.get_product_list(single_obs)
+   ...
+   >>> product = data_products[0]["dataURI"]
+   >>> result = Observations.download_products(product)   # doctest: +IGNORE_OUTPUT
+   RemoteServiceError: Error converting data type varchar to bigint.
+
+.. doctest-skip::
+   
+   >>> result = Observations.download_file(data_products)
+   TypeError: can only concatenate str (not "Table") to str
+
+
 Cloud Data Access
 ------------------
 Public datasets from the Hubble, Kepler and TESS telescopes are also available for free on Amazon Web Services

--- a/docs/mast/mast.rst
+++ b/docs/mast/mast.rst
@@ -86,9 +86,10 @@ an error if the "radius" field is not specified.
 
 .. doctest-remote-data::
 
-   >>> obs_table = Observations.query_object("M8",".02 deg")
+   >>> obs_table = Observations.query_object("M8", ".02 deg")
+   Traceback (most recent call last):
    ...
-   TypeError: query_object_async() takes 2 positional arguments but 3 were given
+   TypeError: ObservationsClass.query_object_async() takes 2 positional arguments but 3 were given
 
 
 Observation Criteria Queries
@@ -219,16 +220,17 @@ To get a table of metadata associated with observation or product lists use the
             obsID Product Group ID ...         Long integer, e.g. 2007590987
    obs_collection          Mission ... HST, HLA, SWIFT, GALEX, Kepler, K2...
 
-The `~astroquery.mast.ObservationsClass.get_metadata` function only accepts the strings 
-"observations" or "products" as a parameter. Any other string or spelling will result 
+The `~astroquery.mast.ObservationsClass.get_metadata` function only accepts the strings
+"observations" or "products" as a parameter. Any other string or spelling will result
 in an error.
 
 .. doctest-remote-data::
-   
+
    >>> meta_table = Observations.get_metadata("observation")
+   Traceback (most recent call last):
    ...
-   InvalidQueryError: Unknown query type.
-   
+   astroquery.exceptions.InvalidQueryError: Unknown query type.
+
 
 Downloading Data
 ================
@@ -410,19 +412,21 @@ which can be changed with the ``local_path`` keyword argument.
    >>> print(result)
    ('COMPLETE', None, None)
 
-The `~astroquery.mast.ObservationsClass.download_file` and `~astroquery.mast.ObservationsClass.download_products` 
+The `~astroquery.mast.ObservationsClass.download_file` and `~astroquery.mast.ObservationsClass.download_products`
 methods are not interchangeable. Using the incorrect method for either single files or product lists will result
 in an error.
 
 .. doctest-remote-data::
 
    >>> result = Observations.download_products(product)   # doctest: +IGNORE_OUTPUT
+   Traceback (most recent call last):
    ...
    RemoteServiceError: Error converting data type varchar to bigint.
 
 .. doctest-remote-data::
-   
+
    >>> result = Observations.download_file(data_products)
+   Traceback (most recent call last):
    ...
    TypeError: can only concatenate str (not "Table") to str
 
@@ -856,8 +860,9 @@ parameters will result in an error.
    ...
    >>> catalog_data = Catalogs.query_criteria(catalog="Tic",
    ...                                        objectname='M101', radius=1)
+   Traceback (most recent call last):
    ...
-   InvalidQueryError: At least one non-positional criterion must be supplied.
+   astroquery.exceptions.InvalidQueryError: At least one non-positional criterion must be supplied.
 
 
 The PanSTARRS catalog also accepts additional parameters to allow for query refinement. These options include column selection,
@@ -973,7 +978,7 @@ TESSCut
 =======
 
 TESSCut is MAST's tool to provide full-frame image (FFI) cutouts from the Transiting
-Exoplanet Survey Satellite (TESS). The cutouts can be made from either the Science 
+Exoplanet Survey Satellite (TESS). The cutouts can be made from either the Science
 Processing Operation's Center (`SPOC <https://archive.stsci.edu/missions-and-data/tess>`__) FFI products,
 or the TESS Image CAlibrator (`TICA <https://archive.stsci.edu/hlsp/tica>`__) high-level science products.
 Cutouts from the TICA products are not available for sectors 1-26,
@@ -1010,7 +1015,7 @@ Requesting a cutout by coordinate or objectname accesses the
 `MAST TESScut API <https://mast.stsci.edu/tesscut/docs/getting_started.html#requesting-a-cutout>`__
 and returns a target pixel file, with format described
 `here <https://astrocut.readthedocs.io/en/latest/astrocut/file_formats.html#target-pixel-files>`__.
-Note that the product argument will default to request for SPOC cutouts when 
+Note that the product argument will default to request for SPOC cutouts when
 not explicitly called for TICA.
 
 .. doctest-remote-data::
@@ -1028,8 +1033,8 @@ not explicitly called for TICA.
      2  APERTURE      1 ImageHDU        81   (5, 5)   int32
 
 
-For users with time-sensitive targets who would like cutouts from the latest observations, 
-we recommend requesting for the TICA product. Using the same target from the example above, 
+For users with time-sensitive targets who would like cutouts from the latest observations,
+we recommend requesting for the TICA product. Using the same target from the example above,
 this example shows a request for TICA cutouts:
 
 .. doctest-remote-data::
@@ -1088,8 +1093,9 @@ parameter will result in an error when set to 'TICA'.
    >>> from astroquery.mast import Tesscut
    ...
    >>> hdulist = Tesscut.get_cutouts(objectname="Eleonora", product='tica', moving_target=True, size=5, sector=6)
+   Traceback (most recent call last):
    ...
-   InvalidQueryError: Only SPOC is available for moving targets queries.
+   astroquery.exceptions.InvalidQueryError: Only SPOC is available for moving targets queries.
 
 The `~astroquery.mast.TesscutClass.download_cutouts` function takes a product type ("TICA" or "SPOC", but defaults to "SPOC"),
 coordinate, cutout size (in pixels or an angular quantity), or object name (e.g. "M104" or "TIC 32449963") and moving target
@@ -1150,8 +1156,8 @@ To access sector information for a particular coordinate, object, or moving targ
    tess-s0008-1-1      8      1   1
    tess-s0034-1-2     34      1   2
 
-Note that because of the delivery cadence of the 
-TICA high level science products, later sectors will be available sooner with TICA than with 
+Note that because of the delivery cadence of the
+TICA high level science products, later sectors will be available sooner with TICA than with
 SPOC. Also note that TICA is not available for sectors 1-26. The following example is the same
 query as above, but for TICA. Notice that products for sector 8 are no longer available,
 but are now available for sector 61.
@@ -1446,7 +1452,7 @@ Many mast services, specifically JWST and Catalog services, require the two prin
 to list parameters. Positional services will also require right ascension and declination parameters, either in
 addition to columns and filters or on their own. For example, the cone search service only requires the 'ra' and
 'dec' parameters. Using the wrong service parameters will result in an error. Read the
-`MAST API services documentation <https://mast.stsci.edu/api/v0/_services.html>`__ for more information on valid 
+`MAST API services documentation <https://mast.stsci.edu/api/v0/_services.html>`__ for more information on valid
 service parameters.
 
 .. doctest-remote-data::
@@ -1457,9 +1463,10 @@ service parameters.
    >>> params = {'columns': "*",
    ...           'filters': {}}
    >>> observations = Mast.service_request(service, params)
+   Traceback (most recent call last):
    ...
-   RemoteServiceError: Request Object is Missing Required Parameter : RA
-   
+   astroquery.exceptions.RemoteServiceError: Request Object is Missing Required Parameter : RA
+
 
 If the output is not the MAST json result type it cannot be properly parsed into a `~astropy.table.Table`.
 In this case, the async method should be used to get the raw http response, which can then be manually parsed.

--- a/docs/mast/mast.rst
+++ b/docs/mast/mast.rst
@@ -692,18 +692,6 @@ If no catalog is specified, the Hubble Source Catalog will be queried.
    1.7524423152919317 6382034098672634846    AIS ...              --            0
 
 
-The `~astroquery.mast.CatalogsClass.query_object` method for positional queries
-requires a sky position with a right ascension (RA) between 0 and 360 degrees and
-a declination between -90 and 90 degrees. Any values outside of this range will
-result in an error.
-
-.. doctest-remote-data::
-   
-   >>> catalog_data = Catalogs.query_object("-158.47924 -7.30962", catalog="Galex")
-   ...
-   ResolverError: Could not resolve -158.47924 -7.30962 to a sky position.
-
-
 Some catalogs have a maximum number of results they will return.
 If a query results in this maximum number of results a warning will be displayed to alert
 the user that they might be getting a subset of the true result set.
@@ -855,6 +843,21 @@ The TESS Input Catalog (TIC), Disk Detective Catalog, and PanSTARRS Catalog can 
    J165327.01-042546.2 ... https://talk.diskdetective.org/#/subjects/AWI0005ck3
    J165949.90-054300.7 ... https://talk.diskdetective.org/#/subjects/AWI0005ckk
    J170314.11-035210.4 ... https://talk.diskdetective.org/#/subjects/AWI0005ckv
+
+
+The `~astroquery.mast.CatalogsClass.query_criteria` function requires at least one non-positional parameter.
+These parameters are the column names listed in the `field descriptions <https://mast.stsci.edu/api/v0/pages.html>`__
+of the catalog being queried. They do not include objectname, coordinates, or radius. Running a query with only positional
+parameters will result in an error.
+
+.. doctest-remote-data::
+
+   >>> from astroquery.mast import Catalogs
+   ...
+   >>> catalog_data = Catalogs.query_criteria(catalog="Ctl",
+   ...                                        objectname='M101', radius=1)
+   ...
+   InvalidQueryError: At least one non-positional criterion must be supplied.
 
 
 The PanSTARRS catalog also accepts additional parameters to allow for query refinement. These options include column selection,
@@ -1032,13 +1035,6 @@ not explicitly called for TICA.
      1  PIXELS        1 BinTableHDU    280   1196R x 12C   [D, E, J, 25J, 25E, 25E, 25E, 25E, J, E, E, 38A]
      2  APERTURE      1 ImageHDU        81   (5, 5)   int32
 
-The SkyCoord constructor requires the 'unit' parameter. Unspecified units will result in an error.
-
-.. doctest-remote-data::
-
-   >>> cutout_coord = SkyCoord(107.18696, -70.50919)
-   ...
-   UnitTypeError: Longitude instances require units equivalent to 'rad', but no unit was given.
 
 For users with time-sensitive targets who would like cutouts from the latest observations, 
 we recommend requesting for the TICA product. Using the same target from the example above, 

--- a/docs/mast/mast.rst
+++ b/docs/mast/mast.rst
@@ -84,9 +84,10 @@ Radius is an optional parameter and the default is 0.2 degrees.
 Optional parameters must be labeled. For example the query above will produce
 an error if the "radius" field is not specified.
 
-.. doctest-skip::
+.. doctest-remote-data::
 
    >>> obs_table = Observations.query_object("M8",".02 deg")
+   ...
    TypeError: query_object_async() takes 2 positional arguments but 3 were given
 
 
@@ -222,9 +223,10 @@ The `~astroquery.mast.ObservationsClass.get_metadata` function only accepts the 
 "observations" or "products" as a parameter. Any other string or spelling will result 
 in an error.
 
-.. doctest-skip::
+.. doctest-remote-data::
    
    >>> meta_table = Observations.get_metadata("observation")
+   ...
    InvalidQueryError: Unknown query type.
    
 
@@ -412,14 +414,16 @@ The `~astroquery.mast.ObservationsClass.download_file` and `~astroquery.mast.Obs
 methods are not interchangeable. Using the incorrect method for either single files or product lists will result
 in an error.
 
-.. doctest-skip::
+.. doctest-remote-data::
 
    >>> result = Observations.download_products(product)   # doctest: +IGNORE_OUTPUT
+   ...
    RemoteServiceError: Error converting data type varchar to bigint.
 
-.. doctest-skip::
+.. doctest-remote-data::
    
    >>> result = Observations.download_file(data_products)
+   ...
    TypeError: can only concatenate str (not "Table") to str
 
 
@@ -693,9 +697,10 @@ requires a sky position with a right ascension (RA) between 0 and 360 degrees an
 a declination between -90 and 90 degrees. Any values outside of this range will
 result in an error.
 
-.. doctest-skip::
+.. doctest-remote-data::
    
    >>> catalog_data = Catalogs.query_object("-158.47924 -7.30962", catalog="Galex")
+   ...
    ResolverError: Could not resolve -158.47924 -7.30962 to a sky position.
 
 
@@ -917,9 +922,10 @@ Given an HSC Match ID, return all catalog results.
 "MatchID" is case sensitive in this case, and will produce an error with different
 capitalization.
 
-.. doctest-skip::
+.. doctest-remote-data::
 
    >>> matchid = catalog_data[0]["matchid"]
+   ...
    KeyError: 'matchid'
 
 HSC spectra accessed through this class as well. `~astroquery.mast.CatalogsClass.get_hsc_spectra`
@@ -1028,9 +1034,10 @@ not explicitly called for TICA.
 
 The SkyCoord constructor requires the 'unit' parameter. Unspecified units will result in an error.
 
-.. doctest-skip::
+.. doctest-remote-data::
 
    >>> cutout_coord = SkyCoord(107.18696, -70.50919)
+   ...
    UnitTypeError: Longitude instances require units equivalent to 'rad', but no unit was given.
 
 For users with time-sensitive targets who would like cutouts from the latest observations, 

--- a/docs/mast/mast.rst
+++ b/docs/mast/mast.rst
@@ -688,6 +688,17 @@ If no catalog is specified, the Hubble Source Catalog will be queried.
    1.7524423152919317 6382034098672634846    AIS ...              --            0
 
 
+The `~astroquery.mast.CatalogsClass.query_object` method for positional queries
+requires a sky position with a right ascension (RA) between 0 and 360 degrees and
+a declination between -90 and 90 degrees. Any values outside of this range will
+result in an error.
+
+.. doctest-skip::
+   
+   >>> catalog_data = Catalogs.query_object("-158.47924 -7.30962", catalog="Galex")
+   ResolverError: Could not resolve -158.47924 -7.30962 to a sky position.
+
+
 Some catalogs have a maximum number of results they will return.
 If a query results in this maximum number of results a warning will be displayed to alert
 the user that they might be getting a subset of the true result set.

--- a/docs/mast/mast.rst
+++ b/docs/mast/mast.rst
@@ -1210,7 +1210,6 @@ so the query will always default to SPOC.
    >>> from astroquery.mast import Tesscut
    ...
    >>> sector_table = Tesscut.get_sectors(objectname="Ceres", moving_target=True)
-   WARNING: InputWarning: Only SPOC is available for moving targets queries. Defaulting to SPOC. [astroquery.mast.cutouts]
    >>> print(sector_table)
      sectorName   sector camera ccd
    -------------- ------ ------ ---

--- a/docs/mast/mast.rst
+++ b/docs/mast/mast.rst
@@ -1450,18 +1450,23 @@ The basic MAST query function returns query results as an `~astropy.table.Table`
    Length = 77 rows
 
 
-The 'params' parameter for the `~astroquery.mast.MastClass.service_request` method requires a key-value pair
-format, with the key name inside quotation marks. Keys without quotes will produce the following error.
+Many mast services, specifically JWST and Catalog services, require the two principal keywords, columns and filters,
+to list parameters. Positional services will also require right ascension and declination parameters, either in
+addition to columns and filters or on their own. For example, the Cone search service only requires the 'ra' and
+'dec' parameters. Using the wrong service parameters will result in an error. Read the
+`MAST API services documentation <https://mast.stsci.edu/api/v0/_services.html>`__ for more information on valid 
+service parameters.
 
 .. doctest-remote-data::
 
+   >>> from astroquery.mast import Mast
+   ...
    >>> service = 'Mast.Caom.Cone'
-   >>> params = {ra:184.3,
-   ...           dec:54.5,
-   ...           radius:0.2}
+   >>> params = {'columns': "*",
+   ...           'filters': {}}
    >>> observations = Mast.service_request(service, params)
    ...
-   NameError: name 'ra' is not defined
+   RemoteServiceError: Request Object is Missing Required Parameter : RA
    
 
 If the output is not the MAST json result type it cannot be properly parsed into a `~astropy.table.Table`.


### PR DESCRIPTION
Error handling examples to show users how to avoid/fix possible input-based errors.