### PR TITLE
Update gaia astroquery to handle new output formats due to ESAC TAP 9.6.0 library  (gaiapcr-1299)

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -40,7 +40,7 @@ gaia
   considered as source_id. [#2859]
 
 - New output formats. votable, to get an uncompressed votable file (Content-Type: application/x-votable+xml).
-  new votable_gzip, to get a compressed votable file (Content-Encoding: gzip and Content-Type: application/x-votable+gzip).
+  new votable_gzip (which is now the default), to get a compressed votable file (Content-Encoding: gzip and Content-Type: application/x-votable+gzip).
   ecsv, to get an ecsv compressed file (Content-Encoding: gzip and Content-Type: text/ecsv+gzip). [#2907]
 
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -39,6 +39,11 @@ gaia
   therefore, if the parameter is not set, the source identifiers are
   considered as source_id. [#2859]
 
+- New output formats. votable, to get an uncompressed votable file (Content-Type: application/x-votable+xml).
+  new votable_gzip, to get a compressed votable file (Content-Encoding: gzip and Content-Type: application/x-votable+gzip).
+  ecsv, to get an ecsv compressed file (Content-Encoding: gzip and Content-Type: text/ecsv+gzip). [#2907]
+
+
 hsa
 ^^^
 

--- a/astroquery/gaia/core.py
+++ b/astroquery/gaia/core.py
@@ -875,7 +875,8 @@ class GaiaClass(TapPlus):
                                   verbose=verbose,
                                   dump_to_file=dump_to_file,
                                   upload_resource=upload_resource,
-                                  upload_table_name=upload_table_name, format_with_results_compressed=('votable_gzip','fits','ecsv'))
+                                  upload_table_name=upload_table_name,
+                                  format_with_results_compressed=('votable_gzip', 'fits', 'ecsv'))
 
     def launch_job_async(self, query, *, name=None, output_file=None,
                          output_format="votable_gzip", verbose=False,
@@ -927,7 +928,8 @@ class GaiaClass(TapPlus):
                                         background=background,
                                         upload_resource=upload_resource,
                                         upload_table_name=upload_table_name,
-                                        autorun=autorun, format_with_results_compressed=('votable_gzip','fits','ecsv'))
+                                        autorun=autorun,
+                                        format_with_results_compressed=('votable_gzip', 'fits', 'ecsv'))
 
     def get_status_messages(self):
         """Retrieve the messages to inform users about

--- a/astroquery/gaia/core.py
+++ b/astroquery/gaia/core.py
@@ -13,24 +13,24 @@ European Space Agency (ESA)
 Created on 30 jun. 2016
 Modified on 18 Ene. 2022 by mhsarmiento
 """
-import zipfile
 import os
-from datetime import datetime, timezone
 import shutil
+import zipfile
 from collections.abc import Iterable
+from datetime import datetime, timezone
 
 from astropy import units
-from astropy.coordinates import Angle
-from astropy.units import Quantity
-from astropy.io import votable
-from astropy.io import fits
-from astropy.table import Table
 from astropy import units as u
+from astropy.coordinates import Angle
+from astropy.io import fits
+from astropy.io import votable
+from astropy.table import Table
+from astropy.units import Quantity
 from requests import HTTPError
 
-from astroquery.utils.tap import TapPlus
-from astroquery.utils import commons
 from astroquery import log
+from astroquery.utils import commons
+from astroquery.utils.tap import TapPlus
 from astroquery.utils.tap import taputils
 from . import conf
 
@@ -107,11 +107,11 @@ class GaiaClass(TapPlus):
         except HTTPError:
             log.error("Error logging in TAP server")
             return
-        u = self._TapPlus__user
-        p = self._TapPlus__pwd
+        new_user = self._TapPlus__user
+        new_password = self._TapPlus__pwd
         try:
             log.info("Login to gaia data server")
-            TapPlus.login(self.__gaiadata, user=u, password=p,
+            TapPlus.login(self.__gaiadata, user=new_user, password=new_password,
                           verbose=verbose)
         except HTTPError:
             log.error("Error logging in data server")
@@ -132,11 +132,11 @@ class GaiaClass(TapPlus):
         except HTTPError:
             log.error("Error logging in TAP server")
             return
-        u = self._TapPlus__user
-        p = self._TapPlus__pwd
+        new_user = self._TapPlus__user
+        new_password = self._TapPlus__pwd
         try:
             log.info("Login to gaia data server")
-            TapPlus.login(self.__gaiadata, user=u, password=p,
+            TapPlus.login(self.__gaiadata, user=new_user, password=new_password,
                           verbose=verbose)
         except HTTPError:
             log.error("Error logging in data server")
@@ -165,7 +165,7 @@ class GaiaClass(TapPlus):
 
     def load_data(self, ids, *, data_release=None, data_structure='INDIVIDUAL', retrieval_type="ALL",
                   linking_parameter='SOURCE_ID', valid_data=False, band=None, avoid_datatype_check=False,
-                  format="votable",
+                  format="votable_gzip",
                   output_file=None, overwrite_output_file=False, verbose=False):
         """Loads the specified table
         TAP+ only
@@ -212,8 +212,8 @@ class GaiaClass(TapPlus):
         avoid_datatype_check: boolean, optional, default False.
             By default, this value will be set to False. If it is set to 'true'
             the Datalink items tags will not be checked.
-        format : str, optional, default 'votable'
-            loading format. Other available formats are 'csv', 'ecsv','json','votable_plain' and 'fits'
+        format : str, optional, default 'votable_gzip'
+            loading format. Other available formats are 'votable', 'csv', 'ecsv','json','votable_plain' and 'fits'
         output_file : string, optional, default None
             file where the results are saved.
             If it is not provided, the http response contents are returned.
@@ -376,7 +376,7 @@ class GaiaClass(TapPlus):
         return self.__gaiadata.get_datalinks(ids=ids, verbose=verbose)
 
     def __query_object(self, coordinate, *, radius=None, width=None, height=None,
-                       async_job=False, verbose=False, columns=[]):
+                       async_job=False, verbose=False, columns=()):
         """Launches a job
         TAP & TAP+
 
@@ -403,7 +403,7 @@ class GaiaClass(TapPlus):
         The job results (astropy.table).
         """
         coord = self.__getCoordInput(coordinate, "coordinate")
-        job = None
+
         if radius is not None:
             job = self.__cone_search(coord, radius, async_job=async_job,
                                      verbose=verbose, columns=columns)
@@ -455,7 +455,7 @@ class GaiaClass(TapPlus):
         return job.get_results()
 
     def query_object(self, coordinate, *, radius=None, width=None, height=None,
-                     verbose=False, columns=[]):
+                     verbose=False, columns=()):
         """Launches a job
         TAP & TAP+
 
@@ -471,7 +471,7 @@ class GaiaClass(TapPlus):
             box height
         verbose : bool, optional, default 'False'
             flag to display information about the process
-        columns: list, optional, default []
+        columns: list, optional, default ()
             if empty, all columns will be selected
 
         Returns
@@ -483,7 +483,7 @@ class GaiaClass(TapPlus):
                                    verbose=verbose, columns=columns)
 
     def query_object_async(self, coordinate, *, radius=None, width=None,
-                           height=None, verbose=False, columns=[]):
+                           height=None, verbose=False, columns=()):
         """Launches a job (async)
         TAP & TAP+
 
@@ -499,7 +499,7 @@ class GaiaClass(TapPlus):
             box height
         verbose : bool, optional, default 'False'
             flag to display information about the process
-        columns: list, optional, default []
+        columns: list, optional, default ()
             if empty, all columns will be selected
 
         Returns
@@ -515,9 +515,9 @@ class GaiaClass(TapPlus):
                       dec_column_name=MAIN_GAIA_TABLE_DEC,
                       async_job=False,
                       background=False,
-                      output_file=None, output_format="votable", verbose=False,
+                      output_file=None, output_format="votable_gzip", verbose=False,
                       dump_to_file=False,
-                      columns=[]):
+                      columns=()):
         """Cone search sorted by distance
         TAP & TAP+
 
@@ -541,13 +541,14 @@ class GaiaClass(TapPlus):
         output_file : str, optional, default None
             file name where the results are saved if dumpToFile is True.
             If this parameter is not provided, the jobid is used instead
-        output_format : str, optional, default 'votable'
-            results format
+        output_format : str, optional, default 'votable_gzip'
+            results format. Available formats are: 'votable', 'votable_plain',
+             'fits', 'csv', 'ecsv' and 'json', default is 'votable'.
         verbose : bool, optional, default 'False'
             flag to display information about the process
         dump_to_file : bool, optional, default 'False'
             if True, the results are saved in a file instead of using memory
-        columns: list, optional, default []
+        columns: list, optional, default ()
             if empty, all columns will be selected
 
         Returns
@@ -608,9 +609,9 @@ class GaiaClass(TapPlus):
                     ra_column_name=MAIN_GAIA_TABLE_RA,
                     dec_column_name=MAIN_GAIA_TABLE_DEC,
                     output_file=None,
-                    output_format="votable", verbose=False,
+                    output_format="votable_gzip", verbose=False,
                     dump_to_file=False,
-                    columns=[]):
+                    columns=()):
         """Cone search sorted by distance (sync.)
         TAP & TAP+
 
@@ -628,13 +629,14 @@ class GaiaClass(TapPlus):
         output_file : str, optional, default None
             file name where the results are saved if dumpToFile is True.
             If this parameter is not provided, the jobid is used instead
-        output_format : str, optional, default 'votable'
-            results format
+        output_format : str, optional, default 'votable_gzip'
+            results format. Available formats are: 'votable', 'votable_plain',
+             'fits', 'csv', 'ecsv' and 'json', default is 'votable'.
         verbose : bool, optional, default 'False'
             flag to display information about the process
         dump_to_file : bool, optional, default 'False'
             if True, the results are saved in a file instead of using memory
-        columns: list, optional, default []
+        columns: list, optional, default ()
             if empty, all columns will be selected
 
         Returns
@@ -658,8 +660,8 @@ class GaiaClass(TapPlus):
                           ra_column_name=MAIN_GAIA_TABLE_RA,
                           dec_column_name=MAIN_GAIA_TABLE_DEC,
                           background=False,
-                          output_file=None, output_format="votable",
-                          verbose=False, dump_to_file=False, columns=[]):
+                          output_file=None, output_format="votable_gzip",
+                          verbose=False, dump_to_file=False, columns=()):
         """Cone search sorted by distance (async)
         TAP & TAP+
 
