### PR TITLE
get_obs_products method supports product_type parameter as string or list

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -30,6 +30,11 @@ gama
 
 - Change URL to https and thus making the module functional again. [#3056]
 
+esa.jwst
+^^^^^^^^
+
+- get_obs_products method supports product_type parameter as string or list [#2995]
+
 mpc
 ^^^
 

--- a/astroquery/esa/jwst/core.py
+++ b/astroquery/esa/jwst/core.py
@@ -83,6 +83,15 @@ class JwstClass(BaseQuery):
         if show_messages:
             self.get_status_messages()
 
+    def __check_list_strings(self, list):
+        if list is None:
+            return False
+        if list and all(isinstance(elem, str) for elem in list):
+            return True
+        else:
+            raise ValueError("One of the lists is empty or there are "
+                             "elements that are not strings")
+
     def load_tables(self, *, only_names=False, include_shared_tables=False,
                     verbose=False):
         """Loads all public tables
@@ -968,10 +977,10 @@ class JwstClass(BaseQuery):
             composite products based on level 2 products). To request upper
             levels, please use get_related_observations functions first.
             Possible values: 'ALL', 3, 2, 1, -1
-        product_type : str, optional, default None
+        product_type : str or list, optional, default None
             List only products of the given type. If None, all products are \
             listed. Possible values: 'thumbnail', 'preview', 'auxiliary', \
-            'science'.
+            'science', 'info'.
         output_file : str, optional
             Output file. If no value is provided, a temporary one is created.
 
@@ -997,10 +1006,17 @@ class JwstClass(BaseQuery):
                                                 max_cal_level=max_cal_level,
                                                 is_url=True)
         params_dict['planeid'] = plane_ids
+
+        if self.__check_list_strings(product_type):
+            if type(product_type) is list: tap_product_type=",".join(str(elem) for elem in product_type)
+            else: tap_product_type=product_type
+        else:
+            tap_product_type=None
+
         self.__set_additional_parameters(param_dict=params_dict,
                                          cal_level=cal_level,
                                          max_cal_level=max_cal_level,
-                                         product_type=product_type)
+                                         product_type=tap_product_type)
         output_file_full_path, output_dir = self.__set_dirs(output_file=output_file,
                                                             observation_id=observation_id)
         # Get file name only

--- a/astroquery/esa/jwst/core.py
+++ b/astroquery/esa/jwst/core.py
@@ -969,10 +969,10 @@ class JwstClass(BaseQuery):
             levels, please use get_related_observations functions first.
             Possible values: 'ALL', 3, 2, 1, -1
         product_type : str or list, optional, default None
-            List only products of the given type. If None, empty or an element
-            of the list is empty, all products are listed.
-            Possible values: 'thumbnail', 'preview', 'auxiliary',
-            'science', 'info', ['science', 'preview']...
+            If the string or at least one element of the list is empty, the value is replaced by None.
+            With None, all products will be downloaded.
+            Possible string values: 'thumbnail', 'preview', 'auxiliary', 'science' or 'info'.
+            Posible list values: any combination of string values.
         output_file : str, optional
             Output file. If no value is provided, a temporary one is created.
 
@@ -982,7 +982,7 @@ class JwstClass(BaseQuery):
             Returns the local path where the product(s) are saved.
         """
 
-        if (type(product_type) is list and '' in product_type) or not product_type:
+        if (isinstance(product_type, list) and '' in product_type) or not product_type:
             product_type = None
         if observation_id is None:
             raise ValueError(self.REQUESTED_OBSERVATION_ID)

--- a/astroquery/esa/jwst/core.py
+++ b/astroquery/esa/jwst/core.py
@@ -1008,10 +1008,12 @@ class JwstClass(BaseQuery):
         params_dict['planeid'] = plane_ids
 
         if self.__check_list_strings(product_type):
-            if type(product_type) is list: tap_product_type=",".join(str(elem) for elem in product_type)
-            else: tap_product_type=product_type
+            if type(product_type) is list:
+                tap_product_type = ",".join(str(elem) for elem in product_type)
+            else:
+                tap_product_type = product_type
         else:
-            tap_product_type=None
+            tap_product_type = None
 
         self.__set_additional_parameters(param_dict=params_dict,
                                          cal_level=cal_level,

--- a/astroquery/esa/jwst/core.py
+++ b/astroquery/esa/jwst/core.py
@@ -83,15 +83,6 @@ class JwstClass(BaseQuery):
         if show_messages:
             self.get_status_messages()
 
-    def __check_list_strings(self, list):
-        if list is None:
-            return False
-        if list and all(isinstance(elem, str) for elem in list):
-            return True
-        else:
-            raise ValueError("One of the lists is empty or there are "
-                             "elements that are not strings")
-
     def load_tables(self, *, only_names=False, include_shared_tables=False,
                     verbose=False):
         """Loads all public tables
@@ -990,6 +981,11 @@ class JwstClass(BaseQuery):
             Returns the local path where the product(s) are saved.
         """
 
+        if type(product_type) is list and '' in product_type:
+            raise ValueError("A list item is empty")
+        elif not product_type:
+            raise ValueError("The string is empty")
+
         if observation_id is None:
             raise ValueError(self.REQUESTED_OBSERVATION_ID)
         plane_ids, max_cal_level = self._get_plane_id(observation_id=observation_id)
@@ -1007,13 +1003,10 @@ class JwstClass(BaseQuery):
                                                 is_url=True)
         params_dict['planeid'] = plane_ids
 
-        if self.__check_list_strings(product_type):
-            if type(product_type) is list:
-                tap_product_type = ",".join(str(elem) for elem in product_type)
-            else:
-                tap_product_type = product_type
+        if type(product_type) is list:
+            tap_product_type = ",".join(str(elem) for elem in product_type)
         else:
-            tap_product_type = None
+            tap_product_type = product_type     
 
         self.__set_additional_parameters(param_dict=params_dict,
                                          cal_level=cal_level,

--- a/astroquery/esa/jwst/core.py
+++ b/astroquery/esa/jwst/core.py
@@ -969,9 +969,10 @@ class JwstClass(BaseQuery):
             levels, please use get_related_observations functions first.
             Possible values: 'ALL', 3, 2, 1, -1
         product_type : str or list, optional, default None
-            List only products of the given type. If None, all products are \
-            listed. Possible values: 'thumbnail', 'preview', 'auxiliary', \
-            'science', 'info'.
+            List only products of the given type. If None, empty or an element
+            of the list is empty, all products are listed.
+            Possible values: 'thumbnail', 'preview', 'auxiliary',
+            'science', 'info', ['science', 'preview']...
         output_file : str, optional
             Output file. If no value is provided, a temporary one is created.
 
@@ -981,11 +982,9 @@ class JwstClass(BaseQuery):
             Returns the local path where the product(s) are saved.
         """
 
-        if type(product_type) is list and '' in product_type:
-            raise ValueError("A list item is empty")
-        elif not product_type:
-            raise ValueError("The string is empty")
-
+        if (type(product_type) is list and '' in product_type) or not product_type:
+            product_type = None
+       
         if observation_id is None:
             raise ValueError(self.REQUESTED_OBSERVATION_ID)
         plane_ids, max_cal_level = self._get_plane_id(observation_id=observation_id)

--- a/astroquery/esa/jwst/core.py
+++ b/astroquery/esa/jwst/core.py
@@ -984,7 +984,6 @@ class JwstClass(BaseQuery):
 
         if (type(product_type) is list and '' in product_type) or not product_type:
             product_type = None
-       
         if observation_id is None:
             raise ValueError(self.REQUESTED_OBSERVATION_ID)
         plane_ids, max_cal_level = self._get_plane_id(observation_id=observation_id)
@@ -1005,7 +1004,7 @@ class JwstClass(BaseQuery):
         if type(product_type) is list:
             tap_product_type = ",".join(str(elem) for elem in product_type)
         else:
-            tap_product_type = product_type     
+            tap_product_type = product_type
 
         self.__set_additional_parameters(param_dict=params_dict,
                                          cal_level=cal_level,

--- a/astroquery/esa/jwst/tests/test_jwsttap.py
+++ b/astroquery/esa/jwst/tests/test_jwsttap.py
@@ -740,7 +740,7 @@ class TestTap:
         except OSError as err:
             print(f"Creation of the directory {output_file_full_path_dir} failed: {err.strerror}")
             raise err
-        
+
         file = data_path('single_product_retrieval.tar')
         output_file_full_path = output_file_full_path_dir + os.sep + os.path.basename(file)
         shutil.copy(file, output_file_full_path)

--- a/astroquery/esa/jwst/tests/test_jwsttap.py
+++ b/astroquery/esa/jwst/tests/test_jwsttap.py
@@ -733,6 +733,37 @@ class TestTap:
         finally:
             shutil.rmtree(output_file_full_path_dir)
 
+        # Test product_type paramater with a list
+        output_file_full_path_dir = os.getcwd() + os.sep + "temp_test_jwsttap_get_obs_products_1"
+        try:
+            os.makedirs(output_file_full_path_dir, exist_ok=True)
+        except OSError as err:
+            print(f"Creation of the directory {output_file_full_path_dir} failed: {err.strerror}")
+            raise err
+        
+        file = data_path('single_product_retrieval.tar')
+        output_file_full_path = output_file_full_path_dir + os.sep + os.path.basename(file)
+        shutil.copy(file, output_file_full_path)
+        parameters['output_file'] = output_file_full_path
+
+        expected_files = []
+        extracted_file_1 = output_file_full_path_dir + os.sep + 'single_product_retrieval_1.fits'
+        expected_files.append(extracted_file_1)
+        product_type_as_list = ['science', 'info']
+        try:
+            files_returned = (jwst.get_obs_products(
+                              observation_id=observation_id,
+                              cal_level='ALL',
+                              product_type=product_type_as_list,
+                              output_file=output_file_full_path))
+            parameters['params_dict']['product_type'] = 'science,info'
+            dummyTapHandler.check_call('load_data', parameters)
+            self.__check_extracted_files(files_expected=expected_files,
+                                         files_returned=files_returned)
+        finally:
+            shutil.rmtree(output_file_full_path_dir)
+            del parameters['params_dict']['product_type']
+
         # Test single file
         output_file_full_path_dir = os.getcwd() + os.sep +\
             "temp_test_jwsttap_get_obs_products_2"

--- a/docs/esa/jwst/jwst.rst
+++ b/docs/esa/jwst/jwst.rst
@@ -276,7 +276,7 @@ To download a data product
   >>> output_file = Jwst.get_product(file_name='jw01166091001_02102_00002_nrca3_cal.fits')  # doctest: +SKIP
 
 To download products by observation identifier, it is possible to use the get_obs_products function, with the same parameters
-than get_product_list.
+than get_product_list, it also supports product_type parameter as string or list.
 
 .. doctest-remote-data::
 

--- a/docs/esa/jwst/jwst.rst
+++ b/docs/esa/jwst/jwst.rst
@@ -275,14 +275,24 @@ To download a data product
   >>> output_file = Jwst.get_product(artifact_id='6ab73824-6587-4bca-84a8-eb48ac7251be')  # doctest: +SKIP
   >>> output_file = Jwst.get_product(file_name='jw01166091001_02102_00002_nrca3_cal.fits')  # doctest: +SKIP
 
+
 To download products by observation identifier, it is possible to use the get_obs_products function, with the same parameters
-than get_product_list, it also supports product_type parameter as string or list.
+than get_product_list, it also supports product_type parameter as string or list. product_type as string:
 
 .. doctest-remote-data::
 
   >>> from astroquery.esa.jwst import Jwst
   >>> observation_id = 'jw01122001001_0210r_00001_nrs2'
   >>> results = Jwst.get_obs_products(observation_id=observation_id, cal_level=2, product_type='science')  # doctest: +SKIP
+
+
+Here product_type as list:
+
+.. doctest-remote-data::
+  
+  >>> from astroquery.esa.jwst import Jwst
+  >>> observation_id = 'jw01122001001_0210r_00001_nrs2'
+  >>> results = Jwst.get_obs_products(observation_id=observation_id, cal_level=2, product_type=['science', 'preview'])  # doctest: +SKIP
 
 A temporary directory is created with the files and a list of the them is provided.
 

--- a/docs/esa/jwst/jwst.rst
+++ b/docs/esa/jwst/jwst.rst
@@ -283,7 +283,7 @@ than get_product_list, it also supports product_type parameter as string or list
 
   >>> from astroquery.esa.jwst import Jwst
   >>> observation_id = 'jw01122001001_0210r_00001_nrs2'
-  >>> results = Jwst.get_obs_products(observation_id=observation_id, cal_level=2, product_type='science')  # doctest: +SKIP
+  >>> results = Jwst.get_obs_products(observation_id=observation_id, cal_level=2, product_type='science')
 
 
 Here product_type as list:
@@ -292,7 +292,7 @@ Here product_type as list:
   
   >>> from astroquery.esa.jwst import Jwst
   >>> observation_id = 'jw01122001001_0210r_00001_nrs2'
-  >>> results = Jwst.get_obs_products(observation_id=observation_id, cal_level=2, product_type=['science', 'preview'])  # doctest: +SKIP
+  >>> results = Jwst.get_obs_products(observation_id=observation_id, cal_level=2, product_type=['science', 'preview'])
 
 A temporary directory is created with the files and a list of the them is provided.
 


### PR DESCRIPTION
The get_obs_products method now checks the input argument product_type with the method _check_list_strings and allows using strings or lists