### PR TITLE
TST: we should not xfail but fail the tests if server is not available

### DIFF
--- a/astroquery/vsa/tests/test_vista_remote.py
+++ b/astroquery/vsa/tests/test_vista_remote.py
@@ -21,7 +21,7 @@ class TestVista:
         try:
             vista._request("GET", "http://horus.roe.ac.uk:8080/vdfs/VgetImage_form.jsp")
         except Exception as ex:
-            pytest.xfail("VISTA appears to be down.  Exception was: {0}".format(ex))
+            pytest.fail("VISTA appears to be down.  Exception was: {0}".format(ex))
 
     @pytest.mark.dependency(depends=["vsa_up"])
     def test_get_images(self):


### PR DESCRIPTION
It's not useful to hide issues, after all if the server is consistently unreachable then we need to update the code itself (however, if the server is unreachable, it makes sense not to run all the tests anyway just to reach get a timeout)