### PR TITLE
MAINT: dropping pyvo <1.5

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -32,6 +32,7 @@ Infrastructure, Utility and Other Changes and Additions
 
 - Versions of Python <3.9 are no longer supported. [#2966]
 
+- Versions of PyVO <1.5 are no longer supported. [#3002]
 
 utils.tap
 ^^^^^^^^^

--- a/astroquery/alma/core.py
+++ b/astroquery/alma/core.py
@@ -20,12 +20,7 @@ from astropy.utils.console import ProgressBar
 from astropy import units as u
 from astropy.time import Time
 
-try:
-    from pyvo.dal.sia2 import SIA2_PARAMETERS_DESC, SIA2Service
-except ImportError:
-    # Can be removed once min version of pyvo is 1.5
-    from pyvo.dal.sia2 import SIA_PARAMETERS_DESC as SIA2_PARAMETERS_DESC
-    from pyvo.dal.sia2 import SIAService as SIA2Service
+from pyvo.dal.sia2 import SIA2_PARAMETERS_DESC, SIA2Service
 
 from ..exceptions import LoginError
 from ..utils import commons

--- a/astroquery/alma/tests/test_alma_remote.py
+++ b/astroquery/alma/tests/test_alma_remote.py
@@ -10,11 +10,8 @@ from astropy import coordinates
 from astropy import units as u
 import numpy as np
 import pytest
-try:
-    # This requires pyvo 1.4
-    from pyvo.dal.exceptions import DALOverflowWarning
-except ImportError:
-    pass
+
+from pyvo.dal.exceptions import DALOverflowWarning
 
 from astroquery.exceptions import CorruptDataWarning
 from .. import Alma
@@ -52,7 +49,6 @@ def alma(request):
 @pytest.mark.remote_data
 class TestAlma:
     def test_public(self, alma):
-        # This warning was added in pyvo 1.4, but we don't test older versions with remote-data
         with pytest.warns(expected_warning=DALOverflowWarning,
                           match="Partial result set. Potential causes MAXREC, async storage space, etc."):
             results = alma.query(payload=None, public=True, maxrec=100)
@@ -88,7 +84,6 @@ class TestAlma:
     def test_bands(self, alma):
         payload = {'band_list': ['5', '7']}
         # Added maxrec here as downloading and reading the results take too long.
-        # This warning was added in pyvo 1.4, but we don't test older versions with remote-data
         with pytest.warns(expected_warning=DALOverflowWarning,
                           match="Partial result set. Potential causes MAXREC, async storage space, etc."):
             result = alma.query(payload, maxrec=1000)

--- a/astroquery/ipac/irsa/core.py
+++ b/astroquery/ipac/irsa/core.py
@@ -14,12 +14,7 @@ from astropy.utils.decorators import deprecated_renamed_argument
 
 from pyvo.dal import TAPService
 
-try:
-    from pyvo.dal.sia2 import SIA2Service, SIA2_PARAMETERS_DESC
-except ImportError:
-    # Can be removed once min version of pyvo is 1.5
-    from pyvo.dal.sia2 import SIA_PARAMETERS_DESC as SIA2_PARAMETERS_DESC
-    from pyvo.dal.sia2 import SIAService as SIA2Service
+from pyvo.dal.sia2 import SIA2Service, SIA2_PARAMETERS_DESC
 
 from astroquery import log
 from astroquery.query import BaseVOQuery

--- a/astroquery/ipac/irsa/tests/test_irsa_remote.py
+++ b/astroquery/ipac/irsa/tests/test_irsa_remote.py
@@ -6,11 +6,7 @@ from astropy.table import Table
 from astropy.coordinates import SkyCoord
 from astropy.utils.exceptions import AstropyDeprecationWarning
 
-try:
-    # This requires pyvo 1.4
-    from pyvo.dal.exceptions import DALOverflowWarning
-except ImportError:
-    pass
+from pyvo.dal.exceptions import DALOverflowWarning
 
 from astroquery.ipac.irsa import Irsa
 

--- a/astroquery/simbad/tests/test_simbad_remote.py
+++ b/astroquery/simbad/tests/test_simbad_remote.py
@@ -11,13 +11,8 @@ from astroquery.simbad import Simbad
 # Maybe we need to expose SimbadVOTableResult to be in the public API?
 from astroquery.simbad.core import SimbadVOTableResult
 from astroquery.exceptions import BlankResponseWarning
-from packaging import version
-from pyvo import __version__ as pyvo_version
-try:
-    # This requires pyvo 1.4
-    from pyvo.dal.exceptions import DALOverflowWarning
-except ImportError:
-    pass
+
+from pyvo.dal.exceptions import DALOverflowWarning
 
 
 # M42 coordinates
@@ -273,11 +268,9 @@ class TestSimbad:
         expect = "letters numbers\n------- -------\n      a       1\n      b       2\n      c       3"
         assert expect == str(result)
         # Test query_tap raised errors
-        # DALOverflowWarning exists since pyvo 1.4
-        if version.parse(pyvo_version) > version.parse('1.4'):
-            with pytest.raises(DALOverflowWarning, match="Partial result set *"):
-                truncated_result = Simbad.query_tap("SELECT * from basic", maxrec=2)
-                assert len(truncated_result) == 2
+        with pytest.raises(DALOverflowWarning, match="Partial result set *"):
+            truncated_result = Simbad.query_tap("SELECT * from basic", maxrec=2)
+            assert len(truncated_result) == 2
         with pytest.raises(ValueError, match="The maximum number of records cannot exceed 2000000."):
             Simbad.query_tap("select top 5 * from basic", maxrec=10e10)
         with pytest.raises(ValueError, match="Query string contains an odd number of single quotes.*"):

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -95,13 +95,13 @@ building the documentation, in editable mode:
 Requirements
 ------------
 
-Astroquery works with Python 3.7 or later.
+Astroquery works with Python 3.9 or later.
 
 The following packages are required for astroquery installation & use:
 
-* `numpy <http://www.numpy.org>`_ >= 1.18
-* `astropy <http://www.astropy.org>`__ (>=4.2.1)
-* `pyVO`_ (>=1.1)
+* `numpy <http://www.numpy.org>`_ >= 1.20
+* `astropy <http://www.astropy.org>`__ (>=5.0)
+* `pyVO`_ (>=1.5)
 * `requests <https://requests.readthedocs.io/en/latest/>`_
 * `keyring <https://pypi.python.org/pypi/keyring>`_
 * `Beautiful Soup <https://www.crummy.com/software/BeautifulSoup/>`_

--- a/setup.cfg
+++ b/setup.cfg
@@ -137,7 +137,7 @@ install_requires=
    beautifulsoup4>=4.8
    html5lib>=0.999
    keyring>=15.0
-   pyvo>=1.1
+   pyvo>=1.5
 tests_require =
    pytest-doctestplus>=0.13
    pytest-astropy

--- a/tox.ini
+++ b/tox.ini
@@ -37,7 +37,7 @@ deps =
     oldestdeps: astropy==5.0.0
     oldestdeps: numpy==1.20
     oldestdeps: matplotlib==3.4.*
-    oldestdeps: pyvo==1.1
+    oldestdeps: pyvo==1.5
     oldestdeps: pytest-doctestplus==0.13
     oldestdeps: requests==2.25
     oldestdeps: keyring==15.0


### PR DESCRIPTION
Requiring this relatively recent version of pyvo should not cause any issues now that we dropped support for python 3.7.

Should close #2958 and and help with wrapping up #2855