### PR TITLE
Caching documentation update

### DIFF
--- a/astroquery/atomic/core.py
+++ b/astroquery/atomic/core.py
@@ -142,7 +142,7 @@ class AtomicLineListClass(BaseQuery):
 
         cache : bool
             Defaults to True. If set overrides global caching behavior.
-            See [caching documentation](https://astroquery.readthedocs.io/en/latest/index.html#caching).
+            See :ref:`caching documentation <astroquery_cache>`.
 
         Returns
         -------

--- a/astroquery/atomic/core.py
+++ b/astroquery/atomic/core.py
@@ -140,6 +140,10 @@ class AtomicLineListClass(BaseQuery):
             Angular momentum, Transition probability and Level energies
             respectively.
 
+        cache : bool
+            Defaults to True. If set overrides global caching behavior.
+            See [caching documentation](https://astroquery.readthedocs.io/en/latest/index.html#caching).
+
         Returns
         -------
         result : `~astropy.table.Table`

--- a/astroquery/casda/core.py
+++ b/astroquery/casda/core.py
@@ -113,8 +113,9 @@ class CasdaClass(QueryWithLogin):
             the width for a box region
         get_query_payload : bool, optional
             Just return the dict of HTTP request parameters.
-        cache: bool, optional
-            Use the astroquery internal query result cache
+        cache : bool
+            Defaults to True. If set overrides global caching behavior.
+            See [caching documentation](https://astroquery.readthedocs.io/en/latest/index.html#caching).
 
         Returns
         -------

--- a/astroquery/casda/core.py
+++ b/astroquery/casda/core.py
@@ -115,7 +115,7 @@ class CasdaClass(QueryWithLogin):
             Just return the dict of HTTP request parameters.
         cache : bool
             Defaults to True. If set overrides global caching behavior.
-            See [caching documentation](https://astroquery.readthedocs.io/en/latest/index.html#caching).
+            See :ref:`caching documentation <astroquery_cache>`.
 
         Returns
         -------

--- a/astroquery/esa/hsa/core.py
+++ b/astroquery/esa/hsa/core.py
@@ -65,6 +65,9 @@ class HSAClass(BaseQuery):
             values: ALL, AUXILIARY, CALIBRATION, LEVEL0, LEVEL0_5, LEVEL1, LEVEL2, LEVEL2_5, LEVEL3, ALL-LEVEL3
         download_dir : string, optional
             The directory in which the file will be downloaded
+        cache : bool
+            Defaults to True. If set overrides global caching behavior.
+            See [caching documentation](https://astroquery.readthedocs.io/en/latest/index.html#caching).
 
         Returns
         -------

--- a/astroquery/esa/hsa/core.py
+++ b/astroquery/esa/hsa/core.py
@@ -67,7 +67,7 @@ class HSAClass(BaseQuery):
             The directory in which the file will be downloaded
         cache : bool
             Defaults to True. If set overrides global caching behavior.
-            See [caching documentation](https://astroquery.readthedocs.io/en/latest/index.html#caching).
+            See :ref:`caching documentation <astroquery_cache>`.
 
         Returns
         -------

--- a/astroquery/esa/xmm_newton/core.py
+++ b/astroquery/esa/xmm_newton/core.py
@@ -106,7 +106,7 @@ class XMMNewtonClass(BaseQuery):
             values: ASC, ASZ, FTZ, HTM, IND, PDF, PNG
         cache : bool
             Defaults to True. If set overrides global caching behavior.
-            See [caching documentation](https://astroquery.readthedocs.io/en/latest/index.html#caching).
+            See :ref:`caching documentation <astroquery_cache>`.
 
         Returns
         -------

--- a/astroquery/esa/xmm_newton/core.py
+++ b/astroquery/esa/xmm_newton/core.py
@@ -104,6 +104,9 @@ class XMMNewtonClass(BaseQuery):
         extension : string
             file format, optional, by default all formats
             values: ASC, ASZ, FTZ, HTM, IND, PDF, PNG
+        cache : bool
+            Defaults to True. If set overrides global caching behavior.
+            See [caching documentation](https://astroquery.readthedocs.io/en/latest/index.html#caching).
 
         Returns
         -------

--- a/astroquery/eso/core.py
+++ b/astroquery/eso/core.py
@@ -313,7 +313,7 @@ class EsoClass(QueryWithLogin):
         instrument_list : list of strings
         cache : bool
             Defaults to True. If set overrides global caching behavior.
-            See [caching documentation](https://astroquery.readthedocs.io/en/latest/index.html#caching).
+            See :ref:`caching documentation <astroquery_cache>`.
 
         """
         if self._instrument_list is None:
@@ -337,7 +337,7 @@ class EsoClass(QueryWithLogin):
         survey_list : list of strings
         cache : bool
             Defaults to True. If set overrides global caching behavior.
-            See [caching documentation](https://astroquery.readthedocs.io/en/latest/index.html#caching).
+            See :ref:`caching documentation <astroquery_cache>`.
         """
         if self._survey_list is None:
             survey_list_response = self._request(
@@ -375,7 +375,7 @@ class EsoClass(QueryWithLogin):
             survey names.
         cache : bool
             Defaults to True. If set overrides global caching behavior.
-            See [caching documentation](https://astroquery.readthedocs.io/en/latest/index.html#caching).
+            See :ref:`caching documentation <astroquery_cache>`.
 
         Returns
         -------
@@ -440,7 +440,7 @@ class EsoClass(QueryWithLogin):
             ``instrument``.
         cache : bool
             Defaults to True. If set overrides global caching behavior.
-            See [caching documentation](https://astroquery.readthedocs.io/en/latest/index.html#caching).
+            See :ref:`caching documentation <astroquery_cache>`.
 
         Returns
         -------
@@ -478,7 +478,7 @@ class EsoClass(QueryWithLogin):
             ``instrument``.
         cache : bool
             Defaults to True. If set overrides global caching behavior.
-            See [caching documentation](https://astroquery.readthedocs.io/en/latest/index.html#caching).
+            See :ref:`caching documentation <astroquery_cache>`.
 
         Returns
         -------
@@ -556,7 +556,7 @@ class EsoClass(QueryWithLogin):
             List of data product IDs.
         cache : bool
             Defaults to True. If set overrides global caching behavior.
-            See [caching documentation](https://astroquery.readthedocs.io/en/latest/index.html#caching).
+            See :ref:`caching documentation <astroquery_cache>`.
 
         Returns
         -------

--- a/astroquery/eso/core.py
+++ b/astroquery/eso/core.py
@@ -312,7 +312,8 @@ class EsoClass(QueryWithLogin):
         -------
         instrument_list : list of strings
         cache : bool
-            Cache the response for faster subsequent retrieval
+            Defaults to True. If set overrides global caching behavior.
+            See [caching documentation](https://astroquery.readthedocs.io/en/latest/index.html#caching).
 
         """
         if self._instrument_list is None:
@@ -335,7 +336,8 @@ class EsoClass(QueryWithLogin):
         -------
         survey_list : list of strings
         cache : bool
-            Cache the response for faster subsequent retrieval
+            Defaults to True. If set overrides global caching behavior.
+            See [caching documentation](https://astroquery.readthedocs.io/en/latest/index.html#caching).
         """
         if self._survey_list is None:
             survey_list_response = self._request(
@@ -372,7 +374,8 @@ class EsoClass(QueryWithLogin):
             specified as a string, should be a comma-separated list of
             survey names.
         cache : bool
-            Cache the response for faster subsequent retrieval
+            Defaults to True. If set overrides global caching behavior.
+            See [caching documentation](https://astroquery.readthedocs.io/en/latest/index.html#caching).
 
         Returns
         -------
@@ -436,7 +439,8 @@ class EsoClass(QueryWithLogin):
             ``column_filters`` and ``columns`` for the requested
             ``instrument``.
         cache : bool
-            Cache the response for faster subsequent retrieval.
+            Defaults to True. If set overrides global caching behavior.
+            See [caching documentation](https://astroquery.readthedocs.io/en/latest/index.html#caching).
 
         Returns
         -------
@@ -473,7 +477,8 @@ class EsoClass(QueryWithLogin):
             ``column_filters`` and ``columns`` for the requested
             ``instrument``.
         cache : bool
-            Cache the response for faster subsequent retrieval.
+            Defaults to True. If set overrides global caching behavior.
+            See [caching documentation](https://astroquery.readthedocs.io/en/latest/index.html#caching).
 
         Returns
         -------
@@ -549,6 +554,9 @@ class EsoClass(QueryWithLogin):
         ----------
         product_ids : either a list of strings or a `~astropy.table.Column`
             List of data product IDs.
+        cache : bool
+            Defaults to True. If set overrides global caching behavior.
+            See [caching documentation](https://astroquery.readthedocs.io/en/latest/index.html#caching).
 
         Returns
         -------

--- a/astroquery/heasarc/core.py
+++ b/astroquery/heasarc/core.py
@@ -41,6 +41,9 @@ class HeasarcClass(BaseQuery):
         """
         Submit a query based on a given request_payload. This allows detailed
         control of the query to be submitted.
+
+        cache (bool) defaults to True. If set overrides global caching behavior.
+        See [caching documentation](https://astroquery.readthedocs.io/en/latest/index.html#caching).
         """
 
         if url is None:
@@ -53,6 +56,9 @@ class HeasarcClass(BaseQuery):
     def query_mission_list(self, *, cache=True, get_query_payload=False):
         """
         Returns a list of all available mission tables with descriptions
+
+        cache (bool) defaults to True. If set overrides global caching behavior.
+        See [caching documentation](https://astroquery.readthedocs.io/en/latest/index.html#caching).
         """
         request_payload = self._args_to_payload(
             entry='none',
@@ -91,6 +97,9 @@ class HeasarcClass(BaseQuery):
             * Standard      : Return default table columns
             * All (default) : Return all table columns
             * <custom>      : User defined csv list of columns to be returned
+        cache : bool, optional
+            Defaults to True. If set overrides global caching behavior.
+            See [caching documentation](https://astroquery.readthedocs.io/en/latest/index.html#caching).
         All other parameters have no effect
         """
 
@@ -121,6 +130,9 @@ class HeasarcClass(BaseQuery):
             parameter.
         mission : str
             Mission table to search from
+        cache : bool
+            Defaults to True. If set overrides global caching behavior.
+            See [caching documentation](https://astroquery.readthedocs.io/en/latest/index.html#caching).
         **kwargs :
             see `~astroquery.heasarc.HeasarcClass._args_to_payload` for list
             of additional parameters that can be used to refine search query
@@ -159,6 +171,9 @@ class HeasarcClass(BaseQuery):
         radius :
             Astropy Quantity object, or a string that can be parsed into one.
             e.g., '1 degree' or 1*u.degree.
+        cache : bool
+            Defaults to True. If set overrides global caching behavior.
+            See [caching documentation](https://astroquery.readthedocs.io/en/latest/index.html#caching).
         **kwargs :
             see `~astroquery.heasarc.HeasarcClass._args_to_payload` for list
             of additional parameters that can be used to refine search query

--- a/astroquery/heasarc/core.py
+++ b/astroquery/heasarc/core.py
@@ -43,7 +43,7 @@ class HeasarcClass(BaseQuery):
         control of the query to be submitted.
 
         cache (bool) defaults to True. If set overrides global caching behavior.
-        See [caching documentation](https://astroquery.readthedocs.io/en/latest/index.html#caching).
+        See :ref:`caching documentation <astroquery_cache>`.
         """
 
         if url is None:
@@ -58,7 +58,7 @@ class HeasarcClass(BaseQuery):
         Returns a list of all available mission tables with descriptions
 
         cache (bool) defaults to True. If set overrides global caching behavior.
-        See [caching documentation](https://astroquery.readthedocs.io/en/latest/index.html#caching).
+        See :ref:`caching documentation <astroquery_cache>`.
         """
         request_payload = self._args_to_payload(
             entry='none',
@@ -99,7 +99,7 @@ class HeasarcClass(BaseQuery):
             * <custom>      : User defined csv list of columns to be returned
         cache : bool, optional
             Defaults to True. If set overrides global caching behavior.
-            See [caching documentation](https://astroquery.readthedocs.io/en/latest/index.html#caching).
+            See :ref:`caching documentation <astroquery_cache>`.
         All other parameters have no effect
         """
 
@@ -132,7 +132,7 @@ class HeasarcClass(BaseQuery):
             Mission table to search from
         cache : bool
             Defaults to True. If set overrides global caching behavior.
-            See [caching documentation](https://astroquery.readthedocs.io/en/latest/index.html#caching).
+            See :ref:`caching documentation <astroquery_cache>`.
         **kwargs :
             see `~astroquery.heasarc.HeasarcClass._args_to_payload` for list
             of additional parameters that can be used to refine search query
@@ -173,7 +173,7 @@ class HeasarcClass(BaseQuery):
             e.g., '1 degree' or 1*u.degree.
         cache : bool
             Defaults to True. If set overrides global caching behavior.
-            See [caching documentation](https://astroquery.readthedocs.io/en/latest/index.html#caching).
+            See :ref:`caching documentation <astroquery_cache>`.
         **kwargs :
             see `~astroquery.heasarc.HeasarcClass._args_to_payload` for list
             of additional parameters that can be used to refine search query

--- a/astroquery/ipac/irsa/core.py
+++ b/astroquery/ipac/irsa/core.py
@@ -227,7 +227,6 @@ class IrsaClass(BaseVOQuery):
         full : bool
             If True returns the full schema VOTable. If False returns a dictionary of the table names and
             their description.
-
         """
         tap_tables = Irsa.query_tap("SELECT * FROM TAP_SCHEMA.tables")
 
@@ -239,6 +238,7 @@ class IrsaClass(BaseVOQuery):
     # TODO, deprecate this as legacy
     def print_catalogs(self):
         catalogs = self.list_catalogs()
+
         for catname in catalogs:
             print("{:30s}  {:s}".format(catname, catalogs[catname]))
 

--- a/astroquery/ipac/irsa/ibe/core.py
+++ b/astroquery/ipac/irsa/ibe/core.py
@@ -258,7 +258,8 @@ class IbeClass(BaseQuery):
         Parameters
         ----------
         cache : bool
-            Cache the query result
+            Defaults to True. If set overrides global caching behavior.
+            See [caching documentation](https://astroquery.readthedocs.io/en/latest
         """
         if hasattr(self, '_missions') and cache:
             # extra level caching to avoid redoing the BeautifulSoup parsing
@@ -288,7 +289,8 @@ class IbeClass(BaseQuery):
             `~astroquery.ipac.irsa.ibe.IbeClass.list_missions`.  Defaults to the
             configured Mission
         cache : bool
-            Cache the query result
+            Defaults to True. If set overrides global caching behavior.
+            See [caching documentation](https://astroquery.readthedocs.io/en/latest
 
         Returns
         -------
@@ -331,7 +333,8 @@ class IbeClass(BaseQuery):
             A dataset name.  Must be one of the valid dataset from
             ``list_datsets(mission)``.  Defaults to the configured Dataset
         cache : bool
-            Cache the query result
+            Defaults to True. If set overrides global caching behavior.
+            See [caching documentation](https://astroquery.readthedocs.io/en/latest
 
         Returns
         -------

--- a/astroquery/ipac/irsa/ibe/core.py
+++ b/astroquery/ipac/irsa/ibe/core.py
@@ -259,7 +259,7 @@ class IbeClass(BaseQuery):
         ----------
         cache : bool
             Defaults to True. If set overrides global caching behavior.
-            See [caching documentation](https://astroquery.readthedocs.io/en/latest
+            See :ref:`caching documentation <astroquery_cache>`.
         """
         if hasattr(self, '_missions') and cache:
             # extra level caching to avoid redoing the BeautifulSoup parsing
@@ -290,7 +290,7 @@ class IbeClass(BaseQuery):
             configured Mission
         cache : bool
             Defaults to True. If set overrides global caching behavior.
-            See [caching documentation](https://astroquery.readthedocs.io/en/latest
+            See :ref:`caching documentation <astroquery_cache>`.
 
         Returns
         -------
@@ -334,7 +334,7 @@ class IbeClass(BaseQuery):
             ``list_datsets(mission)``.  Defaults to the configured Dataset
         cache : bool
             Defaults to True. If set overrides global caching behavior.
-            See [caching documentation](https://astroquery.readthedocs.io/en/latest
+            See :ref:`caching documentation <astroquery_cache>`.
 
         Returns
         -------

--- a/astroquery/jplhorizons/core.py
+++ b/astroquery/jplhorizons/core.py
@@ -582,7 +582,7 @@ class HorizonsClass(BaseQuery):
 
         cache : bool
             Defaults to True. If set overrides global caching behavior.
-            See [caching documentation](https://astroquery.readthedocs.io/en/latest/index.html#caching).
+            See :ref:`caching documentation <astroquery_cache>`.
 
 
         Returns
@@ -831,7 +831,7 @@ class HorizonsClass(BaseQuery):
 
         cache : bool
             Defaults to True. If set overrides global caching behavior.
-            See [caching documentation](https://astroquery.readthedocs.io/en/latest/index.html#caching).
+            See :ref:`caching documentation <astroquery_cache>`.
 
 
         Returns
@@ -1068,7 +1068,7 @@ class HorizonsClass(BaseQuery):
 
         cache : bool
             Defaults to True. If set overrides global caching behavior.
-            See [caching documentation](https://astroquery.readthedocs.io/en/latest/index.html#caching).
+            See :ref:`caching documentation <astroquery_cache>`.
 
 
         Returns

--- a/astroquery/jplhorizons/core.py
+++ b/astroquery/jplhorizons/core.py
@@ -580,6 +580,10 @@ class HorizonsClass(BaseQuery):
         extra_precision : boolean, optional
             Enables extra precision in RA and DEC values; default: False
 
+        cache : bool
+            Defaults to True. If set overrides global caching behavior.
+            See [caching documentation](https://astroquery.readthedocs.io/en/latest/index.html#caching).
+
 
         Returns
         -------
@@ -825,6 +829,10 @@ class HorizonsClass(BaseQuery):
             Return raw data as obtained by JPL Horizons without parsing the data
             into a table, default: False
 
+        cache : bool
+            Defaults to True. If set overrides global caching behavior.
+            See [caching documentation](https://astroquery.readthedocs.io/en/latest/index.html#caching).
+
 
         Returns
         -------
@@ -1057,6 +1065,10 @@ class HorizonsClass(BaseQuery):
         delta_T : boolean, optional
             Triggers output of time-varying difference between TDB and UT
             time-scales. Default: False
+
+        cache : bool
+            Defaults to True. If set overrides global caching behavior.
+            See [caching documentation](https://astroquery.readthedocs.io/en/latest/index.html#caching).
 
 
         Returns

--- a/astroquery/jplsbdb/core.py
+++ b/astroquery/jplsbdb/core.py
@@ -109,7 +109,7 @@ class SBDBClass(BaseQuery):
             Default: ``False``
         cache : bool
             Defaults to True. If set overrides global caching behavior.
-            See [caching documentation](https://astroquery.readthedocs.io/en/latest/index.html#caching).
+            See :ref:`caching documentation <astroquery_cache>`.
 
         Returns
         -------

--- a/astroquery/jplsbdb/core.py
+++ b/astroquery/jplsbdb/core.py
@@ -107,6 +107,9 @@ class SBDBClass(BaseQuery):
         get_uri : boolean, optional
             Add the query URI to the output as ``query_uri`` field.
             Default: ``False``
+        cache : bool
+            Defaults to True. If set overrides global caching behavior.
+            See [caching documentation](https://astroquery.readthedocs.io/en/latest/index.html#caching).
 
         Returns
         -------

--- a/astroquery/jplspec/core.py
+++ b/astroquery/jplspec/core.py
@@ -66,7 +66,7 @@ class JPLSpecClass(BaseQuery):
             parameters as a dict. Default value is set to False
         cache : bool
             Defaults to True. If set overrides global caching behavior.
-            See [caching documentation](https://astroquery.readthedocs.io/en/latest/index.html#caching).
+            See :ref:`caching documentation <astroquery_cache>`.
 
         Returns
         -------

--- a/astroquery/jplspec/core.py
+++ b/astroquery/jplspec/core.py
@@ -64,6 +64,9 @@ class JPLSpecClass(BaseQuery):
         get_query_payload : bool, optional
             When set to `True` the method should return the HTTP request
             parameters as a dict. Default value is set to False
+        cache : bool
+            Defaults to True. If set overrides global caching behavior.
+            See [caching documentation](https://astroquery.readthedocs.io/en/latest/index.html#caching).
 
         Returns
         -------

--- a/astroquery/lamda/core.py
+++ b/astroquery/lamda/core.py
@@ -77,7 +77,7 @@ class LamdaClass(BaseQuery):
 
         cache : bool
             Defaults to True. If set overrides global caching behavior.
-            See [caching documentation](https://astroquery.readthedocs.io/en/latest/index.html#caching).
+            See :ref:`caching documentation <astroquery_cache>`.
 
         Returns
         -------
@@ -119,7 +119,7 @@ class LamdaClass(BaseQuery):
         ----------
         cache : bool
             Defaults to True. If set overrides global caching behavior.
-            See [caching documentation](https://astroquery.readthedocs.io/en/latest/index.html#caching).
+            See :ref:`caching documentation <astroquery_cache>`.
         """
 
         if cache and hasattr(self, '_molecule_dict'):

--- a/astroquery/lamda/core.py
+++ b/astroquery/lamda/core.py
@@ -75,6 +75,10 @@ class LamdaClass(BaseQuery):
             Molecule or atom designation. For a list of valid designations see
             the :meth:`print_mols` method.
 
+        cache : bool
+            Defaults to True. If set overrides global caching behavior.
+            See [caching documentation](https://astroquery.readthedocs.io/en/latest/index.html#caching).
+
         Returns
         -------
         Tuple of tables: ({rateid: Table, },
@@ -110,7 +114,14 @@ class LamdaClass(BaseQuery):
     def get_molecules(self, *, cache=True):
         """
         Scrape the list of valid molecules
+
+        Parameters
+        ----------
+        cache : bool
+            Defaults to True. If set overrides global caching behavior.
+            See [caching documentation](https://astroquery.readthedocs.io/en/latest/index.html#caching).
         """
+
         if cache and hasattr(self, '_molecule_dict'):
             return self._molecule_dict
         elif cache and os.path.isfile(self.moldict_path):

--- a/astroquery/linelists/cdms/core.py
+++ b/astroquery/linelists/cdms/core.py
@@ -83,7 +83,7 @@ class CDMSClass(BaseQuery):
 
         cache : bool
             Defaults to True. If set overrides global caching behavior.
-            See [caching documentation](https://astroquery.readthedocs.io/en/latest/index.html#caching).
+            See :ref:`caching documentation <astroquery_cache>`.
 
         Returns
         -------

--- a/astroquery/linelists/cdms/core.py
+++ b/astroquery/linelists/cdms/core.py
@@ -82,8 +82,8 @@ class CDMSClass(BaseQuery):
             parameters as a dict. Default value is set to False
 
         cache : bool
-            Cache the request and, for repeat identical requests, reuse the
-            cache?
+            Defaults to True. If set overrides global caching behavior.
+            See [caching documentation](https://astroquery.readthedocs.io/en/latest/index.html#caching).
 
         Returns
         -------

--- a/astroquery/mpc/core.py
+++ b/astroquery/mpc/core.py
@@ -441,8 +441,9 @@ class MPCClass(BaseQuery):
             Return raw data without parsing into a table (default:
             ``False``).
 
-        cache : bool, optional
-            Cache results or use cached results (default: ``False``).
+        cache : bool
+            Defaults to False. If set overrides global caching behavior.
+            See [caching documentation](https://astroquery.readthedocs.io/en/latest/index.html#caching).
 
 
         Returns
@@ -617,8 +618,9 @@ class MPCClass(BaseQuery):
             Return raw data without parsing into a table (default:
             `False`).
 
-        cache : bool, optional
-            Cache results or use cached results (default: `True`).
+        cache : bool
+            Defaults to True. If set overrides global caching behavior.
+            See [caching documentation](https://astroquery.readthedocs.io/en/latest/index.html#caching).
 
 
         Returns
@@ -662,9 +664,9 @@ class MPCClass(BaseQuery):
         code : string
             Three-character IAU observatory code.
 
-        cache : bool, optional
-            Cache observatory table or use cached results (default:
-            `True`).
+        cache : bool
+            Defaults to True. If set overrides global caching behavior.
+            See [caching documentation](https://astroquery.readthedocs.io/en/latest/index.html#caching).
 
 
         Returns
@@ -820,8 +822,9 @@ class MPCClass(BaseQuery):
             Return the HTTP request parameters as a dictionary
             (default: ``False``).
 
-        cache : bool, optional
-            If ``True``, queries will be cached. Default: ``True``
+        cache : bool
+            Defaults to True. If set overrides global caching behavior.
+            See [caching documentation](https://astroquery.readthedocs.io/en/latest/index.html#caching).
 
 
         Raises

--- a/astroquery/mpc/core.py
+++ b/astroquery/mpc/core.py
@@ -443,7 +443,7 @@ class MPCClass(BaseQuery):
 
         cache : bool
             Defaults to False. If set overrides global caching behavior.
-            See [caching documentation](https://astroquery.readthedocs.io/en/latest/index.html#caching).
+            See :ref:`caching documentation <astroquery_cache>`.
 
 
         Returns
@@ -620,7 +620,7 @@ class MPCClass(BaseQuery):
 
         cache : bool
             Defaults to True. If set overrides global caching behavior.
-            See [caching documentation](https://astroquery.readthedocs.io/en/latest/index.html#caching).
+            See :ref:`caching documentation <astroquery_cache>`.
 
 
         Returns
@@ -666,7 +666,7 @@ class MPCClass(BaseQuery):
 
         cache : bool
             Defaults to True. If set overrides global caching behavior.
-            See [caching documentation](https://astroquery.readthedocs.io/en/latest/index.html#caching).
+            See :ref:`caching documentation <astroquery_cache>`.
 
 
         Returns
@@ -824,7 +824,7 @@ class MPCClass(BaseQuery):
 
         cache : bool
             Defaults to True. If set overrides global caching behavior.
-            See [caching documentation](https://astroquery.readthedocs.io/en/latest/index.html#caching).
+            See :ref:`caching documentation <astroquery_cache>`.
 
 
         Raises

--- a/astroquery/oac/core.py
+++ b/astroquery/oac/core.py
@@ -84,6 +84,9 @@ class OACClass(BaseQuery):
             When set to `True` the method returns the HTTP request
             parameters as a dict. The actual HTTP request is not made.
             The default value is False.
+        cache : bool
+            Defaults to True. If set overrides global caching behavior.
+            See [caching documentation](https://astroquery.readthedocs.io/en/latest/index.html#caching).
 
         Returns
         -------
@@ -174,6 +177,9 @@ class OACClass(BaseQuery):
             When set to `True` the method returns the HTTP request
             parameters as a dict. The actual HTTP request is not made.
             The default value is False.
+        cache : bool
+            Defaults to True. If set overrides global caching behavior.
+            See [caching documentation](https://astroquery.readthedocs.io/en/latest/index.html#caching).
 
         Returns
         -------
@@ -291,6 +297,9 @@ class OACClass(BaseQuery):
             only those table rows with all of the requested attributes.
             A complete list of commands and their usage can be found at:
             https://github.com/astrocatalogs/OACAPI. The default is None.
+        cache : bool
+            Defaults to True. If set overrides global caching behavior.
+            See [caching documentation](https://astroquery.readthedocs.io/en/latest/index.html#caching).
 
         Returns
         -------
@@ -330,6 +339,9 @@ class OACClass(BaseQuery):
         time : float, required
             A single MJD time to query. This time does not need to be
             exact. The closest spectrum will be returned.
+        cache : bool
+            Defaults to True. If set overrides global caching behavior.
+            See [caching documentation](https://astroquery.readthedocs.io/en/latest/index.html#caching).
 
         Returns
         -------
@@ -366,6 +378,9 @@ class OACClass(BaseQuery):
         event : str, required
             Name of the event to query. Can be a single event or a
             list of events.
+        cache : bool
+            Defaults to True. If set overrides global caching behavior.
+            See [caching documentation](https://astroquery.readthedocs.io/en/latest/index.html#caching).
 
         Returns
         -------

--- a/astroquery/oac/core.py
+++ b/astroquery/oac/core.py
@@ -86,7 +86,7 @@ class OACClass(BaseQuery):
             The default value is False.
         cache : bool
             Defaults to True. If set overrides global caching behavior.
-            See [caching documentation](https://astroquery.readthedocs.io/en/latest/index.html#caching).
+            See :ref:`caching documentation <astroquery_cache>`.
 
         Returns
         -------
@@ -179,7 +179,7 @@ class OACClass(BaseQuery):
             The default value is False.
         cache : bool
             Defaults to True. If set overrides global caching behavior.
-            See [caching documentation](https://astroquery.readthedocs.io/en/latest/index.html#caching).
+            See :ref:`caching documentation <astroquery_cache>`.
 
         Returns
         -------
@@ -299,7 +299,7 @@ class OACClass(BaseQuery):
             https://github.com/astrocatalogs/OACAPI. The default is None.
         cache : bool
             Defaults to True. If set overrides global caching behavior.
-            See [caching documentation](https://astroquery.readthedocs.io/en/latest/index.html#caching).
+            See :ref:`caching documentation <astroquery_cache>`.
 
         Returns
         -------
@@ -341,7 +341,7 @@ class OACClass(BaseQuery):
             exact. The closest spectrum will be returned.
         cache : bool
             Defaults to True. If set overrides global caching behavior.
-            See [caching documentation](https://astroquery.readthedocs.io/en/latest/index.html#caching).
+            See :ref:`caching documentation <astroquery_cache>`.
 
         Returns
         -------
@@ -380,7 +380,7 @@ class OACClass(BaseQuery):
             list of events.
         cache : bool
             Defaults to True. If set overrides global caching behavior.
-            See [caching documentation](https://astroquery.readthedocs.io/en/latest/index.html#caching).
+            See :ref:`caching documentation <astroquery_cache>`.
 
         Returns
         -------

--- a/astroquery/sdss/core.py
+++ b/astroquery/sdss/core.py
@@ -125,7 +125,7 @@ class SDSSClass(BaseQuery):
             The data release of the SDSS to use.
         cache : bool
             Defaults to True. If set overrides global caching behavior.
-            See [caching documentation](https://astroquery.readthedocs.io/en/latest/index.html#caching).
+            See :ref:`caching documentation <astroquery_cache>`.
 
         Raises
         ------
@@ -290,7 +290,7 @@ class SDSSClass(BaseQuery):
             The data release of the SDSS to use.
         cache : bool
             Defaults to True. If set overrides global caching behavior.
-            See [caching documentation](https://astroquery.readthedocs.io/en/latest/index.html#caching).
+            See :ref:`caching documentation <astroquery_cache>`.
 
         Raises
         ------
@@ -433,7 +433,7 @@ class SDSSClass(BaseQuery):
             The data release of the SDSS to use.
         cache : bool
             Defaults to True. If set overrides global caching behavior.
-            See [caching documentation](https://astroquery.readthedocs.io/en/latest/index.html#caching).
+            See :ref:`caching documentation <astroquery_cache>`.
 
         Examples
         --------
@@ -514,7 +514,7 @@ class SDSSClass(BaseQuery):
             The data release of the SDSS to use.
         cache : bool
             Defaults to True. If set overrides global caching behavior.
-            See [caching documentation](https://astroquery.readthedocs.io/en/latest/index.html#caching).
+            See :ref:`caching documentation <astroquery_cache>`.
 
         Examples
         --------
@@ -577,7 +577,7 @@ class SDSSClass(BaseQuery):
             The data release of the SDSS to use.
         cache : bool
             Defaults to True. If set overrides global caching behavior.
-            See [caching documentation](https://astroquery.readthedocs.io/en/latest/index.html#caching).
+            See :ref:`caching documentation <astroquery_cache>`.
 
         Examples
         --------
@@ -669,7 +669,7 @@ class SDSSClass(BaseQuery):
             only supports DR8 or later.
         cache : bool
             Defaults to True. If set overrides global caching behavior.
-            See [caching documentation](https://astroquery.readthedocs.io/en/latest/index.html#caching).
+            See :ref:`caching documentation <astroquery_cache>`.
         show_progress : bool, optional
             If False, do not display download progress.
 
@@ -837,7 +837,7 @@ class SDSSClass(BaseQuery):
             but does not actually do the query.
         cache : bool
             Defaults to True. If set overrides global caching behavior.
-            See [caching documentation](https://astroquery.readthedocs.io/en/latest/index.html#caching).
+            See :ref:`caching documentation <astroquery_cache>`.
         data_release : int, optional
             The data release of the SDSS to use.
         show_progress : bool, optional

--- a/astroquery/sdss/core.py
+++ b/astroquery/sdss/core.py
@@ -123,8 +123,9 @@ class SDSSClass(BaseQuery):
             but does not actually do the query.
         data_release : int, optional
             The data release of the SDSS to use.
-        cache : bool, optional
-            If ``True`` use the request caching mechanism.
+        cache : bool
+            Defaults to True. If set overrides global caching behavior.
+            See [caching documentation](https://astroquery.readthedocs.io/en/latest/index.html#caching).
 
         Raises
         ------
@@ -287,8 +288,9 @@ class SDSSClass(BaseQuery):
             but does not actually do the query.
         data_release : int, optional
             The data release of the SDSS to use.
-        cache : bool, optional
-            If ``True`` use the request caching mechanism.
+        cache : bool
+            Defaults to True. If set overrides global caching behavior.
+            See [caching documentation](https://astroquery.readthedocs.io/en/latest/index.html#caching).
 
         Raises
         ------
@@ -429,8 +431,9 @@ class SDSSClass(BaseQuery):
             but does not actually do the query.
         data_release : int, optional
             The data release of the SDSS to use.
-        cache : bool, optional
-            If ``True`` use the request caching mechanism.
+        cache : bool
+            Defaults to True. If set overrides global caching behavior.
+            See [caching documentation](https://astroquery.readthedocs.io/en/latest/index.html#caching).
 
         Examples
         --------
@@ -509,8 +512,9 @@ class SDSSClass(BaseQuery):
             but does not actually do the query.
         data_release : int, optional
             The data release of the SDSS to use.
-        cache : bool, optional
-            If ``True`` use the request caching mechanism.
+        cache : bool
+            Defaults to True. If set overrides global caching behavior.
+            See [caching documentation](https://astroquery.readthedocs.io/en/latest/index.html#caching).
 
         Examples
         --------
@@ -571,8 +575,9 @@ class SDSSClass(BaseQuery):
             remote server.  Defaults to `SDSSClass.TIMEOUT`.
         data_release : int, optional
             The data release of the SDSS to use.
-        cache : bool, optional
-            If ``True`` use the request caching mechanism.
+        cache : bool
+            Defaults to True. If set overrides global caching behavior.
+            See [caching documentation](https://astroquery.readthedocs.io/en/latest/index.html#caching).
 
         Examples
         --------
@@ -662,8 +667,9 @@ class SDSSClass(BaseQuery):
         data_release : int, optional
             The data release of the SDSS to use. With the default server, this
             only supports DR8 or later.
-        cache : bool, optional
-            Cache the spectra using astropy's caching system
+        cache : bool
+            Defaults to True. If set overrides global caching behavior.
+            See [caching documentation](https://astroquery.readthedocs.io/en/latest/index.html#caching).
         show_progress : bool, optional
             If False, do not display download progress.
 
@@ -829,8 +835,9 @@ class SDSSClass(BaseQuery):
         get_query_payload : bool, optional
             If True, this will return the data the query would have sent out,
             but does not actually do the query.
-        cache : bool, optional
-            Cache the images using astropy's caching system
+        cache : bool
+            Defaults to True. If set overrides global caching behavior.
+            See [caching documentation](https://astroquery.readthedocs.io/en/latest/index.html#caching).
         data_release : int, optional
             The data release of the SDSS to use.
         show_progress : bool, optional

--- a/astroquery/simbad/core.py
+++ b/astroquery/simbad/core.py
@@ -554,7 +554,7 @@ class SimbadClass(BaseVOQuery, SimbadBaseQuery):
             (e.g., {'otype':'SNR'} will be rendered as otype=SNR)
         cache : bool
             Defaults to True. If set overrides global caching behavior.
-            See [caching documentation](https://astroquery.readthedocs.io/en/latest/index.html#caching).
+            See :ref:`caching documentation <astroquery_cache>`.
 
         Returns
         -------
@@ -617,7 +617,7 @@ class SimbadClass(BaseVOQuery, SimbadBaseQuery):
             Defaults to `False`.
         cache : bool
             Defaults to True. If set overrides global caching behavior.
-            See [caching documentation](https://astroquery.readthedocs.io/en/latest/index.html#caching).
+            See :ref:`caching documentation <astroquery_cache>`.
 
         Returns
         -------
@@ -678,7 +678,7 @@ class SimbadClass(BaseVOQuery, SimbadBaseQuery):
             Defaults to `False`.
         cache : bool
             Defaults to True. If set overrides global caching behavior.
-            See [caching documentation](https://astroquery.readthedocs.io/en/latest/index.html#caching).
+            See :ref:`caching documentation <astroquery_cache>`.
 
         Returns
         -------
@@ -713,7 +713,7 @@ class SimbadClass(BaseVOQuery, SimbadBaseQuery):
             Defaults to `False`.
         cache : bool
             Defaults to True. If set overrides global caching behavior.
-            See [caching documentation](https://astroquery.readthedocs.io/en/latest/index.html#caching).
+            See :ref:`caching documentation <astroquery_cache>`.
 
         Returns
         -------
@@ -791,7 +791,7 @@ class SimbadClass(BaseVOQuery, SimbadBaseQuery):
             Defaults to `False`.
         cache : bool
             Defaults to True. If set overrides global caching behavior.
-            See [caching documentation](https://astroquery.readthedocs.io/en/latest/index.html#caching).
+            See :ref:`caching documentation <astroquery_cache>`.
 
         Returns
         -------
@@ -820,7 +820,7 @@ class SimbadClass(BaseVOQuery, SimbadBaseQuery):
             Defaults to `False`.
         cache : bool
             Defaults to True. If set overrides global caching behavior.
-            See [caching documentation](https://astroquery.readthedocs.io/en/latest/index.html#caching).
+            See :ref:`caching documentation <astroquery_cache>`.
 
         Returns
         -------
@@ -877,7 +877,7 @@ class SimbadClass(BaseVOQuery, SimbadBaseQuery):
             Defaults to `False`.
         cache : bool
             Defaults to True. If set overrides global caching behavior.
-            See [caching documentation](https://astroquery.readthedocs.io/en/latest/index.html#caching).
+            See :ref:`caching documentation <astroquery_cache>`.
 
         Returns
         -------
@@ -913,7 +913,7 @@ class SimbadClass(BaseVOQuery, SimbadBaseQuery):
             Defaults to `False`.
         cache : bool
             Defaults to True. If set overrides global caching behavior.
-            See [caching documentation](https://astroquery.readthedocs.io/en/latest/index.html#caching).
+            See :ref:`caching documentation <astroquery_cache>`.
 
         Returns
         -------
@@ -949,7 +949,7 @@ class SimbadClass(BaseVOQuery, SimbadBaseQuery):
             Defaults to `False`.
         cache : bool
             Defaults to True. If set overrides global caching behavior.
-            See [caching documentation](https://astroquery.readthedocs.io/en/latest/index.html#caching).
+            See :ref:`caching documentation <astroquery_cache>`.
 
         Returns
         -------
@@ -984,7 +984,7 @@ class SimbadClass(BaseVOQuery, SimbadBaseQuery):
             Defaults to `False`.
         cache : bool
             Defaults to True. If set overrides global caching behavior.
-            See [caching documentation](https://astroquery.readthedocs.io/en/latest/index.html#caching).
+            See :ref:`caching documentation <astroquery_cache>`.
 
         Returns
         -------
@@ -1012,7 +1012,7 @@ class SimbadClass(BaseVOQuery, SimbadBaseQuery):
             name of object to be queried
         cache : bool
             Defaults to True. If set overrides global caching behavior.
-            See [caching documentation](https://astroquery.readthedocs.io/en/latest/index.html#caching).
+            See :ref:`caching documentation <astroquery_cache>`.
 
         Returns
         -------

--- a/astroquery/simbad/core.py
+++ b/astroquery/simbad/core.py
@@ -540,7 +540,7 @@ class SimbadClass(BaseVOQuery, SimbadBaseQuery):
         result = self.query_criteria_async(*args, **kwargs)
         return self._parse_result(result, SimbadVOTableResult, verbose=verbose)
 
-    def query_criteria_async(self, *args, **kwargs):
+    def query_criteria_async(self, *args, cache=True, **kwargs):
         """
         Query SIMBAD based on any criteria.
 
@@ -553,14 +553,14 @@ class SimbadClass(BaseVOQuery, SimbadBaseQuery):
             Keyword / value pairs passed to SIMBAD's script engine
             (e.g., {'otype':'SNR'} will be rendered as otype=SNR)
         cache : bool
-            Cache the query?
+            Defaults to True. If set overrides global caching behavior.
+            See [caching documentation](https://astroquery.readthedocs.io/en/latest/index.html#caching).
 
         Returns
         -------
         response : `requests.Response`
             Response of the query from the server
         """
-        cache = kwargs.pop('cache', True)
 
         request_payload = self._args_to_payload(caller='query_criteria_async',
                                                 *args, **kwargs)
@@ -615,6 +615,9 @@ class SimbadClass(BaseVOQuery, SimbadBaseQuery):
         get_query_payload : bool, optional
             When set to `True` the method returns the HTTP request parameters.
             Defaults to `False`.
+        cache : bool
+            Defaults to True. If set overrides global caching behavior.
+            See [caching documentation](https://astroquery.readthedocs.io/en/latest/index.html#caching).
 
         Returns
         -------
@@ -673,6 +676,9 @@ class SimbadClass(BaseVOQuery, SimbadBaseQuery):
         get_query_payload : bool, optional
             When set to `True` the method returns the HTTP request parameters.
             Defaults to `False`.
+        cache : bool
+            Defaults to True. If set overrides global caching behavior.
+            See [caching documentation](https://astroquery.readthedocs.io/en/latest/index.html#caching).
 
         Returns
         -------
@@ -705,6 +711,9 @@ class SimbadClass(BaseVOQuery, SimbadBaseQuery):
         get_query_payload : bool, optional
             When set to `True` the method returns the HTTP request parameters.
             Defaults to `False`.
+        cache : bool
+            Defaults to True. If set overrides global caching behavior.
+            See [caching documentation](https://astroquery.readthedocs.io/en/latest/index.html#caching).
 
         Returns
         -------
@@ -780,6 +789,9 @@ class SimbadClass(BaseVOQuery, SimbadBaseQuery):
         get_query_payload : bool, optional
             When set to `True` the method returns the HTTP request parameters.
             Defaults to `False`.
+        cache : bool
+            Defaults to True. If set overrides global caching behavior.
+            See [caching documentation](https://astroquery.readthedocs.io/en/latest/index.html#caching).
 
         Returns
         -------
@@ -806,6 +818,9 @@ class SimbadClass(BaseVOQuery, SimbadBaseQuery):
         get_query_payload : bool, optional
             When set to `True` the method returns the HTTP request parameters.
             Defaults to `False`.
+        cache : bool
+            Defaults to True. If set overrides global caching behavior.
+            See [caching documentation](https://astroquery.readthedocs.io/en/latest/index.html#caching).
 
         Returns
         -------
@@ -860,6 +875,9 @@ class SimbadClass(BaseVOQuery, SimbadBaseQuery):
         get_query_payload : bool, optional
             When set to `True` the method returns the HTTP request parameters.
             Defaults to `False`.
+        cache : bool
+            Defaults to True. If set overrides global caching behavior.
+            See [caching documentation](https://astroquery.readthedocs.io/en/latest/index.html#caching).
 
         Returns
         -------
@@ -893,6 +911,9 @@ class SimbadClass(BaseVOQuery, SimbadBaseQuery):
         get_query_payload : bool, optional
             When set to `True` the method returns the HTTP request parameters.
             Defaults to `False`.
+        cache : bool
+            Defaults to True. If set overrides global caching behavior.
+            See [caching documentation](https://astroquery.readthedocs.io/en/latest/index.html#caching).
 
         Returns
         -------
@@ -926,6 +947,9 @@ class SimbadClass(BaseVOQuery, SimbadBaseQuery):
         get_query_payload : bool, optional
             When set to `True` the method returns the HTTP request parameters.
             Defaults to `False`.
+        cache : bool
+            Defaults to True. If set overrides global caching behavior.
+            See [caching documentation](https://astroquery.readthedocs.io/en/latest/index.html#caching).
 
         Returns
         -------
@@ -958,6 +982,9 @@ class SimbadClass(BaseVOQuery, SimbadBaseQuery):
         get_query_payload : bool, optional
             When set to `True` the method returns the HTTP request parameters.
             Defaults to `False`.
+        cache : bool
+            Defaults to True. If set overrides global caching behavior.
+            See [caching documentation](https://astroquery.readthedocs.io/en/latest/index.html#caching).
 
         Returns
         -------
@@ -983,6 +1010,9 @@ class SimbadClass(BaseVOQuery, SimbadBaseQuery):
         ----------
         object_name : str
             name of object to be queried
+        cache : bool
+            Defaults to True. If set overrides global caching behavior.
+            See [caching documentation](https://astroquery.readthedocs.io/en/latest/index.html#caching).
 
         Returns
         -------

--- a/astroquery/skyview/core.py
+++ b/astroquery/skyview/core.py
@@ -180,6 +180,9 @@ class SkyViewClass(BaseQuery):
         height : `~astropy.units.Quantity` or None
             The height of the specified field.  Must be specified
             with ``width``.
+        cache : bool
+            Defaults to True. If set overrides global caching behavior.
+            See [caching documentation](https://astroquery.readthedocs.io/en/latest/index.html#caching).
 
         References
         ----------

--- a/astroquery/skyview/core.py
+++ b/astroquery/skyview/core.py
@@ -182,7 +182,7 @@ class SkyViewClass(BaseQuery):
             with ``width``.
         cache : bool
             Defaults to True. If set overrides global caching behavior.
-            See [caching documentation](https://astroquery.readthedocs.io/en/latest/index.html#caching).
+            See :ref:`caching documentation <astroquery_cache>`.
 
         References
         ----------

--- a/astroquery/svo_fps/core.py
+++ b/astroquery/svo_fps/core.py
@@ -52,7 +52,7 @@ class SvoFpsClass(BaseQuery):
             of the query made (default is 'No data found for requested query')
         cache : bool
             Defaults to True. If set overrides global caching behavior.
-            See [caching documentation](https://astroquery.readthedocs.io/en/latest/index.html#caching).
+            See :ref:`caching documentation <astroquery_cache>`.
 
         Returns
         -------

--- a/astroquery/svo_fps/core.py
+++ b/astroquery/svo_fps/core.py
@@ -51,7 +51,8 @@ class SvoFpsClass(BaseQuery):
             responded VOTable. Use this to make error message verbose in context
             of the query made (default is 'No data found for requested query')
         cache : bool
-            Cache the results?  Defaults to True
+            Defaults to True. If set overrides global caching behavior.
+            See [caching documentation](https://astroquery.readthedocs.io/en/latest/index.html#caching).
 
         Returns
         -------

--- a/astroquery/vizier/core.py
+++ b/astroquery/vizier/core.py
@@ -372,7 +372,7 @@ class VizierClass(BaseQuery):
             B1950, B1900, B1875, B1855, Galactic, Supergal., Ecl.J2000, )
         cache : bool
             Defaults to True. If set overrides global caching behavior.
-            See [caching documentation](https://astroquery.readthedocs.io/en/latest/index.html#caching).
+            See :ref:`caching documentation <astroquery_cache>`.
 
         Returns
         -------
@@ -446,7 +446,7 @@ class VizierClass(BaseQuery):
             box requests.
         cache : bool
             Defaults to True. If set overrides global caching behavior.
-            See [caching documentation](https://astroquery.readthedocs.io/en/latest/index.html#caching).
+            See :ref:`caching documentation <astroquery_cache>`.
 
         Returns
         -------
@@ -559,7 +559,7 @@ class VizierClass(BaseQuery):
             as additional column filters.
         cache : bool
             Defaults to True. If set overrides global caching behavior.
-            See [caching documentation](https://astroquery.readthedocs.io/en/latest/index.html#caching).
+            See :ref:`caching documentation <astroquery_cache>`.
 
         Returns
         -------

--- a/astroquery/vizier/core.py
+++ b/astroquery/vizier/core.py
@@ -370,6 +370,9 @@ class VizierClass(BaseQuery):
             `~astroquery.vizier.VizierClass.query_region`, but you can
             specify a coordinate frame here instead (today, J2000, B1975,
             B1950, B1900, B1875, B1855, Galactic, Supergal., Ecl.J2000, )
+        cache : bool
+            Defaults to True. If set overrides global caching behavior.
+            See [caching documentation](https://astroquery.readthedocs.io/en/latest/index.html#caching).
 
         Returns
         -------
@@ -441,6 +444,9 @@ class VizierClass(BaseQuery):
             The frame to use for the request. It should be 'fk5', 'icrs',
             or 'galactic'. This choice influences the the orientation of
             box requests.
+        cache : bool
+            Defaults to True. If set overrides global caching behavior.
+            See [caching documentation](https://astroquery.readthedocs.io/en/latest/index.html#caching).
 
         Returns
         -------
@@ -551,6 +557,9 @@ class VizierClass(BaseQuery):
         kwargs : dict
             Any key/value pairs besides "catalog" will be parsed
             as additional column filters.
+        cache : bool
+            Defaults to True. If set overrides global caching behavior.
+            See [caching documentation](https://astroquery.readthedocs.io/en/latest/index.html#caching).
 
         Returns
         -------

--- a/astroquery/vo_conesearch/core.py
+++ b/astroquery/vo_conesearch/core.py
@@ -112,7 +112,7 @@ class ConeSearchClass(BaseQuery):
             websites referenced by the database still needs internet
             connection.
             Defaults to True. If set overrides global caching behavior.
-            See [caching documentation](https://astroquery.readthedocs.io/en/latest/index.html#caching).
+            See :ref:`caching documentation <astroquery_cache>`.
 
         verbose : bool, optional
             Verbose output, including VO table warnings.

--- a/astroquery/vo_conesearch/core.py
+++ b/astroquery/vo_conesearch/core.py
@@ -111,6 +111,8 @@ class ConeSearchClass(BaseQuery):
             Use caching for VO Service database. Access to actual VO
             websites referenced by the database still needs internet
             connection.
+            Defaults to True. If set overrides global caching behavior.
+            See [caching documentation](https://astroquery.readthedocs.io/en/latest/index.html#caching).
 
         verbose : bool, optional
             Verbose output, including VO table warnings.

--- a/astroquery/xmatch/core.py
+++ b/astroquery/xmatch/core.py
@@ -66,7 +66,7 @@ class XMatchClass(BaseQuery):
             this region will be considered.
         cache : bool
             Defaults to True. If set overrides global caching behavior.
-            See [caching documentation](https://astroquery.readthedocs.io/en/latest/index.html#caching).
+            See :ref:`caching documentation <astroquery_cache>`.
 
         Returns
         -------
@@ -184,7 +184,7 @@ class XMatchClass(BaseQuery):
         ----------
         cache : bool
             Defaults to True. If set overrides global caching behavior.
-            See [caching documentation](https://astroquery.readthedocs.io/en/latest/index.html#caching).
+            See :ref:`caching documentation <astroquery_cache>`.
         """
         response = self._request(
             'GET',

--- a/astroquery/xmatch/core.py
+++ b/astroquery/xmatch/core.py
@@ -64,6 +64,9 @@ class XMatchClass(BaseQuery):
             Default value is 'allsky' (no restriction). If a
             ``regions.CircleSkyRegion`` object is given, only sources in
             this region will be considered.
+        cache : bool
+            Defaults to True. If set overrides global caching behavior.
+            See [caching documentation](https://astroquery.readthedocs.io/en/latest/index.html#caching).
 
         Returns
         -------
@@ -177,6 +180,11 @@ class XMatchClass(BaseQuery):
         """Get the list of the VizieR tables which are available in the
         xMatch service and return them as a list of strings.
 
+        Parameters
+        ----------
+        cache : bool
+            Defaults to True. If set overrides global caching behavior.
+            See [caching documentation](https://astroquery.readthedocs.io/en/latest/index.html#caching).
         """
         response = self._request(
             'GET',

--- a/docs/atomic/atomic.rst
+++ b/docs/atomic/atomic.rst
@@ -40,6 +40,20 @@ the atomic package takes care to support all spectral units.
           199.0122     C IV   E1 ... 1/2-* 157000000.0 0.00 -   502481.80
 
 
+Troubleshooting
+===============
+
+If you are repeatedly getting failed queries, or bad/out-of-date results, try clearing your cache:
+
+.. code-block:: python
+
+    >>> from astroquery.atomic import AtomicLineList
+    >>> AtomicLineList.clear_cache()
+
+If this function is unavailable, upgrade your version of astroquery. 
+The `clear_cache` function was introduced in version 0.4.7.dev8479.
+
+
 Reference/API
 =============
 

--- a/docs/atomic/atomic.rst
+++ b/docs/atomic/atomic.rst
@@ -51,7 +51,7 @@ If you are repeatedly getting failed queries, or bad/out-of-date results, try cl
     >>> AtomicLineList.clear_cache()
 
 If this function is unavailable, upgrade your version of astroquery. 
-The `clear_cache` function was introduced in version 0.4.7.dev8479.
+The ``clear_cache`` function was introduced in version 0.4.7.dev8479.
 
 
 Reference/API

--- a/docs/casda/casda.rst
+++ b/docs/casda/casda.rst
@@ -205,7 +205,7 @@ If you are repeatedly getting failed queries, or bad/out-of-date results, try cl
     >>> Casda.clear_cache()
 
 If this function is unavailable, upgrade your version of astroquery. 
-The `clear_cache` function was introduced in version 0.4.7.dev8479.
+The ``clear_cache`` function was introduced in version 0.4.7.dev8479.
 
 
 

--- a/docs/casda/casda.rst
+++ b/docs/casda/casda.rst
@@ -194,6 +194,21 @@ is shown below:
     >>> filelist = casda.download_files(url_list, savedir='/tmp')
 
 
+Troubleshooting
+===============
+
+If you are repeatedly getting failed queries, or bad/out-of-date results, try clearing your cache:
+
+.. code-block:: python
+
+    >>> from astroquery.casda import Casda
+    >>> Casda.clear_cache()
+
+If this function is unavailable, upgrade your version of astroquery. 
+The `clear_cache` function was introduced in version 0.4.7.dev8479.
+
+
+
 Reference/API
 =============
 

--- a/docs/dace/dace.rst
+++ b/docs/dace/dace.rst
@@ -42,7 +42,7 @@ If you are repeatedly getting failed queries, or bad/out-of-date results, try cl
     >>> Dace.clear_cache()
 
 If this function is unavailable, upgrade your version of astroquery. 
-The `clear_cache` function was introduced in version 0.4.7.dev8479.
+The ``clear_cache`` function was introduced in version 0.4.7.dev8479.
 
 
 Reference/API

--- a/docs/dace/dace.rst
+++ b/docs/dace/dace.rst
@@ -31,6 +31,20 @@ If you need to get radial velocities data for an object you can do the following
     Length = 600 rows
 
 
+Troubleshooting
+===============
+
+If you are repeatedly getting failed queries, or bad/out-of-date results, try clearing your cache:
+
+.. code-block:: python
+
+    >>> from astroquery.dace import Dace
+    >>> Dace.clear_cache()
+
+If this function is unavailable, upgrade your version of astroquery. 
+The `clear_cache` function was introduced in version 0.4.7.dev8479.
+
+
 Reference/API
 =============
 

--- a/docs/esa/hsa/hsa.rst
+++ b/docs/esa/hsa/hsa.rst
@@ -238,6 +238,20 @@ After obtaining the desire ID, download the product of the observation '13422050
   '1342205057.tar'
 
 
+Troubleshooting
+===============
+
+If you are repeatedly getting failed queries, or bad/out-of-date results, try clearing your cache:
+
+.. code-block:: python
+
+    >>> from astroquery.esa.hsa import HSA
+    >>> HSA.clear_cache()
+
+If this function is unavailable, upgrade your version of astroquery. 
+The `clear_cache` function was introduced in version 0.4.7.dev8479.
+
+  
 Reference/API
 =============
 

--- a/docs/esa/hsa/hsa.rst
+++ b/docs/esa/hsa/hsa.rst
@@ -249,7 +249,7 @@ If you are repeatedly getting failed queries, or bad/out-of-date results, try cl
     >>> HSA.clear_cache()
 
 If this function is unavailable, upgrade your version of astroquery. 
-The `clear_cache` function was introduced in version 0.4.7.dev8479.
+The ``clear_cache`` function was introduced in version 0.4.7.dev8479.
 
   
 Reference/API

--- a/docs/esa/iso/iso.rst
+++ b/docs/esa/iso/iso.rst
@@ -399,6 +399,20 @@ And spectra can be displayed by using the following code:
    :alt: Dynamic exploration of ISO spectra in python
 
 
+Troubleshooting
+===============
+
+If you are repeatedly getting failed queries, or bad/out-of-date results, try clearing your cache:
+
+.. code-block:: python
+
+    >>> from astroquery.esa.iso import ISO
+    >>> ISO.clear_cache()
+
+If this function is unavailable, upgrade your version of astroquery. 
+The `clear_cache` function was introduced in version 0.4.7.dev8479.
+
+
 Reference/API
 =============
 

--- a/docs/esa/iso/iso.rst
+++ b/docs/esa/iso/iso.rst
@@ -410,7 +410,7 @@ If you are repeatedly getting failed queries, or bad/out-of-date results, try cl
     >>> ISO.clear_cache()
 
 If this function is unavailable, upgrade your version of astroquery. 
-The `clear_cache` function was introduced in version 0.4.7.dev8479.
+The ``clear_cache`` function was introduced in version 0.4.7.dev8479.
 
 
 Reference/API

--- a/docs/esa/xmm_newton/xmm_newton.rst
+++ b/docs/esa/xmm_newton/xmm_newton.rst
@@ -206,7 +206,7 @@ If you are repeatedly getting failed queries, or bad/out-of-date results, try cl
     >>> XMMNewton.clear_cache()
 
 If this function is unavailable, upgrade your version of astroquery. 
-The `clear_cache` function was introduced in version 0.4.7.dev8479.
+The ``clear_cache`` function was introduced in version 0.4.7.dev8479.
 
 
 Reference/API

--- a/docs/esa/xmm_newton/xmm_newton.rst
+++ b/docs/esa/xmm_newton/xmm_newton.rst
@@ -194,6 +194,21 @@ The EPIC metadata can be found in four tables in the XSA TAP:
 
 This will return the metadata within the four TAP tables in four `~astropy.table.Table` for the given target.
 
+
+Troubleshooting
+===============
+
+If you are repeatedly getting failed queries, or bad/out-of-date results, try clearing your cache:
+
+.. code-block:: python
+
+    >>> from astroquery.esa.xmm_newton import XMMNewton
+    >>> XMMNewton.clear_cache()
+
+If this function is unavailable, upgrade your version of astroquery. 
+The `clear_cache` function was introduced in version 0.4.7.dev8479.
+
+
 Reference/API
 =============
 

--- a/docs/eso/eso.rst
+++ b/docs/eso/eso.rst
@@ -383,6 +383,20 @@ To force the retrieval of data that are present in the destination directory, us
 in the call to :meth:`~astroquery.eso.EsoClass.retrieve_data`.
 
 
+Troubleshooting
+===============
+
+If you are repeatedly getting failed queries, or bad/out-of-date results, try clearing your cache:
+
+.. code-block:: python
+
+    >>> from astroquery.eso import Eso
+    >>> Eso.clear_cache()
+
+If this function is unavailable, upgrade your version of astroquery. 
+The `clear_cache` function was introduced in version 0.4.7.dev8479.
+
+
 Reference/API
 =============
 

--- a/docs/eso/eso.rst
+++ b/docs/eso/eso.rst
@@ -394,7 +394,7 @@ If you are repeatedly getting failed queries, or bad/out-of-date results, try cl
     >>> Eso.clear_cache()
 
 If this function is unavailable, upgrade your version of astroquery. 
-The `clear_cache` function was introduced in version 0.4.7.dev8479.
+The ``clear_cache`` function was introduced in version 0.4.7.dev8479.
 
 
 Reference/API

--- a/docs/fermi/fermi.rst
+++ b/docs/fermi/fermi.rst
@@ -10,13 +10,26 @@ centered on M 31 for the energy range 1 to 100 GeV for the first day in 2013.
 
 .. doctest-remote-data::
 
-    >>> from astroquery import fermi
-    >>> result = fermi.FermiLAT.query_object('M31', energyrange_MeV='1000, 100000',
+    >>> from astroquery.fermi import FermiLAT
+    >>> result = FermiLAT.query_object('M31', energyrange_MeV='1000, 100000',
     ...                                      obsdates='2013-01-01 00:00:00, 2013-01-02 00:00:00')
     >>> print(result)  # doctest: +IGNORE_OUTPUT
     ['https://fermi.gsfc.nasa.gov/FTP/fermi/data/lat/queries/L210111120827756AAA3A88_PH00.fits',
     'https://fermi.gsfc.nasa.gov/FTP/fermi/data/lat/queries/L210111120827756AAA3A88_SC00.fits']
 
+
+Troubleshooting
+===============
+
+If you are repeatedly getting failed queries, or bad/out-of-date results, try clearing your cache:
+
+.. code-block:: python
+
+    >>> from astroquery.fermi import FermiLAT
+    >>> FermiLAT.clear_cache()
+
+If this function is unavailable, upgrade your version of astroquery. 
+The `clear_cache` function was introduced in version 0.4.7.dev8479.
 
 
 Reference/API

--- a/docs/fermi/fermi.rst
+++ b/docs/fermi/fermi.rst
@@ -29,7 +29,7 @@ If you are repeatedly getting failed queries, or bad/out-of-date results, try cl
     >>> FermiLAT.clear_cache()
 
 If this function is unavailable, upgrade your version of astroquery. 
-The `clear_cache` function was introduced in version 0.4.7.dev8479.
+The ``clear_cache`` function was introduced in version 0.4.7.dev8479.
 
 
 Reference/API

--- a/docs/gama/gama.rst
+++ b/docs/gama/gama.rst
@@ -62,7 +62,7 @@ If you are repeatedly getting failed queries, or bad/out-of-date results, try cl
     >>> GAMA.clear_cache()
 
 If this function is unavailable, upgrade your version of astroquery. 
-The `clear_cache` function was introduced in version 0.4.7.dev8479.
+The ``clear_cache`` function was introduced in version 0.4.7.dev8479.
 
     
 Reference/API

--- a/docs/gama/gama.rst
+++ b/docs/gama/gama.rst
@@ -50,6 +50,21 @@ first 100 spectroscopic objects in the database:
     1031448324500121600   SDSS           1 212.70039 ... 0.05        0       0
     Length = 100 rows
 
+
+Troubleshooting
+===============
+
+If you are repeatedly getting failed queries, or bad/out-of-date results, try clearing your cache:
+
+.. code-block:: python
+
+    >>> from astroquery.gama import GAMA
+    >>> GAMA.clear_cache()
+
+If this function is unavailable, upgrade your version of astroquery. 
+The `clear_cache` function was introduced in version 0.4.7.dev8479.
+
+    
 Reference/API
 =============
 

--- a/docs/heasarc/heasarc.rst
+++ b/docs/heasarc/heasarc.rst
@@ -295,7 +295,7 @@ If you are repeatedly getting failed queries, or bad/out-of-date results, try cl
     >>> Heasarc.clear_cache()
 
 If this function is unavailable, upgrade your version of astroquery. 
-The `clear_cache` function was introduced in version 0.4.7.dev8479.
+The ``clear_cache`` function was introduced in version 0.4.7.dev8479.
 
 
 Reference/API

--- a/docs/heasarc/heasarc.rst
+++ b/docs/heasarc/heasarc.rst
@@ -284,6 +284,20 @@ tables listing the most recent INTEGRAL data.
     Length = 1601 rows
 
 
+Troubleshooting
+===============
+
+If you are repeatedly getting failed queries, or bad/out-of-date results, try clearing your cache:
+
+.. code-block:: python
+
+    >>> from astroquery.heasarc import Heasarc
+    >>> Heasarc.clear_cache()
+
+If this function is unavailable, upgrade your version of astroquery. 
+The `clear_cache` function was introduced in version 0.4.7.dev8479.
+
+
 Reference/API
 =============
 

--- a/docs/hitran/hitran.rst
+++ b/docs/hitran/hitran.rst
@@ -44,6 +44,21 @@ The data are returned as an `~astropy.table.Table` instance.
            1            1 9.834255 1.969e-35 ...                    135.0   141.0
            1            1 9.921502 6.136e-28 ...                     13.0    15.0
 
+
+Troubleshooting
+===============
+
+If you are repeatedly getting failed queries, or bad/out-of-date results, try clearing your cache:
+
+.. code-block:: python
+
+    >>> from astroquery.hitran import Hitran
+    >>> Hitran.clear_cache()
+
+If this function is unavailable, upgrade your version of astroquery. 
+The `clear_cache` function was introduced in version 0.4.7.dev8479.
+
+
 Reference/API
 =============
 

--- a/docs/hitran/hitran.rst
+++ b/docs/hitran/hitran.rst
@@ -56,7 +56,7 @@ If you are repeatedly getting failed queries, or bad/out-of-date results, try cl
     >>> Hitran.clear_cache()
 
 If this function is unavailable, upgrade your version of astroquery. 
-The `clear_cache` function was introduced in version 0.4.7.dev8479.
+The ``clear_cache`` function was introduced in version 0.4.7.dev8479.
 
 
 Reference/API

--- a/docs/image_cutouts/first/first.rst
+++ b/docs/image_cutouts/first/first.rst
@@ -33,6 +33,21 @@ For instance the image size may be specified by setting the ``image_size``
 parameter. It defaults to 1 arcmin, but may be set to another value using the
 appropriate `~astropy.units.Quantity` object.
 
+
+Troubleshooting
+===============
+
+If you are repeatedly getting failed queries, or bad/out-of-date results, try clearing your cache:
+
+.. code-block:: python
+
+    >>> from astroquery.image_cutouts.first import First
+    >>> First.clear_cache()
+
+If this function is unavailable, upgrade your version of astroquery. 
+The `clear_cache` function was introduced in version 0.4.7.dev8479.
+
+
 Reference/API
 =============
 

--- a/docs/image_cutouts/first/first.rst
+++ b/docs/image_cutouts/first/first.rst
@@ -45,7 +45,7 @@ If you are repeatedly getting failed queries, or bad/out-of-date results, try cl
     >>> First.clear_cache()
 
 If this function is unavailable, upgrade your version of astroquery. 
-The `clear_cache` function was introduced in version 0.4.7.dev8479.
+The ``clear_cache`` function was introduced in version 0.4.7.dev8479.
 
 
 Reference/API

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -182,6 +182,8 @@ uncomment the relevant configuration item(s), and insert your desired value(s).
   configuration
 
 
+.. _astroquery_cache:
+ 
 Caching
 -------
 
@@ -197,7 +199,7 @@ Service specific settings
 The Astroquery cache location is specific to individual services,
 so each service's cache should be managed invidually.
 The cache location can be viewed with the following command
-(using `Simbad <simbad/simbad.rst>`_ as an example):
+(using :ref:`Simbad <astroquery_simbad>` as an example):
 
 .. code-block:: python
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -191,19 +191,46 @@ and change the cache location. Caching persists between Astroquery sessions.
 If you know the service you are using has released new data recently, or if you believe you are
 not recieving the newest data, try clearing the cache.
 
+Service specific settings
+^^^^^^^^^^^^^^^^^^^^^^^^^
 
-The Astroquery cache location is divided by service, so each service's cache should be managed invidually,
-however whether the cache is active and the expiration time are controlled centrally through the
-astroquery ``cache_conf`` module. Astroquery uses the Astropy configuration infrastructure, information about
-temporarily or permanently changing configuration values can be found
-`here <https://docs.astropy.org/en/latest/config/index.html>`_.
-
-Shown here are the cache properties, using Simbad as an example:
+The Astroquery cache location is specific to individual services,
+so each service's cache should be managed invidually.
+The cache location can be viewed with the following command
+(using `Simbad <simbad/simbad.rst>`_ as an example):
 
 .. code-block:: python
 
-  >>> from astroquery import cache_conf
-  >>> from astroquery.simbad import Simbad
+    >>> from astroquery.simbad import Simbad
+    >>> print(Simbad.cache_location)   # doctest: +IGNORE_OUTPUT
+    /Users/username/.astropy/cache/astroquery/Simbad
+
+Each service's cache is cleared with the `clear_cache` function within that service.
+
+.. code-block:: python
+
+    >>> import os
+    >>> from astroquery.simbad import Simbad
+    ...
+    >>> os.listdir(Simbad.cache_location)   # doctest: +IGNORE_OUTPUT
+    ['8abafe54f49661237bdbc2707179df53b6ee0d74ca6b7679c0e4fac0.pickle',
+    '0e4766a7673ddfa4adaee2cfa27a924ed906badbfae8cc4a4a04256c.pickle']
+    >>> Simbad.clear_cache()
+    >>> os.listdir(Simbad.cache_location)   # doctest: +IGNORE_OUTPUT
+    []
+
+Astroquery-wide settings
+^^^^^^^^^^^^^^^^^^^^^^^^
+    
+Whether caching is active and when cached files expire are controlled centrally through the
+astroquery ``cache_conf`` module, and shared among all services.
+Astroquery uses the Astropy configuration infrastructure, information about
+temporarily or permanently changing configuration values can be found
+`here <https://docs.astropy.org/en/latest/config/index.html>`_.
+
+.. code-block:: python
+
+  >>> from astroquery import cache_conf 
   ...
   >>> # Is the cache active?
   >>> print(cache_conf.cache_active)
@@ -211,17 +238,6 @@ Shown here are the cache properties, using Simbad as an example:
   >>> # Cache timout in seconds
   >>> print(cache_conf.cache_timeout)
   604800
-  >>> # Cache location
-  >>> print(Simbad.cache_location)   # doctest: +IGNORE_OUTPUT
-  /Users/username/.astropy/cache/astroquery/Simbad
-
-
-To clear the cache:
-
-.. code-block:: python
-
-    >>> Simbad.clear_cache()
-
 
 
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -205,7 +205,7 @@ The cache location can be viewed with the following command
     >>> print(Simbad.cache_location)   # doctest: +IGNORE_OUTPUT
     /Users/username/.astropy/cache/astroquery/Simbad
 
-Each service's cache is cleared with the `clear_cache` function within that service.
+Each service's cache is cleared with the ``clear_cache`` function within that service.
 
 .. code-block:: python
 

--- a/docs/ipac/irsa/ibe/ibe.rst
+++ b/docs/ipac/irsa/ibe/ibe.rst
@@ -16,6 +16,20 @@ addition to supporting the standard query methods
 query the available missions (:meth:`~astroquery.ipac.irsa.ibe.IbeClass.list_missions`), datasets (:meth:`~astroquery.ipac.irsa.ibe.IbeClass.list_datasets`), tables (:meth:`~astroquery.ipac.irsa.ibe.IbeClass.list_tables`), and columns (:meth:`~astroquery.ipac.irsa.ibe.IbeClass.get_columns`).
 
 
+Troubleshooting
+===============
+
+If you are repeatedly getting failed queries, or bad/out-of-date results, try clearing your cache:
+
+.. code-block:: python
+
+    >>> from astroquery.ipac.irsa.ibe import Ibe
+    >>> Ibe.clear_cache()
+
+If this function is unavailable, upgrade your version of astroquery. 
+The `clear_cache` function was introduced in version 0.4.7.dev8479.
+
+
 Reference/API
 =============
 

--- a/docs/ipac/irsa/ibe/ibe.rst
+++ b/docs/ipac/irsa/ibe/ibe.rst
@@ -27,7 +27,7 @@ If you are repeatedly getting failed queries, or bad/out-of-date results, try cl
     >>> Ibe.clear_cache()
 
 If this function is unavailable, upgrade your version of astroquery. 
-The `clear_cache` function was introduced in version 0.4.7.dev8479.
+The ``clear_cache`` function was introduced in version 0.4.7.dev8479.
 
 
 Reference/API

--- a/docs/ipac/irsa/irsa.rst
+++ b/docs/ipac/irsa/irsa.rst
@@ -289,20 +289,6 @@ change the setting only for the ongoing python session, you could also do:
     >>> Irsa.ROW_LIMIT = 1000   # 1000 is the new value for row limit here.
 
 
-Troubleshooting
-===============
-
-If you are repeatedly getting failed queries, or bad/out-of-date results, try clearing your cache:
-
-.. code-block:: python
-
-    >>> from astroquery.ipac.irsa import Irsa
-    >>> Irsa.clear_cache()
-
-If this function is unavailable, upgrade your version of astroquery. 
-The `clear_cache` function was introduced in version 0.4.7.dev8479.
-
-
 Reference/API
 =============
 

--- a/docs/ipac/irsa/irsa.rst
+++ b/docs/ipac/irsa/irsa.rst
@@ -289,6 +289,20 @@ change the setting only for the ongoing python session, you could also do:
     >>> Irsa.ROW_LIMIT = 1000   # 1000 is the new value for row limit here.
 
 
+Troubleshooting
+===============
+
+If you are repeatedly getting failed queries, or bad/out-of-date results, try clearing your cache:
+
+.. code-block:: python
+
+    >>> from astroquery.ipac.irsa import Irsa
+    >>> Irsa.clear_cache()
+
+If this function is unavailable, upgrade your version of astroquery. 
+The `clear_cache` function was introduced in version 0.4.7.dev8479.
+
+
 Reference/API
 =============
 

--- a/docs/ipac/irsa/irsa_dust/irsa_dust.rst
+++ b/docs/ipac/irsa/irsa_dust/irsa_dust.rst
@@ -177,7 +177,7 @@ If you are repeatedly getting failed queries, or bad/out-of-date results, try cl
     >>> IrsaDust.clear_cache()
 
 If this function is unavailable, upgrade your version of astroquery. 
-The `clear_cache` function was introduced in version 0.4.7.dev8479.
+The ``clear_cache`` function was introduced in version 0.4.7.dev8479.
 
 
 Reference/API

--- a/docs/ipac/irsa/irsa_dust/irsa_dust.rst
+++ b/docs/ipac/irsa/irsa_dust/irsa_dust.rst
@@ -173,7 +173,7 @@ If you are repeatedly getting failed queries, or bad/out-of-date results, try cl
 
 .. code-block:: python
 
-    >>> from astroquery.pac.irsa.irsa_dust import IrsaDust
+    >>> from astroquery.ipac.irsa.irsa_dust import IrsaDust
     >>> IrsaDust.clear_cache()
 
 If this function is unavailable, upgrade your version of astroquery. 

--- a/docs/ipac/irsa/irsa_dust/irsa_dust.rst
+++ b/docs/ipac/irsa/irsa_dust/irsa_dust.rst
@@ -166,6 +166,20 @@ with all the four sections will be returned.
     E(B-V) Reddening ...      0.1099
 
 
+Troubleshooting
+===============
+
+If you are repeatedly getting failed queries, or bad/out-of-date results, try clearing your cache:
+
+.. code-block:: python
+
+    >>> from astroquery.pac.irsa.irsa_dust import IrsaDust
+    >>> IrsaDust.clear_cache()
+
+If this function is unavailable, upgrade your version of astroquery. 
+The `clear_cache` function was introduced in version 0.4.7.dev8479.
+
+
 Reference/API
 =============
 

--- a/docs/ipac/ned/ned.rst
+++ b/docs/ipac/ned/ned.rst
@@ -276,7 +276,7 @@ If you are repeatedly getting failed queries, or bad/out-of-date results, try cl
     >>> Ned.clear_cache()
 
 If this function is unavailable, upgrade your version of astroquery. 
-The `clear_cache` function was introduced in version 0.4.7.dev8479.
+The ``clear_cache`` function was introduced in version 0.4.7.dev8479.
 
     
 Reference/API

--- a/docs/ipac/ned/ned.rst
+++ b/docs/ipac/ned/ned.rst
@@ -265,6 +265,20 @@ for the specified object. We look at a simple example:
     Length = 154 rows
 
 
+Troubleshooting
+===============
+
+If you are repeatedly getting failed queries, or bad/out-of-date results, try clearing your cache:
+
+.. code-block:: python
+
+    >>> from astroquery.ned import Ned
+    >>> Ned.clear_cache()
+
+If this function is unavailable, upgrade your version of astroquery. 
+The `clear_cache` function was introduced in version 0.4.7.dev8479.
+
+    
 Reference/API
 =============
 

--- a/docs/jplhorizons/jplhorizons.rst
+++ b/docs/jplhorizons/jplhorizons.rst
@@ -635,6 +635,20 @@ The development of this submodule is in part funded through NASA PDART Grant No.
 80NSSC18K0987 to the `sbpy project <https://sbpy.org>`_.
 
 
+Troubleshooting
+===============
+
+If you are repeatedly getting failed queries, or bad/out-of-date results, try clearing your cache:
+
+.. code-block:: python
+
+    >>> from astroquery.jplhorizons import Horizons
+    >>> Horizons.clear_cache()
+
+If this function is unavailable, upgrade your version of astroquery. 
+The `clear_cache` function was introduced in version 0.4.7.dev8479.
+
+
 Reference/API
 =============
 

--- a/docs/jplhorizons/jplhorizons.rst
+++ b/docs/jplhorizons/jplhorizons.rst
@@ -646,7 +646,7 @@ If you are repeatedly getting failed queries, or bad/out-of-date results, try cl
     >>> Horizons.clear_cache()
 
 If this function is unavailable, upgrade your version of astroquery. 
-The `clear_cache` function was introduced in version 0.4.7.dev8479.
+The ``clear_cache`` function was introduced in version 0.4.7.dev8479.
 
 
 Reference/API

--- a/docs/jplsbdb/jplsbdb.rst
+++ b/docs/jplsbdb/jplsbdb.rst
@@ -296,7 +296,7 @@ If you are repeatedly getting failed queries, or bad/out-of-date results, try cl
     >>> SBDB.clear_cache()
 
 If this function is unavailable, upgrade your version of astroquery. 
-The `clear_cache` function was introduced in version 0.4.7.dev8479.
+The ``clear_cache`` function was introduced in version 0.4.7.dev8479.
 
 
 Reference/API

--- a/docs/jplsbdb/jplsbdb.rst
+++ b/docs/jplsbdb/jplsbdb.rst
@@ -285,6 +285,20 @@ The development of this submodule is funded through NASA PDART
 Grant No. 80NSSC18K0987 to the `sbpy project <https://sbpy.org>`_.
 
 
+Troubleshooting
+===============
+
+If you are repeatedly getting failed queries, or bad/out-of-date results, try clearing your cache:
+
+.. code-block:: python
+
+    >>> from astroquery.jplsbdb import SBDB
+    >>> SBDB.clear_cache()
+
+If this function is unavailable, upgrade your version of astroquery. 
+The `clear_cache` function was introduced in version 0.4.7.dev8479.
+
+
 Reference/API
 =============
 

--- a/docs/jplspec/jplspec.rst
+++ b/docs/jplspec/jplspec.rst
@@ -318,7 +318,7 @@ If you are repeatedly getting failed queries, or bad/out-of-date results, try cl
     >>> JPLSpec.clear_cache()
 
 If this function is unavailable, upgrade your version of astroquery. 
-The `clear_cache` function was introduced in version 0.4.7.dev8479.
+The ``clear_cache`` function was introduced in version 0.4.7.dev8479.
 
 
 Reference/API

--- a/docs/jplspec/jplspec.rst
+++ b/docs/jplspec/jplspec.rst
@@ -307,6 +307,20 @@ results from a molecule and its isotopes, in this case H2O and HDO:
 This pattern matches any H2O and HDO isotopes.
 
 
+Troubleshooting
+===============
+
+If you are repeatedly getting failed queries, or bad/out-of-date results, try clearing your cache:
+
+.. code-block:: python
+
+    >>> from astroquery.jplspec import JPLSpec
+    >>> JPLSpec.clear_cache()
+
+If this function is unavailable, upgrade your version of astroquery. 
+The `clear_cache` function was introduced in version 0.4.7.dev8479.
+
+
 Reference/API
 =============
 

--- a/docs/lamda/lamda.rst
+++ b/docs/lamda/lamda.rst
@@ -24,18 +24,15 @@ query, use:
 
 The dictionary is created dynamically from the LAMDA website the first time it
 is called, then cached for future use.  If there has been an update and you
-want to reload the cache, you can find the cache file ``'molecules.json'`` and
-remove it:
+want to reload the cache, clear the cache as follows:
 
 .. doctest-skip::
 
-    >>> import os
-    >>> Lamda.cache_location
-    '/Users/your_username/.astropy/cache/astroquery/Lamda'
-    >>> Lamda.moldict_path
-    '/Users/your_username/.astropy/cache/astroquery/Lamda/molecules.json'
-    >>> os.remove(Lamda.moldict_path)
+    >>> from astroquery.lamda import Lamda
+    >>> Lamda.clear_cache()
 
+If this function is unavailable, upgrade your version of astroquery. 
+The `clear_cache` function was introduced in version 0.4.7.dev8479.
 
 You can query for any molecule in that dictionary.
 

--- a/docs/lamda/lamda.rst
+++ b/docs/lamda/lamda.rst
@@ -24,15 +24,18 @@ query, use:
 
 The dictionary is created dynamically from the LAMDA website the first time it
 is called, then cached for future use.  If there has been an update and you
-want to reload the cache, clear the cache as follows:
+want to reload the cache, clear the cache and remove the molecule dictionary as follows:
 
 .. doctest-skip::
 
     >>> from astroquery.lamda import Lamda
+    >>> import os
+    ...
     >>> Lamda.clear_cache()
+    >>> os.remove(Lamda.moldict_path)
 
 If this function is unavailable, upgrade your version of astroquery. 
-The `clear_cache` function was introduced in version 0.4.7.dev8479.
+The ``clear_cache`` function was introduced in version 0.4.7.dev8479.
 
 You can query for any molecule in that dictionary.
 

--- a/docs/linelists/cdms/cdms.rst
+++ b/docs/linelists/cdms/cdms.rst
@@ -305,6 +305,21 @@ Querying the Catalog with Regexes and Relative names
 
 The regular expression parsing is analogous to that in the JPLSpec module.
 
+
+Troubleshooting
+===============
+
+If you are repeatedly getting failed queries, or bad/out-of-date results, try clearing your cache:
+
+.. code-block:: python
+
+    >>> from astroquery.linelists.cdms import CDMS
+    >>> CDMS.clear_cache()
+
+If this function is unavailable, upgrade your version of astroquery. 
+The `clear_cache` function was introduced in version 0.4.7.dev8479.
+
+
 Reference/API
 =============
 

--- a/docs/linelists/cdms/cdms.rst
+++ b/docs/linelists/cdms/cdms.rst
@@ -317,7 +317,7 @@ If you are repeatedly getting failed queries, or bad/out-of-date results, try cl
     >>> CDMS.clear_cache()
 
 If this function is unavailable, upgrade your version of astroquery. 
-The `clear_cache` function was introduced in version 0.4.7.dev8479.
+The ``clear_cache`` function was introduced in version 0.4.7.dev8479.
 
 
 Reference/API

--- a/docs/magpis/magpis.rst
+++ b/docs/magpis/magpis.rst
@@ -71,6 +71,20 @@ parameters as well.
     [<astropy.io.fits.hdu.image.PrimaryHDU at 0x4013e10>]
 
 
+Troubleshooting
+===============
+
+If you are repeatedly getting failed queries, or bad/out-of-date results, try clearing your cache:
+
+.. code-block:: python
+
+    >>> from astroquery.magpis import Magpis
+    >>> Magpis.clear_cache()
+
+If this function is unavailable, upgrade your version of astroquery. 
+The `clear_cache` function was introduced in version 0.4.7.dev8479.
+
+
 Reference/API
 =============
 

--- a/docs/magpis/magpis.rst
+++ b/docs/magpis/magpis.rst
@@ -82,7 +82,7 @@ If you are repeatedly getting failed queries, or bad/out-of-date results, try cl
     >>> Magpis.clear_cache()
 
 If this function is unavailable, upgrade your version of astroquery. 
-The `clear_cache` function was introduced in version 0.4.7.dev8479.
+The ``clear_cache`` function was introduced in version 0.4.7.dev8479.
 
 
 Reference/API

--- a/docs/mpc/mpc.rst
+++ b/docs/mpc/mpc.rst
@@ -497,7 +497,7 @@ If you are repeatedly getting failed queries, or bad/out-of-date results, try cl
     >>> MPC.clear_cache()
 
 If this function is unavailable, upgrade your version of astroquery. 
-The `clear_cache` function was introduced in version 0.4.7.dev8479.
+The ``clear_cache`` function was introduced in version 0.4.7.dev8479.
 
 
 Reference/API

--- a/docs/mpc/mpc.rst
+++ b/docs/mpc/mpc.rst
@@ -485,6 +485,21 @@ Palomar-Leiden Survey designations, and individual comet fragments. In
 case an object name cannot be resolved, a ``ValueError`` is raised. If
 a query returns no results, a ``RuntimeError`` is raised.
 
+
+Troubleshooting
+===============
+
+If you are repeatedly getting failed queries, or bad/out-of-date results, try clearing your cache:
+
+.. code-block:: python
+
+    >>> from astroquery.mpc import MPC
+    >>> MPC.clear_cache()
+
+If this function is unavailable, upgrade your version of astroquery. 
+The `clear_cache` function was introduced in version 0.4.7.dev8479.
+
+
 Reference/API
 =============
 

--- a/docs/nist/nist.rst
+++ b/docs/nist/nist.rst
@@ -101,6 +101,21 @@ or 'vac+air'. Here is an example with all these parameters.
           --    6946.756   1439.5208    -- ...     20     |      |   -- T8637    --
     Length = 37 rows
 
+
+Troubleshooting
+===============
+
+If you are repeatedly getting failed queries, or bad/out-of-date results, try clearing your cache:
+
+.. code-block:: python
+
+    >>> from astroquery.nist import Nist
+    >>> Nist.clear_cache()
+
+If this function is unavailable, upgrade your version of astroquery. 
+The `clear_cache` function was introduced in version 0.4.7.dev8479.
+
+    
 Reference/API
 =============
 

--- a/docs/nist/nist.rst
+++ b/docs/nist/nist.rst
@@ -113,7 +113,7 @@ If you are repeatedly getting failed queries, or bad/out-of-date results, try cl
     >>> Nist.clear_cache()
 
 If this function is unavailable, upgrade your version of astroquery. 
-The `clear_cache` function was introduced in version 0.4.7.dev8479.
+The ``clear_cache`` function was introduced in version 0.4.7.dev8479.
 
     
 Reference/API

--- a/docs/nvas/nvas.rst
+++ b/docs/nvas/nvas.rst
@@ -88,7 +88,7 @@ If you are repeatedly getting failed queries, or bad/out-of-date results, try cl
     >>> Nvas.clear_cache()
 
 If this function is unavailable, upgrade your version of astroquery. 
-The `clear_cache` function was introduced in version 0.4.7.dev8479.
+The ``clear_cache`` function was introduced in version 0.4.7.dev8479.
 
      
 Reference/API

--- a/docs/nvas/nvas.rst
+++ b/docs/nvas/nvas.rst
@@ -77,6 +77,20 @@ arguments as :meth:`~astroquery.nvas.NvasClass.get_images` above except for the
      'http://www.vla.nrao.edu/astro/archive/pipeline/position/J053431.9+220052/8.46I1.60_AM503_1996FEB01_1_483.U2.59M.imfits']
 
 
+Troubleshooting
+===============
+
+If you are repeatedly getting failed queries, or bad/out-of-date results, try clearing your cache:
+
+.. code-block:: python
+
+    >>> from astroquery.nvas import Nvas
+    >>> Nvas.clear_cache()
+
+If this function is unavailable, upgrade your version of astroquery. 
+The `clear_cache` function was introduced in version 0.4.7.dev8479.
+
+     
 Reference/API
 =============
 

--- a/docs/oac/oac.rst
+++ b/docs/oac/oac.rst
@@ -150,6 +150,21 @@ The basic dictionary structure is:
 [wavelength_n, flux_n]]], ... , [mjd_m, [[wavelength_0, flux_0], ... ,
 [wavelength_n, flux_n]]]}}
 
+
+Troubleshooting
+===============
+
+If you are repeatedly getting failed queries, or bad/out-of-date results, try clearing your cache:
+
+.. code-block:: python
+
+    >>> from astroquery.oac import OAC
+    >>> OAC.clear_cache()
+
+If this function is unavailable, upgrade your version of astroquery. 
+The `clear_cache` function was introduced in version 0.4.7.dev8479.
+
+
 Reference/API
 =============
 

--- a/docs/oac/oac.rst
+++ b/docs/oac/oac.rst
@@ -162,7 +162,7 @@ If you are repeatedly getting failed queries, or bad/out-of-date results, try cl
     >>> OAC.clear_cache()
 
 If this function is unavailable, upgrade your version of astroquery. 
-The `clear_cache` function was introduced in version 0.4.7.dev8479.
+The ``clear_cache`` function was introduced in version 0.4.7.dev8479.
 
 
 Reference/API

--- a/docs/ogle/ogle.rst
+++ b/docs/ogle/ogle.rst
@@ -39,6 +39,20 @@ to FK5.
 Note that non-Astropy coordinates may not be supported in a future version.
 
 
+Troubleshooting
+===============
+
+If you are repeatedly getting failed queries, or bad/out-of-date results, try clearing your cache:
+
+.. code-block:: python
+
+    >>> from astroquery.ogle import Ogle
+    >>> Ogle.clear_cache()
+
+If this function is unavailable, upgrade your version of astroquery. 
+The `clear_cache` function was introduced in version 0.4.7.dev8479.
+
+
 Reference/API
 =============
 

--- a/docs/ogle/ogle.rst
+++ b/docs/ogle/ogle.rst
@@ -50,7 +50,7 @@ If you are repeatedly getting failed queries, or bad/out-of-date results, try cl
     >>> Ogle.clear_cache()
 
 If this function is unavailable, upgrade your version of astroquery. 
-The `clear_cache` function was introduced in version 0.4.7.dev8479.
+The ``clear_cache`` function was introduced in version 0.4.7.dev8479.
 
 
 Reference/API

--- a/docs/sdss/sdss.rst
+++ b/docs/sdss/sdss.rst
@@ -131,7 +131,7 @@ If you are repeatedly getting failed queries, or bad/out-of-date results, try cl
     >>> SDSS.clear_cache()
 
 If this function is unavailable, upgrade your version of astroquery. 
-The `clear_cache` function was introduced in version 0.4.7.dev8479.
+The ``clear_cache`` function was introduced in version 0.4.7.dev8479.
 
 
 Reference/API

--- a/docs/sdss/sdss.rst
+++ b/docs/sdss/sdss.rst
@@ -119,6 +119,21 @@ The variable "template" is a list of `~astropy.io.fits.HDUList` objects
 result, but in a few cases there are multiple templates available to choose
 from (*e.g.*, the "galaxy" spectral template will actually return 3 templates).
 
+
+Troubleshooting
+===============
+
+If you are repeatedly getting failed queries, or bad/out-of-date results, try clearing your cache:
+
+.. code-block:: python
+
+    >>> from astroquery.sdss import SDSS
+    >>> SDSS.clear_cache()
+
+If this function is unavailable, upgrade your version of astroquery. 
+The `clear_cache` function was introduced in version 0.4.7.dev8479.
+
+
 Reference/API
 =============
 

--- a/docs/simbad/simbad.rst
+++ b/docs/simbad/simbad.rst
@@ -737,7 +737,7 @@ If you are repeatedly getting failed queries, or bad/out-of-date results, try cl
     >>> Simbad.clear_cache()
 
 If this function is unavailable, upgrade your version of astroquery. 
-The `clear_cache` function was introduced in version 0.4.7.dev8479.
+The ``clear_cache`` function was introduced in version 0.4.7.dev8479.
 
     
 Reference/API

--- a/docs/simbad/simbad.rst
+++ b/docs/simbad/simbad.rst
@@ -725,6 +725,21 @@ be specified as follows (e.g. epoch of J2017.5 and equinox of 2000):
     HD 189733            20 00 43.7107            +22 42 39.064
 
 
+
+Troubleshooting
+===============
+
+If you are repeatedly getting failed queries, or bad/out-of-date results, try clearing your cache:
+
+.. code-block:: python
+
+    >>> from astroquery.simbad import Simbad
+    >>> Simbad.clear_cache()
+
+If this function is unavailable, upgrade your version of astroquery. 
+The `clear_cache` function was introduced in version 0.4.7.dev8479.
+
+    
 Reference/API
 =============
 

--- a/docs/skyview/skyview.rst
+++ b/docs/skyview/skyview.rst
@@ -227,6 +227,20 @@ Without the download:
      'http://skyview.gsfc.nasa.gov/tempspace/fits/skv669807193757_3.fits']
 
 
+Troubleshooting
+===============
+
+If you are repeatedly getting failed queries, or bad/out-of-date results, try clearing your cache:
+
+.. code-block:: python
+
+    >>> from astroquery.skyview import SkyView
+    >>> SkyView.clear_cache()
+
+If this function is unavailable, upgrade your version of astroquery. 
+The `clear_cache` function was introduced in version 0.4.7.dev8479.
+
+
 Reference/API
 =============
 

--- a/docs/skyview/skyview.rst
+++ b/docs/skyview/skyview.rst
@@ -238,7 +238,7 @@ If you are repeatedly getting failed queries, or bad/out-of-date results, try cl
     >>> SkyView.clear_cache()
 
 If this function is unavailable, upgrade your version of astroquery. 
-The `clear_cache` function was introduced in version 0.4.7.dev8479.
+The ``clear_cache`` function was introduced in version 0.4.7.dev8479.
 
 
 Reference/API

--- a/docs/splatalogue/splatalogue.rst
+++ b/docs/splatalogue/splatalogue.rst
@@ -261,6 +261,20 @@ be fixed)
        H2CO  Formaldehyde 1(1,0)-1(1,1),F=1-2 4.8296665            --   -8.82819 15.39497
 
 
+Troubleshooting
+===============
+
+If you are repeatedly getting failed queries, or bad/out-of-date results, try clearing your cache:
+
+.. code-block:: python
+
+    >>> from astroquery.splatalogue import Splatalogue
+    >>> Splatalogue.clear_cache()
+
+If this function is unavailable, upgrade your version of astroquery. 
+The `clear_cache` function was introduced in version 0.4.7.dev8479.
+
+       
 Reference/API
 =============
 

--- a/docs/splatalogue/splatalogue.rst
+++ b/docs/splatalogue/splatalogue.rst
@@ -272,7 +272,7 @@ If you are repeatedly getting failed queries, or bad/out-of-date results, try cl
     >>> Splatalogue.clear_cache()
 
 If this function is unavailable, upgrade your version of astroquery. 
-The `clear_cache` function was introduced in version 0.4.7.dev8479.
+The ``clear_cache`` function was introduced in version 0.4.7.dev8479.
 
        
 Reference/API

--- a/docs/svo_fps/svo_fps.rst
+++ b/docs/svo_fps/svo_fps.rst
@@ -174,6 +174,19 @@ These are the data needed to plot the transmission curve for filter:
    The 2MASS H-band transmission curve
 
 
+Troubleshooting
+===============
+
+If you are repeatedly getting failed queries, or bad/out-of-date results, try clearing your cache:
+
+.. code-block:: python
+
+    >>> from astroquery.svo_fps import SvoFps
+    >>> SvoFps.clear_cache()
+
+If this function is unavailable, upgrade your version of astroquery. 
+The `clear_cache` function was introduced in version 0.4.7.dev8479.
+   
 
 Reference/API
 =============

--- a/docs/svo_fps/svo_fps.rst
+++ b/docs/svo_fps/svo_fps.rst
@@ -185,7 +185,7 @@ If you are repeatedly getting failed queries, or bad/out-of-date results, try cl
     >>> SvoFps.clear_cache()
 
 If this function is unavailable, upgrade your version of astroquery. 
-The `clear_cache` function was introduced in version 0.4.7.dev8479.
+The ``clear_cache`` function was introduced in version 0.4.7.dev8479.
    
 
 Reference/API

--- a/docs/ukidss/ukidss.rst
+++ b/docs/ukidss/ukidss.rst
@@ -245,6 +245,20 @@ results are returned in a `~astropy.table.Table`.
     438758414982 438086690175 272.616576986 ...  -9.99999e+08 0.0214102038115
 
 
+Troubleshooting
+===============
+
+If you are repeatedly getting failed queries, or bad/out-of-date results, try clearing your cache:
+
+.. code-block:: python
+
+    >>> from astroquery.ukidss import Ukidss
+    >>> Ukidss.clear_cache()
+
+If this function is unavailable, upgrade your version of astroquery. 
+The `clear_cache` function was introduced in version 0.4.7.dev8479.
+
+    
 Reference/API
 =============
 

--- a/docs/ukidss/ukidss.rst
+++ b/docs/ukidss/ukidss.rst
@@ -256,7 +256,7 @@ If you are repeatedly getting failed queries, or bad/out-of-date results, try cl
     >>> Ukidss.clear_cache()
 
 If this function is unavailable, upgrade your version of astroquery. 
-The `clear_cache` function was introduced in version 0.4.7.dev8479.
+The ``clear_cache`` function was introduced in version 0.4.7.dev8479.
 
     
 Reference/API

--- a/docs/vizier/vizier.rst
+++ b/docs/vizier/vizier.rst
@@ -373,6 +373,21 @@ index to the ``agn`` table (not the 0-based python convention).
      11 192.721982  41.121040 12505327+4107157 10.822 ...  200  100  c00    2    0
      11 192.721179  41.120201 12505308+4107127  9.306 ...  222  111  000    2    0
 
+
+Troubleshooting
+===============
+
+If you are repeatedly getting failed queries, or bad/out-of-date results, try clearing your cache:
+
+.. code-block:: python
+
+    >>> from astroquery.vizier import Vizier
+    >>> Vizier.clear_cache()
+
+If this function is unavailable, upgrade your version of astroquery. 
+The `clear_cache` function was introduced in version 0.4.7.dev8479.
+
+     
 Reference/API
 =============
 

--- a/docs/vizier/vizier.rst
+++ b/docs/vizier/vizier.rst
@@ -385,7 +385,7 @@ If you are repeatedly getting failed queries, or bad/out-of-date results, try cl
     >>> Vizier.clear_cache()
 
 If this function is unavailable, upgrade your version of astroquery. 
-The `clear_cache` function was introduced in version 0.4.7.dev8479.
+The ``clear_cache`` function was introduced in version 0.4.7.dev8479.
 
      
 Reference/API

--- a/docs/vo_conesearch/vo_conesearch.rst
+++ b/docs/vo_conesearch/vo_conesearch.rst
@@ -211,7 +211,7 @@ If you are repeatedly getting failed queries, or bad/out-of-date results, try cl
     >>> ConeSearch.clear_cache()
 
 If this function is unavailable, upgrade your version of astroquery. 
-The `clear_cache` function was introduced in version 0.4.7.dev8479.
+The ``clear_cache`` function was introduced in version 0.4.7.dev8479.
 
   
 Reference/API

--- a/docs/vo_conesearch/vo_conesearch.rst
+++ b/docs/vo_conesearch/vo_conesearch.rst
@@ -200,6 +200,20 @@ See Also
 - `STScI VO Databases <https://astroconda.org/aux/vo_databases/>`_
 
 
+Troubleshooting
+===============
+
+If you are repeatedly getting failed queries, or bad/out-of-date results, try clearing your cache:
+
+.. code-block:: python
+
+    >>> from astroquery.vo_conesearch import ConeSearch
+    >>> ConeSearch.clear_cache()
+
+If this function is unavailable, upgrade your version of astroquery. 
+The `clear_cache` function was introduced in version 0.4.7.dev8479.
+
+  
 Reference/API
 =============
 

--- a/docs/xmatch/xmatch.rst
+++ b/docs/xmatch/xmatch.rst
@@ -76,6 +76,20 @@ in the resulting table for demonstration purposes.  Finally, ``colRa1`` and
     >>> cleanup_saved_downloads(['pos_list.csv'])
 
 
+Troubleshooting
+===============
+
+If you are repeatedly getting failed queries, or bad/out-of-date results, try clearing your cache:
+
+.. code-block:: python
+
+    >>> from astroquery.xmatch import XMatch
+    >>> XMatch.clear_cache()
+
+If this function is unavailable, upgrade your version of astroquery. 
+The `clear_cache` function was introduced in version 0.4.7.dev8479.
+
+    
 Reference/API
 =============
 

--- a/docs/xmatch/xmatch.rst
+++ b/docs/xmatch/xmatch.rst
@@ -87,7 +87,7 @@ If you are repeatedly getting failed queries, or bad/out-of-date results, try cl
     >>> XMatch.clear_cache()
 
 If this function is unavailable, upgrade your version of astroquery. 
-The `clear_cache` function was introduced in version 0.4.7.dev8479.
+The ``clear_cache`` function was introduced in version 0.4.7.dev8479.
 
     
 Reference/API


### PR DESCRIPTION
Implementing cache documentation updates from https://github.com/astropy/astroquery/issues/1239.

Included in this PR:
- Improved general caching documentation in ``index.rst``
- Added troubleshooting section with info aboue clearing the cache for all modules that use the caching infrastructure in a way that this is possible
- Added cache documentation and link to the main docs in doc strings for all modules that allow user access to the cache argument