### PR TITLE
Fix for alma.utils.footprint_to_reg

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -76,6 +76,7 @@ alma
 - New DataLink API handling. [#2493]
 - Fixed bug #2489 in which blank URLs were being sent to the downloader [#2490]
 - Removed deprecated broken functions from ``alma.utils``. [#2331]
+- Fixed a bug in slicing of ALMA regions. [#2810]
 
 astrometry_net
 ^^^^^^^^^^^^^^

--- a/astroquery/alma/tests/test_alma_utils.py
+++ b/astroquery/alma/tests/test_alma_utils.py
@@ -6,7 +6,7 @@ from astropy import units as u
 from astropy.coordinates import SkyCoord
 
 try:
-    from regions import CircleSkyRegion, PolygonSkyRegion
+    from regions import CircleSkyRegion
 
     HAS_REGIONS = True
 except ImportError:
@@ -41,9 +41,9 @@ mosaic_footprint_str = '''Polygon ICRS 266.519781 -28.724666 266.524678 -28.7319
     -28.681414 266.530644 -28.685630 266.521788 -28.689453 266.519784
     -28.694332 266.521332 -28.699778'''
 
+
 @pytest.mark.skipif(not HAS_REGIONS, reason="regions is required")
 def test_footprint_to_reg_mosaic(mosaic_footprint_str=mosaic_footprint_str):
-
 
     pairs = zip(mosaic_footprint_str.split()[2::2], mosaic_footprint_str.split()[3::2])
     vertices = [SkyCoord(float(ra) * u.deg, float(dec) * u.deg, frame='icrs')
@@ -80,6 +80,7 @@ def test_footprint_to_reg_mosaic_multiple(mosaic_footprint_str=mosaic_footprint_
 
 pointing_footprint_str = 'Circle ICRS 266.519781 -28.724666 0.01'
 
+
 @pytest.mark.skipif(not HAS_REGIONS, reason="regions is required")
 def test_footprint_to_reg_pointing(pointing_footprint_str=pointing_footprint_str):
 
@@ -89,7 +90,6 @@ def test_footprint_to_reg_pointing(pointing_footprint_str=pointing_footprint_str
 
     actual_reg = CircleSkyRegion(center, radius=float(rad) * u.deg)
 
-
     reg_output = utils.footprint_to_reg(pointing_footprint_str)
 
     assert len(reg_output) == 1
@@ -97,4 +97,3 @@ def test_footprint_to_reg_pointing(pointing_footprint_str=pointing_footprint_str
     assert actual_reg.center.ra == reg_output[0].center.ra
     assert actual_reg.center.dec == reg_output[0].center.dec
     assert actual_reg.radius == reg_output[0].radius
-

--- a/astroquery/alma/tests/test_alma_utils.py
+++ b/astroquery/alma/tests/test_alma_utils.py
@@ -1,6 +1,16 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
+import pytest
+
 import numpy as np
 from astropy import units as u
+from astropy.coordinates import SkyCoord
+
+try:
+    from regions import CircleSkyRegion, PolygonSkyRegion
+
+    HAS_REGIONS = True
+except ImportError:
+    HAS_REGIONS = False
 
 from .. import utils
 
@@ -22,3 +32,69 @@ def test_parse_frequency_support(frq_sup_str=frq_sup_str, result=franges):
 def approximate_primary_beam_sizes(frq_sup_str=frq_sup_str,
                                    beamsizes=beamsizes):
     assert np.all(utils.approximate_primary_beam_sizes(frq_sup_str) == beamsizes)
+
+
+mosaic_footprint_str = '''Polygon ICRS 266.519781 -28.724666 266.524678 -28.731930 266.536683
+    -28.737784 266.543860 -28.737586 266.549277 -28.733370 266.558133
+    -28.729545 266.560136 -28.724666 266.558845 -28.719605 266.560133
+    -28.694332 266.555234 -28.687069 266.543232 -28.681216 266.536058
+    -28.681414 266.530644 -28.685630 266.521788 -28.689453 266.519784
+    -28.694332 266.521332 -28.699778'''
+
+@pytest.mark.skipif(not HAS_REGIONS, reason="regions is required")
+def test_footprint_to_reg_mosaic(mosaic_footprint_str=mosaic_footprint_str):
+
+
+    pairs = zip(mosaic_footprint_str.split()[2::2], mosaic_footprint_str.split()[3::2])
+    vertices = [SkyCoord(float(ra) * u.deg, float(dec) * u.deg, frame='icrs')
+                for ra, dec in pairs]
+
+    reg_output = utils.footprint_to_reg(mosaic_footprint_str)
+
+    assert len(reg_output) == 1
+
+    for vertex in vertices:
+        assert vertex in reg_output[0].vertices
+
+
+@pytest.mark.skipif(not HAS_REGIONS, reason="regions is required")
+def test_footprint_to_reg_mosaic_multiple(mosaic_footprint_str=mosaic_footprint_str):
+
+    multiple_mosaic_footprint_str = f"{mosaic_footprint_str} {mosaic_footprint_str}"
+
+    print(multiple_mosaic_footprint_str)
+
+    pairs = zip(mosaic_footprint_str.split()[2::2], mosaic_footprint_str.split()[3::2])
+    vertices = [SkyCoord(float(ra) * u.deg, float(dec) * u.deg, frame='icrs')
+                for ra, dec in pairs]
+
+    reg_output = utils.footprint_to_reg(multiple_mosaic_footprint_str)
+
+    assert len(reg_output) == 2
+
+    for this_region in reg_output:
+
+        for vertex in vertices:
+            assert vertex in this_region.vertices
+
+
+pointing_footprint_str = 'Circle ICRS 266.519781 -28.724666 0.01'
+
+@pytest.mark.skipif(not HAS_REGIONS, reason="regions is required")
+def test_footprint_to_reg_pointing(pointing_footprint_str=pointing_footprint_str):
+
+    ra, dec, rad = pointing_footprint_str.split()[2:]
+
+    center = SkyCoord(float(ra) * u.deg, float(dec) * u.deg, frame='icrs')
+
+    actual_reg = CircleSkyRegion(center, radius=float(rad) * u.deg)
+
+
+    reg_output = utils.footprint_to_reg(pointing_footprint_str)
+
+    assert len(reg_output) == 1
+
+    assert actual_reg.center.ra == reg_output[0].center.ra
+    assert actual_reg.center.dec == reg_output[0].center.dec
+    assert actual_reg.radius == reg_output[0].radius
+

--- a/astroquery/alma/utils.py
+++ b/astroquery/alma/utils.py
@@ -50,7 +50,12 @@ def footprint_to_reg(footprint):
     if footprint[:7] != 'Polygon' and footprint[:6] != 'Circle':
         raise ValueError("Unrecognized footprint type")
 
-    import regions
+    try:
+        import regions
+    except ImportError:
+        print('Could not import `regions`, which is required for the '
+              'functionality of this function.')
+        raise
 
     reglist = []
 

--- a/astroquery/alma/utils.py
+++ b/astroquery/alma/utils.py
@@ -61,7 +61,7 @@ def footprint_to_reg(footprint):
     entries = footprint.split()
     if entries[0] == 'Circle':
         center = SkyCoord(float(entries[2]), float(entries[3]), frame='icrs', unit=(u.deg, u.deg))
-        reg = regions.CircleSkyRegion(center,radius=float(entries[4])*u.deg,
+        reg = regions.CircleSkyRegion(center, radius=float(entries[4])*u.deg,
                                       meta=meta, visual=visual)
         reglist.append(reg)
 

--- a/astroquery/alma/utils.py
+++ b/astroquery/alma/utils.py
@@ -61,17 +61,19 @@ def footprint_to_reg(footprint):
     entries = footprint.split()
     if entries[0] == 'Circle':
         center = SkyCoord(float(entries[2]), float(entries[3]), frame='icrs', unit=(u.deg, u.deg))
-        reg = regions.CircleSkyRegion(center, radius=float(entries[4]), meta=meta, visual=visual)
+        reg = regions.CircleSkyRegion(center,radius=float(entries[4])*u.deg,
+                                      meta=meta, visual=visual)
         reglist.append(reg)
 
     else:
         polygons = [index for index, entry in enumerate(entries) if entry == 'Polygon']
 
-        for start, stop in zip(polygons, polygons[1:]+[None]):
+        for start, stop in zip(polygons, polygons[1:]+[len(entries)]):
+            start += 1
             ra = [float(x) for x in entries[start+1:stop:2]]*u.deg
             dec = [float(x) for x in entries[start+2:stop:2]]*u.deg
             vertices = SkyCoord(ra, dec, frame='icrs')
-            reg = regions.PolygonSkyCoord(vertices=vertices, meta=meta, visual=visual)
+            reg = regions.PolygonSkyRegion(vertices=vertices, meta=meta, visual=visual)
             reglist.append(reg)
 
     return reglist

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -114,7 +114,7 @@ and for running the tests:
 * `pytest-rerunfailures <https://github.com/pytest-dev/pytest-rerunfailures>`__
 
 The following packages are optional dependencies and are required for the
-full functionality of the `~astroquery.mocserver` module:
+full functionality of the `~astroquery.mocserver`, `~astroquery.alma`, and `~astroquery.xmatch` modules:
 
 * `astropy-healpix <http://astropy-healpix.readthedocs.io/en/latest/>`_
 * `regions <https://astropy-regions.readthedocs.io/en/latest/>`_


### PR DESCRIPTION
There's a bug in the slicing of `s_region` strings returned by the ALMA archive, where a +1 is needed in the slice after identifying the type of regions (Circle or Polygon) to account for the frame in the string (e.g., `ICRS`).

Also:
- updated to using `regions.PolygonSkyRegion`
- added tests for `footprint_to_reg`