@@ -681,12 +683,15 @@ class GaiaClass(TapPlus):
         output_file : str, optional, default None
             file name where the results are saved if dumpToFile is True.
             If this parameter is not provided, the jobid is used instead
-        output_format : str, optional, default 'votable'
-            results format
+        output_format : str, optional, default 'votable_gzip'
+            results format. Available formats are: 'votable', 'votable_plain',
+             'fits', 'csv', 'ecsv' and 'json', default is 'votable'.
         verbose : bool, optional, default 'False'
             flag to display information about the process
         dump_to_file : bool, optional, default 'False'
             if True, the results are saved in a file instead of using memory
+        columns: list, optional, default ()
+            if empty, all columns will be selected
 
         Returns
         -------
@@ -787,6 +792,9 @@ class GaiaClass(TapPlus):
             a table name without schema. The schema is set to the user one
         radius : float (arc. seconds), optional, default 1.0
             radius  (valid range: 0.1-10.0)
+        background : bool, optional, default 'False'
+            when the job is executed in asynchronous mode, this flag specifies
+            whether the execution will wait until results are available
         verbose : bool, optional, default 'False'
             flag to display information about the process
 
@@ -819,7 +827,7 @@ class GaiaClass(TapPlus):
         return self.launch_job_async(query=query,
                                      name=name,
                                      output_file=None,
-                                     output_format="votable",
+                                     output_format="votable_gzip",
                                      verbose=verbose,
                                      dump_to_file=False,
                                      background=background,
@@ -827,7 +835,7 @@ class GaiaClass(TapPlus):
                                      upload_table_name=None)
 
     def launch_job(self, query, *, name=None, output_file=None,
-                   output_format="votable", verbose=False,
+                   output_format="votable_gzip", verbose=False,
                    dump_to_file=False, upload_resource=None,
                    upload_table_name=None):
         """Launches a synchronous job
@@ -841,10 +849,10 @@ class GaiaClass(TapPlus):
         output_file : str, optional, default None
             file name where the results are saved if dumpToFile is True.
             If this parameter is not provided, the jobid is used instead
-        output_format : str, optional, default 'votable'
-            results format. Available formats are: 'votable', 'votable_plain',
-             'fits', 'csv', 'ecsv' and 'json', default is 'votable'.
-             Returned results for 'votable' and 'fits' formats are compressed
+        output_format : str, optional, default 'votable_gzip'
+            results format. Available formats are: 'votable_gzip', 'votable', 'votable_plain',
+             'fits', 'csv', 'ecsv' and 'json', default is 'votable_gzip'.
+             Returned results for 'votable_gzip', 'ecsv' and 'fits' formats are compressed
              gzip files.
         verbose : bool, optional, default 'False'
             flag to display information about the process
@@ -867,10 +875,10 @@ class GaiaClass(TapPlus):
                                   verbose=verbose,
                                   dump_to_file=dump_to_file,
                                   upload_resource=upload_resource,
-                                  upload_table_name=upload_table_name)
+                                  upload_table_name=upload_table_name, format_with_results_compressed=('votable_gzip','fits','ecsv'))
 
     def launch_job_async(self, query, *, name=None, output_file=None,
-                         output_format="votable", verbose=False,
+                         output_format="votable_gzip", verbose=False,
                          dump_to_file=False, background=False,
                          upload_resource=None, upload_table_name=None,
                          autorun=True):
@@ -885,10 +893,10 @@ class GaiaClass(TapPlus):
         output_file : str, optional, default None
             file name where the results are saved if dumpToFile is True.
             If this parameter is not provided, the jobid is used instead
-        output_format : str, optional, default 'votable'
-            results format. Available formats are: 'votable', 'votable_plain',
-             'fits', 'csv' and 'json', default is 'votable'.
-             Returned results for 'votable' 'ecsv' and 'fits' format are compressed
+        output_format : str, optional, default 'votable_gzip'
+            results format. Available formats are: 'votable_gzip', 'votable', 'votable_plain',
+             'fits', 'csv' and 'json', default is 'votable_gzip'.
+             Returned results for 'votable_gzip' 'ecsv' and 'fits' format are compressed
              gzip files.
         verbose : bool, optional, default 'False'
             flag to display information about the process
@@ -919,16 +927,16 @@ class GaiaClass(TapPlus):
                                         background=background,
                                         upload_resource=upload_resource,
                                         upload_table_name=upload_table_name,
-                                        autorun=autorun)
+                                        autorun=autorun, format_with_results_compressed=('votable_gzip','fits','ecsv'))
 
     def get_status_messages(self):
         """Retrieve the messages to inform users about
         the status of Gaia TAP
         """
         try:
-            subContext = self.GAIA_MESSAGES
-            connHandler = self._TapPlus__getconnhandler()
-            response = connHandler.execute_tapget(subContext, verbose=False)
+            sub_context = self.GAIA_MESSAGES
+            conn_handler = self._TapPlus__getconnhandler()
+            response = conn_handler.execute_tapget(sub_context, verbose=False)
             if response.status == 200:
                 if isinstance(response, Iterable):
                     for line in response:

--- a/astroquery/gaia/tests/test_gaiatap.py
+++ b/astroquery/gaia/tests/test_gaiatap.py
@@ -178,7 +178,7 @@ def test_load_data(monkeypatch, tmp_path):
         assert params_dict == {
             "VALID_DATA": "true",
             "ID": "1,2,3,4",
-            "FORMAT": "votable",
+            "FORMAT": "votable_gzip",
             "RETRIEVAL_TYPE": "epoch_photometry",
             "DATA_STRUCTURE": "INDIVIDUAL",
             "USE_ZIP_ALWAYS": "true"}
@@ -201,7 +201,7 @@ def test_load_data_linking_parameter(monkeypatch, tmp_path):
         assert params_dict == {
             "VALID_DATA": "true",
             "ID": "1,2,3,4",
-            "FORMAT": "votable",
+            "FORMAT": "votable_gzip",
             "RETRIEVAL_TYPE": "epoch_photometry",
             "DATA_STRUCTURE": "INDIVIDUAL",
             "LINKING_PARAMETER": "TRANSIT_ID",

--- a/astroquery/utils/tap/conn/tapconn.py
+++ b/astroquery/utils/tap/conn/tapconn.py
@@ -587,11 +587,14 @@ class TapConn:
             if p >= 0:
                 filename = os.path.basename(content_disposition[p+10:len(content_disposition)-1])
                 content_encoding = self.find_header(headers, 'Content-Encoding')
+
                 if content_encoding is not None:
-                    if "gzip" == content_encoding.lower():
-                        filename += ".gz"
-                    elif "zip" == content_encoding.lower():
-                        filename += ".zip"
+                    if not (filename.endswith('.gz') or filename.endswith('.zip')):
+                        if "gzip" == content_encoding.lower():
+                            filename += ".gz"
+                        elif "zip" == content_encoding.lower():
+                            filename += ".zip"
+
                 return filename
         return None
 

--- a/astroquery/utils/tap/core.py
+++ b/astroquery/utils/tap/core.py
@@ -273,8 +273,7 @@ class Tap:
         A Job object
         """
         output_file_updated = taputils.get_suitable_output_file_name_for_current_output_format(output_file,
-                                                                                               output_format,
-                                                                                               format_with_results_compressed=format_with_results_compressed)
+            output_format,format_with_results_compressed=format_with_results_compressed)
 
         query = taputils.set_top_in_query(query, 2000)
         if verbose:

