### PR TITLE
API: adding EmptyResponseError to public API

### DIFF
--- a/astroquery/exceptions.py
+++ b/astroquery/exceptions.py
@@ -9,7 +9,7 @@ __all__ = ['TimeoutError', 'InvalidQueryError', 'RemoteServiceError',
            'TableParseError', 'LoginError', 'ResolverError',
            'NoResultsWarning', 'LargeQueryWarning', 'InputWarning',
            'AuthenticationWarning', 'MaxResultsWarning', 'CorruptDataWarning',
-           'BlankResponseWarning']
+           'EmptyResponseError', 'BlankResponseWarning']
 
 
 class TimeoutError(Exception):


### PR DESCRIPTION
Noticed this inconsistency while suggesting to use this class in another PR