### PR TITLE
Gaia: Fix the astroquery method launch_job to retrieve the Table from the job when a json format is used

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -49,7 +49,8 @@ gaia
 
 - The method ``get_datalinks`` can be used with the new parameter linking_parameter. It completes PR #2859. [#2936]
 
-- Fix the thrown exception when the functions launch_job and launch_job_async retrieve the data for the json output_format but do not dump the results to a file . [#]
+- Fix the exception thrown when the functions launch_job and launch_job_async retrieve the data for the json output_format but
+  do not dump the results to a file . [#]
 
 
 hsa

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -49,6 +49,8 @@ gaia
 
 - The method ``get_datalinks`` can be used with the new parameter linking_parameter. It completes PR #2859. [#2936]
 
+- Fix the thrown exception when the functions launch_job and launch_job_async retrieve the data for the json output_format but do not dump the results to a file . [#]
+
 
 hsa
 ^^^

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -50,7 +50,7 @@ gaia
 - The method ``get_datalinks`` can be used with the new parameter linking_parameter. It completes PR #2859. [#2936]
 
 - Fix the exception thrown when the functions launch_job and launch_job_async retrieve the data for the json output_format but
-  do not dump the results to a file . [#]
+  do not dump the results to a file . [#2947]
 
 
 hsa

--- a/astroquery/gaia/tests/test_gaia_remote.py
+++ b/astroquery/gaia/tests/test_gaia_remote.py
@@ -8,51 +8,51 @@ from .. import GaiaClass
 @pytest.mark.remote_data
 def test_query_object_columns_with_radius():
     # Regression test: `columns` were ignored if `radius` was provided [#2025]
-    Gaia = GaiaClass()
-    sc = SkyCoord(ra=0*u.deg, dec=0*u.deg)
-    table = Gaia.query_object_async(sc, radius=10*u.arcsec, columns=['ra'])
+    gaia = GaiaClass()
+    sc = SkyCoord(ra=0 * u.deg, dec=0 * u.deg)
+    table = gaia.query_object_async(sc, radius=10 * u.arcsec, columns=['ra'])
     assert table.colnames == ['ra', 'dist']
 
 
 @pytest.mark.remote_data
 def test_query_object_row_limit():
-    Gaia = GaiaClass()
+    gaia = GaiaClass()
     coord = SkyCoord(ra=280, dec=-60, unit=(u.degree, u.degree), frame='icrs')
     width = u.Quantity(0.1, u.deg)
     height = u.Quantity(0.1, u.deg)
-    r = Gaia.query_object_async(coordinate=coord, width=width, height=height)
+    r = gaia.query_object_async(coordinate=coord, width=width, height=height)
 
-    assert len(r) == Gaia.ROW_LIMIT
+    assert len(r) == gaia.ROW_LIMIT
 
-    Gaia.ROW_LIMIT = 10
-    r = Gaia.query_object_async(coordinate=coord, width=width, height=height)
+    gaia.ROW_LIMIT = 10
+    r = gaia.query_object_async(coordinate=coord, width=width, height=height)
 
-    assert len(r) == 10 == Gaia.ROW_LIMIT
+    assert len(r) == 10 == gaia.ROW_LIMIT
 
-    Gaia.ROW_LIMIT = -1
-    r = Gaia.query_object_async(coordinate=coord, width=width, height=height)
+    gaia.ROW_LIMIT = -1
+    r = gaia.query_object_async(coordinate=coord, width=width, height=height)
 
     assert len(r) == 184
 
 
 @pytest.mark.remote_data
 def test_cone_search_row_limit():
-    Gaia = GaiaClass()
+    gaia = GaiaClass()
     coord = SkyCoord(ra=280, dec=-60, unit=(u.degree, u.degree), frame='icrs')
     radius = u.Quantity(0.1, u.deg)
-    j = Gaia.cone_search_async(coord, radius=radius)
+    j = gaia.cone_search_async(coord, radius=radius)
     r = j.get_results()
 
-    assert len(r) == Gaia.ROW_LIMIT
+    assert len(r) == gaia.ROW_LIMIT
 
-    Gaia.ROW_LIMIT = 10
-    j = Gaia.cone_search_async(coord, radius=radius)
+    gaia.ROW_LIMIT = 10
+    j = gaia.cone_search_async(coord, radius=radius)
     r = j.get_results()
 
-    assert len(r) == 10 == Gaia.ROW_LIMIT
+    assert len(r) == 10 == gaia.ROW_LIMIT
 
-    Gaia.ROW_LIMIT = -1
-    j = Gaia.cone_search_async(coord, radius=radius)
+    gaia.ROW_LIMIT = -1
+    j = gaia.cone_search_async(coord, radius=radius)
     r = j.get_results()
 
     assert len(r) == 1218

--- a/astroquery/gaia/tests/test_gaiatap.py
+++ b/astroquery/gaia/tests/test_gaiatap.py
@@ -389,8 +389,8 @@ def test_launch_job_json_format(tmp_path_factory, column_attrs_launch_json, mock
         assert results[colname].unit == attrs.unit
         assert results[colname].dtype == attrs.dtype
 
-def test_launch_job_json_format_no_dump(tmp_path_factory, column_attrs_launch_json, mock_querier_json):
 
+def test_launch_job_json_format_no_dump(tmp_path_factory, column_attrs_launch_json, mock_querier_json):
     dump_to_file = False
     output_format = 'json'
     query = "SELECT TOP 1 source_id, ra, dec, parallax from gaiadr3.gaia_source"
@@ -411,6 +411,7 @@ def test_launch_job_json_format_no_dump(tmp_path_factory, column_attrs_launch_js
         assert results[colname].description == attrs.description
         assert results[colname].unit == attrs.unit
         assert results[colname].dtype == attrs.dtype
+
 
 def test_cone_search_and_changing_MAIN_GAIA_TABLE(mock_querier_async):
     # Regression test for #2093 and #2099 - changing the MAIN_GAIA_TABLE

--- a/astroquery/gaia/tests/test_gaiatap.py
+++ b/astroquery/gaia/tests/test_gaiatap.py
@@ -362,7 +362,7 @@ def test_launch_job_async_json_format(tmp_path_factory, column_attrs_launch_json
         assert results[colname].dtype == attrs.dtype
 
 
-def test_launch_job_json_format(tmp_path_factory, column_attrs_launch_json, mock_querier_json, ):
+def test_launch_job_json_format(tmp_path_factory, column_attrs_launch_json, mock_querier_json):
     d = tmp_path_factory.mktemp("data") / 'launch_job.json'
     d.write_text(JOB_DATA_QUERIER_ASYNC_JSON, encoding="utf-8")
 
@@ -389,6 +389,28 @@ def test_launch_job_json_format(tmp_path_factory, column_attrs_launch_json, mock
         assert results[colname].unit == attrs.unit
         assert results[colname].dtype == attrs.dtype
 
+def test_launch_job_json_format_no_dump(tmp_path_factory, column_attrs_launch_json, mock_querier_json):
+
+    dump_to_file = False
+    output_format = 'json'
+    query = "SELECT TOP 1 source_id, ra, dec, parallax from gaiadr3.gaia_source"
+
+    job = mock_querier_json.launch_job(query, output_format=output_format, dump_to_file=dump_to_file)
+
+    assert job.async_ is False
+    assert job.get_phase() == "COMPLETED"
+    assert job.failed is False
+    # results
+    results = job.get_results()
+
+    assert type(results) is Table
+    assert 1 == len(results), len(results)
+
+    for colname, attrs in column_attrs_launch_json.items():
+        assert results[colname].name == attrs.name
+        assert results[colname].description == attrs.description
+        assert results[colname].unit == attrs.unit
+        assert results[colname].dtype == attrs.dtype
 
 def test_cone_search_and_changing_MAIN_GAIA_TABLE(mock_querier_async):
     # Regression test for #2093 and #2099 - changing the MAIN_GAIA_TABLE

--- a/astroquery/utils/tap/xmlparser/utils.py
+++ b/astroquery/utils/tap/xmlparser/utils.py
@@ -40,7 +40,7 @@ def read_http_response(response, output_format, *, correct_units=True):
 
         if output_format == 'json':
 
-            data = json.load(data)
+            data = json.load(response)
 
             if data.get('data') and data.get('metadata'):
 

--- a/astroquery/utils/tap/xmlparser/utils.py
+++ b/astroquery/utils/tap/xmlparser/utils.py
@@ -16,9 +16,11 @@ Created on 30 jun. 2016
 """
 import gzip
 import io
+import json
 
 from astropy import units as u
 from astropy.table import Table as APTable
+from astropy.table.table import Table
 
 
 def util_create_string_from_buffer(buffer):
@@ -35,8 +37,29 @@ def read_http_response(response, output_format, *, correct_units=True):
         result = APTable.read(io.BytesIO(gzip.decompress(data.read())), format=astropy_format)
     except OSError:
         # data is not a valid gzip file by BadGzipFile.
-        result = APTable.read(data, format=astropy_format)
-        pass
+
+        if output_format == 'json':
+
+            data = json.load(data)
+
+            if data.get('data') and data.get('metadata'):
+
+                column_name = []
+                for name in data['metadata']:
+                    column_name.append(name['name'])
+
+                result = Table(rows=data['data'], names=column_name, masked=True)
+
+                for v in data['metadata']:
+                    col_name = v['name']
+                    result[col_name].unit = v['unit']
+                    result[col_name].description = v['description']
+                    result[col_name].meta = {'metadata': v}
+
+            else:
+                result = APTable.read(data, format=astropy_format)
+        else:
+            result = APTable.read(data, format=astropy_format)
 
     if correct_units:
         modify_unrecognized_table_units(result)


### PR DESCRIPTION
If the Table is extracted from the job returned after the execution of the function launch_job, the following exception is thrown


```
>>> from astroquery.gaia import Gaia

>>> r=Gaia.launch_job("select top 10 * from gaiadr3.gaia_source order by source_id", output_format="json",dump_to_file=False)

Traceback (most recent call last):
  File "/home/jfernandez/anaconda3/envs/test_astroquery/lib/python3.11/site-packages/astroquery/utils/tap/xmlparser/utils.py", line 35, in read_http_response
    result = APTable.read(io.BytesIO(gzip.decompress(data.read())), format=astropy_format)
                                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/jfernandez/anaconda3/envs/test_astroquery/lib/python3.11/gzip.py", line 601, in decompress
    if _read_gzip_header(fp) is None:
       ^^^^^^^^^^^^^^^^^^^^^
  File "/home/jfernandez/anaconda3/envs/test_astroquery/lib/python3.11/gzip.py", line 428, in _read_gzip_header
    raise BadGzipFile('Not a gzipped file (%r)' % magic)
gzip.BadGzipFile: Not a gzipped file (b'{"')

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/home/jfernandez/anaconda3/envs/test_astroquery/lib/python3.11/site-packages/astropy/io/misc/pandas/connect.py", line 56, in _pandas_read
    import pandas
ModuleNotFoundError: No module named 'pandas'

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/home/jfernandez/anaconda3/envs/test_astroquery/lib/python3.11/site-packages/astroquery/gaia/core.py", line 971, in launch_job
    return TapPlus.launch_job(self, query=query, name=name,
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/jfernandez/anaconda3/envs/test_astroquery/lib/python3.11/site-packages/astroquery/utils/tap/core.py", line 358, in launch_job
    results = utils.read_http_response(response, output_format)
              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/jfernandez/anaconda3/envs/test_astroquery/lib/python3.11/site-packages/astroquery/utils/tap/xmlparser/utils.py", line 38, in read_http_response
    result = APTable.read(data, format=astropy_format)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/jfernandez/anaconda3/envs/test_astroquery/lib/python3.11/site-packages/astropy/table/connect.py", line 62, in __call__
    out = self.registry.read(cls, *args, **kwargs)
          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/jfernandez/anaconda3/envs/test_astroquery/lib/python3.11/site-packages/astropy/io/registry/core.py", line 221, in read
    data = reader(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/jfernandez/anaconda3/envs/test_astroquery/lib/python3.11/site-packages/astropy/io/misc/pandas/connect.py", line 58, in _pandas_read
    raise ImportError("pandas must be installed to use pandas table reader")
ImportError: pandas must be installed to use pandas table reader
```



We found this issue in astroquery version


```
>>> import astroquery
>>> print(astroquery.__version__)
0.4.7.dev9137
```


jira ticket GAIAPCR-1308

cc @esdc-esac-esa-int 