### PR TITLE
GAIA: Include the parameter linking_parameter in the function get_datalinks

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -45,6 +45,8 @@ gaia
 
 - For the functions cone_search, cone_search_async, launch_job and launch_job_async the data can be retrieved for the json output_format [##2927]
 
+- The method ``get_datalinks`` can be used with the new parameter linking_parameter. It completes PR #2859 [#2859]
+
 
 hsa
 ^^^

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -45,7 +45,7 @@ gaia
 
 - For the functions cone_search, cone_search_async, launch_job and launch_job_async the data can be retrieved for the json output_format [##2927]
 
-- The method ``get_datalinks`` can be used with the new parameter linking_parameter. It completes PR #2859 [#2859]
+- The method ``get_datalinks`` can be used with the new parameter linking_parameter. It completes PR #2859. [#2936]
 
 
 hsa

--- a/astroquery/gaia/__init__.py
+++ b/astroquery/gaia/__init__.py
@@ -37,6 +37,8 @@ class Conf(_config.ConfigNamespace):
                                       'RVS_EPOCH',
                                       'RVS_TRANSIT']
 
+    VALID_LINKING_PARAMETERS = {'SOURCE_ID', 'TRANSIT_ID', 'IMAGE_ID'}
+
 
 conf = Conf()
 

--- a/astroquery/gaia/core.py
+++ b/astroquery/gaia/core.py
@@ -627,7 +627,7 @@ class GaiaClass(TapPlus):
             when the job is executed in asynchronous mode, this flag specifies
             whether the execution will wait until results are available
         output_file : str, optional, default None
-            file name where the results are saved if `dump_to_file` is True.
+            file name where the results are saved if ``dump_to_file`` is True.
             If this parameter is not provided, the jobid is used instead
         output_format : str, optional, default 'votable_gzip'
             results format. Available formats are: 'votable', 'votable_plain',
@@ -715,7 +715,7 @@ class GaiaClass(TapPlus):
         dec_column_name : str, optional, default dec column in main gaia table
             dec column doing the cone search against
         output_file : str, optional, default None
-            file name where the results are saved if `dump_to_file` is True.
+            file name where the results are saved if ``dump_to_file`` is True.
             If this parameter is not provided, the jobid is used instead
         output_format : str, optional, default 'votable_gzip'
             results format. Available formats are: 'votable', 'votable_plain',
@@ -769,7 +769,7 @@ class GaiaClass(TapPlus):
             specifies whether
             the execution will wait until results are available
         output_file : str, optional, default None
-            file name where the results are saved if `dump_to_file` is True.
+            file name where the results are saved if ``dump_to_file`` is True.
             If this parameter is not provided, the jobid is used instead
         output_format : str, optional, default 'votable_gzip'
             results format. Available formats are: 'votable', 'votable_plain',
@@ -835,7 +835,7 @@ class GaiaClass(TapPlus):
 
         Parameters
         ----------
-        table :Table, mandatory
+        table : `~astropy.table.Table`, mandatory
             change the format of the units in the columns of the input table: '.' by ' ' and "'" by ""
         """
 
@@ -944,7 +944,7 @@ class GaiaClass(TapPlus):
         name : str, optional, default None
             custom name defined by the user for the job that is going to be created
         output_file : str, optional, default None
-            file name where the results are saved if `dump_to_file` is True.
+            file name where the results are saved if ``dump_to_file`` is True.
             If this parameter is not provided, the jobid is used instead
         output_format : str, optional, default 'votable_gzip'
             results format. Available formats are: 'votable_gzip', 'votable', 'votable_plain',
@@ -959,7 +959,7 @@ class GaiaClass(TapPlus):
             resource to be uploaded to UPLOAD_SCHEMA
         upload_table_name : str, optional, default None
             resource temporary table name associated to the uploaded resource.
-            This argument is required if `upload_resource` is provided.
+            This argument is required if ``upload_resource`` is provided.
 
         Returns
         -------
@@ -989,7 +989,7 @@ class GaiaClass(TapPlus):
         name : str, optional, default None
             custom name defined by the user for the job that is going to be created
         output_file : str, optional, default None
-            file name where the results are saved if `dump_to_file` is True.
+            file name where the results are saved if ``dump_to_file`` is True.
             If this parameter is not provided, the jobid is used instead
         output_format : str, optional, default 'votable_gzip'
             results format. Available formats are: 'votable_gzip', 'votable', 'votable_plain',
@@ -1007,7 +1007,7 @@ class GaiaClass(TapPlus):
             resource to be uploaded to UPLOAD_SCHEMA
         upload_table_name : str, optional, default None
             resource temporary table name associated to the uploaded resource.
-            This argument is required if `upload_resource` is provided.
+            This argument is required if ``upload_resource`` is provided.
         autorun : boolean, optional, default True
             if 'True', sets 'phase' parameter to 'RUN',
             so the framework can start the job.

--- a/astroquery/gaia/core.py
+++ b/astroquery/gaia/core.py
@@ -413,29 +413,40 @@ class GaiaClass(TapPlus):
         --------
         Id formats.
 
-        >>> Gaia.get_datalinks(iids=1104405489608579584) # single id as an int
-        >>> Gaia.get_datalinks(ids='1104405489608579584, 1809140662896080256') # multiple ids as a str
-        >>> Gaia.get_datalinks(ids=(1104405489608579584, 1809140662896080256)) # multiple ids as an int list
-        >>> Gaia.get_datalinks(ids=('1104405489608579584','1809140662896080256')) # multiple ids as str list
-        >>> Gaia.get_datalinks(ids='4295806720-38655544960') # range of ids as a str
-        >>> Gaia.get_datalinks(ids='4295806720-38655544960, 549755818112-1275606125952') # multiple ranges of ids as
+        -- Gaia.get_datalinks(iids=1104405489608579584) # single id as an int
+
+        -- Gaia.get_datalinks(ids='1104405489608579584, 1809140662896080256') # multiple ids as a str
+
+        -- Gaia.get_datalinks(ids=(1104405489608579584, 1809140662896080256)) # multiple ids as an int list
+
+        -- Gaia.get_datalinks(ids=('1104405489608579584','1809140662896080256')) # multiple ids as str list
+        -- Gaia.get_datalinks(ids='4295806720-38655544960') # range of ids as a str
+
+        -- Gaia.get_datalinks(ids='4295806720-38655544960, 549755818112-1275606125952') # multiple ranges of ids as
         a str
-        >>> Gaia.get_datalinks(ids=('4295806720-38655544960', '549755818112-1275606125952') # multiple ranges of ids
+
+        -- Gaia.get_datalinks(ids=('4295806720-38655544960', '549755818112-1275606125952') # multiple ranges of ids
         as a str list
 
-        >>> Gaia.get_datalinks(ids='Gaia DR3 1104405489608579584') # single designator
-        >>> Gaia.get_datalinks(ids='Gaia DR3 1104405489608579584, Gaia DR3 1809140662896080256') # multiple
+        -- Gaia.get_datalinks(ids='Gaia DR3 1104405489608579584') # single designator
+        -- Gaia.get_datalinks(ids='Gaia DR3 1104405489608579584, Gaia DR3 1809140662896080256') # multiple
         designators as a str
-        >>> Gaia.get_datalinks(ids=('Gaia DR3 1104405489608579584','Gaia DR3 1809140662896080256')) # multiple
+
+        -- Gaia.get_datalinks(ids=('Gaia DR3 1104405489608579584','Gaia DR3 1809140662896080256')) # multiple
         designators as a str list
-        >>> Gaia.get_datalinks(ids='Gaia DR3 4295806720-Gaia DR3 38655544960') # range of designators as a str
-        >>> Gaia.get_datalinks(ids='Gaia DR3 4295806720-Gaia DR3 38655544960, Gaia DR3 549755818112-Gaia DR3
+
+        -- Gaia.get_datalinks(ids='Gaia DR3 4295806720-Gaia DR3 38655544960') # range of designators as a str
+
+        -- Gaia.get_datalinks(ids='Gaia DR3 4295806720-Gaia DR3 38655544960, Gaia DR3 549755818112-Gaia DR3
         1275606125952') # multiple ranges of designators as a str
-        >>> Gaia.get_datalinks(ids=('Gaia DR3 4295806720-Gaia DR3 38655544960', 'Gaia DR3 549755818112-Gaia DR3
+
+        -- Gaia.get_datalinks(ids=('Gaia DR3 4295806720-Gaia DR3 38655544960', 'Gaia DR3 549755818112-Gaia DR3
         1275606125952')) # multiple ranges of designators as a str list
-        >>> Gaia.get_datalinks(ids='Gaia DR3 4295806720-Gaia DR3 38655544960, Gaia DR2 549755818112-Gaia DR2
+
+        -- Gaia.get_datalinks(ids='Gaia DR3 4295806720-Gaia DR3 38655544960, Gaia DR2 549755818112-Gaia DR2
         1275606125952') # multiple ranges of designators with difference releases as a str
-        >>> Gaia.get_datalinks(ids=('Gaia DR3 4295806720-Gaia DR3 38655544960', 'Gaia DR2 549755818112-Gaia DR2
+
+        -- Gaia.get_datalinks(ids=('Gaia DR3 4295806720-Gaia DR3 38655544960', 'Gaia DR2 549755818112-Gaia DR2
         1275606125952')) # multiple ranges of designators with difference releases as a str list
         """
 

--- a/astroquery/gaia/tests/test_gaiatap.py
+++ b/astroquery/gaia/tests/test_gaiatap.py
@@ -473,7 +473,7 @@ def test_load_data_linking_parameter(monkeypatch, tmp_path):
 
 
 @pytest.mark.parametrize("linking_param", ['TRANSIT_ID', 'IMAGE_ID'])
-def test_load_data_linking_parameter(monkeypatch, tmp_path, linking_param):
+def test_load_data_linking_parameter_with_values(monkeypatch, tmp_path, linking_param):
     def load_data_monkeypatched(self, params_dict, output_file, verbose):
         assert params_dict == {
             "VALID_DATA": "true",

--- a/astroquery/gaia/tests/test_gaiatap.py
+++ b/astroquery/gaia/tests/test_gaiatap.py
@@ -50,11 +50,12 @@ ids_ints = [1104405489608579584, '1104405489608579584, 1809140662896080256', (11
             ('4295806720-38655544960', '549755818112-1275606125952')]
 
 ids_designator = ['Gaia DR3 1104405489608579584', 'Gaia DR3 1104405489608579584, Gaia DR3 1809140662896080256',
-           ('Gaia DR3 1104405489608579584', 'Gaia DR3 1809140662896080256'), 'Gaia DR3 4295806720-Gaia DR3 38655544960',
-           'Gaia DR3 4295806720-Gaia DR3 38655544960, Gaia DR3 549755818112-Gaia DR3 1275606125952',
-           ('Gaia DR3 4295806720-Gaia DR3 38655544960', 'Gaia DR3 549755818112-Gaia DR3 1275606125952'),
-           'Gaia DR3 4295806720-Gaia DR3 38655544960, Gaia DR2 549755818112-Gaia DR2 1275606125952',
-           ('Gaia DR3 4295806720-Gaia DR3 38655544960', 'Gaia DR2 549755818112-Gaia DR2 1275606125952')]
+                  ('Gaia DR3 1104405489608579584', 'Gaia DR3 1809140662896080256'),
+                  'Gaia DR3 4295806720-Gaia DR3 38655544960',
+                  'Gaia DR3 4295806720-Gaia DR3 38655544960, Gaia DR3 549755818112-Gaia DR3 1275606125952',
+                  ('Gaia DR3 4295806720-Gaia DR3 38655544960', 'Gaia DR3 549755818112-Gaia DR3 1275606125952'),
+                  'Gaia DR3 4295806720-Gaia DR3 38655544960, Gaia DR2 549755818112-Gaia DR2 1275606125952',
+                  ('Gaia DR3 4295806720-Gaia DR3 38655544960', 'Gaia DR2 549755818112-Gaia DR2 1275606125952')]
 
 RADIUS = 1 * u.deg
 SKYCOORD = SkyCoord(ra=19 * u.deg, dec=20 * u.deg, frame="icrs")
@@ -533,6 +534,7 @@ def test_get_datalinks_linking_parameter_ids_int(monkeypatch, id_int):
     result = GAIA_QUERIER.get_datalinks(ids=id_int, verbose=True)
     assert isinstance(result, Table)
 
+
 @pytest.mark.parametrize("id_des", ids_designator)
 def test_get_datalinks_linking_parameter_ids_designator(monkeypatch, id_des):
     def get_datalinks_monkeypatched(self, ids, linking_parameter, verbose):
@@ -544,6 +546,7 @@ def test_get_datalinks_linking_parameter_ids_designator(monkeypatch, id_des):
     monkeypatch.setattr(TapPlus, "get_datalinks", get_datalinks_monkeypatched)
     result = GAIA_QUERIER.get_datalinks(ids=id_des, verbose=True)
     assert isinstance(result, Table)
+
 
 def test_get_datalinks_exception(monkeypatch):
     def get_datalinks_monkeypatched(self, ids, linking_parameter, verbose):

--- a/astroquery/utils/tap/core.py
+++ b/astroquery/utils/tap/core.py
@@ -849,7 +849,6 @@ class TapPlus(Tap):
         verbose : bool, optional, default 'False'
             flag to display information about the process
 
-
         Returns
         -------
         A table object if output_file is None.
@@ -1299,7 +1298,7 @@ class TapPlus(Tap):
                 ids_arg = f"ID={','.join(str(item) for item in ids)}"
 
         if linking_parameter is not None:
-            ids_arg = f'{ids_arg}?LINKING_PARAMETER={linking_parameter}'
+            ids_arg = f'{ids_arg}&LINKING_PARAMETER={linking_parameter}'
 
         if verbose:
             print(f"Datalink request: {ids_arg}")

--- a/astroquery/utils/tap/core.py
+++ b/astroquery/utils/tap/core.py
@@ -1266,13 +1266,18 @@ class TapPlus(Tap):
             print(f"USER response = {user}")
         return user.startswith(f"{user_id}:") and user.count("\\n") == 0
 
-    def get_datalinks(self, ids, *, verbose=False):
+    def get_datalinks(self, ids, *, linking_parameter=None, verbose=False):
         """Gets datalinks associated to the provided identifiers
 
         Parameters
         ----------
         ids : str list, mandatory
             list of identifiers
+        linking_parameter : str, optional, default SOURCE_ID, valid values: SOURCE_ID, TRANSIT_ID, IMAGE_ID
+            By default, all the identifiers are considered as source_id
+            SOURCE_ID: the identifiers are considered as source_id
+            TRANSIT_ID: the identifiers are considered as transit_id
+            IMAGE_ID: the identifiers are considered as sif_observation_id
         verbose : bool, optional, default 'False'
             flag to display information about the process
 
@@ -1282,15 +1287,20 @@ class TapPlus(Tap):
         """
         if verbose:
             print("Retrieving datalink.")
+
         if ids is None:
             raise ValueError("Missing mandatory argument 'ids'")
         if isinstance(ids, str):
             ids_arg = f"ID={ids}"
         else:
             if isinstance(ids, int):
-                ids_arg = f"ID={ids}"
+                ids_arg = f"ID={str(ids)}"
             else:
                 ids_arg = f"ID={','.join(str(item) for item in ids)}"
+
+        if linking_parameter is not None:
+            ids_arg = f'{ids_arg}?LINKING_PARAMETER={linking_parameter}'
+
         if verbose:
             print(f"Datalink request: {ids_arg}")
         connHandler = self.__getconnhandler()

--- a/docs/gaia/gaia.rst
+++ b/docs/gaia/gaia.rst
@@ -202,6 +202,7 @@ To load only table names metadata (TAP+ capability):
   >>> for table in (tables):
   ...   print(table.get_qualified_name())
   external.external.apassdr9
+  external.external.catwise2020
   external.external.gaiadr2_astrophysical_parameters
   external.external.gaiadr2_geometric_distance
   external.external.gaiaedr3_distance


### PR DESCRIPTION
In the PR [#2859] the new parameter ``linking_parameter`` was introduced in the method ``load_data`` .

The same parameter should be available in the the function ``get_datalinks``, since in the next realeas of the gaia archive (February/March) the ids will be identified by this new parameter.

This PR contains new tests. We have also reviewed and updated the docstrings of the functions.

cc @esdc-esac-esa-int 