### PR TITLE
Linelists: make lookuptables a little more robust

### DIFF
--- a/astroquery/jplspec/lookup_table.py
+++ b/astroquery/jplspec/lookup_table.py
@@ -22,9 +22,12 @@ class Lookuptable(dict):
 
         Returns
         -------
-        The list of values corresponding to the matches
+        The dictionary containing only values whose keys match the regex
 
         """
+
+        if s in self:
+            return {s: self[s]}
 
         R = re.compile(s, flags)
 

--- a/astroquery/linelists/cdms/core.py
+++ b/astroquery/linelists/cdms/core.py
@@ -375,9 +375,12 @@ class Lookuptable(dict):
 
         Returns
         -------
-        The list of values corresponding to the matches
+        The dictionary containing only values whose keys match the regex
 
         """
+
+        if st in self:
+            return {st: self[st]}
 
         out = {}
 


### PR DESCRIPTION
The lookuptables used in linelist searches are a little touchy because of lines like `HCO+` and `HOCO+`.  You have to escape the `+`'s to get them to work, which means that even exact matches to molecules, like `29002 HCO+ v=0,1,2` will not work.

This change means that _exact_ matches will work, while partial matches will still need to be escaped.