### PR TITLE
fix simbad region async remote test

### DIFF
--- a/astroquery/simbad/tests/test_simbad_remote.py
+++ b/astroquery/simbad/tests/test_simbad_remote.py
@@ -103,9 +103,11 @@ class TestSimbad:
         simbad.ROW_LIMIT = 100
         simbad.cache_location = temp_dir
         response = simbad.query_region_async(
-            ICRS_COORDS_M42, radius=2 * u.deg, equinox=2000.0, epoch='J2000')
-
-        assert response is not None
+            ICRS_COORDS_M42, radius=5 * u.arcsec, equinox=2000.0, epoch='J2000')
+        # A correct response code
+        assert response.status_code == 200
+        # Check that Orion was found
+        assert "NAME Ori Region" in response.text
 
     @pytest.mark.parametrize("radius", (0.5 * u.arcsec, "0.5s"))
     def test_query_region_async_vector(self, temp_dir, radius):


### PR DESCRIPTION
Hello astroquery devs!

This PR was motivated by the recent conversation in #1674 

It does very little things: 

- make a query in a way smaller circle so that we avoid this long query on our side
- add a check for a 200 status code
- see if Orion is correctly found around the given coordinates

Hope this solves the issue

Edit: do I add a changelog entry since this only changes the test?