### PR TITLE
Update tap.rst

### DIFF
--- a/docs/utils/tap.rst
+++ b/docs/utils/tap.rst
@@ -800,7 +800,7 @@ Example 1: TAPVizieR.cds.unistra.fr
   >>> #Inspect tables
   >>> tables = tap.load_tables()
   >>> for table in (tables):
-  >>>   print(table.get_name())
+  >>>   print(table.get_qualified_name())
 
   ...
   J/ApJS/173/104/memb


### PR DESCRIPTION
small change to docs in 3. Using TAP+ to connect other TAP services

unsupported 
print(table.get_name())

corrected to:

print(table.get_qualified_name())