### PR TITLE
MastClass query helper function

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -248,6 +248,9 @@ mast
 
 - Bug fix in ``Observations.query_criteria()`` to use ``page`` and ``pagesize`` parameters [#2915]
 
+- Added ``Mast.mast_query`` to ``MastClass`` to handle the creation of parameter dictionaries for
+  MAST Service queries. [#2785]
+
 nist
 ^^^^
 

--- a/astroquery/mast/observations.py
+++ b/astroquery/mast/observations.py
@@ -909,26 +909,48 @@ class MastClass(MastQueryWithLogin):
 
         return self._portal_api_connection.service_request_async(service, params, pagesize, page, **kwargs)
 
-    def mast_query(self, service, columns='*', **kwargs):
+    def mast_query(self, service, columns=None, **kwargs):
+        """
+        Given a Mashup service and parameters as keyword arguments, builds and excecutes a Mashup query.
+
+        Parameters
+        ----------
+        service : str
+            The Mashup service to query.
+        columns : str, optional
+            Specifies the columns to be returned as a comma-separated list, e.g. "ID, ra, dec".
+        **kwargs :
+            Service-specific parameters and MashupRequest properties. See the
+            `service documentation <https://mast.stsci.edu/api/v0/_services.html>`__ and the
+            `MashupRequest Class Reference <https://mast.stsci.edu/api/v0/class_mashup_1_1_mashup_request.html>`__
+            for valid keyword arguments.
+
+        Returns
+        -------
+        response : `~astropy.table.Table`
+        """
         # Specific keywords related to positional and MashupRequest parameters.
         position_keys = ['ra', 'dec', 'radius', 'position']
         request_keys = ['format', 'data', 'filename', 'timeout', 'clearcache',
                         'removecache', 'removenullcolumns', 'page', 'pagesize']
 
         # Explicit formatting for Mast's filtered services
-        if 'Filtered' in service:
+        if 'filtered' in service.lower():
 
             # Separating the filter params from the positional and service_request method params.
             filters = [{'paramName': k, 'values': kwargs[k]} for k in kwargs
-                       if k not in position_keys+request_keys]
-            position_params = {k: v for k, v in kwargs.items() if k in position_keys}
-            request_params = {k: v for k, v in kwargs.items() if k in request_keys}
+                       if k.lower() not in position_keys+request_keys]
+            position_params = {k: v for k, v in kwargs.items() if k.lower() in position_keys}
+            request_params = {k: v for k, v in kwargs.items() if k.lower() in request_keys}
 
             # Mast's filtered services require at least one filter
             if filters == []:
                 raise InvalidQueryError("Please provide at least one filter.")
 
             # Building 'params' for Mast.service_request
+            if columns is None:
+                columns = '*'
+
             params = {'columns': columns,
                       'filters': filters,
                       **position_params
@@ -936,8 +958,12 @@ class MastClass(MastQueryWithLogin):
         else:
 
             # Separating service specific params from service_request method params
-            params = {k: v for k, v in kwargs.items() if k not in request_keys}
-            request_params = {k: v for k, v in kwargs.items() if k in request_keys}
+            params = {k: v for k, v in kwargs.items() if k.lower() not in request_keys}
+            request_params = {k: v for k, v in kwargs.items() if k.lower() in request_keys}
+
+            # Warning for wrong input
+            if columns is not None:
+                warnings.warn("'columns' parameter will not mask non-filtered services", InputWarning)
 
         return self.service_request(service, params, **request_params)
 

--- a/astroquery/mast/tests/test_mast.py
+++ b/astroquery/mast/tests/test_mast.py
@@ -299,6 +299,21 @@ def test_mast_service_request(patch_post):
     assert isinstance(result, Table)
 
 
+def test_mast_query(patch_post):
+    # cone search
+    result = mast.Mast.mast_query('Mast.Caom.Cone', ra=23.34086, dec=60.658, radius=0.2)
+    assert isinstance(result, Table)
+
+    # filtered search
+    result = mast.Mast.mast_query('Mast.Caom.Filtered',
+                                  dataproduct_type=['image'],
+                                  proposal_pi=['Osten, Rachel A.'],
+                                  s_dec=[{'min': 43.5, 'max': 45.5}])
+    assert isinstance(result, Table)
+
+    # filtered search with position
+
+
 def test_resolve_object(patch_post):
     m103_loc = mast.Mast.resolve_object("M103")
     print(m103_loc)

--- a/astroquery/mast/tests/test_mast.py
+++ b/astroquery/mast/tests/test_mast.py
@@ -309,9 +309,17 @@ def test_mast_query(patch_post):
                                   dataproduct_type=['image'],
                                   proposal_pi=['Osten, Rachel A.'],
                                   s_dec=[{'min': 43.5, 'max': 45.5}])
+    pp_list = result['proposal_pi']
+    sd_list = result['s_dec']
     assert isinstance(result, Table)
+    assert len(set(pp_list)) == 1
+    assert max(sd_list) < 45.5
+    assert min(sd_list) > 43.5
 
-    # filtered search with position
+    # error handling
+    with pytest.raises(InvalidQueryError) as invalid_query:
+        mast.Mast.mast_query('Mast.Caom.Filtered')
+    assert "Please provide at least one filter." in str(invalid_query.value)
 
 
 def test_resolve_object(patch_post):

--- a/astroquery/mast/tests/test_mast_remote.py
+++ b/astroquery/mast/tests/test_mast_remote.py
@@ -83,6 +83,21 @@ class TestMast:
         # Are the two GALEX observations with obs_id 6374399093149532160 in the results table
         assert len(result[np.where(result["obs_id"] == "6374399093149532160")]) == 2
 
+    def test_mast_query(self):
+        # clear columns config
+        mast.Mast._column_configs = dict()
+
+        result = mast.Mast.mast_query('Mast.Caom.Cone', ra=184.3, dec=54.5, radius=0.2)
+
+        # Is result in the right format
+        assert isinstance(result, Table)
+
+        # Are the GALEX observations in the results table
+        assert "GALEX" in result['obs_collection']
+
+        # Are the two GALEX observations with obs_id 6374399093149532160 in the results table
+        assert len(result[np.where(result["obs_id"] == "6374399093149532160")]) == 2
+
     def test_mast_session_info(self):
         sessionInfo = mast.Mast.session_info(verbose=False)
         assert sessionInfo['ezid'] == 'anonymous'


### PR DESCRIPTION
The MAST API requires users to use JSON/Python Dictionaries to query MAST services. We want to create a helper function to format parameter dictionaries to make `astroquery.mast.Mast` queries easier for the users. 