### PR TITLE
Fix issue 2889: NIST wl keyword

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -231,8 +231,9 @@ mast
 nist
 ^^^^
 
-- Vectoized ``linename`` option to query multiple spectral lines with one call
+- Vectorized ``linename`` option to query multiple spectral lines with one call
   of ``Nist.query``. [#2678]
+- Fix wavelength keywords, which were changed upstream [#2918]
 
 oac
 ^^^

--- a/astroquery/nist/core.py
+++ b/astroquery/nist/core.py
@@ -88,15 +88,15 @@ class NistClass(BaseQuery):
         linename = kwargs["linename"]
         request_payload["spectra"] = linename if isinstance(linename, str) else "; ".join(linename)
         (min_wav, max_wav, wav_unit) = _parse_wavelength(args[0], args[1])
-        request_payload["low_wl"] = min_wav
-        request_payload["upp_wl"] = max_wav
+        request_payload["low_w"] = min_wav
+        request_payload["upp_w"] = max_wav
         request_payload["unit"] = wav_unit
         request_payload["submit"] = "Retrieve Data"
         request_payload["format"] = 1  # ascii
         request_payload["line_out"] = 0  # All lines
         request_payload["en_unit"] = Nist.energy_level_code[
             kwargs["energy_level_unit"]]
-        request_payload["output"] = 0  # entirely rather than pagewise
+        request_payload["output_type"] = 0  # entirely rather than pagewise
         request_payload["bibrefs"] = 1
         request_payload["show_obs_wl"] = 1
         request_payload["show_calc_wl"] = 1

--- a/astroquery/nist/tests/test_nist_remote.py
+++ b/astroquery/nist/tests/test_nist_remote.py
@@ -12,11 +12,11 @@ from ... import nist
 class TestNist:
 
     def test_query_async(self):
-        response = nist.core.Nist.query_async(4000 * u.nm, 7000 * u.nm)
+        response = nist.core.Nist.query_async(4000 * u.AA, 7000 * u.AA)
         assert response is not None
 
     def test_query(self):
-        result = nist.core.Nist.query(4000 * u.nm, 7000 * u.nm)
+        result = nist.core.Nist.query(4000 * u.AA, 7000 * u.AA)
         assert isinstance(result, Table)
 
         # check that no javascript was left in the table
@@ -30,3 +30,23 @@ class TestNist:
         # raw HTML code equivalents during parsing
         response = nist.core.Nist._parse_result(response)
         assert any('†' in s for s in response['Ei           Ek'])
+
+    def test_query_limits(self):
+        result = nist.core.Nist.query(4101 * u.AA, 4103 * u.AA)
+        # check that min, max wavelengths are appropriately set
+        assert result['Ritz'].min() >= 4101
+        assert result['Ritz'].max() <= 4103
+
+        # check that the units are respected
+        result = nist.core.Nist.query(410.1 * u.nm, 410.3 * u.nm)
+        assert result['Ritz'].min() >= 410.1
+        assert result['Ritz'].max() <= 410.3
+
+        result = nist.core.Nist.query(0.4101 * u.um, 0.4103 * u.um)
+        assert result['Ritz'].min() >= 0.4101
+        assert result['Ritz'].max() <= 0.4103
+
+        # check that non-supported units default to angstroms
+        result = nist.core.Nist.query(4101 * 1e-10 * u.m, 4103 * 1e-10 * u.m)
+        assert result['Ritz'].min() >= 4101
+        assert result['Ritz'].max() <= 4103


### PR DESCRIPTION
NIST changed the keyword specification for wavelengths at some point in the last 11 years.  This fixes the keywords that no longer seem to be supported.

 * [x] TODO: add a remote test that checks for this