### PR TITLE
GAIA: The function upload_table in the TapPlus class must not allow table names that contain a dot

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -12,8 +12,11 @@ Service fixes and enhancements
 Infrastructure, Utility and Other Changes and Additions
 -------------------------------------------------------
 
+utils.tap
+^^^^^^^^^
 
-
+- ``TapPlus.upload_table`` should not allow table names to contain a
+  dot. ``ValueError`` is now raised for such cases. [#2971]
 
 
 0.4.7 (2024-03-08)
@@ -210,9 +213,6 @@ gaia
   [#2376]
 
 - Default Gaia catalog updated to DR3. [#2596]
-
-- The function upload_table in the TapPlus class does not allow table names that contain a dot. [#2971]
-
 
 heasarc
 ^^^^^^^

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -211,6 +211,9 @@ gaia
 
 - Default Gaia catalog updated to DR3. [#2596]
 
+- The function upload_table in the TapPlus class does not allow table names that contain a dot. [#2596]
+
+
 heasarc
 ^^^^^^^
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -211,7 +211,7 @@ gaia
 
 - Default Gaia catalog updated to DR3. [#2596]
 
-- The function upload_table in the TapPlus class does not allow table names that contain a dot. [#2596]
+- The function upload_table in the TapPlus class does not allow table names that contain a dot. [#2971]
 
 
 heasarc

--- a/astroquery/utils/tap/core.py
+++ b/astroquery/utils/tap/core.py
@@ -1425,6 +1425,8 @@ class TapPlus(Tap):
             raise ValueError("Missing mandatory argument 'upload_resource'")
         if table_name is None:
             raise ValueError("Missing mandatory argument 'table_name'")
+        if "." in table_name:
+            raise ValueError(f"Table name is not allowed to contain a dot: {table_name}")
         if table_description is None:
             description = ""
         else:

--- a/astroquery/utils/tap/tests/test_tap.py
+++ b/astroquery/utils/tap/tests/test_tap.py
@@ -27,6 +27,7 @@ from astroquery.utils.tap.conn.tests.DummyConnHandler import DummyConnHandler
 from astroquery.utils.tap.conn.tests.DummyResponse import DummyResponse
 from astroquery.utils.tap.core import TapPlus
 from astroquery.utils.tap import taputils
+from astropy.table import Table
 
 
 def read_file(filename):
@@ -936,3 +937,17 @@ def test_logout(mock_logout):
     with pytest.raises(HTTPError):
         tap.logout()
     assert (mock_logout.call_count == 2)
+
+
+def test_upload_table():
+    conn_handler = DummyConnHandler()
+    tap = TapPlus(url="http://test:1111/tap", connhandler=conn_handler)
+    a = [1, 2, 3]
+    b = ['a', 'b', 'c']
+    table = Table([a, b], names=['col1', 'col2'], meta={'meta': 'first table'})
+
+    table_name = 'hola.table_test_from_astropy'
+    with pytest.raises(ValueError) as exc_info:
+        tap.upload_table(upload_resource=table, table_name=table_name)
+
+    assert str(exc_info.value) == f"Table name is not allowed to contain a dot: {table_name}"


### PR DESCRIPTION
If a table name that contains a dot is used in the function _upload_table_, the corresponding table in the Gaia ESA Archive cannot be accessed/removed . The following example describes the issue. 

 

```
from astroquery.gaia import Gaia 
from astropy.table import Table 
a=[1,2,3] b=['a','b','c'] 
table = Table([a,b], names=['col1','col2'], meta={'meta':'first table'}) 

# Upload 
Gaia.login() 
Gaia.upload_table(upload_resource=table, table_name='hola.table_test_from_astropy')

```

The previous commands generated the following table in the archive

![image](https://github.com/astropy/astroquery/assets/19255991/e7ffa910-0342-4ce6-9336-5c3cfa158367)
\
\
A posible solution is to check whether the table name passed to the function _upload_table_, contains a dot.
\
\
cc @esdc-esac-esa-int 
\
\
Jira: GAIAMNGT-1548