### PR TITLE
Esa ehst download improvements

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -31,6 +31,8 @@ esa.hubble
 
 - Update to TAP url to query data and download files, aligned with the new eHST Science Archive. [#2567][#2597]
 - Status and maintenance messages from eHST TAP when the module is instantiated. get_status_messages method to retrieve them. [#2597]
+- New methods to download single files and download FITS associated to an observation. [#2797]
+- New function to retrieve all the files associated to an observation. [#2797]
 
 solarsystem.neodys
 ^^^^^^^^^^^^^^^^^^
@@ -64,6 +66,7 @@ esa.hubble
   a lot faster. [#2524]
 - Method query_hst_tap has been deprecated and is replaced with query_tap, with the same arguments. [#2597]
 - Product types in download_product method have been modified to: PRODUCT, SCIENCE_PRODUCT or POSTCARD. [#2597]
+- query_criteria method now allows user to filter by Proposal ID. [#2797]
 
 alma
 ^^^^

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -66,7 +66,7 @@ esa.hubble
   a lot faster. [#2524]
 - Method query_hst_tap has been deprecated and is replaced with query_tap, with the same arguments. [#2597]
 - Product types in download_product method have been modified to: PRODUCT, SCIENCE_PRODUCT or POSTCARD. [#2597]
-- Added `proposal` keyword argument to several methods now allows to filter by Proposal ID. [#2797]
+- Added ``proposal`` keyword argument to several methods now allows to filter by Proposal ID. [#2797]
 
 alma
 ^^^^

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -31,7 +31,7 @@ esa.hubble
 
 - Update to TAP url to query data and download files, aligned with the new eHST Science Archive. [#2567][#2597]
 - Status and maintenance messages from eHST TAP when the module is instantiated. get_status_messages method to retrieve them. [#2597]
-- New methods to download single files and download FITS associated to an observation. [#2797]
+- New methods to download single files ``download_file`` and download FITS associated to an observation ``download_fits_files``. [#2797]
 - New function to retrieve all the files associated to an observation. [#2797]
 
 solarsystem.neodys
@@ -66,7 +66,7 @@ esa.hubble
   a lot faster. [#2524]
 - Method query_hst_tap has been deprecated and is replaced with query_tap, with the same arguments. [#2597]
 - Product types in download_product method have been modified to: PRODUCT, SCIENCE_PRODUCT or POSTCARD. [#2597]
-- query_criteria method now allows user to filter by Proposal ID. [#2797]
+- Added `proposal` keyword argument to several methods now allows to filter by Proposal ID. [#2797]
 
 alma
 ^^^^

--- a/astroquery/esa/hubble/core.py
+++ b/astroquery/esa/hubble/core.py
@@ -25,7 +25,7 @@ from astropy.utils.decorators import deprecated
 from . import conf
 from astroquery import log
 
-__all__ = ['ESAHubble', 'ESAHubbleClass', '_check_rename_to_gz']
+__all__ = ['ESAHubble', 'ESAHubbleClass']
 
 
 def _check_rename_to_gz(filename):

--- a/astroquery/esa/hubble/core.py
+++ b/astroquery/esa/hubble/core.py
@@ -465,6 +465,7 @@ class ESAHubbleClass(BaseQuery):
                              obs_collection=None,
                              instrument_name=None,
                              filters=None,
+                             proposal=None,
                              async_job=True,
                              filename=None,
                              output_format='votable',
@@ -502,6 +503,8 @@ class ESAHubbleClass(BaseQuery):
             Name(s) of the instrument(s) used to generate the dataset
         filters : list of str, optional
             Name(s) of the filter(s) used to generate the dataset
+        proposal : int, optional
+            Proposal ID associated to the observations
         async_job : bool, optional, default 'False'
             executes the query (job) in asynchronous/synchronous mode (default
             synchronous)
@@ -534,6 +537,7 @@ class ESAHubbleClass(BaseQuery):
                                          obs_collection=obs_collection,
                                          instrument_name=instrument_name,
                                          filters=filters,
+                                         proposal=proposal,
                                          async_job=True,
                                          get_query=True)
         if crit_query.endswith(")"):
@@ -693,7 +697,7 @@ class ESAHubbleClass(BaseQuery):
     def query_criteria(self, *, calibration_level=None,
                        data_product_type=None, intent=None,
                        obs_collection=None, instrument_name=None,
-                       filters=None, async_job=True, output_file=None,
+                       filters=None, proposal=None, async_job=True, output_file=None,
                        output_format="votable", verbose=False,
                        get_query=False):
         """
@@ -713,13 +717,15 @@ class ESAHubbleClass(BaseQuery):
         intent : str, optional
             The intent of the original observer in acquiring this observation.
             SCIENCE or CALIBRATION
-        collection : list of str, optional
+        obs_collection : list of str, optional
             List of collections that are available in eHST catalogue.
-            HLA, HST
+            HLA, HST, HAP
         instrument_name : list of str, optional
             Name(s) of the instrument(s) used to generate the dataset
         filters : list of str, optional
             Name(s) of the filter(s) used to generate the dataset
+        proposal : int, optional
+            Proposal ID associated to the observations
         async_job : bool, optional, default 'True'
             executes the query (job) in asynchronous/synchronous mode (default
             synchronous)
@@ -754,6 +760,11 @@ class ESAHubbleClass(BaseQuery):
                 parameters.append("intent LIKE '%{}%'".format(intent.lower()))
             else:
                 raise ValueError("intent must be a string")
+        if proposal is not None:
+            if isinstance(proposal, int):
+                parameters.append("proposal_id = '{}'".format(proposal))
+            else:
+                raise ValueError("Proposal ID must be an integer")
         if self.__check_list_strings(obs_collection):
             parameters.append("(collection LIKE '%{}%')".format(
                 "%' OR collection LIKE '%".join(obs_collection)

--- a/astroquery/esa/hubble/core.py
+++ b/astroquery/esa/hubble/core.py
@@ -111,13 +111,18 @@ class ESAHubbleClass(BaseQuery):
         return self.check_rename_to_gz(filename=filename)
 
     def check_rename_to_gz(self, filename):
+        rename = False
         if os.path.exists(filename):
             with open(filename, 'rb') as test_f:
                 if test_f.read(2) == b'\x1f\x8b' and not filename.endswith('.fits.gz'):
-                    output = os.path.splitext(filename)[0] + '.fits.gz'
-                    os.rename(filename, output)
-                    return output
-        return filename
+                    rename = True
+
+        if rename:
+            output = os.path.splitext(filename)[0] + '.fits.gz'
+            os.rename(filename, output)
+            return output
+        else:
+            return filename
 
     def __set_product_type(self, product_type):
         if product_type:

--- a/astroquery/esa/hubble/core.py
+++ b/astroquery/esa/hubble/core.py
@@ -28,6 +28,21 @@ from astroquery import log
 __all__ = ['ESAHubble', 'ESAHubbleClass']
 
 
+def check_rename_to_gz(filename):
+    rename = False
+    if os.path.exists(filename):
+        with open(filename, 'rb') as test_f:
+            if test_f.read(2) == b'\x1f\x8b' and not filename.endswith('.fits.gz'):
+                rename = True
+
+    if rename:
+        output = os.path.splitext(filename)[0] + '.fits.gz'
+        os.rename(filename, output)
+        return output
+    else:
+        return filename
+
+
 class ESAHubbleClass(BaseQuery):
     """
     Class to init ESA Hubble Module and communicate with eHST TAP
@@ -108,21 +123,7 @@ class ESAHubbleClass(BaseQuery):
         filename = self._get_product_filename(product_type, filename)
         self._tap.load_data(params_dict=params, output_file=filename, verbose=verbose)
 
-        return self.check_rename_to_gz(filename=filename)
-
-    def check_rename_to_gz(self, filename):
-        rename = False
-        if os.path.exists(filename):
-            with open(filename, 'rb') as test_f:
-                if test_f.read(2) == b'\x1f\x8b' and not filename.endswith('.fits.gz'):
-                    rename = True
-
-        if rename:
-            output = os.path.splitext(filename)[0] + '.fits.gz'
-            os.rename(filename, output)
-            return output
-        else:
-            return filename
+        return check_rename_to_gz(filename=filename)
 
     def __set_product_type(self, product_type):
         if product_type:
@@ -311,7 +312,7 @@ class ESAHubbleClass(BaseQuery):
 
     def download_file(self, file, *, filename=None, verbose=False):
         """
-        Download a file from EHST based on its filename. Similar to get_a
+        Download a file from eHST based on its filename.
 
         Parameters
         ----------
@@ -335,7 +336,7 @@ class ESAHubbleClass(BaseQuery):
 
         self._tap.load_data(params_dict=params, output_file=filename, verbose=verbose)
 
-        return self.check_rename_to_gz(filename=filename)
+        return check_rename_to_gz(filename=filename)
 
     def get_postcard(self, observation_id, *, calibration_level="RAW",
                      resolution=256, filename=None, verbose=False):

--- a/astroquery/esa/hubble/core.py
+++ b/astroquery/esa/hubble/core.py
@@ -25,10 +25,10 @@ from astropy.utils.decorators import deprecated
 from . import conf
 from astroquery import log
 
-__all__ = ['ESAHubble', 'ESAHubbleClass']
+__all__ = ['ESAHubble', 'ESAHubbleClass', '_check_rename_to_gz']
 
 
-def check_rename_to_gz(filename):
+def _check_rename_to_gz(filename):
     rename = False
     if os.path.exists(filename):
         with open(filename, 'rb') as test_f:
@@ -123,7 +123,7 @@ class ESAHubbleClass(BaseQuery):
         filename = self._get_product_filename(product_type, filename)
         self._tap.load_data(params_dict=params, output_file=filename, verbose=verbose)
 
-        return check_rename_to_gz(filename=filename)
+        return _check_rename_to_gz(filename=filename)
 
     def __set_product_type(self, product_type):
         if product_type:
@@ -336,7 +336,7 @@ class ESAHubbleClass(BaseQuery):
 
         self._tap.load_data(params_dict=params, output_file=filename, verbose=verbose)
 
-        return check_rename_to_gz(filename=filename)
+        return _check_rename_to_gz(filename=filename)
 
     def get_postcard(self, observation_id, *, calibration_level="RAW",
                      resolution=256, filename=None, verbose=False):

--- a/astroquery/esa/hubble/tests/test_esa_hubble.py
+++ b/astroquery/esa/hubble/tests/test_esa_hubble.py
@@ -270,11 +270,11 @@ class TestESAHubble:
 
     def test_is_not_gz(self, tmp_path):
         target_file = data_path('cone_search.vot')
-        ehst = ESAHubbleClass(tap_handler=self.get_dummy_tap_handler(), show_messages=False)
+        ESAHubbleClass(tap_handler=self.get_dummy_tap_handler(), show_messages=False)
         assert check_rename_to_gz(target_file) == target_file
 
     def test_is_gz(self, tmp_path):
-        ehst = ESAHubbleClass(tap_handler=self.get_dummy_tap_handler(), show_messages=False)
+        ESAHubbleClass(tap_handler=self.get_dummy_tap_handler(), show_messages=False)
         # test_file = data_path('m31.vot.test')
         temp_file = 'testgz'
         target_file = os.path.join(tmp_path, temp_file)

--- a/astroquery/esa/hubble/tests/test_esa_hubble.py
+++ b/astroquery/esa/hubble/tests/test_esa_hubble.py
@@ -11,6 +11,7 @@ European Space Agency (ESA)
 
 import os
 import shutil
+import gzip
 from pathlib import Path
 from unittest.mock import MagicMock
 from unittest.mock import patch
@@ -76,8 +77,10 @@ class MockResponse:
 
 class TestESAHubble:
 
-    def get_dummy_tap_handler(self):
-        parameterst = {'query': "select top 10 * from hsc_v2.hubble_sc2",
+    def get_dummy_tap_handler(self, query=None):
+        if query is None:
+            query = "select top 10 * from hsc_v2.hubble_sc2"
+        parameterst = {'query': query,
                        'output_file': "test2.vot",
                        'output_format': "votable",
                        'verbose': False}
@@ -227,6 +230,58 @@ class TestESAHubble:
         ehst = ESAHubbleClass(tap_handler=self.get_dummy_tap_handler(), show_messages=False)
         path = Path(tmp_path, "w0ji0v01t_c2f.fits.gz")
         ehst.get_artifact(artifact_id=path)
+
+    def test_download_file(self, tmp_path):
+        ehst = ESAHubbleClass(tap_handler=self.get_dummy_tap_handler(), show_messages=False)
+        file = 'w0ji0v01t_c2f.fits'
+        path = Path(tmp_path, file + '.gz')
+        ehst.download_file(file=path, filename=path)
+
+    def test_get_associated_files(self):
+        observation_id = 'test'
+        query = (f"select art.artifact_id as filename, p.calibration_level, art.archive_class as type, "
+                 f"pg_size_pretty(art.size_uncompr) as size_uncompressed from ehst.artifact art "
+                 f"join ehst.plane p on p.plane_id = art.plane_id where "
+                 f"art.observation_id = '{observation_id}'")
+        parameters = {'query': query,
+                      'output_file': 'test2.vot',
+                      'output_format': "votable",
+                      'verbose': False}
+        ehst = ESAHubbleClass(tap_handler=self.get_dummy_tap_handler(query=query), show_messages=False)
+        ehst.get_associated_files(observation_id=observation_id)
+        self.get_dummy_tap_handler(query=query).check_call("launch_job", parameters)
+
+    @patch.object(ESAHubbleClass, 'get_associated_files')
+    def test_download_fits(self, mock_associated_files):
+        observation_id = 'test'
+        query = (f"select art.artifact_id as filename, p.calibration_level, art.archive_class as type, "
+                 f"pg_size_pretty(art.size_uncompr) as size_uncompressed from ehst.artifact art "
+                 f"join ehst.plane p on p.plane_id = art.plane_id where "
+                 f"art.observation_id = '{observation_id}'")
+        parameters = {'query': query,
+                      'output_file': 'test2.vot',
+                      'output_format': "votable",
+                      'verbose': False}
+        mock_associated_files.return_value = [{'filename': 'test.fits'}]
+        ehst = ESAHubbleClass(tap_handler=self.get_dummy_tap_handler(query=query), show_messages=False)
+        ehst.download_fits_files(observation_id=observation_id)
+        self.get_dummy_tap_handler(query=query).check_call("launch_job", parameters)
+
+    def test_is_not_gz(self, tmp_path):
+        target_file = data_path('cone_search.vot')
+        ehst = ESAHubbleClass(tap_handler=self.get_dummy_tap_handler(), show_messages=False)
+        assert ehst.check_rename_to_gz(target_file) == target_file
+
+    def test_is_gz(self, tmp_path):
+        ehst = ESAHubbleClass(tap_handler=self.get_dummy_tap_handler(), show_messages=False)
+        # test_file = data_path('m31.vot.test')
+        temp_file = 'testgz'
+        target_file = os.path.join(tmp_path, temp_file)
+        with gzip.open(target_file, 'wb') as f:
+            f.write(b'')
+        # with open(test_file, 'rb') as f_in, gzip.open(target_file, 'wb') as f_out:
+        #     f_out.writelines(f_in)
+        assert ehst.check_rename_to_gz(target_file) == target_file + '.fits.gz'
 
     def test_get_columns(self):
         parameters = {'table_name': "table",

--- a/astroquery/esa/hubble/tests/test_esa_hubble.py
+++ b/astroquery/esa/hubble/tests/test_esa_hubble.py
@@ -23,6 +23,7 @@ from astropy.table.table import Table
 from requests.models import Response
 
 from astroquery.esa.hubble import ESAHubbleClass
+from astroquery.esa.hubble.core import check_rename_to_gz
 from astroquery.esa.hubble.tests.dummy_tap_handler import DummyHubbleTapHandler
 from astropy.utils.exceptions import AstropyDeprecationWarning
 
@@ -270,7 +271,7 @@ class TestESAHubble:
     def test_is_not_gz(self, tmp_path):
         target_file = data_path('cone_search.vot')
         ehst = ESAHubbleClass(tap_handler=self.get_dummy_tap_handler(), show_messages=False)
-        assert ehst.check_rename_to_gz(target_file) == target_file
+        assert check_rename_to_gz(target_file) == target_file
 
     def test_is_gz(self, tmp_path):
         ehst = ESAHubbleClass(tap_handler=self.get_dummy_tap_handler(), show_messages=False)
@@ -281,7 +282,7 @@ class TestESAHubble:
             f.write(b'')
         # with open(test_file, 'rb') as f_in, gzip.open(target_file, 'wb') as f_out:
         #     f_out.writelines(f_in)
-        assert ehst.check_rename_to_gz(target_file) == target_file + '.fits.gz'
+        assert check_rename_to_gz(target_file) == target_file + '.fits.gz'
 
     def test_get_columns(self):
         parameters = {'table_name': "table",

--- a/astroquery/esa/hubble/tests/test_esa_hubble.py
+++ b/astroquery/esa/hubble/tests/test_esa_hubble.py
@@ -23,7 +23,7 @@ from astropy.table.table import Table
 from requests.models import Response
 
 from astroquery.esa.hubble import ESAHubbleClass
-from astroquery.esa.hubble.core import check_rename_to_gz
+from astroquery.esa.hubble.core import _check_rename_to_gz
 from astroquery.esa.hubble.tests.dummy_tap_handler import DummyHubbleTapHandler
 from astropy.utils.exceptions import AstropyDeprecationWarning
 
@@ -271,7 +271,7 @@ class TestESAHubble:
     def test_is_not_gz(self, tmp_path):
         target_file = data_path('cone_search.vot')
         ESAHubbleClass(tap_handler=self.get_dummy_tap_handler(), show_messages=False)
-        assert check_rename_to_gz(target_file) == target_file
+        assert _check_rename_to_gz(target_file) == target_file
 
     def test_is_gz(self, tmp_path):
         ESAHubbleClass(tap_handler=self.get_dummy_tap_handler(), show_messages=False)
@@ -282,7 +282,7 @@ class TestESAHubble:
             f.write(b'')
         # with open(test_file, 'rb') as f_in, gzip.open(target_file, 'wb') as f_out:
         #     f_out.writelines(f_in)
-        assert check_rename_to_gz(target_file) == target_file + '.fits.gz'
+        assert _check_rename_to_gz(target_file) == target_file + '.fits.gz'
 
     def test_get_columns(self):
         parameters = {'table_name': "table",

--- a/astroquery/esa/hubble/tests/test_esa_hubble.py
+++ b/astroquery/esa/hubble/tests/test_esa_hubble.py
@@ -293,6 +293,32 @@ class TestESAHubble:
         ehst.get_columns(table_name="table", only_names=True, verbose=True)
         dummyTapHandler.check_call("get_columns", parameters)
 
+    def test_query_criteria_proposal(self):
+        parameters1 = {'proposal': 12345,
+                       'async_job': False,
+                       'output_file': "output_test_query_by_criteria.vot.gz",
+                       'output_format': "votable",
+                       'verbose': True,
+                       'get_query': True}
+        ehst = ESAHubbleClass(tap_handler=self.get_dummy_tap_handler(), show_messages=False)
+        test_query = ehst.query_criteria(proposal=parameters1['proposal'],
+                                         async_job=parameters1['async_job'],
+                                         output_file=parameters1['output_file'],
+                                         output_format=parameters1['output_format'],
+                                         verbose=parameters1['verbose'],
+                                         get_query=parameters1['get_query'])
+        parameters2 = {'query': test_query,
+                       'output_file': "output_test_query_by_criteria.vot.gz",
+                       'output_format': "votable",
+                       'verbose': False}
+        parameters3 = {'query': "select * from ehst.archive where("
+                                "proposal_id = '12345')",
+                       'output_file': "output_test_query_by_criteria.vot.gz",
+                       'output_format': "votable",
+                       'verbose': False}
+        dummy_tap_handler = DummyHubbleTapHandler("launch_job", parameters2)
+        dummy_tap_handler.check_call("launch_job", parameters3)
+
     def test_query_criteria(self):
         parameters1 = {'calibration_level': "PRODUCT",
                        'data_product_type': "image",

--- a/astroquery/esa/hubble/tests/test_esa_hubble_remote.py
+++ b/astroquery/esa/hubble/tests/test_esa_hubble_remote.py
@@ -45,8 +45,8 @@ class TestEsaHubbleRemoteData:
     hst_query = "select top 50 a.observation_id from ehst.archive " \
                 "a where a.collection='HST'"
 
-    top_artifact_query = f"select a.artifact_id, a.observation_id from ehst.artifact a "\
-                         f"where a.observation_id = 'iexn02e9q'"
+    top_artifact_query = (f"select a.artifact_id, a.observation_id from ehst.artifact a "
+                          f"where a.observation_id = 'iexn02e9q'")
 
     temp_folder = create_temp_folder()
 
@@ -60,8 +60,8 @@ class TestEsaHubbleRemoteData:
         result = esa_hubble.query_tap(query=self.hst_query)
         observation_id = np.random.choice((result['observation_id']))
         temp_file = self.temp_folder.name + "/" + observation_id
-        downloaded_file = esa_hubble.download_product(observation_id=observation_id,
-                                                      filename=temp_file)
+        esa_hubble.download_product(observation_id=observation_id,
+                                    filename=temp_file)
         possible_values = [os.path.exists(temp_file + '.jpg'),
                            os.path.exists(temp_file + '.zip'),
                            os.path.exists(temp_file + 'fits.gz')]

--- a/astroquery/esa/hubble/tests/test_esa_hubble_remote.py
+++ b/astroquery/esa/hubble/tests/test_esa_hubble_remote.py
@@ -45,8 +45,8 @@ class TestEsaHubbleRemoteData:
     hst_query = "select top 50 a.observation_id from ehst.archive " \
                 "a where a.collection='HST'"
 
-    top_artifact_query = (f"select a.artifact_id, a.observation_id from ehst.artifact a "
-                          f"where a.observation_id = 'iexn02e9q'")
+    top_artifact_query = "select a.artifact_id, a.observation_id from ehst.artifact a " \
+                         "where a.observation_id = 'iexn02e9q'"
 
     temp_folder = create_temp_folder()
 

--- a/astroquery/esa/hubble/tests/test_esa_hubble_remote.py
+++ b/astroquery/esa/hubble/tests/test_esa_hubble_remote.py
@@ -45,8 +45,8 @@ class TestEsaHubbleRemoteData:
     hst_query = "select top 50 a.observation_id from ehst.archive " \
                 "a where a.collection='HST'"
 
-    top_artifact_query = "select top 50 a.artifact_id, a.observation_id " \
-                         " from ehst.artifact a"
+    top_artifact_query = f"select a.artifact_id, a.observation_id from ehst.artifact a "\
+                         f"where a.observation_id = 'iexn02e9q'"
 
     temp_folder = create_temp_folder()
 
@@ -59,18 +59,24 @@ class TestEsaHubbleRemoteData:
     def test_download_product(self):
         result = esa_hubble.query_tap(query=self.hst_query)
         observation_id = np.random.choice((result['observation_id']))
-        temp_file = self.temp_folder.name + "/" + observation_id + ".tar"
-        esa_hubble.download_product(observation_id=observation_id,
-                                    filename=temp_file)
-        assert os.path.exists(temp_file)
+        temp_file = self.temp_folder.name + "/" + observation_id
+        downloaded_file = esa_hubble.download_product(observation_id=observation_id,
+                                                      filename=temp_file)
+        possible_values = [os.path.exists(temp_file + '.jpg'),
+                           os.path.exists(temp_file + '.zip'),
+                           os.path.exists(temp_file + 'fits.gz')]
+        assert any([os.path.exists(f) for f in possible_values])
 
     def test_get_artifact(self):
         result = esa_hubble.query_tap(query=self.top_artifact_query)
         assert "artifact_id" in result.keys()
         artifact_id = np.random.choice(result["artifact_id"])
-        temp_file = self.temp_folder.name + "/" + artifact_id + ".gz"
+        temp_file = self.temp_folder.name + "/" + artifact_id
         esa_hubble.get_artifact(artifact_id=artifact_id, filename=temp_file)
-        assert os.path.exists(temp_file)
+        possible_values = [os.path.exists(temp_file),
+                           os.path.exists(temp_file + '.zip'),
+                           os.path.exists(temp_file + 'fits.gz')]
+        assert any([os.path.exists(f) for f in possible_values])
 
     def test_cone_search(self):
         esa_hubble = ESAHubble()
@@ -101,7 +107,7 @@ class TestEsaHubbleRemoteData:
     def test_hap_simple_to_hap_composite(self):
         esa_hubble = ESAHubble()
         result = esa_hubble.get_member_observations(observation_id='hst_16316_71_acs_sbc_f150lp_jec071i9')
-        assert result == [' hst_16316_71_acs_sbc_total_jec071', 'hst_16316_71_acs_sbc_f150lp_jec071']
+        assert result == ['hst_16316_71_acs_sbc_f150lp_jec071']
 
     def test_hap_simple_to_hst_simple(self):
         esa_hubble = ESAHubble()

--- a/astroquery/esa/hubble/tests/test_esa_hubble_remote.py
+++ b/astroquery/esa/hubble/tests/test_esa_hubble_remote.py
@@ -59,7 +59,7 @@ class TestEsaHubbleRemoteData:
     def test_download_product(self):
         result = esa_hubble.query_tap(query=self.hst_query)
         observation_id = np.random.choice((result['observation_id']))
-        temp_file = self.temp_folder.name + "/" + observation_id
+        temp_file = os.path.join(self.temp_folder.name, observation_id)
         esa_hubble.download_product(observation_id=observation_id,
                                     filename=temp_file)
         possible_values = [os.path.exists(temp_file + '.jpg'),
@@ -71,7 +71,7 @@ class TestEsaHubbleRemoteData:
         result = esa_hubble.query_tap(query=self.top_artifact_query)
         assert "artifact_id" in result.keys()
         artifact_id = np.random.choice(result["artifact_id"])
-        temp_file = self.temp_folder.name + "/" + artifact_id
+        temp_file = os.path.join(self.temp_folder.name, artifact_id)
         esa_hubble.get_artifact(artifact_id=artifact_id, filename=temp_file)
         possible_values = [os.path.exists(temp_file),
                            os.path.exists(temp_file + '.zip'),
@@ -81,7 +81,7 @@ class TestEsaHubbleRemoteData:
     def test_cone_search(self):
         esa_hubble = ESAHubble()
         c = coordinates.SkyCoord("00h42m44.51s +41d16m08.45s", frame='icrs')
-        compressed_temp_file = self.temp_folder.name + "/cone_search_m31_5.vot.gz"
+        compressed_temp_file = os.path.join(self.temp_folder.name, "cone_search_m31_5.vot.gz")
         # open & extracting the file
         table = esa_hubble.cone_search(coordinates=c, radius=7, filename=compressed_temp_file, verbose=True)
         assert 'observation_id' in table.columns
@@ -120,6 +120,6 @@ class TestEsaHubbleRemoteData:
         assert result == ['hst_16316_71_acs_sbc_f150lp_jec071i9']
 
     def test_query_target(self):
-        compressed_temp_file = self.temp_folder.name + "/" + "m31_query.xml.gz"
+        compressed_temp_file = os.path.join(self.temp_folder.name, "m31_query.xml.gz")
         table = esa_hubble.query_target(name="m3", filename=compressed_temp_file)
         assert 'observation_id' in table.columns

--- a/docs/esa/hubble/hubble.rst
+++ b/docs/esa/hubble/hubble.rst
@@ -14,7 +14,7 @@ important science projects ever, with over 500 000 observations of more than
 30000 targets available for retrieval from the Archive.
 
 This package allows the access to the `European Space Agency Hubble Archive
-<http://archives.esac.esa.int/ehst/>`__. All the HST observations available
+<http://hst.esac.esa.int/ehst/>`__. All the HST observations available
 in the EHST are synchronised with the MAST services for HST reprocessed
 public data and corresponding metadata.  Therefore, excluding proprietary
 data, all HST data in the EHST are identical to those in MAST.

--- a/docs/esa/hubble/hubble.rst
+++ b/docs/esa/hubble/hubble.rst
@@ -19,10 +19,6 @@ in the EHST are synchronised with the MAST services for HST reprocessed
 public data and corresponding metadata.  Therefore, excluding proprietary
 data, all HST data in the EHST are identical to those in MAST.
 
-========
-Examples
-========
-
 It is highly recommended checking the status of eHST TAP before executing this module. To do this:
 
 .. doctest-remote-data::
@@ -33,6 +29,19 @@ It is highly recommended checking the status of eHST TAP before executing this m
 
 This method will retrieve the same warning messages shown in eHST Science Archive with information about
 service degradation.
+
+========
+Examples
+========
+
+.. note::
+    The recommended steps to work with eHST Astroquery module are described below:
+        #. Retrieve the desired observations, fulfilling the user requirements, using one of the following methods: ``query_target``, ``query_criteria``, ``cone_search`` or ``cone_search_criteria``. In the results, the user will allways find a column named 'observation_id' that will be used as a reference.
+        #. If all the products associated to an observation are required, then use ``download_product``.
+        #. If only FITS files associated to an observation are required, then use ``download_fits_files``.
+        #. It is possible to retrieve the name of the files associated to an observation using ``get_associated_files``, together with their calibration level, size and type.
+        #. Users can filter the previous list to get the specific files to download and use them in ``download_file`` function.
+        #. Use your algorithms and code to process the data.
 
 ----------------------------------------------
 1. Querying target names in the Hubble archive
@@ -374,10 +383,12 @@ After retrieving the metadata, the user can filter the result table and get the 
 The most important column is 'observation_id' and it is possible to use it to retrieve all the
 associated files.
 
-In eHST is it possible to download products based on their observation ID (mandatory) and
-a required calibration_level (RAW, CALIBRATED, PRODUCT or AUXILIARY) and/or product type (SCIENCE, PREVIEW, THUMBNAIL or AUXILIARY).
+.. note::
+    In eHST is it possible to download products based on their observation ID (mandatory) and
+    a required calibration_level (RAW, CALIBRATED, PRODUCT or AUXILIARY) and/or product type (SCIENCE, PREVIEW, THUMBNAIL or AUXILIARY).
 
-Deprecation Warning: product types PRODUCT, SCIENCE_PRODUCT or POSTCARD are no longer supported. Please modify your scripts accordingly.
+.. warning::
+    Deprecation Warning: product types PRODUCT, SCIENCE_PRODUCT or POSTCARD are no longer supported. Please modify your scripts accordingly.
 
 For instance, next commands will download all files for the raw calibration level
 of the observation 'j6fl25s4q' and it will store them in a file called
@@ -388,7 +399,8 @@ of the observation 'j6fl25s4q' and it will store them in a file called
   >>> from astroquery.esa.hubble import ESAHubble
   >>> esahubble = ESAHubble()
   >>> esahubble.download_product(observation_id="j6fl25s4q", calibration_level="RAW",
-  ...                            filename="raw_data_for_j6fl25s4q")  # doctest: +IGNORE_OUTPUT
+  ...                            filename="raw_data_for_j6fl25s4q")
+  'raw_data_for_j6fl25s4q.zip'
 
 This second example will download the science files associated to the observation 'j6fl25s4q' and it will store them in a file called
 'science_data_for_j6fl25s4q.zip', modifying the filename provided to ensure that the extension of the file is correct.
@@ -398,17 +410,20 @@ This second example will download the science files associated to the observatio
   >>> from astroquery.esa.hubble import ESAHubble
   >>> esahubble = ESAHubble()
   >>> esahubble.download_product(observation_id="j6fl25s4q", product_type="SCIENCE",
-  ...                            filename="science_data_for_j6fl25s4q")   # doctest: +IGNORE_OUTPUT
+  ...                            filename="science_data_for_j6fl25s4q")
+  'science_data_for_j6fl25s4q.zip'
 
 This third case will download the science files associated to the observation 'j6fl25s4q' in raw calibration level and it will store them in a file called
-'science_raw_data_for_j6fl25s4q.fits.gz', modifying the filename provided to ensure that the extension of the file is correct.
+'science_raw_data_for_j6fl25s4q.fits.gz', modifying the filename provided to ensure that the extension of the file is correct. There is only
+one file fulfilling these conditions and it is a FITS file, so the extension is adapted to the contents of the request.
 
 .. doctest-remote-data::
 
   >>> from astroquery.esa.hubble import ESAHubble
   >>> esahubble = ESAHubble()
   >>> esahubble.download_product(observation_id="j6fl25s4q", calibration_level="RAW",
-  ...                            filename="science_raw_data_for_j6fl25s4q", product_type="SCIENCE")   # doctest: +IGNORE_OUTPUT
+  ...                            filename="science_raw_data_for_j6fl25s4q", product_type="SCIENCE")
+  'science_raw_data_for_j6fl25s4q.fits.gz'
 
 If the user wants to filter the files to be downloaded, this module provides additional mechanisms.
 
@@ -448,7 +463,7 @@ In case the user is only interested in FITS files, this module contains a specif
 .. doctest-remote-data::
   >>> from astroquery.esa.hubble import ESAHubble
   >>> esahubble = ESAHubble()
-  >>> esahubble.download_fits_files(observation_id='w0ji0v01t')
+  >>> esahubble.download_fits_files(observation_id='w0ji0v01t') # doctest: +IGNORE_OUTPUT
 
 ---------------------------
 6. Getting Hubble postcards
@@ -458,7 +473,8 @@ In case the user is only interested in FITS files, this module contains a specif
 
   >>> from astroquery.esa.hubble import ESAHubble
   >>> esahubble = ESAHubble()
-  >>> esahubble.get_postcard(observation_id="j6fl25s4q", calibration_level="RAW", resolution=256, filename="raw_postcard_for_j6fl25s4q.jpg")  # doctest: +IGNORE_OUTPUT
+  >>> esahubble.get_postcard(observation_id="j6fl25s4q", calibration_level="RAW", resolution=256, filename="raw_postcard_for_j6fl25s4q.jpg")
+  'raw_postcard_for_j6fl25s4q.jpg'
 
 This will download the postcard for the observation 'J8VP03010' with low
 resolution (256) and it will stored in a jpg called
@@ -509,7 +525,7 @@ method returns the simple observations that make it up.
   >>> from astroquery.esa.hubble import ESAHubble
   >>> esahubble = ESAHubble()
   >>> result = esahubble.get_member_observations(observation_id="jdrz0c010")
-  >>> print(result)
+  >>> result
   ['jdrz0cjxq', 'jdrz0cjyq']
 
 
@@ -525,7 +541,7 @@ returns the corresponding HAP or HST observation
   >>> from astroquery.esa.hubble import ESAHubble
   >>> esahubble = ESAHubble()
   >>> result = esahubble.get_hap_hst_link(observation_id="hst_16316_71_acs_sbc_f150lp_jec071i9")
-  >>> print(result)
+  >>> result
   ['jec071i9q']
 
 

--- a/docs/esa/hubble/hubble.rst
+++ b/docs/esa/hubble/hubble.rst
@@ -365,6 +365,11 @@ This function allows the same parameters than the search criteria (see Section 2
 5. Getting Hubble products
 --------------------------
 
+.. warning::
+
+   Please bear in mind that the default format to download
+   sets of files has been modified from TAR to ZIP.
+
 After retrieving the metadata, the user can filter the result table and get the rows of interest.
 The most important column is 'observation_id' and it is possible to use it to retrieve all the
 associated files.

--- a/docs/esa/hubble/hubble.rst
+++ b/docs/esa/hubble/hubble.rst
@@ -34,88 +34,15 @@ It is highly recommended checking the status of eHST TAP before executing this m
 This method will retrieve the same warning messages shown in eHST Science Archive with information about
 service degradation.
 
---------------------------
-1. Getting Hubble products
---------------------------
-
-This function allows the user to download products based on their observation ID (mandatory) and
-a required calibration_level (RAW, CALIBRATED, PRODUCT or AUXILIARY) and/or product type (SCIENCE, PREVIEW, THUMBNAIL or AUXILIARY).
-
-Deprecation Warning: product types PRODUCT, SCIENCE_PRODUCT or POSTCARD are no longer supported. Please modify your scripts accordingly.
-
-
-This will download all files for the raw calibration level of the observation 'j6fl25s4q' and it will store them in a tar called
-'raw_data_for_j6fl25s4q.tar'.
-
-.. doctest-remote-data::
-
-  >>> from astroquery.esa.hubble import ESAHubble
-  >>> esahubble = ESAHubble()
-  >>> esahubble.download_product(observation_id="j6fl25s4q", calibration_level="RAW",
-  ...                            filename="raw_data_for_j6fl25s4q.fits")  # doctest: +IGNORE_OUTPUT
-
-This will download the science files associated to the observation 'j6fl25s4q' and it will store them in a file called
-'science_data_for_j6fl25s4q.tar.fits.gz', modifying the filename provided to ensure that the extension of the file is correct.
-
-.. doctest-remote-data::
-
-  >>> from astroquery.esa.hubble import ESAHubble
-  >>> esahubble = ESAHubble()
-  >>> esahubble.download_product(observation_id="j6fl25s4q", product_type="SCIENCE",
-  ...                            filename="science_data_for_j6fl25s4q.fits")   # doctest: +IGNORE_OUTPUT
-
-This third case will download the science files associated to the observation 'j6fl25s4q' in raw calibration level and it will store them in a file called
-'science_raw_data_for_j6fl25s4q.fits.gz', modifying the filename provided to ensure that the extension of the file is correct.
-
-.. doctest-remote-data::
-
-  >>> from astroquery.esa.hubble import ESAHubble
-  >>> esahubble = ESAHubble()
-  >>> esahubble.download_product(observation_id="j6fl25s4q", calibration_level="RAW",
-  ...                            filename="science_raw_data_for_j6fl25s4q", product_type="SCIENCE")   # doctest: +IGNORE_OUTPUT
-
----------------------------
-2. Getting Hubble postcards
----------------------------
-
-.. doctest-remote-data::
-
-  >>> from astroquery.esa.hubble import ESAHubble
-  >>> esahubble = ESAHubble()
-  >>> esahubble.get_postcard(observation_id="j6fl25s4q", calibration_level="RAW", resolution=256, filename="raw_postcard_for_j6fl25s4q.jpg")  # doctest: +IGNORE_OUTPUT
-
-This will download the postcard for the observation 'J8VP03010' with low
-resolution (256) and it will stored in a jpg called
-'raw_postcard_for_j6fl25s4q.jpg'. Resolution of 1024 is also available.
-
-Calibration levels can be RAW, CALIBRATED, PRODUCT or AUXILIARY.
-
----------------------------
-3. Getting Hubble artifacts
----------------------------
-
-Note: Artifact is a single Hubble product file.
-
-.. Doesn't run
-.. doctest-skip::
-
-  >>> from astroquery.esa.hubble import ESAHubble
-  >>> esahubble = ESAHubble()
-  >>> esahubble.get_artifact(artifact_id="w0ji0v01t_c2f.fits")
-
-This will download the compressed artifact
-'w0ji0v01t_c2f.fits.gz'. 'w0ji0v01t_c2f.fits' is the name of the Hubble
-artifact to be download.
-
 ----------------------------------------------
-4. Querying target names in the Hubble archive
+1. Querying target names in the Hubble archive
 ----------------------------------------------
 
 The query_target function queries the name of the target as given by the proposer of the observations.
 
 .. doctest-remote-data::
 
-  >>> from astroquery.esa.hubble import ESAHubble 
+  >>> from astroquery.esa.hubble import ESAHubble
   >>> esahubble = ESAHubble()
   >>> table = esahubble.query_target(name="m31", filename="m31_query.xml.gz")  # doctest: +IGNORE_OUTPUT
 
@@ -124,9 +51,9 @@ It will also download a file storing all metadata for all observations
 associated with target name 'm31'. The result of the query will be stored in
 file 'm31_query.xml.gz'.
 
------------------------------------------------------------------
-5. Querying observations by search criteria in the Hubble archive
------------------------------------------------------------------
+-------------------------------------------------------------------
+2. Retrieving observations by search criteria in the Hubble archive
+-------------------------------------------------------------------
 
 The query_criteria function uses a set of established parameters to create
 and execute an ADQL query, accessing the HST archive database usgin the Table
@@ -154,11 +81,13 @@ Access Protocol (TAP).
 
  + HLA
  + HST
+ + HAP
 
  Do not forget that this is a list of elements, so it must be defined as ['HST'], ['HST', 'HLA']...
 
 - **instrument_name** (*list of strings, optional*): Name(s) of the instrument(s) used to generate the dataset. This is also a list of elements.
 - **filters** (*list of strings, optional*): Name(s) of the filter(s) used to generate the dataset. This is also a list of elements.
+- **proposal** (*int, optional*): Proposal or Program ID to be searched.
 - **async_job** (*bool, optional, default 'True'*): executes the query (job) in asynchronous/synchronous mode (default synchronous)
 - **output_file** (*str, optional, default None*) file name where the results are saved if dumpToFile is True. If this parameter is not provided, the jobid is used instead
 - **output_format** (*str, optional, default 'votable'*) results format
@@ -194,8 +123,8 @@ This is an example of a query with all the parameters and the verbose flag activ
   Saving results to: output1.vot.gz
   Query finished.
   >>> print(result)    # doctest: +IGNORE_OUTPUT
-   algorithm_name  collection ...         ra                 dec        
-       object        object   ...      float64             float64      
+   algorithm_name  collection ...         ra                 dec
+       object        object   ...      float64             float64
   ---------------- ---------- ... ------------------ -------------------
   HLA ASSOCIATIONS        HLA ... 196.03170537675234 -49.368511417967795
           exposure        HLA ... 196.03171011284857  -49.36851677699096
@@ -243,7 +172,7 @@ The following example uses the string definition of the calibration level ('PROD
   ...                                   verbose = False,
   ...                                   get_query = False)
   >>> print(result)  # doctest: +IGNORE_OUTPUT
-   algorithm_name  collection ...         ra                 dec        
+   algorithm_name  collection ...         ra                 dec
   ---------------- ---------- ... ------------------ -------------------
   HLA ASSOCIATIONS        HLA ... 196.03170537675234 -49.368511417967795
           exposure        HLA ... 196.03171011284857  -49.36851677699096
@@ -323,7 +252,7 @@ This last example will provide the ADQL query based on the criteria defined by t
   select * from ehst.archive where(calibration_level=3 AND data_product_type LIKE '%image%' AND intent LIKE '%science%' AND (collection LIKE '%HLA%') AND (instrument_name LIKE '%WFC3%') AND (instrument_configuration LIKE '%F555W%' OR instrument_configuration LIKE '%F606W%'))
 
 --------------------------------------
-6. Cone searches in the Hubble archive
+3. Cone searches in the Hubble archive
 --------------------------------------
 
 .. doctest-remote-data::
@@ -341,7 +270,7 @@ the module will provide a default name. It is also possible to store only the re
 in memory, without defining neither a filename nor the "save" tag.
 
 ----------------------------------------------------
-7. Cone searches with criteria in the Hubble archive
+4. Cone searches with criteria in the Hubble archive
 ----------------------------------------------------
 
 It is also possible to perform a cone search defined by a target name or coordinates, a radius
@@ -360,7 +289,7 @@ and a set of criteria to filter the results.
   ...                                         filename = 'output1.vot.gz',
   ...                                         output_format="votable")
   >>> print(result)    # doctest: +IGNORE_OUTPUT
-  algorithm_name collection            end_time           ...         ra                dec        
+  algorithm_name collection            end_time           ...         ra                dec
   -------------- ---------- ----------------------------- ... ------------------ ------------------
     multidrizzle        HST 2002-06-29 15:25:57.556128+00 ... 10.773035733571806  41.28459914735614
          drizzle        HST    2002-06-29 12:15:20.787+00 ... 10.809522856742248  41.29351658280752
@@ -404,7 +333,7 @@ and a set of criteria to filter the results.
   ...                                         filename = 'output1.vot.gz',
   ...                                         output_format="votable")
   >>> print(result)   # doctest: +IGNORE_OUTPUT
-  algorithm_name collection          end_time          ...         ra                dec        
+  algorithm_name collection          end_time          ...         ra                dec
   -------------- ---------- -------------------------- ... ------------------ ------------------
         exposure        HST 1996-07-11 19:57:16.567+00 ... 10.707934959432448  41.29717554921647
         exposure        HST 1996-07-11 19:57:16.567+00 ... 10.707934959432448  41.29717554921647
@@ -430,11 +359,110 @@ and a set of criteria to filter the results.
 This will perform a cone search with radius 7 arcmins around the target (defined by
 its coordinates or its name) using the filters defined when executing the function.
 
-This function allows the same parameters than the search criteria (see Section 5).
+This function allows the same parameters than the search criteria (see Section 2).
 
+--------------------------
+5. Getting Hubble products
+--------------------------
+
+After retrieving the metadata, the user can filter the result table and get the rows of interest.
+The most important column is 'observation_id' and it is possible to use it to retrieve all the
+associated files.
+
+In eHST is it possible to download products based on their observation ID (mandatory) and
+a required calibration_level (RAW, CALIBRATED, PRODUCT or AUXILIARY) and/or product type (SCIENCE, PREVIEW, THUMBNAIL or AUXILIARY).
+
+Deprecation Warning: product types PRODUCT, SCIENCE_PRODUCT or POSTCARD are no longer supported. Please modify your scripts accordingly.
+
+For instance, next commands will download all files for the raw calibration level
+of the observation 'j6fl25s4q' and it will store them in a file called
+'raw_data_for_j6fl25s4q.zip'.
+
+.. doctest-remote-data::
+
+  >>> from astroquery.esa.hubble import ESAHubble
+  >>> esahubble = ESAHubble()
+  >>> esahubble.download_product(observation_id="j6fl25s4q", calibration_level="RAW",
+  ...                            filename="raw_data_for_j6fl25s4q")  # doctest: +IGNORE_OUTPUT
+
+This second example will download the science files associated to the observation 'j6fl25s4q' and it will store them in a file called
+'science_data_for_j6fl25s4q.zip', modifying the filename provided to ensure that the extension of the file is correct.
+
+.. doctest-remote-data::
+
+  >>> from astroquery.esa.hubble import ESAHubble
+  >>> esahubble = ESAHubble()
+  >>> esahubble.download_product(observation_id="j6fl25s4q", product_type="SCIENCE",
+  ...                            filename="science_data_for_j6fl25s4q")   # doctest: +IGNORE_OUTPUT
+
+This third case will download the science files associated to the observation 'j6fl25s4q' in raw calibration level and it will store them in a file called
+'science_raw_data_for_j6fl25s4q.fits.gz', modifying the filename provided to ensure that the extension of the file is correct.
+
+.. doctest-remote-data::
+
+  >>> from astroquery.esa.hubble import ESAHubble
+  >>> esahubble = ESAHubble()
+  >>> esahubble.download_product(observation_id="j6fl25s4q", calibration_level="RAW",
+  ...                            filename="science_raw_data_for_j6fl25s4q", product_type="SCIENCE")   # doctest: +IGNORE_OUTPUT
+
+If the user wants to filter the files to be downloaded, this module provides additional mechanisms.
+
+The first step is to query eHST Server to retrieve them. For instance, for observation w0ji0v01t:
+
+.. doctest-remote-data::
+
+  >>> from astroquery.esa.hubble import ESAHubble
+  >>> esahubble = ESAHubble()
+  >>> table = esahubble.get_associated_files(observation_id='w0ji0v01t')
+  >>> print(result)    # doctest: +IGNORE_OUTPUT
+         filename      calibration_level    type   size_uncompressed
+          object             object        object        object
+    ------------------ ----------------- --------- -----------------
+    w0ji0v01t_c0f.fits        CALIBRATED   science          10035 kB
+     w0ji0v01t_c0f.jpg        CALIBRATED   preview             15 kB
+                   ...               ...       ...               ...
+    w0ji0v01t_shf.fits               RAW auxiliary             31 kB
+    w0ji0v01t_trl.fits               RAW auxiliary             23 kB
+    w0ji0v01t_x0f.fits               RAW auxiliary            101 kB
+
+
+Now it is possible to download a specific file using the filename column.
+
+.. doctest-remote-data::
+
+  >>> from astroquery.esa.hubble import ESAHubble
+  >>> esahubble = ESAHubble()
+  >>> esahubble.download_file(file="w0ji0v01t_x0f.fits")
+  'w0ji0v01t_x0f.fits.gz'
+
+
+This will download the compressed file 'w0ji0v01t_x0f.fits.gz'. This table can be iterated to download all the files.
+
+In case the user is only interested in FITS files, this module contains a specific function to execute this request.
+
+.. doctest-remote-data::
+  >>> from astroquery.esa.hubble import ESAHubble
+  >>> esahubble = ESAHubble()
+  >>> esahubble.download_fits_files(observation_id='w0ji0v01t')
+
+---------------------------
+6. Getting Hubble postcards
+---------------------------
+
+.. doctest-remote-data::
+
+  >>> from astroquery.esa.hubble import ESAHubble
+  >>> esahubble = ESAHubble()
+  >>> esahubble.get_postcard(observation_id="j6fl25s4q", calibration_level="RAW", resolution=256, filename="raw_postcard_for_j6fl25s4q.jpg")  # doctest: +IGNORE_OUTPUT
+
+This will download the postcard for the observation 'J8VP03010' with low
+resolution (256) and it will stored in a jpg called
+'raw_postcard_for_j6fl25s4q.jpg'. Resolution of 1024 is also available.
+
+Calibration levels can be RAW, CALIBRATED, PRODUCT or AUXILIARY.
 
 -------------------------------
-8. Getting access to catalogues
+7. Getting access to catalogues
 -------------------------------
 
 This function provides access to the HST archive database using the Table
@@ -463,7 +491,7 @@ To access the same information shown in eHST Science Archive:
 Deprecation Warning: this method was previously named as query_hst_tap. Please modify your scripts accordingly.
 
 ------------------------------------------------------
-9. Getting related members of HAP and HST observations
+8. Getting related members of HAP and HST observations
 ------------------------------------------------------
 
 This function takes in an observation id of a Composite or Simple observation.
@@ -480,9 +508,9 @@ method returns the simple observations that make it up.
   ['jdrz0cjxq', 'jdrz0cjyq']
 
 
---------------------------------------------------------
-10. Getting link between Simple HAP and HST observations
---------------------------------------------------------
+-------------------------------------------------------
+9. Getting link between Simple HAP and HST observations
+-------------------------------------------------------
 
 This function takes in an observation id of a Simple HAP or HST observation and
 returns the corresponding HAP or HST observation


### PR DESCRIPTION
Dear Astroquery Team,

This PR aims to offer a more intuitive way for users to download products from eHST Science Archive. I have left get_artifact method to ensure backwards compatibility, but I have moved its functionality to download_file method. In addition to this, we have added a mechanism to retrieve the files associated to an observation and download only FITS files. Finally, the criteria methods have been updated so now users can search by proposal.

Let's iterate in this new pull request. Please let me know your thoughts and comments. Thanks in advance for your support!

cc @esdc-esac-esa-int 