### PR TITLE
BUG: fix numpy dev version as their versioning system changed

### DIFF
--- a/astroquery/conftest.py
+++ b/astroquery/conftest.py
@@ -14,7 +14,7 @@ from pytest_astropy_header.display import (PYTEST_HEADER_MODULES,
 
 
 # Keep this until we require numpy to be >=2.0
-if minversion(np, "2.0.0.dev0+151"):
+if minversion(np, "2.0.0.dev0+git20230726"):
     np.set_printoptions(legacy="1.25")
 
 


### PR DESCRIPTION
Numpy's versioning has changed in https://github.com/numpy/numpy/pull/24196 causing the repr issues we see in #2811 

This PR fixes #2811 