--- a/astroquery/utils/tap/core.py
+++ b/astroquery/utils/tap/core.py
@@ -272,8 +272,10 @@ class Tap:
         -------
         A Job object
         """
-        output_file_updated = taputils.get_suitable_output_file_name_for_current_output_format(output_file,
-            output_format, format_with_results_compressed=format_with_results_compressed)
+        output_file_updated = taputils.get_suitable_output_file_name_for_current_output_format(
+            output_file,
+            output_format,
+            format_with_results_compressed=format_with_results_compressed)
 
         query = taputils.set_top_in_query(query, 2000)
         if verbose:
@@ -402,9 +404,10 @@ class Tap:
         A Job object
         """
 
-        output_file_updated = taputils.get_suitable_output_file_name_for_current_output_format(output_file,
-                                                                                               output_format,
-                                                                                               format_with_results_compressed=format_with_results_compressed)
+        output_file_updated = taputils.get_suitable_output_file_name_for_current_output_format(
+            output_file,
+            output_format,
+            format_with_results_compressed=format_with_results_compressed)
 
         if verbose:
             print(f"Launched query: '{query}'")

--- a/astroquery/utils/tap/core.py
+++ b/astroquery/utils/tap/core.py
@@ -230,7 +230,7 @@ class Tap:
         if isError:
             log.info(f"{response.status} {response.reason}")
             raise requests.exceptions.HTTPError(response.reason)
