### PR TITLE
BUG: SDSS object IDs to use uint64

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -231,8 +231,8 @@ sdss
 - Switching to https to avoid issues originating in relying on server side
   redirects. [#2654]
 
-- Fix bug to have object IDs as integers on windows. [#2800, #2806]
-
+- Fix bug to have object IDs as unsigned integers, on Windows, too. [#2800,
+  #2806, #2879]
 
 simbad
 ^^^^^^

--- a/astroquery/sdss/core.py
+++ b/astroquery/sdss/core.py
@@ -1042,7 +1042,7 @@ class SDSSClass(BaseQuery):
             arr = Table.read(response.text, format='ascii.csv', comment="#")
             for id_column in ('objid', 'specobjid', 'objID', 'specobjID', 'specObjID'):
                 if id_column in arr.columns:
-                    arr[id_column] = arr[id_column].astype(np.int64)
+                    arr[id_column] = arr[id_column].astype(np.uint64)
 
         if len(arr) == 0:
             return None

--- a/astroquery/sdss/tests/test_sdss.py
+++ b/astroquery/sdss/tests/test_sdss.py
@@ -205,7 +205,7 @@ def test_sdss_sql(patch_request, patch_get_readable_fileobj, dr):
         data = Table.read(data_path(DATA_FILES['images_id']),
                           format='ascii.csv', comment='#')
 
-        data['objid'] = data['objid'].astype(np.int64)
+        data['objid'] = data['objid'].astype(np.uint64)
         compare_xid_data(xid, data)
         url_tester(dr)
 
@@ -248,8 +248,8 @@ def test_sdss_specobj(patch_request, dr):
                                     message=r'OverflowError converting.*')
         data = Table.read(data_path(DATA_FILES['spectra_id']),
                           format='ascii.csv', comment='#')
-        data['objid'] = data['objid'].astype(np.int64)
-        data['specobjid'] = data['specobjid'].astype(np.int64)
+        data['objid'] = data['objid'].astype(np.uint64)
+        data['specobjid'] = data['specobjid'].astype(np.uint64)
         compare_xid_data(xid, data)
         url_tester(dr)
 
@@ -266,7 +266,7 @@ def test_sdss_photoobj(patch_request, dr):
         data = Table.read(data_path(DATA_FILES['images_id']),
                           format='ascii.csv', comment='#')
 
-        data['objid'] = data['objid'].astype(np.int64)
+        data['objid'] = data['objid'].astype(np.uint64)
         compare_xid_data(xid, data)
         url_tester(dr)
 
@@ -293,7 +293,7 @@ def test_list_coordinates(patch_request, dr, radius, width):
             data = Table.read(data_path(DATA_FILES['images_id']),
                               format='ascii.csv', comment='#')
 
-            data['objid'] = data['objid'].astype(np.int64)
+            data['objid'] = data['objid'].astype(np.uint64)
 
             compare_xid_data(xid, data)
             if width is None:
@@ -331,7 +331,7 @@ def test_list_coordinates_with_height(patch_request, width, height):
             data = Table.read(data_path(DATA_FILES['images_id']),
                               format='ascii.csv', comment='#')
 
-            data['objid'] = data['objid'].astype(np.int64)
+            data['objid'] = data['objid'].astype(np.uint64)
 
             compare_xid_data(xid, data)
 
@@ -347,7 +347,7 @@ def test_column_coordinates(patch_request, dr):
         data = Table.read(data_path(DATA_FILES['images_id']),
                           format='ascii.csv', comment='#')
 
-        data['objid'] = data['objid'].astype(np.int64)
+        data['objid'] = data['objid'].astype(np.uint64)
 
         compare_xid_data(xid, data)
         url_tester_crossid(dr)
@@ -379,7 +379,7 @@ def test_query_crossid(patch_request, dr):
         data = Table.read(data_path(DATA_FILES['images_id']),
                           format='ascii.csv', comment='#')
 
-        data['objid'] = data['objid'].astype(np.int64)
+        data['objid'] = data['objid'].astype(np.uint64)
 
         compare_xid_data(xid, data)
         url_tester_crossid(dr)


### PR DESCRIPTION
Use uint64 instead of int64 to avoid the overflow error reported in #2879 



FIxes #2879