### PR TITLE
BUG: MAST: update query_criteria to use page params

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -223,6 +223,8 @@ mast
 
 - Updating documentation to address the difference between ``obsid`` and ``obs_id`` database fields. [#2857]
 
+- Bug fix in ``Observations.query_criteria()`` to use ``page`` and ``pagesize`` parameters [#2915]
+
 nist
 ^^^^
 

--- a/astroquery/mast/observations.py
+++ b/astroquery/mast/observations.py
@@ -291,7 +291,7 @@ class ObservationsClass(MastQueryWithLogin):
             params = {"columns": "*",
                       "filters": mashup_filters}
 
-        return self._portal_api_connection.service_request_async(service, params)
+        return self._portal_api_connection.service_request_async(service, params, pagesize=pagesize, page=page)
 
     def query_region_count(self, coordinates, *, radius=0.2*u.deg, pagesize=None, page=None):
         """


### PR DESCRIPTION
Bug fix for `astroquery.mast.Observations`, where `query_criteria` was not using the `page` and `pagesize` kwargs

Resolves Issue https://github.com/astropy/astroquery/issues/2788