-            return None
+
         log.info("Parsing tables...")
         tsp = TableSaxParser()
         tsp.parseData(response)
@@ -238,9 +238,9 @@ class Tap:
         return tsp.get_tables()
 
     def launch_job(self, query, *, name=None, output_file=None,
-                   output_format="votable", verbose=False,
+                   output_format="votable_gzip", verbose=False,
                    dump_to_file=False, upload_resource=None,
-                   upload_table_name=None, maxrec=None):
+                   upload_table_name=None, maxrec=None, format_with_results_compressed=('votable', 'fits', 'ecsv')):
         """Launches a synchronous job
 
         Parameters
@@ -265,13 +265,17 @@ class Tap:
             This argument is required if upload_resource is provided.
         maxrec : int, optional, default None
             maximum number of rows to return (TAP ``MAXREC`` parameter)
+        format_with_results_compressed: tuple, zipped result formats
+            list of result formats that are returned as zipped files
 
         Returns
         -------
         A Job object
         """
         output_file_updated = taputils.get_suitable_output_file_name_for_current_output_format(output_file,
-                                                                                               output_format)
+                                                                                               output_format,
+                                                                                               format_with_results_compressed=format_with_results_compressed)
+
         query = taputils.set_top_in_query(query, 2000)
         if verbose:
             print(f"Launched query: '{query}'")
