### PR TITLE
TEST: using new continue on failure mode of doctestplus

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -33,7 +33,7 @@ astropy_header = true
 text_file_format = rst
 xfail_strict = true
 remote_data_strict = true
-addopts = --color=yes --doctest-rst
+addopts = --color=yes --doctest-rst --doctest-continue-on-failure
 filterwarnings =
     error
 #   These are temporary measures, all of these should be fixed:
@@ -120,7 +120,7 @@ install_requires=
    keyring>=15.0
    pyvo>=1.1
 tests_require =
-   pytest-doctestplus>=0.10.1
+   pytest-doctestplus>=0.13
    pytest-astropy
 
 [options.extras_require]


### PR DESCRIPTION
This will only work once I do a new doctestplus release which will happen maybe later this week, or next week (new features are in the works that are worth the waiting for)