### PR TITLE
MAINT: adding warning filter for numpy._core rename

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -77,10 +77,13 @@ filterwarnings =
     ignore:due to the retirement of its upstream website:astropy.utils.exceptions.AstropyDeprecationWarning
 # Leap second update related warning
     ignore:leap-second auto-update failed:astropy.utils.exceptions.AstropyWarning
-
-
 # Should ignore these for astropy<5.0
     ignore:getName|currentThread:DeprecationWarning:astropy
+# Numpy 2.0 deprecations triggered by upstream libraries.
+# Exact warning messages differ, thus using a super generic filter.
+    ignore:numpy.core:DeprecationWarning
+
+
 markers =
     bigdata: marks tests that are expected to trigger a large download (deselect with '-m "not bigdata"')
     noautofixt: disabling fixture autouse


### PR DESCRIPTION
We don't use numpy dev in our CI, but errors pop up locally without this patch when numpy 2.0dev is being used. The deprecations are all triggered upstream I expect it would take some time that we could remove this workaround from our config.