@@ -322,6 +326,7 @@ class Tap:
                                                                headers,
                                                                isError,
                                                                output_format)
+
         job.outputFile = suitableOutputFile
         job.outputFileUser = output_file
         job.parameters['format'] = output_format
@@ -356,10 +361,10 @@ class Tap:
         return job
 
     def launch_job_async(self, query, *, name=None, output_file=None,
-                         output_format="votable", verbose=False,
+                         output_format="votable_gzip", verbose=False,
                          dump_to_file=False, background=False,
                          upload_resource=None, upload_table_name=None,
-                         autorun=True, maxrec=None):
+                         autorun=True, maxrec=None, format_with_results_compressed=('votable', 'fits', 'ecsv')):
         """Launches an asynchronous job
 
         Parameters
@@ -372,7 +377,7 @@ class Tap:
             file name where the results are saved if dumpToFile is True.
             If this parameter is not provided, the jobid is used instead
         output_format : str, optional, default 'votable'
-            results format
+            result formats
         verbose : bool, optional, default 'False'
             flag to display information about the process
         dump_to_file : bool, optional, default 'False'
@@ -390,6 +395,8 @@ class Tap:
             so the framework can start the job.
         maxrec : int, optional, default None
             maximum number of rows to return (TAP ``MAXREC`` parameter)
+        format_with_results_compressed: tuple, zipped result formats
+            list of result formats that are returned as zipped files
 
         Returns
         -------
@@ -397,7 +404,8 @@ class Tap:
         """
 
         output_file_updated = taputils.get_suitable_output_file_name_for_current_output_format(output_file,
-                                                                                               output_format)
+                                                                                               output_format,
+                                                                                               format_with_results_compressed=format_with_results_compressed)
 
         if verbose:
             print(f"Launched query: '{query}'")
@@ -512,7 +520,7 @@ class Tap:
         if isError:
             log.info(response.reason)
             raise requests.exceptions.HTTPError(response.reason)
-            return None
+
         # parse job
         jsp = JobSaxParser(async_job=True)
         job = jsp.parseData(response)[0]
@@ -546,7 +554,7 @@ class Tap:
         if isError:
             log.info(response.reason)
             raise requests.exceptions.HTTPError(response.reason)
-            return None
+
         # parse jobs
         jsp = JobListSaxParser(async_job=True)
         jobs = jsp.parseData(response)
