### PR TITLE
CI: force to pick up dev versions for devdeps

### DIFF
--- a/astroquery/ogle/core.py
+++ b/astroquery/ogle/core.py
@@ -52,8 +52,6 @@ class OgleClass(BaseQuery):
     algorithms = ['NG', 'NN']
     quality_codes = ['GOOD', 'ALL']
     coord_systems = ['RD', 'LB']
-    result_dtypes = ['f8', 'f8', 'f8', 'f8', 'f8', 'f8', 'f8', 'f8', 'i8',
-                     'a2', 'f8']
 
     @_validate_params
     def _args_to_payload(self, *, coord=None, algorithm='NG', quality='GOOD',
@@ -144,13 +142,8 @@ class OgleClass(BaseQuery):
         return response
 
     def _parse_result(self, response, *, verbose=False):
-        # Parse table, ignore last two (blank) lines
-        raw_data = response.text.split('\n')[:-2]
-        # Select first row and skip first character ('#') to find column
-        # headers
-        header = raw_data[0][1:].split()
-        data = self._parse_raw(raw_data)
-        t = Table(data, names=header, dtype=self.result_dtypes)
+        # Header is in first row starting with #, this works with the default
+        t = Table.read(response.text.split('\n'), format='ascii')
         return t
 
     def _parse_coords(self, coord, coord_sys):

--- a/tox.ini
+++ b/tox.ini
@@ -50,6 +50,9 @@ extras =
 
 
 commands =
+    # Force numpy reinstall to work around upper version limits in downstream dependencies
+    devdeps: pip install -U --pre --no-deps --extra-index-url https://pypi.anaconda.org/scientific-python-nightly-wheels/simple numpy
+
     python -m pip freeze
     !cov: pytest --pyargs astroquery {toxinidir}/docs {env:PYTEST_ARGS} {posargs}
     cov:  pytest --pyargs astroquery {toxinidir}/docs --cov astroquery --cov-config={toxinidir}/setup.cfg {env:PYTEST_ARGS} {posargs}

--- a/tox.ini
+++ b/tox.ini
@@ -23,11 +23,12 @@ description = run tests
 setenv =
     PYTEST_ARGS = ''
     online: PYTEST_ARGS = --remote-data=any --reruns=1 --reruns-delay 10
-    devdeps: PIP_EXTRA_INDEX_URL =  https://pypi.anaconda.org/scientific-python-nightly-wheels/simple https://pypi.anaconda.org/astropy/simple
+    devdeps: PIP_EXTRA_INDEX_URL =  https://pypi.anaconda.org/scientific-python-nightly-wheels/simple https://pypi.anaconda.org/astropy/simple https://pypi.anaconda.org/liberfa/simple
 
 deps =
     devdeps: numpy>=0.0.dev0
     devdeps: astropy>=0.0.dev0
+    devdeps: pyerfa>=0.0.dev0
     devdeps: git+https://github.com/astropy/pyvo.git#egg=pyvo
 
 # mpl while not a dependency, it's required for the tests, and would pull up a newer numpy version if not pinned.

--- a/tox.ini
+++ b/tox.ini
@@ -27,6 +27,7 @@ setenv =
 
 deps =
     devdeps: numpy>=0.0.dev0
+    devdeps: matplotlib>=0.0.dev0
     devdeps: astropy>=0.0.dev0
     devdeps: pyerfa>=0.0.dev0
     devdeps: git+https://github.com/astropy/pyvo.git#egg=pyvo


### PR DESCRIPTION
Apparently, we haven't been testing with npdev even though the config suggests we do.

A long-term solution would be to make a version checker and make these jobs fail when a required version is being downgraded by another dependency...

Locally, I see a couple of issues, so more commits to come for this PR.

