### PR TITLE
Skip `mast` remote tests that need `boto3` if it is not installed

### DIFF
--- a/astroquery/mast/tests/test_mast_remote.py
+++ b/astroquery/mast/tests/test_mast_remote.py
@@ -386,6 +386,7 @@ class TestMast:
         assert result == ('COMPLETE', None, None)
 
     def test_get_cloud_uri(self):
+        pytest.importorskip("boto3")
         test_obs_id = '25568122'
 
         # get a product list
@@ -403,6 +404,7 @@ class TestMast:
         assert len(uri) > 0, f'Product for OBSID {test_obs_id} was not found in the cloud.'
 
     def test_get_cloud_uris(self):
+        pytest.importorskip("boto3")
         test_obs_id = '25568122'
 
         # get a product list


### PR DESCRIPTION
If `astroquery` is installed with `pip install astroquery[test]` then `pytest --remote-data=any -k test_get_cloud_uri astroquery/mast` results in two tests failing with `ModuleNotFoundError: No module named 'boto3'` because although `boto3` is listed among the `all` dependencies, it is not listed among the `test` dependencies: https://github.com/astropy/astroquery/blob/aa9ce56fbe6904939fba6c53253bbdc61f17851c/setup.cfg#L136-L140 https://github.com/astropy/astroquery/blob/aa9ce56fbe6904939fba6c53253bbdc61f17851c/setup.cfg#L127-L131
The tests therefore cannot assume that `boto3` is installed. There are two simple solutions to this problem. One would be to add `boto3` to the test dependencies, but adding a whole new dependency only for the two remote tests in `mast` is in my opinion excessive. This pull request implements the other simple option, which is to check whether `boto3` is installed in the two tests that require it and to skip them if it isn't.