@@ -1507,7 +1515,7 @@ class TapPlus(Tap):
             j = self.load_async_job(jobid=job, load_results=False)
             if j is None:
                 raise ValueError(f"Job {job} not found")
-                return
+
             description = j.parameters['query']
         if table_name is None:
             table_name = f"t{j.jobid}"
@@ -1652,7 +1660,7 @@ class TapPlus(Tap):
             }
         return args
 
-    def update_user_table(self, *, table_name=None, list_of_changes=[],
+    def update_user_table(self, *, table_name=None, list_of_changes=(),
                           verbose=False):
         """Updates a user table
 

--- a/astroquery/utils/tap/core.py
+++ b/astroquery/utils/tap/core.py
@@ -273,7 +273,7 @@ class Tap:
         A Job object
         """
         output_file_updated = taputils.get_suitable_output_file_name_for_current_output_format(output_file,
-            output_format,format_with_results_compressed=format_with_results_compressed)
+            output_format, format_with_results_compressed=format_with_results_compressed)
 
         query = taputils.set_top_in_query(query, 2000)
         if verbose:

--- a/astroquery/utils/tap/core.py
+++ b/astroquery/utils/tap/core.py
@@ -238,7 +238,7 @@ class Tap:
         return tsp.get_tables()
 
     def launch_job(self, query, *, name=None, output_file=None,
-                   output_format="votable_gzip", verbose=False,
+                   output_format="votable", verbose=False,
                    dump_to_file=False, upload_resource=None,
                    upload_table_name=None, maxrec=None, format_with_results_compressed=('votable', 'fits', 'ecsv')):
         """Launches a synchronous job
@@ -362,7 +362,7 @@ class Tap:
         return job
 
     def launch_job_async(self, query, *, name=None, output_file=None,
-                         output_format="votable_gzip", verbose=False,
+                         output_format="votable", verbose=False,
                          dump_to_file=False, background=False,
                          upload_resource=None, upload_table_name=None,
                          autorun=True, maxrec=None, format_with_results_compressed=('votable', 'fits', 'ecsv')):

--- a/astroquery/utils/tap/taputils.py
+++ b/astroquery/utils/tap/taputils.py
@@ -256,7 +256,8 @@ def get_suitable_output_file_name_for_current_output_format(output_file, output_
         'fits', 'csv', 'ecsv' and 'json'. Default is 'votable'.
         Returned results for formats 'votable' 'ecsv' and 'fits' are compressed
         gzip files.
-    format_with_results_compressed: a set of output formats
+    format_with_results_compressed : tuple of str, optional
+        a set of output formats
 
     Returns
     -------

--- a/astroquery/utils/tap/taputils.py
+++ b/astroquery/utils/tap/taputils.py
@@ -269,9 +269,9 @@ def get_suitable_output_file_name_for_current_output_format(output_file, output_
         if output_format in format_with_results_compressed:
             # In this case we will have to take also into account the .fits format
             if not output_file.endswith(compressed_extension):
-                warnings.warn('By default, results in ' + ", ".join(format_with_results_compressed) +
-                              f' format are returned in compressed format therefore your file {output_file} '
-                              f'will be renamed to {output_file}.gz')
+                warnings.warn('By default, results in ' + ", ".join(
+                    format_with_results_compressed) + f' format are returned in compressed format therefore your file '
+                                                      f'{output_file} will be renamed to {output_file}.gz')
                 if output_format == 'votable':
                     if output_file.endswith('.vot'):
                         output_file_with_extension = output_file + '.gz'

--- a/astroquery/utils/tap/taputils.py
+++ b/astroquery/utils/tap/taputils.py
@@ -242,7 +242,8 @@ def get_suitable_output_file(conn_handler, async_job, output_file, headers,
     return file_name
 
 
-def get_suitable_output_file_name_for_current_output_format(output_file, output_format):
+def get_suitable_output_file_name_for_current_output_format(output_file, output_format, *,
+                                                            format_with_results_compressed=('votable', 'fits', 'ecsv')):
     """
     Renames the name given for the output_file if the results for current_output
     format are returned compressed by default
