### PR TITLE
CI: add extra astropy pip index to pick up new dependency

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -23,9 +23,11 @@ description = run tests
 setenv =
     PYTEST_ARGS = ''
     online: PYTEST_ARGS = --remote-data=any --reruns=1 --reruns-delay 10
+    devdeps: PIP_EXTRA_INDEX_URL =  https://pypi.anaconda.org/scientific-python-nightly-wheels/simple https://pypi.anaconda.org/astropy/simple
 
 deps =
-    # Installation of nightly wheels happen below in the `commands` section for devdeps
+    devdeps: numpy>=0.0.dev0
+    devdeps: astropy>=0.0.dev0
     devdeps: git+https://github.com/astropy/pyvo.git#egg=pyvo
 
 # mpl while not a dependency, it's required for the tests, and would pull up a newer numpy version if not pinned.
@@ -48,9 +50,6 @@ extras =
 
 
 commands =
-    devdeps: python -m pip install -U --pre --only-binary :all: -i https://pypi.anaconda.org/scientific-python-nightly-wheels/simple numpy
-    devdeps: python -m pip install -U --pre -i https://pypi.anaconda.org/astropy/simple astropy
-
     python -m pip freeze
     !cov: pytest --pyargs astroquery {toxinidir}/docs {env:PYTEST_ARGS} {posargs}
     cov:  pytest --pyargs astroquery {toxinidir}/docs --cov astroquery --cov-config={toxinidir}/setup.cfg {env:PYTEST_ARGS} {posargs}


### PR DESCRIPTION
This should fix the issue that we've been testing with a ~month old astropy dev version (as `astropy-iers-data` is a new dependency that hasn't been picked up with a newer dev wheel)

https://github.com/astropy/astropy/issues/15146

This should fix the failures we see because of https://github.com/astropy/astroquery/issues/2798