### PR TITLE
TST: handling more warnings issued by astropy

### DIFF
--- a/astroquery/vizier/tests/test_vizier_remote.py
+++ b/astroquery/vizier/tests/test_vizier_remote.py
@@ -103,8 +103,13 @@ class TestVizierRemote:
             keywords=['Radio', 'IR'], row_limit=5000)
         C = SkyCoord(359.61687 * u.deg, -0.242457 * u.deg, frame="galactic")
 
-        with pytest.warns(UserWarning, match="VOTABLE parsing raised exception"):
+        # With newer versions UnitsWarning may be issued as well
+        with pytest.warns() as w:
             V.query_region(C, radius=2 * u.arcmin)
+
+        for i in w:
+            message = str(i.message)
+            assert ("VOTABLE parsing raised exception" in message or "not supported by the VOUnit standard" in message)
 
     def test_multicoord(self):
 


### PR DESCRIPTION
I started to see UnitsWarning for this test for certain version combinations when running the remote tests locally. Somehow I haven't seen the same issue on CI, but nevertheless, I suppose this won't hurt.

```
WARNING: UnitsWarning: Unit 'pct' not supported by the VOUnit standard. Did you mean PC, PT, Pct, pC, pT or pc? [astropy.units.format.vounit]
```