### PR TITLE
Gaia: delete any reference to data_structure "Combined" in the function load_data and in the documentation [ci skip]

### DIFF
--- a/astroquery/gaia/core.py
+++ b/astroquery/gaia/core.py
@@ -182,15 +182,12 @@ class GaiaClass(TapPlus):
             data release from which data should be taken. E.g. 'Gaia DR3'
             By default, it takes the current default one.
         data_structure: str, optional, default 'INDIVIDUAL'
-            it can be 'INDIVIDUAL', 'COMBINED', 'RAW':
+            it can be 'INDIVIDUAL' or 'RAW':
             'INDIVIDUAL' means products are provided in separate files for each sourceId. All files are zipped
             in a single bundle, even if only one source/file is considered
-            'COMBINED' means products are provided in a single file concatenating the data of all sourceIds together.
-            How this is organised depends on the chosen format
             'RAW' means products are provided following a Data Model similar to that used in the MDB, meaning in
-            particular that parameters stored as arrays will remain as such. Like in the COMBINED structure, a single
-            file is provided for the data of all sourceIds together, but in this case there will be always be one
-            row per sourceId
+            particular that parameters stored as arrays will remain as such. A single file is provided for the data of
+            all sourceIds together, but in this case there will be always be one row per sourceId
         retrieval_type : str, optional, default 'ALL' to retrieve all data  from the list of sources
             retrieval type identifier. For GAIA DR2 possible values are ['EPOCH_PHOTOMETRY']
             For GAIA DR3, possible values are ['EPOCH_PHOTOMETRY', 'RVS', 'XP_CONTINUOUS', 'XP_SAMPLED',

--- a/docs/gaia/gaia.rst
+++ b/docs/gaia/gaia.rst
@@ -859,7 +859,7 @@ The following example shows how to retrieve the DataLink products associated wit
 .. doctest-remote-data::
 
   >>> retrieval_type = 'ALL'          # Options are: 'EPOCH_PHOTOMETRY', 'MCMC_GSPPHOT', 'MCMC_MSC', 'XP_SAMPLED', 'XP_CONTINUOUS', 'RVS', 'ALL'
-  >>> data_structure = 'COMBINED'     # Options are: 'INDIVIDUAL', 'COMBINED', 'RAW'
+  >>> data_structure = 'INDIVIDUAL'     # Options are: 'INDIVIDUAL' or 'RAW'
   >>> data_release   = 'Gaia DR3'     # Options are: 'Gaia DR3' (default), 'Gaia DR2'
   >>> datalink = Gaia.load_data(ids=[2263166706630078848, 2263178457660566784, 2268372099615724288],
   ...                           data_release=data_release, retrieval_type=retrieval_type, data_structure=data_structure)


### PR DESCRIPTION
In a near future, the gaia datalink service is going to generate ancillary products for data_structure as "Individual" or "Raw", so the option "Combined" will not be available anymore.

We would like to delete any reference to this data_structure in the method  _load\_data_ as well as in the general documentation.

cc @esdc-esac-esa-int 

Jira ticket: GAIAMNGT-1704 