### PR TITLE
New retrieval types for Gaia Datalink (GAIAPCR-1281 C9GACS-9070)

### DIFF
--- a/astroquery/gaia/__init__.py
+++ b/astroquery/gaia/__init__.py
@@ -36,7 +36,12 @@ class Conf(_config.ConfigNamespace):
                                       'XP_SAMPLED',
                                       'RVS',
                                       'MCMC_GSPPHOT',
-                                      'MCMC_MSC']
+                                      'MCMC_MSC',
+                                      'EPOCH_ASTROMETRY',
+                                      'RV_EPOCH_SINGLE',
+                                      'RV_EPOCH_DOUBLE',
+                                      'RVS_EPOCH',
+                                      'RVS_TRANSIT']
 
 
 conf = Conf()

--- a/astroquery/gaia/core.py
+++ b/astroquery/gaia/core.py
@@ -191,6 +191,9 @@ class GaiaClass(TapPlus):
             retrieval type identifier. For GAIA DR2 possible values are ['EPOCH_PHOTOMETRY']
             For GAIA DR3, possible values are ['EPOC_PHOTOMETRY', 'RVS', 'XP_CONTINUOUS', 'XP_SAMPLED',
             'MCMC_GSPPHOT' or 'MCMC_MSC']
+            For GAIA DR4, possible values are ['EPOC_PHOTOMETRY', 'RVS', 'XP_CONTINUOUS', 'XP_SAMPLED',
+            'MCMC_GSPPHOT', 'MCMC_MSC', 'EPOCH_ASTROMETRY', 'RV_EPOCH_SINGLE', 'RV_EPOCH_DOUBLE', 'RVS_EPOCH' or 
+            'RVS_TRANSIT']
         valid_data : bool, optional, default False
             By default, the epoch photometry service returns all available data, including
             data rows where flux is null and/or the rejected_by_photometry flag is set to True.

--- a/astroquery/gaia/core.py
+++ b/astroquery/gaia/core.py
@@ -189,9 +189,9 @@ class GaiaClass(TapPlus):
             row per sourceId
         retrieval_type : str, optional, default 'ALL' to retrieve all data  from the list of sources
             retrieval type identifier. For GAIA DR2 possible values are ['EPOCH_PHOTOMETRY']
-            For GAIA DR3, possible values are ['EPOC_PHOTOMETRY', 'RVS', 'XP_CONTINUOUS', 'XP_SAMPLED',
+            For GAIA DR3, possible values are ['EPOCH_PHOTOMETRY', 'RVS', 'XP_CONTINUOUS', 'XP_SAMPLED',
             'MCMC_GSPPHOT' or 'MCMC_MSC']
-            For GAIA DR4, possible values are ['EPOC_PHOTOMETRY', 'RVS', 'XP_CONTINUOUS', 'XP_SAMPLED',
+            For GAIA DR4, possible values will be ['EPOCH_PHOTOMETRY', 'RVS', 'XP_CONTINUOUS', 'XP_SAMPLED',
             'MCMC_GSPPHOT', 'MCMC_MSC', 'EPOCH_ASTROMETRY', 'RV_EPOCH_SINGLE', 'RV_EPOCH_DOUBLE', 'RVS_EPOCH' or
             'RVS_TRANSIT']
         valid_data : bool, optional, default False

--- a/astroquery/gaia/core.py
+++ b/astroquery/gaia/core.py
@@ -192,7 +192,7 @@ class GaiaClass(TapPlus):
             For GAIA DR3, possible values are ['EPOC_PHOTOMETRY', 'RVS', 'XP_CONTINUOUS', 'XP_SAMPLED',
             'MCMC_GSPPHOT' or 'MCMC_MSC']
             For GAIA DR4, possible values are ['EPOC_PHOTOMETRY', 'RVS', 'XP_CONTINUOUS', 'XP_SAMPLED',
-            'MCMC_GSPPHOT', 'MCMC_MSC', 'EPOCH_ASTROMETRY', 'RV_EPOCH_SINGLE', 'RV_EPOCH_DOUBLE', 'RVS_EPOCH' or 
+            'MCMC_GSPPHOT', 'MCMC_MSC', 'EPOCH_ASTROMETRY', 'RV_EPOCH_SINGLE', 'RV_EPOCH_DOUBLE', 'RVS_EPOCH' or
             'RVS_TRANSIT']
         valid_data : bool, optional, default False
             By default, the epoch photometry service returns all available data, including


### PR DESCRIPTION
We include new retrieval types for data link that will be used in DR4:

1. 'EPOCH_ASTROMETRY',
2. 'RV_EPOCH_SINGLE',
3. 'RV_EPOCH_DOUBLE',
4. 'RVS_EPOCH',
5. 'RVS_TRANSIT'