### PR TITLE
EHSTPCR-1181: fix for get_datalabs_path

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -219,7 +219,7 @@ esa.hubble
 
 - New method ``get_datalabs_path`` to return the complete path of a file in
   datalabs by combining the datalabs volume path with the path of the file
-  in the table ehst.artifact [#2998]
+  in the table ehst.artifact [#2998, #3010]
 
 esa.jwst
 ^^^^^^^^

--- a/astroquery/esa/hubble/core.py
+++ b/astroquery/esa/hubble/core.py
@@ -1018,6 +1018,10 @@ class ESAHubbleClass(BaseQuery):
         The complete path of the file name in Datalabs
         """
 
+        # FITS files are always compressed
+        if filename.endswith('.fits'):
+            filename = f"{filename}.gz"
+
         query = f"select file_path from ehst.artifact where file_name = '{filename}'"
         job = self.query_tap(query=query)
         if job is None:

--- a/astroquery/esa/hubble/tests/test_esa_hubble_remote.py
+++ b/astroquery/esa/hubble/tests/test_esa_hubble_remote.py
@@ -130,6 +130,10 @@ class TestEsaHubbleRemoteData:
                                                folder=str(self.temp_folder_for_fits.name))
         assert len(os.listdir(self.temp_folder_for_fits.name)) > 0
 
-    def test_get_datalabs_path(self):
+    def test_get_datalabs_path_image(self):
         result = esa_hubble.get_datalabs_path(filename='ib4x04ivq_flt.jpg', default_volume=None)
         assert result == '/data/user/hub_hstdata_i/i/b4x/04/ib4x04ivq_flt.jpg'
+
+    def test_get_datalabs_path_fits(self):
+        result = esa_hubble.get_datalabs_path(filename='ib4x04ivq_flt.fits', default_volume=None)
+        assert result == '/data/user/hub_hstdata_i/i/b4x/04/ib4x04ivq_flt.fits.gz'


### PR DESCRIPTION
Dear Astroquery team,
This PR aims to fix a small bug associated to the previous pull request, with our new method, get_datalabs_path. In the end, in our Archive FITS are always retrieved as FITS.GZ and, with this fix, we are ensuring this is always considered. Thanks in advance for yout support!
cc @esdc-esac-esa-int 