### PR TITLE
astroquery.mast : adding cloud support for Pan-STARRS mission

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -398,6 +398,8 @@ mast
 
 - Optional keyword arguments are now keyword only. [#2317]
 
+- PanSTARRS data is now available to download anonymously from the public STScI S3 buckets. [#2893]
+
 sdss
 ^^^^
 

--- a/astroquery/mast/cloud.py
+++ b/astroquery/mast/cloud.py
@@ -52,7 +52,7 @@ class CloudAccess:  # pragma:no-cover
         import boto3
         import botocore
 
-        self.supported_missions = ["mast:hst/product", "mast:tess/product", "mast:kepler", "mast:galex"]
+        self.supported_missions = ["mast:hst/product", "mast:tess/product", "mast:kepler", "mast:galex", "mast:ps1"]
 
         self.boto3 = boto3
         self.botocore = botocore
@@ -117,6 +117,8 @@ class CloudAccess:  # pragma:no-cover
 
         if 'galex' in path:
             path = path.lstrip("/mast/")
+        elif '/ps1/' in path:
+            path = path.replace("/ps1/", "panstarrs/ps1/public/")
         else:
             path = path.lstrip("/")
 

--- a/docs/mast/mast_obsquery.rst
+++ b/docs/mast/mast_obsquery.rst
@@ -418,7 +418,7 @@ Public datasets from the Hubble, Kepler and TESS telescopes are also available f
 in `public S3 buckets <https://registry.opendata.aws/collab/stsci/>`__.
 
 Using AWS resources to process public data no longer requires an AWS account for all AWS regions.
-To enable cloud data access for the Hubble, Kepler, TESS, and GALEX missions, follow the steps below:
+To enable cloud data access for the Hubble, Kepler, TESS, GALEX, and Pan-STARRS missions, follow the steps below:
 
 You can enable cloud data access via the `~astroquery.mast.ObservationsClass.enable_cloud_dataset`
 function, which sets AWS to become the preferred source for data access as opposed to on-premise


### PR DESCRIPTION
This PR adds functionality to `astroquery.mast` to enable cloud data access for the Pan-STARRS mission data, which is now available via the MAST public S3 bucket (https://registry.opendata.aws/collab/stsci/)

This is similar to https://github.com/astropy/astroquery/pull/2261, which were the similar updates for GALEX mission that Jenny did last year.

Thank you!!