### PR TITLE
Remove Non-functional Overlay Args from Skyview

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -25,6 +25,13 @@ vizier
   from ``IndexError`` to ``EmptyResponseError`` [#2980]
 
 
+skyview
+^^^^^^^
+
+- Overlay arguments `lut`, `grid`, and `gridlabel` are removed, as they
+  only apply to output types not returned by Astroquery [#2979]
+
+
 Infrastructure, Utility and Other Changes and Additions
 -------------------------------------------------------
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -28,7 +28,7 @@ vizier
 skyview
 ^^^^^^^
 
-- Overlay arguments `lut`, `grid`, and `gridlabel` are removed, as they
+- Overlay arguments ``lut``, ``grid``, and ``gridlabel`` are removed, as they
   only apply to output types not returned by Astroquery [#2979]
 
 

--- a/astroquery/skyview/core.py
+++ b/astroquery/skyview/core.py
@@ -87,8 +87,7 @@ class SkyViewClass(BaseQuery):
 
     def get_images(self, position, survey, *, coordinates=None, projection=None,
                    pixels=None, scaling=None, sampler=None, resolver=None,
-                   deedger=None, lut=None, grid=None, gridlabels=None,
-                   radius=None, height=None, width=None, cache=True,
+                   deedger=None, radius=None, height=None, width=None, cache=True,
                    show_progress=True):
         """
         Query the SkyView service, download the FITS file that will be
@@ -164,13 +163,6 @@ class SkyViewClass(BaseQuery):
             de-edging algorithm. The supported values are: ``"_skip_"`` to
             use the survey default, ``"skyview.process.Deedger"`` (for
             enabling de-edging), and ``"null"`` to disable.
-        lut : str
-            Choose from the color table selections to display the data in
-            false color.
-        grid : bool
-            overlay a coordinate grid on the image if True
-        gridlabels : bool
-            annotate the grid with coordinates positions if True
         radius : `~astropy.units.Quantity` or None
             The angular radius of the specified field.
             Overrides the ``width`` and ``height`` parameters.
@@ -204,7 +196,6 @@ class SkyViewClass(BaseQuery):
         readable_objects = self.get_images_async(position, survey, coordinates=coordinates,
                                                  projection=projection, pixels=pixels, scaling=scaling,
                                                  sampler=sampler, resolver=resolver, deedger=deedger,
-                                                 lut=lut, grid=grid, gridlabels=gridlabels,
                                                  radius=radius, height=height, width=width,
                                                  cache=cache, show_progress=show_progress)
         return [obj.get_fits() for obj in readable_objects]
@@ -212,9 +203,9 @@ class SkyViewClass(BaseQuery):
     @prepend_docstr_nosections(get_images.__doc__)
     def get_images_async(self, position, survey, *, coordinates=None,
                          projection=None, pixels=None, scaling=None,
-                         sampler=None, resolver=None, deedger=None, lut=None,
-                         grid=None, gridlabels=None, radius=None, height=None,
-                         width=None, cache=True, show_progress=True):
+                         sampler=None, resolver=None, deedger=None,
+                         radius=None, height=None, width=None,
+                         cache=True, show_progress=True):
         """
         Returns
         -------
@@ -222,10 +213,8 @@ class SkyViewClass(BaseQuery):
         """
         image_urls = self.get_image_list(position, survey, coordinates=coordinates,
                                          projection=projection, pixels=pixels, scaling=scaling, sampler=sampler,
-                                         resolver=resolver, deedger=deedger, lut=lut, grid=grid,
-                                         gridlabels=gridlabels, radius=radius,
-                                         height=height, width=width,
-                                         cache=cache)
+                                         resolver=resolver, deedger=deedger, radius=radius,
+                                         height=height, width=width, cache=cache)
         return [commons.FileContainer(url, encoding='binary',
                                       show_progress=show_progress)
                 for url in image_urls]
@@ -233,9 +222,8 @@ class SkyViewClass(BaseQuery):
     @prepend_docstr_nosections(get_images.__doc__, sections=['Returns', 'Examples'])
     def get_image_list(self, position, survey, *, coordinates=None,
                        projection=None, pixels=None, scaling=None,
-                       sampler=None, resolver=None, deedger=None, lut=None,
-                       grid=None, gridlabels=None, radius=None, width=None,
-                       height=None, cache=True):
+                       sampler=None, resolver=None, deedger=None,
+                       radius=None, width=None, height=None, cache=True):
         """
         Returns
         -------
@@ -267,12 +255,9 @@ class SkyViewClass(BaseQuery):
             'Position': parse_coordinates(position),
             'survey': survey,
             'Deedger': deedger,
-            'lut': lut,
             'projection': projection,
-            'gridlabels': '1' if gridlabels else '0',
             'coordinates': coordinates,
             'scaling': scaling,
-            'grid': grid,
             'resolver': resolver,
             'Sampler': sampler,
             'imscale': size_deg,


### PR DESCRIPTION
As discussed in #2976, `lut`, `grid`, and `gridlabel` arguments only apply for JPEG output from Skyview, though Astroquery only returns FITS objects. These values are effectively non-functional for Astroquery. This PR removes those arguments as arguments from the relevant Skyview methods and updates the docstring accordingly. Skyview tests and codestyle checks were checked and passing.

Changelog will be updated once this PR goes live and a PR number is generated.

Thanks!
Duy Nguyen (NASA HEASARC)

Fixes #2976 