### PR TITLE
DEP: flagging the SHA module for removal

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -346,6 +346,9 @@ Infrastructure, Utility and Other Changes and Additions
 
 - Removed deprecated function ``utils.download_list_of_fitsfiles()``. [#2594]
 
+- Deprecation of the module ``ipac.irsa.sha`` due to upstream API changes
+  and in favour of recommending using ``ipac.irsa`` instead. [#2924]
+
 - Versions of astropy <4.2.1 and numpy <1.18 are no longer supported. [#2602]
 
 

--- a/astroquery/ipac/irsa/sha/__init__.py
+++ b/astroquery/ipac/irsa/sha/__init__.py
@@ -11,8 +11,8 @@ found at: https://sha.ipac.caltech.edu/applications/Spitzer/SHA.
 from .core import query, save_file, get_file
 
 import warnings
-warnings.warn("Experimental: SHA has not yet been refactored to have its "
-              "API match the rest of astroquery.")
+warnings.warn("The upstream SHA API has been changed resulting this module to be broken. "
+              "Please use the main IRSA module to access Spitzer data.")
 
 
 __all__ = ['query', 'save_file', 'get_file']

--- a/astroquery/ipac/irsa/sha/tests/test_sha.py
+++ b/astroquery/ipac/irsa/sha/tests/test_sha.py
@@ -18,6 +18,7 @@ pytest.skip(allow_module_level=True,
             reason="Skip tests in this file until as the upstream API has changed and is scheduled to be removed."
             "https://github.com/astropy/astroquery/issues/2834")
 
+
 def data_path(filename):
     data_dir = os.path.join(os.path.dirname(__file__), 'data')
     return os.path.join(data_dir, filename)

--- a/astroquery/ipac/irsa/sha/tests/test_sha.py
+++ b/astroquery/ipac/irsa/sha/tests/test_sha.py
@@ -14,6 +14,10 @@ DATA_FILES = {'img': 'img.fits',
               }
 
 
+pytest.skip(allow_module_level=True,
+            reason="Skip tests in this file until as the upstream API has changed and is scheduled to be removed."
+            "https://github.com/astropy/astroquery/issues/2834")
+
 def data_path(filename):
     data_dir = os.path.join(os.path.dirname(__file__), 'data')
     return os.path.join(data_dir, filename)

--- a/astroquery/ipac/irsa/sha/tests/test_sha_remote.py
+++ b/astroquery/ipac/irsa/sha/tests/test_sha_remote.py
@@ -5,6 +5,10 @@ from astropy.table import Table
 from astroquery.ipac.irsa import sha
 from astroquery.exceptions import NoResultsWarning
 
+pytest.skip(allow_module_level=True,
+            reason="Skip tests in this file until as the upstream API has changed and is scheduled to be removed."
+            "https://github.com/astropy/astroquery/issues/2834")
+
 
 @pytest.mark.remote_data
 def test_query_no_results():

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -2,7 +2,7 @@ Astroquery
 ==========
 
 This is the documentation for the Astroquery coordinated package of `astropy
-<https://www.astropy.org>`__.
+<http://www.astropy.org>`__.
 
 Code and issue tracker are on `GitHub <https://github.com/astropy/astroquery>`_.
 
@@ -99,8 +99,8 @@ Astroquery works with Python 3.7 or later.
 
 The following packages are required for astroquery installation & use:
 
-* `numpy <https://numpy.org>`_ >= 1.18
-* `astropy <https://www.astropy.org>`__ (>=4.2.1)
+* `numpy <http://www.numpy.org>`_ >= 1.18
+* `astropy <http://www.astropy.org>`__ (>=4.2.1)
 * `pyVO`_ (>=1.1)
 * `requests <https://requests.readthedocs.io/en/latest/>`_
 * `keyring <https://pypi.python.org/pypi/keyring>`_
@@ -296,7 +296,6 @@ These others are functional, but do not follow a common & consistent API:
   ogle/ogle.rst
   open_exoplanet_catalogue/open_exoplanet_catalogue.rst
   sdss/sdss.rst
-  ipac/irsa/sha/sha.rst
 
 There are also subpackages that serve as the basis of others.
 
@@ -334,7 +333,6 @@ for each source)
   open_exoplanet_catalogue/open_exoplanet_catalogue.rst
   sdss/sdss.rst
   simbad/simbad.rst
-  ipac/irsa/sha/sha.rst
   ukidss/ukidss.rst
   vizier/vizier.rst
   vo_conesearch/vo_conesearch.rst
@@ -370,7 +368,6 @@ generally return a table listing the available data first.
   nvas/nvas.rst
   sdss/sdss.rst
   skyview/skyview.rst
-  ipac/irsa/sha/sha.rst
   ukidss/ukidss.rst
   vsa/vsa.rst
 

--- a/docs/ipac/irsa/sha/sha.rst
+++ b/docs/ipac/irsa/sha/sha.rst
@@ -1,3 +1,5 @@
+:orphan:
+
 .. _astroquery.ipac.irsa.sha:
 
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -82,6 +82,8 @@ filterwarnings =
 # Numpy 2.0 deprecations triggered by upstream libraries.
 # Exact warning messages differ, thus using a super generic filter.
     ignore:numpy.core:DeprecationWarning
+# SHA module deprecation/defunct
+    ignore:The upstream SHA API has been changed:UserWarning
 
 
 markers =


### PR DESCRIPTION
I run into failures in https://github.com/astropy/astroquery/pull/2906 coming from the SHA module, so this deprecation cannot be postponed any longer.

 The Spitzer datasets should be accessible via the more standard IRSA VO tools, the one missing step (besides actually removing the module) is to write more documentation with Spitzer examples (https://github.com/astropy/astroquery/issues/2834)

