### PR TITLE
BUG: fix jplspec build lookup

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -216,6 +216,12 @@ jplsbdb
 - Fix a bug for jplsdbd query when the returned physical quantity contains
   a unit with exponential. [#2377]
 
+jplspec
+^^^^^^^
+
+- Fix a bug in lookup-table generation when using ``parse_name_locally``
+  option. [#2945]
+
 linelists.cdms
 ^^^^^^^^^^^^^^
 

--- a/astroquery/jplspec/core.py
+++ b/astroquery/jplspec/core.py
@@ -238,9 +238,9 @@ JPLSpec = JPLSpecClass()
 def build_lookup():
 
     result = JPLSpec.get_species_table()
-    keys = list(result[1][:])  # convert NAME column to list
-    values = list(result[0][:])  # convert TAG column to list
-    dictionary = dict(zip(keys, values))  # make k,v dictionary
+    keys = list(result['NAME'])
+    values = list(result['TAG'])
+    dictionary = dict(zip(keys, values))
     lookuptable = lookup_table.Lookuptable(dictionary)  # apply the class above
 
     return lookuptable


### PR DESCRIPTION
This should fix the devdeps CI job.

Given the columns have a well defined name, we should just select columns based on names. Note, this hasn't caused any issues up until the 6.1dev cycle. I haven't done any bisecting to pinpoint what made it fail upstream as this fix will work for us here.

ps: no need to add a test as currently existing tests alerted us about this regression