### PR TITLE
CI: remove deprecated/removed RTD config

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -15,7 +15,6 @@ sphinx:
 # Install regular dependencies.
 # Then, install special pinning for RTD.
 python:
-  system_packages: false
   install:
     - method: pip
       path: .


### PR DESCRIPTION
RTD build in other repos started to fail due to this today.