### PR TITLE
Fix issue 2749

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -2,7 +2,6 @@
 name = astroquery
 version = 0.4.7.dev
 description = Functions and classes to access online astronomical data resources
-# FIXME long_description =
 author = The Astroquery Developers
 license = BSD
 url = http://astropy.org/astroquery

--- a/setup.py
+++ b/setup.py
@@ -15,4 +15,9 @@ builtins._ASTROPY_SETUP_ = True
 
 from astropy_helpers.setup_helpers import setup
 
-setup()
+# Read the contents of the README file
+from pathlib import Path
+this_directory = Path(__file__).parent
+long_description = (this_directory / "README.rst").read_text()
+
+setup(long_description=long_description, long_description_content_type='text/x-rst')


### PR DESCRIPTION
Add long_description and long_description_content_type metadata for README to show in pypi. Validated with twine.