### PR TITLE
Extend Gemini to include getting file content and logging out of GOA

### DIFF
--- a/astroquery/gemini/tests/test_gemini.py
+++ b/astroquery/gemini/tests/test_gemini.py
@@ -211,4 +211,3 @@ def test_get_file_url():
     """Test generating file URL based on filename."""
     url = gemini.Observations.get_file_url("filename")
     assert url == "https://archive.gemini.edu/file/filename"
-

--- a/astroquery/gemini/tests/test_remote.py
+++ b/astroquery/gemini/tests/test_remote.py
@@ -8,6 +8,7 @@ documentation at:
 https://astroquery.readthedocs.io/en/latest/testing.html
 """
 import pytest
+import requests
 
 import os
 import shutil
@@ -22,6 +23,10 @@ from astroquery import gemini
 
 """ Coordinates to use for testing """
 coords = SkyCoord(210.80242917, 54.34875, unit="deg")
+
+# Filename and url
+filename = "S20231016S0018.fits.bz2"  # Small file
+file_url = f"https://archive.gemini.edu/file{filename}"
 
 
 @pytest.mark.remote_data
@@ -78,3 +83,14 @@ class TestGemini:
             os.unlink(filepath)
         if os.path.exists(tempdir):
             shutil.rmtree(tempdir)
+
+    def test_get_file_content(self):
+        """Test the `get_file_content` function."""
+        content = gemini.Observations.get_file_content(filename)
+        assert isinstance(content, bytes)
+        assert len(content) > 0
+
+    def test_get_file_content_with_timeout(self):
+        """Test `get_file_content` with a timeout."""
+        with pytest.raises(requests.exceptions.Timeout):
+            gemini.Observations.get_file_content(filename, timeout=0.001)

--- a/docs/gemini/gemini.rst
+++ b/docs/gemini/gemini.rst
@@ -132,19 +132,21 @@ the *NotFail* or *notengineering* terms respectively.
 Authenticated Sessions
 ----------------------
 
-The Gemini module allows for authenticated sessions using your GOA account.  This is the same account you login
-with on the GOA homepage at `<https://archive.gemini.edu/>`__.  The `astroquery.gemini.ObservationsClass.login`
-method returns `True` if successful.
+The Gemini module allows for authenticated sessions using your GOA account.  This is the same account you
+login with on the GOA homepage at `<https://archive.gemini.edu/>`__.  The
+`astroquery.gemini.ObservationsClass.login` method returns `True` if successful. To logout, use the
+`astroquery.gemini.ObservationsClass.logout` method to remove the Gemini Observatory Archive session cookie.
 
 .. doctest-skip::
 
                 >>> from astroquery.gemini import Observations
                 >>> Observations.login(username, password)
                 >>> # do something with your elevated access
+                >>> Observations.logout()
 
 
-File Downloading
-----------------
+File Downloading and File Content Getting
+-----------------------------------------
 
 As a convenience, you can request file downloads directly from the Gemini module.  This constructs the appropriate
 URL and fetches the file.  It will use any authenticated session you may have, so it will retrieve any
@@ -154,6 +156,15 @@ proprietary data you may be permissioned for.
 
                 >>> from astroquery.gemini import Observations
                 >>> Observations.get_file("GS2020AQ319-10.fits", download_dir="/tmp")  # doctest: +IGNORE_OUTPUT
+
+
+To get the file content without writing to disk, you can use the method
+`astroquery.gemini.ObservationsClass.get_file_content`. This constructs the appropriate url and fetches the
+file contents. This will use any authenticated session you have for proprietary data.
+
+.. doctest-remote-data::
+                >>> from astroquery.gemini import Observations
+                >>> Observations.get_file_content("GS2020AQ319-10.fits")  # doctest: +IGNORE_OUTPUT
 
 
 Reference/API


### PR DESCRIPTION
This PR extends the `Gemini` module. 
1. `get_file_content` - Grabs the content of a file, does not save to disk.
2. `logout` - Deletes the Gemini Observatory Archive cookie.
3. `get_file_url` - helper method to get the URL for direct file download.

I have updated the documentation to include the new functions and included tests. 