@@ -255,20 +256,20 @@ def get_suitable_output_file_name_for_current_output_format(output_file, output_
         'fits', 'csv', 'ecsv' and 'json'. Default is 'votable'.
         Returned results for formats 'votable' 'ecsv' and 'fits' are compressed
         gzip files.
+    format_with_results_compressed: a set of output formats
 
     Returns
     -------
     A string with the new name for the file.
     """
     compressed_extension = ".gz"
-    format_with_results_compressed = ['votable', 'fits', 'ecsv']
     output_file_with_extension = output_file
 
     if output_file is not None:
         if output_format in format_with_results_compressed:
             # In this case we will have to take also into account the .fits format
             if not output_file.endswith(compressed_extension):
-                warnings.warn('By default, results in "votable", "ecsv" and "fits" format are returned in '
+                warnings.warn('By default, results in ' + ", ".join(format_with_results_compressed) + ' format are returned in '
                               f'compressed format therefore your file {output_file} '
                               f'will be renamed to {output_file}.gz')
                 if output_format == 'votable':

--- a/astroquery/utils/tap/taputils.py
+++ b/astroquery/utils/tap/taputils.py
@@ -269,8 +269,8 @@ def get_suitable_output_file_name_for_current_output_format(output_file, output_
         if output_format in format_with_results_compressed:
             # In this case we will have to take also into account the .fits format
             if not output_file.endswith(compressed_extension):
-                warnings.warn('By default, results in ' + ", ".join(format_with_results_compressed) + ' format are returned in '
-                              f'compressed format therefore your file {output_file} '
+                warnings.warn('By default, results in ' + ", ".join(format_with_results_compressed) +
+                              f' format are returned in compressed format therefore your file {output_file} '
                               f'will be renamed to {output_file}.gz')
                 if output_format == 'votable':
                     if output_file.endswith('.vot'):

--- a/astroquery/utils/tap/tests/test_tap.py
+++ b/astroquery/utils/tap/tests/test_tap.py
@@ -153,7 +153,7 @@ def test_launch_sync_job():
     dictTmp = {
         "REQUEST": "doQuery",
         "LANG": "ADQL",
-        "FORMAT": "votable",
+        "FORMAT": "votable_gzip",
         "tapclient": str(tap.tap_client_id),
         "PHASE": "RUN",
         "QUERY": quote_plus(query)}
@@ -207,7 +207,7 @@ def test_launch_sync_job_secure():
     dictTmp = {
         "REQUEST": "doQuery",
         "LANG": "ADQL",
-        "FORMAT": "votable",
+        "FORMAT": "votable_gzip",
         "tapclient": str(tap.tap_client_id),
         "PHASE": "RUN",
         "QUERY": quote_plus(query)}
@@ -267,7 +267,7 @@ def test_launch_sync_job_redirect():
     dictTmp = {
         "REQUEST": "doQuery",
         "LANG": "ADQL",
-        "FORMAT": "votable",
+        "FORMAT": "votable_gzip",
         "tapclient": str(tap.tap_client_id),
         "PHASE": "RUN",
         "QUERY": quote_plus(query)}
@@ -347,7 +347,7 @@ def test_launch_async_job():
     dictTmp = {
         "REQUEST": "doQuery",
         "LANG": "ADQL",
-        "FORMAT": "votable",
+        "FORMAT": "votable_gzip",
         "tapclient": str(tap.tap_client_id),
         "PHASE": "RUN",
         "QUERY": str(query)}
@@ -428,7 +428,7 @@ def test_start_job():
     dictTmp = {
         "REQUEST": "doQuery",
         "LANG": "ADQL",
-        "FORMAT": "votable",
+        "FORMAT": "votable_gzip",
         "tapclient": str(tap.tap_client_id),
         "QUERY": str(query)}
     sortedKey = taputils.taputil_create_sorted_dict_key(dictTmp)
@@ -483,7 +483,7 @@ def test_abort_job():
     dictTmp = {
         "REQUEST": "doQuery",
         "LANG": "ADQL",
-        "FORMAT": "votable",
+        "FORMAT": "votable_gzip",
         "MAXREC": 10,
         "tapclient": str(tap.tap_client_id),
         "QUERY": str(query)}
@@ -517,7 +517,7 @@ def test_job_parameters():
     dictTmp = {
         "REQUEST": "doQuery",
         "LANG": "ADQL",
-        "FORMAT": "votable",
+        "FORMAT": "votable_gzip",
         "MAXREC": 10,
         "tapclient": str(tap.tap_client_id),
         "QUERY": str(query)}

--- a/astroquery/utils/tap/tests/test_tap.py
+++ b/astroquery/utils/tap/tests/test_tap.py
@@ -153,7 +153,7 @@ def test_launch_sync_job():
     dictTmp = {
         "REQUEST": "doQuery",
         "LANG": "ADQL",
-        "FORMAT": "votable_gzip",
+        "FORMAT": "votable",
         "tapclient": str(tap.tap_client_id),
         "PHASE": "RUN",
         "QUERY": quote_plus(query)}
@@ -207,7 +207,7 @@ def test_launch_sync_job_secure():
     dictTmp = {
         "REQUEST": "doQuery",
         "LANG": "ADQL",
-        "FORMAT": "votable_gzip",
+        "FORMAT": "votable",
         "tapclient": str(tap.tap_client_id),
         "PHASE": "RUN",
         "QUERY": quote_plus(query)}
@@ -267,7 +267,7 @@ def test_launch_sync_job_redirect():
     dictTmp = {
         "REQUEST": "doQuery",
         "LANG": "ADQL",
-        "FORMAT": "votable_gzip",
+        "FORMAT": "votable",
         "tapclient": str(tap.tap_client_id),
         "PHASE": "RUN",
         "QUERY": quote_plus(query)}
@@ -347,7 +347,7 @@ def test_launch_async_job():
     dictTmp = {
         "REQUEST": "doQuery",
         "LANG": "ADQL",
-        "FORMAT": "votable_gzip",
+        "FORMAT": "votable",
         "tapclient": str(tap.tap_client_id),
         "PHASE": "RUN",
         "QUERY": str(query)}
@@ -428,7 +428,7 @@ def test_start_job():
     dictTmp = {
         "REQUEST": "doQuery",
         "LANG": "ADQL",
-        "FORMAT": "votable_gzip",
+        "FORMAT": "votable",
         "tapclient": str(tap.tap_client_id),
         "QUERY": str(query)}
     sortedKey = taputils.taputil_create_sorted_dict_key(dictTmp)
@@ -483,7 +483,7 @@ def test_abort_job():
     dictTmp = {
         "REQUEST": "doQuery",
         "LANG": "ADQL",
-        "FORMAT": "votable_gzip",
+        "FORMAT": "votable",
         "MAXREC": 10,
         "tapclient": str(tap.tap_client_id),
         "QUERY": str(query)}
@@ -517,7 +517,7 @@ def test_job_parameters():
     dictTmp = {
         "REQUEST": "doQuery",
         "LANG": "ADQL",
-        "FORMAT": "votable_gzip",
+        "FORMAT": "votable",
         "MAXREC": 10,
         "tapclient": str(tap.tap_client_id),
         "QUERY": str(query)}

--- a/astroquery/utils/tap/xmlparser/utils.py
+++ b/astroquery/utils/tap/xmlparser/utils.py
@@ -48,7 +48,7 @@ def get_suitable_astropy_format(output_format):
         return 'ascii.ecsv'
     elif 'csv' == output_format:
         return 'ascii.csv'
-    elif 'votable_plain' == output_format:
+    elif 'votable_plain' == output_format or 'votable_gzip' == output_format:
         return 'votable'
     return output_format
 


### PR DESCRIPTION
Recently ESAC has release the new 9.6.0 TAP library, that has been tested in the gaia DEVELOPMENT environment (https://geadev.esac.esa.int/). The changes in the TAP library imply that:

1. now  for the output format _votable_, an uncompressed votable file is returned. With Content-Type: application/x-votable+xml
2. the new output format _votable\_gzip_ was introduced, to return compressed votable files. With Content-Encoding: gzip and Content-Type: application/x-votable+gzip
3. for the output format ecsv, a compressed file is returned. With Content-Encoding: gzip and Content-Type: text/ecsv+gzip.

This implies the following issues in astroquery:

```
from astroquery.gaia import GaiaClass

gaia = GaiaClass(gaia_tap_server='https://geadev.esac.esa.int/')

job = gaia.launch_job("select top 100 solution_id,ref_epoch,ra_dec_corr,astrometric_n_obs_al, matched_transits,duplicated_source,phot_variable_flag from gaiadr3.gaia_source order by source_id", dump_to_file=True, output_format='votable_gzip')

job = gaia.launch_job("select top 100 solution_id,ref_epoch,ra_dec_corr,astrometric_n_obs_al, matched_transits,duplicated_source,phot_variable_flag from gaiadr3.gaia_source order by source_id", dump_to_file=True, output_format='ecsv')
```

The name of the output files are 1698154295940D-result.**vot.gz.gz** and 698154295940D-result.**ecsv.gz.gz**, respectively.

The issue is located in:

1. the method get_file_from_header in utils/tap/conn/tapconn.py. The function astroquery/utils/tap/conn/tapconn.py/get_file_from_header is called from astroquery/utils/tap/conn/tapconn.py/get_suitable_output_file
2.  get_suitable_output_file_name_for_current_output_format in utils/tap/taputils.py. This is only used in utils/tap/core.py:
      1.    launch_job
      2.    launch_job_async

Note the the proposed  solution is backward compatible for those ESAC archives that do not use the new 9.6.0 TAP library.



Note that the new 9.6.0 TAP library will use in the gaia PRODUCTION environment by February 2024.



cc @esdc-esac-esa-int