### PR TITLE
Allow astropy Quantity in query locations

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -156,6 +156,8 @@ jplhorizons
 
 - Assign units to ``"hour_angle"``, ``"solartime"``, and ``"siderealtime"`` columns. [#2794]
 
+- Allow using units in locations specified as coordinates. [#2746]
+
 jplsbdb
 ^^^^^^^
 

--- a/astroquery/jplhorizons/core.py
+++ b/astroquery/jplhorizons/core.py
@@ -1210,14 +1210,13 @@ class HorizonsClass(BaseQuery):
 
     @staticmethod
     def _location_to_params(loc_dict):
-        """translate a 'location' dict to a dict of request parameters"""
-        loc_dict = {
+        """translate a 'location' dict to request parameters"""
+        location = {
             "CENTER": f"coord@{loc_dict['body']}",
             "COORD_TYPE": "GEODETIC",
-            "SITE_COORD": HorizonsClass._format_site_coords(loc_dict)
+            "SITE_COORD": "'{}'".format(str(HorizonsClass._format_site_coords(loc_dict)))
         }
-        loc_dict["SITE_COORD"] = f"'{loc_dict['SITE_COORD']}'"
-        return loc_dict
+        return location
 
     @staticmethod
     def _format_site_coords(coords):

--- a/astroquery/jplhorizons/core.py
+++ b/astroquery/jplhorizons/core.py
@@ -1218,13 +1218,10 @@ class HorizonsClass(BaseQuery):
         }
         loc_dict["SITE_COORD"] = f"'{loc_dict['SITE_COORD']}'"
         return loc_dict
-    
+
     @staticmethod
     def _format_site_coords(coords):
         # formats lon/lat/elevation/body (e.g., id and location dictionaries) for the Horizons API
-        ",".join(
-                str(coords[k].to_value()) for k in ['lon', 'lat', 'elevation']
-            )
         return (f"{coords['lon'].to_value('deg')},{coords['lat'].to_value('deg')},"
                 f"{coords['elevation'].to_value('km')}@{coords['body']}")
 

--- a/astroquery/jplhorizons/tests/test_jplhorizons_remote.py
+++ b/astroquery/jplhorizons/tests/test_jplhorizons_remote.py
@@ -362,10 +362,11 @@ class TestHorizonsClass:
         assert len(res) >= 6412
 
     @pytest.mark.parametrize(
-            "location",
-            ({"lon": 244, "lat": 33, "elevation": 1.7},
-             {"lon": (244 * u.deg).to(u.rad), "lat": (33 * u.deg).to(u.rad), "elevation": 1700 * u.m},
-             )
+        "location",
+        (
+            {"lon": 244, "lat": 33, "elevation": 1.7},
+            {"lon": (244 * u.deg).to(u.rad), "lat": (33 * u.deg).to(u.rad), "elevation": 1700 * u.m},
+        )
     )
     def test_vectors_query_topocentric_coordinates(self, location):
         "Test vectors query specifying observer's longitude, latitude, and elevation"

--- a/astroquery/jplhorizons/tests/test_jplhorizons_remote.py
+++ b/astroquery/jplhorizons/tests/test_jplhorizons_remote.py
@@ -364,9 +364,9 @@ class TestHorizonsClass:
     def test_vectors_query_topocentric_coordinates(self):
         "Test vectors query specifying observer's longitude, latitude, and elevation"
         q = jplhorizons.Horizons(id='Ceres',
-                                location={"lon": 244, "lat": 33, "elevation": 1700},
-                                id_type='smallbody',
-                                epochs=2451544.5)
+                                 location={"lon": 244, "lat": 33, "elevation": 1700},
+                                 id_type='smallbody',
+                                 epochs=2451544.5)
         res = q.vectors_async()
         i = res.text.find("Center geodetic :")
         j = res.text.find("\n", i)

--- a/astroquery/jplhorizons/tests/test_jplhorizons_remote.py
+++ b/astroquery/jplhorizons/tests/test_jplhorizons_remote.py
@@ -361,17 +361,23 @@ class TestHorizonsClass:
 
         assert len(res) >= 6412
 
-    def test_vectors_query_topocentric_coordinates(self):
+    @pytest.mark.parametrize(
+            "location",
+            ({"lon": 244, "lat": 33, "elevation": 1.7},
+             {"lon": (244 * u.deg).to(u.rad), "lat": (33 * u.deg).to(u.rad), "elevation": 1700 * u.m},
+             )
+    )
+    def test_vectors_query_topocentric_coordinates(self, location):
         "Test vectors query specifying observer's longitude, latitude, and elevation"
         q = jplhorizons.Horizons(id='Ceres',
-                                 location={"lon": 244, "lat": 33, "elevation": 1700},
+                                 location=location,
                                  id_type='smallbody',
                                  epochs=2451544.5)
         res = q.vectors_async()
         i = res.text.find("Center geodetic :")
         j = res.text.find("\n", i)
         parts = res.text[i:j].split()
-        assert parts[3:6] == ['244.0,', '33.0,', '1700.0']
+        assert parts[3:6] == ['244.0,', '33.0,', '1.7']
 
         start = res.text.find("$$SOE")
         end = res.text.find("$$EOE")

--- a/astroquery/jplhorizons/tests/test_jplhorizons_remote.py
+++ b/astroquery/jplhorizons/tests/test_jplhorizons_remote.py
@@ -361,6 +361,22 @@ class TestHorizonsClass:
 
         assert len(res) >= 6412
 
+    def test_vectors_query_topocentric_coordinates(self):
+        "Test vectors query specifying observer's longitude, latitude, and elevation"
+        q = jplhorizons.Horizons(id='Ceres',
+                                location={"lon": 244, "lat": 33, "elevation": 1700},
+                                id_type='smallbody',
+                                epochs=2451544.5)
+        res = q.vectors_async()
+        i = res.text.find("Center geodetic :")
+        j = res.text.find("\n", i)
+        parts = res.text[i:j].split()
+        assert parts[3:6] == ['244.0,', '33.0,', '1700.0']
+
+        start = res.text.find("$$SOE")
+        end = res.text.find("$$EOE")
+        assert res.text[start:end].find("2000-Jan-01") > 0
+
     def test_unknownobject(self):
         with pytest.raises(ValueError):
             jplhorizons.Horizons(id='spamspamspameggsspam', location='500',

--- a/docs/jplhorizons/jplhorizons.rst
+++ b/docs/jplhorizons/jplhorizons.rst
@@ -103,7 +103,7 @@ as the observer's location, and Ceres as the target:
     ...                location=statue_of_liberty,
     ...                epochs=2458133.33546)
     >>> print(obj)
-    JPLHorizons instance "Ceres"; location={'lon': -74.0466891, 'lat': 40.6892534, 'elevation': 0.093, 'body': 399}, epochs=[2458133.33546], id_type=None
+    JPLHorizons instance "Ceres"; location={'lon': <Quantity -74.0466891 deg>, 'lat': <Quantity 40.6892534 deg>, 'elevation': <Quantity 0.093 km>, 'body': 399}, epochs=[2458133.33546], id_type=None
 
 2. Specifying topocentric coordinates for both location and observer is often
 useful when performing geometric calculations for artificial satellites without

--- a/docs/jplhorizons/jplhorizons.rst
+++ b/docs/jplhorizons/jplhorizons.rst
@@ -96,6 +96,7 @@ as the observer's location, and Ceres as the target:
 
 .. doctest-remote-data::
 
+    >>> import astropy.units as u
     >>> statue_of_liberty = {'lon': -74.0466891 * u.deg,
     ...                      'lat': 40.6892534 * u.deg,
     ...                      'elevation': 0.093 * u.km}

--- a/docs/jplhorizons/jplhorizons.rst
+++ b/docs/jplhorizons/jplhorizons.rst
@@ -78,7 +78,7 @@ must still be entered in east-longitude, which means they must be negative; Hori
 will raise an error if given any positive longitude value for such bodies. Instead enter
 the west-longitude - 360. For instance, a site on Mars (id code 499) at 30 degrees
 longitude, 30 degrees latitude, 0 km elevation should be specified as
-``{'body': 499, 'elevation': 0, 'lon': -330, 'lat': 30}``.
+``{'body': 499, 'elevation': 0 * u.km, 'lon': -330 * u.deg, 'lat': 30 * u.deg}``.
 2. This does not apply to the Earth, Moon, and Sun. Although they are prograde,
 Horizons interprets east-longitude as positive and west-longitude as negative for these
 bodies.
@@ -96,9 +96,9 @@ as the observer's location, and Ceres as the target:
 
 .. doctest-remote-data::
 
-    >>> statue_of_liberty = {'lon': -74.0466891,
-    ...                      'lat': 40.6892534,
-    ...                      'elevation': 0.093}
+    >>> statue_of_liberty = {'lon': -74.0466891 * u.deg,
+    ...                      'lat': 40.6892534 * u.deg,
+    ...                      'elevation': 0.093 * u.km}
     >>> obj = Horizons(id='Ceres',
     ...                location=statue_of_liberty,
     ...                epochs=2458133.33546)
@@ -116,8 +116,8 @@ at a particular point in time to the center of the crater Double:
 
 .. doctest-remote-data::
 
-    >>> ce_2 = {'lon': 23.522, 'lat': 0.637, 'elevation': 181.2, 'body': 301}
-    >>> double = {'lon': 23.47, 'lat': 0.67, 'elevation': 0, 'body': 301}
+    >>> ce_2 = {'lon': 23.522 * u.deg, 'lat': 0.637 * u.deg, 'elevation': 181.2 * u.km, 'body': 301}
+    >>> double = {'lon': 23.47 * u.deg, 'lat': 0.67 * u.deg, 'elevation': 0 * u.km, 'body': 301}
     >>> obj = Horizons(id=double, location=ce_2, epochs=2454483.84247)
     >>> vecs = obj.vectors()
     >>> distance_km = (vecs['x'] ** 2 + vecs['y'] ** 2 + vecs['z'] ** 2) ** 0.5 * 1.496e8


### PR DESCRIPTION
* Allow using units in locations
* Test topographic a query
* ~~Enable a float comparison in documentation doctest~~

This PR is mainly in response to #2702.  Now, locations can be specified with astropy units:

```python
>>> from astroquery.jplhorizons import Horizons
>>> observer = {"lat": -31.9 * u.deg, "lon": -111.6 * u.deg, "elevation": 2097 * u.m}
>>> q = Horizons(id="1", id_type="smallbody", location=observer, epochs=[2460000.5])
>>> eph = q.ephemerides(quantities="1")
>>> print(eph)
    targetname          datetime_str       datetime_jd  H    G   solar_presence lunar_presence     RA      DEC   
       ---                  ---                 d      mag  ---       ---            ---          deg      deg   
----------------- ------------------------ ----------- ---- ---- -------------- -------------- --------- --------
1 Ceres (A801 AA) 2023-Feb-25 00:00:00.000   2460000.5 3.33 0.12              *              m 191.16595 12.93824
```

The old behavior, using floats, is preserved (note elevation now in km):
```python
>>> observer_alt = {"lat": -31.9, "lon": -111.6, "elevation": 2.097}
>>> q = Horizons(id="1", id_type="smallbody", location=observer_alt, epochs=[2460000.5])
>>> eph = q.ephemerides(quantities="1")
>>> print(eph)
    targetname          datetime_str       datetime_jd  H    G   solar_presence lunar_presence     RA      DEC   
       ---                  ---                 d      mag  ---       ---            ---          deg      deg   
----------------- ------------------------ ----------- ---- ---- -------------- -------------- --------- --------
1 Ceres (A801 AA) 2023-Feb-25 00:00:00.000   2460000.5 3.33 0.12              *              m 191.16595 12.93824
```