### PR TITLE
Refactor WFAU image retrieval to reject deprecated images

### DIFF
--- a/astroquery/ukidss/tests/test_ukidss_remote.py
+++ b/astroquery/ukidss/tests/test_ukidss_remote.py
@@ -58,3 +58,14 @@ class TestUkidss:
 
         assert isinstance(table_constraint, Table)
         assert len(table_noconstraint) >= len(table_constraint)
+
+    def test_deprecated_image_list(self):
+        """
+        Regression test for Issue 2808
+        """
+        crd = SkyCoord(ra=211.3194905, dec=54.413845, unit=(u.deg,u.deg))
+        ukidss = ukidss.core.UkidssClass()
+        ukidss.database = 'UHSDR2'
+        result = ukidss.get_image_list(crd, waveband='all', ignore_deprecated=True)
+        assert "http://wsa.roe.ac.uk/cgi-bin/getImage.cgi?file=/disk73/wsa/ingest/fits/20190614_v5/w20190614_00626_st.fit&mfid=11076607&extNo=4&lx=1276&hx=1426&ly=187&hy=337&rf=0&flip=1&uniq=834_579_14_86394_6&xpos=75.9&ypos=75.7&band=K&ra=211.3194905&dec=54.413845" in result
+        assert "http://wsa.roe.ac.uk/cgi-bin/getImage.cgi?file=/disk53/wsa/ingest/fits/20150129_v5/w20150129_02901_st.fit&mfid=8278383&extNo=4&lx=1274&hx=1425&ly=195&hy=345&rf=0&flip=1&uniq=834_579_14_86394_5&xpos=76.6&ypos=75.9&band=J&ra=211.3194905&dec=54.413845" not in result


### PR DESCRIPTION
This refactor also adds a new method to retrieve the very useful metadata tables rather than just scrape them for download URLs.

Solves #2808