### PR TITLE
ENH: adding minimalist BaseVOQuery baseclass

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -301,7 +301,9 @@ Infrastructure, Utility and Other Changes and Additions
 - New function, ``utils.cleanup_downloads.cleanup_saved_downloads``, is
   added to help the testcleanup narrative in narrative documentations. [#2384]
 
-- Adding more system information to User-Agent. [#2762]
+- Adding new ``BaseVOQuery`` baseclass for modules using VO tools. [#2836]
+
+- Adding more system and package information to User-Agent. [#2762, #2836]
 
 - Removal of the non-functional ``nrao`` module as it was completely
   incompatible with the refactored upstream API. [#2546]

--- a/astroquery/alma/core.py
+++ b/astroquery/alma/core.py
@@ -30,7 +30,7 @@ except ImportError:
 from ..exceptions import LoginError
 from ..utils import commons
 from ..utils.process_asyncs import async_to_sync
-from ..query import BaseQuery, QueryWithLogin
+from ..query import BaseQuery, QueryWithLogin, BaseVOQuery
 from .tapsql import (_gen_pos_sql, _gen_str_sql, _gen_numeric_sql,
                      _gen_band_list_sql, _gen_datetime_sql, _gen_pol_sql, _gen_pub_sql,
                      _gen_science_sql, _gen_spec_res_sql, ALMA_DATE_FORMAT)
@@ -212,7 +212,7 @@ def _gen_sql(payload):
     return sql + where
 
 
-class AlmaAuth(BaseQuery):
+class AlmaAuth(BaseVOQuery, BaseQuery):
     """Authentication session information for passing credentials to an OIDC instance
 
     Assumes an OIDC system like Keycloak with a preconfigured client app called "oidc" to validate against.
@@ -366,7 +366,7 @@ class AlmaClass(QueryWithLogin):
     @property
     def tap(self):
         if not self._tap:
-            self._tap = pyvo.dal.tap.TAPService(baseurl=self.tap_url)
+            self._tap = pyvo.dal.tap.TAPService(baseurl=self.tap_url, session=self._session)
         return self._tap
 
     @property

--- a/astroquery/cadc/core.py
+++ b/astroquery/cadc/core.py
@@ -17,7 +17,7 @@ from urllib.error import HTTPError
 
 from ..utils.class_or_instance import class_or_instance
 from ..utils import async_to_sync, commons
-from ..query import BaseQuery
+from ..query import BaseQuery, BaseVOQuery
 from bs4 import BeautifulSoup
 from astropy import units as u
 from astropy.coordinates import Angle
@@ -37,7 +37,7 @@ warnings.filterwarnings('ignore', module='astropy.io.votable')
 
 
 @async_to_sync
-class CadcClass(BaseQuery):
+class CadcClass(BaseVOQuery, BaseQuery):
     """
     Class for accessing CADC data. Typical usage:
 

--- a/astroquery/ipac/irsa/core.py
+++ b/astroquery/ipac/irsa/core.py
@@ -13,7 +13,7 @@ from astropy import units as u
 from astropy.utils.decorators import deprecated_renamed_argument
 from pyvo.dal import TAPService
 from astroquery import log
-from astroquery.query import BaseQuery
+from astroquery.query import BaseVOQuery
 from astroquery.utils.commons import parse_coordinates
 from astroquery.ipac.irsa import conf
 from astroquery.exceptions import InvalidQueryError
@@ -22,7 +22,7 @@ from astroquery.exceptions import InvalidQueryError
 __all__ = ['Irsa', 'IrsaClass']
 
 
-class IrsaClass(BaseQuery):
+class IrsaClass(BaseVOQuery):
 
     def __init__(self):
         super().__init__()
@@ -32,7 +32,7 @@ class IrsaClass(BaseQuery):
     @property
     def tap(self):
         if not self._tap:
-            self._tap = TAPService(baseurl=self.tap_url)
+            self._tap = TAPService(baseurl=self.tap_url, session=self._session)
         return self._tap
 
     def query_tap(self, query, *, maxrec=None):

--- a/astroquery/ipac/nexsci/nasa_exoplanet_archive/core.py
+++ b/astroquery/ipac/nexsci/nasa_exoplanet_archive/core.py
@@ -21,7 +21,7 @@ from astropy.utils.exceptions import AstropyWarning
 
 # Import astroquery utilities
 from astroquery.exceptions import InputWarning, InvalidQueryError, NoResultsWarning, RemoteServiceError
-from astroquery.query import BaseQuery
+from astroquery.query import BaseQuery, BaseVOQuery
 from astroquery.utils import async_to_sync, commons
 from astroquery.utils.class_or_instance import class_or_instance
 from astroquery.ipac.nexsci.nasa_exoplanet_archive import conf
@@ -129,7 +129,7 @@ class InvalidTableError(InvalidQueryError):
 # Class decorator, async_to_sync, modifies NasaExoplanetArchiveClass to convert
 # all query_x_async methods to query_x methods
 @async_to_sync
-class NasaExoplanetArchiveClass(BaseQuery):
+class NasaExoplanetArchiveClass(BaseVOQuery, BaseQuery):
     """
     The interface for querying the NASA Exoplanet Archive TAP and API services
 
@@ -230,7 +230,7 @@ class NasaExoplanetArchiveClass(BaseQuery):
             cache = self.CACHE
 
         if table in self.TAP_TABLES:
-            tap = pyvo.dal.tap.TAPService(baseurl=self.URL_TAP)
+            tap = pyvo.dal.tap.TAPService(baseurl=self.URL_TAP, session=self._session)
             # construct query from table and request_payload (including format)
             tap_query = self._request_to_sql(request_payload)
 

--- a/astroquery/query.py
+++ b/astroquery/query.py
@@ -185,11 +185,19 @@ class BaseVOQuery:
     """
     def __init__(self):
         super().__init__()
-        self._session = requests.Session()
-        self._session.headers['User-Agent'] = (
-            f"astroquery/{version.version} pyVO/{pyvo.__version__} Python/{platform.python_version()} "
-            f"({platform.system()}) "
-            f"{self._session.headers['User-Agent']}")
+        if not hasattr(self, '_session'):
+            # We don't want to override another, e.g. already authenticated session from another baseclass
+            self._session = requests.Session()
+
+        user_agents = self._session.headers['User-Agent'].split()
+        if 'astroquery' in user_agents[0]:
+            if 'pyVO' not in user_agents[1]:
+                user_agents[0] = f"astroquery/{version.version} pyVO/{pyvo.__version__}"
+        else:
+            user_agents = [f"astroquery/{version.version} pyVO/{pyvo.__version__} "
+                           f"Python/{platform.python_version()} ({platform.system()})"] + user_agents
+
+        self._session.headers['User-Agent'] = " ".join(user_agents)
 
         self.name = self.__class__.__name__.split("Class")[0]
 

--- a/astroquery/query.py
+++ b/astroquery/query.py
@@ -193,6 +193,8 @@ class BaseVOQuery:
         if 'astroquery' in user_agents[0]:
             if 'pyVO' not in user_agents[1]:
                 user_agents[0] = f"astroquery/{version.version} pyVO/{pyvo.__version__}"
+        elif 'pyVO' in user_agents[0]:
+            user_agents[0] = f"astroquery/{version.version} pyVO/{pyvo.__version__}"
         else:
             user_agents = [f"astroquery/{version.version} pyVO/{pyvo.__version__} "
                            f"Python/{platform.python_version()} ({platform.system()})"] + user_agents

--- a/astroquery/query.py
+++ b/astroquery/query.py
@@ -27,7 +27,7 @@ from astroquery import version, log, cache_conf
 from astroquery.utils import system_tools
 
 
-__all__ = ['BaseQuery', 'QueryWithLogin']
+__all__ = ['BaseVOQuery', 'BaseQuery', 'QueryWithLogin']
 
 
 def to_cache(response, cache_file):

--- a/astroquery/tests/test_query.py
+++ b/astroquery/tests/test_query.py
@@ -1,0 +1,39 @@
+# Licensed under a 3-clause BSD style license - see LICENSE.rst
+from astroquery.query import BaseQuery, BaseVOQuery
+
+
+class with_VO(BaseVOQuery, BaseQuery):
+    pass
+
+
+class without_VO(BaseQuery):
+    pass
+
+
+class only_VO(BaseVOQuery):
+    pass
+
+
+def test_session_VO_header():
+    test_instance = with_VO()
+    user_agent = test_instance._session.headers['User-Agent']
+    assert 'astroquery' in user_agent
+    assert 'pyVO' in user_agent
+    assert user_agent.count('astroquery') == 1
+
+
+def test_session_nonVO_header():
+    test_instance = without_VO()
+    user_agent = test_instance._session.headers['User-Agent']
+    assert 'astroquery' in user_agent
+    assert 'pyVO' not in user_agent
+    assert user_agent.count('astroquery') == 1
+
+
+def test_session_hooks():
+    # Test that we don't override the session in the BaseVOQuery
+    test_instance = with_VO()
+    assert len(test_instance._session.hooks['response']) > 0
+
+    test_VO_instance = only_VO()
+    assert len(test_VO_instance._session.hooks['response']) == 0


### PR DESCRIPTION
Inheriting a lot of unused methods, properties, etc from `BaseQuery` makes little sense for modules that rely fully on pyvo rather than making their own GET/POST queries.

This PR also ensures that the session set in the class is being passed onto TAPServcie rather than using a new one from pyvo. `cadc` is basically doing this already, the PR also adds the same approach to `alma`, `nexsci` and `irsa`.

To merge this, I would like to see approvals or thumbs-ups from the affected modules: `alma` and `nexsci`

cc @andamian @rickynilsson 