### PR TITLE
CI: limit pytest version for old python

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -44,6 +44,9 @@ deps =
     oldestdeps: beautifulsoup4==4.8
     oldestdeps-alldeps: mocpy==0.9
 
+    # pytest warnings issue for older versions, workaround until we drop 3.8 support
+    py38: pytest<8
+
     online: pytest-rerunfailures
 
 extras =


### PR DESCRIPTION
This should fix one of the CI jobs where the new pytest version triggers an error while handling a warning, all of which is upstream from astroquery.
This should be a sufficient workaround until we can finally drop python 3.8 support.