### PR TITLE
Gaia: Update contact email included in the gaia documentation [ci skip]

### DIFF
--- a/astroquery/gaia/__init__.py
+++ b/astroquery/gaia/__init__.py
@@ -4,14 +4,8 @@
 Gaia TAP plus
 =============
 
-@author: Juan Carlos Segovia
-@contact: juan.carlos.segovia@sciops.esa.int
-
 European Space Astronomy Centre (ESAC)
 European Space Agency (ESA)
-
-Created on 30 jun. 2016
-
 
 """
 from astropy import config as _config

--- a/docs/gaia/gaia.rst
+++ b/docs/gaia/gaia.rst
@@ -63,13 +63,13 @@ This python module provides an Astroquery API access that implements the
 The Gaia Archive table used for the methods where no table is specified is
 the latest data release catalogue.
 
-========
+
 Examples
 ========
 
----------------------------
+
 1. Public access
----------------------------
+----------------
 
 1.1. Query object
 ^^^^^^^^^^^^^^^^^
@@ -150,7 +150,6 @@ To return an unlimited number of rows set ``Gaia.ROW_LIMIT`` to -1.
     0.05321040019668312 1636148068921376768 Gaia DR3 6633086847005369088 ...                 0.0003                 0.0043           MARCS
   Length = 184 rows
 
-
 1.2. Cone search
 ^^^^^^^^^^^^^^^^
 
@@ -182,7 +181,6 @@ radius argument.
   1636148068921376768 Gaia DR3 6636089514478677504 ...  0.019967388048343956
   1636148068921376768 Gaia DR3 6636066871411763968 ...  0.020149893249057697
   Length = 50 rows
-
 
 1.3. Getting public tables metadata
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -359,7 +357,6 @@ Note: you can inspect the status of the job by typing:
   Output file: 1668864127567O-result.vot.gz
   Results: None
 
-
 1.5. Synchronous query on an 'on-the-fly' uploaded table
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
@@ -434,7 +431,6 @@ available formats are: 'votable', 'votable_plain', 'fits', 'csv' and 'json', def
   Output file: 1611860482314O-result.vot.gz
   Results: None
 
-
 1.7. Asynchronous job removal
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
@@ -444,9 +440,8 @@ To remove asynchronous jobs::
   >>> Gaia.remove_jobs(["job_id_1","job_id_2",...])
 
 
----------------------------
 2. Authenticated access
----------------------------
+-----------------------
 
 Authenticated users are able to access to TAP+ capabilities (shared tables, persistent jobs, etc.)
 In order to authenticate a user, ``login`` or ``login_gui`` methods must be called. After a
@@ -459,7 +454,6 @@ The main differences are:
 
 * Asynchronous results are kept at server side for ever (until the user decides to remove one of them).
 * Users can access to shared tables.
-
 
 2.1. Login/Logout
 ^^^^^^^^^^^^^^^^^
@@ -510,8 +504,6 @@ To logout::
 
   >>> Gaia.logout()
 
-
-
 2.2. Listing shared tables
 ^^^^^^^^^^^^^^^^^^^^^^^^^^
 
@@ -549,7 +541,6 @@ Each user has a database schema described as: 'user_<user_login_name>'. For inst
 login name is 'joe', the database schema is 'user_joe'. Your uploaded table can be
 referenced as 'user_joe.table_name'
 
-
 2.3.1. Uploading table from URL
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
@@ -578,7 +569,6 @@ i.e.: *user_<your_login_name>.<table_name>*)::
   >>> job = Gaia.launch_job(query=query)
   >>> results = job.get_results()
 
-
 2.3.2. Uploading table from file
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
@@ -606,7 +596,6 @@ i.e.: *user_<your_login_name>.<table_name>*)::
   >>> job = Gaia.launch_job(query=query)
   >>> results = job.get_results()
 
-
 2.3.3. Uploading table from an astropy Table
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
@@ -633,8 +622,6 @@ i.e.: *user_<your_login_name>.<table_name>*)::
   >>> query = 'select * from ' + full_qualified_table_name
   >>> job = Gaia.launch_job(query=query)
   >>> results = job.get_results()
-
-
 
 2.3.4. Uploading table from job
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -668,7 +655,6 @@ A table from the user private area can be deleted as follows::
   >>> Gaia.login_gui()
   >>> job = Gaia.delete_user_table("table_test_from_file")
   Table 'table_test_from_file' deleted.
-
 
 2.5. Updating table metadata
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -774,8 +760,6 @@ Once you have your cross match finished, you can obtain the results::
 
 Cross-matching catalogues is one of the most popular operations executed in the Gaia archive.
 
-
-
 2.7. Tables sharing
 ^^^^^^^^^^^^^^^^^^^
 
@@ -830,7 +814,6 @@ will be able to access to your shared table in a query.
   >>> Gaia.login()
   >>> Gaia.share_group_delete_user(group_name="my_group",user_id="<user_login_name>")
 
-
 2.7.6. Sharing a table to a group
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
@@ -842,7 +825,6 @@ will be able to access to your shared table in a query.
   ...                  table_name="user_<user_login_name>.my_table",
   ...                  description="description")
 
-
 2.7.7. Stop sharing a table
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
@@ -853,10 +835,8 @@ will be able to access to your shared table in a query.
   >>> Gaia.share_table_stop(table_name="user_<user_login_name>.my_table", group_name="my_group")
 
 
-----------------------------------------------
 3. Datalink service (Public and Authenticated)
 ----------------------------------------------
-
 
 DataLink_ is a data access protocol compliant with the IVOA_ architecture that provides a linking mechanism between
 datasets offered by different services. In practice, it can be seen and used as a web service providing the list of additional

--- a/docs/gaia/gaia.rst
+++ b/docs/gaia/gaia.rst
@@ -83,7 +83,7 @@ It is possible to choose which data release to query, by default the Gaia DR3 ca
   >>> Gaia.MAIN_GAIA_TABLE = "gaiadr3.gaia_source"  # Reselect Data Release 3, default
 
 The following example searches for all the sources contained in an squared region of side = 0.1
-degrees around an specific point in RA/Dec coordinates.
+degrees around an specific point in RA/Dec coordinates. The results are sorted by distance (``dist``) in ascending order.
 
 .. doctest-remote-data::
 
@@ -853,7 +853,7 @@ will be able to access to your shared table in a query.
   >>> Gaia.share_table_stop(table_name="user_<user_login_name>.my_table", group_name="my_group")
 
 
-
+----------------------------------------------
 3. Datalink service (Public and Authenticated)
 ----------------------------------------------
 


### PR DESCRIPTION
In order to keep a coherent format for the ESAC projects, we would like to update the gaia documentation, removing the contact email address that is included at the bottom of the document. Moreover, the included email is obsolete.

![image](https://github.com/astropy/astroquery/assets/19255991/90d75465-8e1d-4e03-98b2-dcdf7fec2d75)


cc @esdc-esac-esa-int

