### PR TITLE
EXP: check if upstream patch in astropy fixes devdeps

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -28,7 +28,7 @@ setenv =
 deps =
     devdeps: numpy>=0.0.dev0
     devdeps: matplotlib>=0.0.dev0
-    devdeps: astropy>=0.0.dev0
+    devdeps: git+https://github.com/neutrinoceros/astropy.git@rfc/numpy2/maskedndarray_wrap_array_early_returner
     devdeps: pyerfa>=0.0.dev0
     devdeps: git+https://github.com/astropy/pyvo.git#egg=pyvo
 


### PR DESCRIPTION
I think https://github.com/astropy/astropy/pull/15948 should resolve errors currently seen here in devdeps. Let's put that to the test.