### PR TITLE
Download file with a directory specified by local_path parameter

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -53,6 +53,11 @@ jplhorizons
 
 - Add missing column definitions, especially for ``refraction=True`` and ``extra_precision=True``. [#2986]
 
+mast
+^^^^
+
+- Fix bug in which the ``local_path`` parameter for the ``mast.observations.download_file`` method does not accept a directory. [#3016]
+
 
 0.4.7 (2024-03-08)
 ==================

--- a/astroquery/mast/observations.py
+++ b/astroquery/mast/observations.py
@@ -535,7 +535,7 @@ class ObservationsClass(MastQueryWithLogin):
         # parse a local file path from local_path parameter.  Use current directory as default.
         filename = os.path.basename(uri)
         if not local_path:  # local file path is not defined
-            local_path = os.path.join(os.path.abspath('.'), filename)
+            local_path = filename
         elif os.path.isdir(local_path):  # local file path is directory
             local_path = os.path.join(local_path, filename)  # append filename
 

--- a/astroquery/mast/observations.py
+++ b/astroquery/mast/observations.py
@@ -534,10 +534,10 @@ class ObservationsClass(MastQueryWithLogin):
 
         # parse a local file path from local_path parameter.  Use current directory as default.
         filename = os.path.basename(uri)
-        if not local_path: # local file path is not defined
+        if not local_path:  # local file path is not defined
             local_path = os.path.join(os.path.abspath('.'), filename)
-        elif os.path.isdir(local_path): # local file path is directory
-            local_path = os.path.join(local_path, filename) # append filename
+        elif os.path.isdir(local_path):  # local file path is directory
+            local_path = os.path.join(local_path, filename)  # append filename
 
         # recreate the data_product key for cloud connection check
         data_product = {'dataURI': uri}

--- a/astroquery/mast/observations.py
+++ b/astroquery/mast/observations.py
@@ -6,6 +6,7 @@ MAST Observations
 This module contains various methods for querying MAST observations.
 """
 
+from pathlib import Path
 import warnings
 import time
 import os
@@ -536,8 +537,12 @@ class ObservationsClass(MastQueryWithLogin):
         filename = os.path.basename(uri)
         if not local_path:  # local file path is not defined
             local_path = filename
-        elif os.path.isdir(local_path):  # local file path is directory
-            local_path = os.path.join(local_path, filename)  # append filename
+        else:
+            path = Path(local_path)
+            if not path.suffix:  # local_path is a directory
+                local_path = path / filename  # append filename
+                if not path.exists():  # create directory if it doesn't exist
+                    path.mkdir(parents=True, exist_ok=True)
 
         # recreate the data_product key for cloud connection check
         data_product = {'dataURI': uri}

--- a/astroquery/mast/observations.py
+++ b/astroquery/mast/observations.py
@@ -508,7 +508,7 @@ class ObservationsClass(MastQueryWithLogin):
         uri : str
             The product dataURI, e.g. mast:JWST/product/jw00736-o039_t001_miri_ch1-long_x1d.fits
         local_path : str
-            Directory in which the files will be downloaded.  Defaults to current working directory.
+            Directory or filename to which the file will be downloaded.  Defaults to current working directory.
         base_url: str
             A base url to use when downloading.  Default is the MAST Portal API
         cache : bool
@@ -532,9 +532,12 @@ class ObservationsClass(MastQueryWithLogin):
         base_url = base_url if base_url else self._portal_api_connection.MAST_DOWNLOAD_URL
         data_url = base_url + "?uri=" + uri
 
-        # create a local file path if none is input.  Use current directory as default.
+        # parse a local file path from local_path parameter.  Use current directory as default.
         filename = os.path.basename(uri)
-        local_path = os.path.join(os.path.abspath('.') if not local_path else local_path, filename)
+        if not local_path: # local file path is not defined
+            local_path = os.path.join(os.path.abspath('.'), filename)
+        elif os.path.isdir(local_path): # local file path is directory
+            local_path = os.path.join(local_path, filename) # append filename
 
         # recreate the data_product key for cloud connection check
         data_product = {'dataURI': uri}

--- a/astroquery/mast/observations.py
+++ b/astroquery/mast/observations.py
@@ -533,9 +533,8 @@ class ObservationsClass(MastQueryWithLogin):
         data_url = base_url + "?uri=" + uri
 
         # create a local file path if none is input.  Use current directory as default.
-        if not local_path:
-            filename = os.path.basename(uri)
-            local_path = os.path.join(os.path.abspath('.'), filename)
+        filename = os.path.basename(uri)
+        local_path = os.path.join(os.path.abspath('.') if not local_path else local_path, filename)
 
         # recreate the data_product key for cloud connection check
         data_product = {'dataURI': uri}

--- a/astroquery/mast/tests/test_mast.py
+++ b/astroquery/mast/tests/test_mast.py
@@ -498,7 +498,8 @@ def test_observations_download_products(patch_post, tmpdir):
 
     # passing row product
     products = mast.Observations.get_product_list('2003738726')
-    result1 = mast.Observations.download_products(products[0])
+    result1 = mast.Observations.download_products(products[0],
+                                                  download_dir=str(tmpdir))
     assert isinstance(result1, Table)
 
 

--- a/astroquery/mast/tests/test_mast_remote.py
+++ b/astroquery/mast/tests/test_mast_remote.py
@@ -394,10 +394,11 @@ class TestMast:
 
         # pull the URI of a single product
         uri = products['dataURI'][0]
-        local_path = Path(tmp_path, Path(uri).name)
+        filename = Path(uri).name
 
-        # download it
-        result = mast.Observations.download_file(uri, local_path=local_path)
+        # download with unspecified local_path parameter
+        # should download to current working directory
+        result = mast.Observations.download_file(uri)
         assert result == ('COMPLETE', None, None)
         assert os.path.exists(Path(os.getcwd(), filename))
         Path.unlink(filename)  # clean up file

--- a/astroquery/mast/tests/test_mast_remote.py
+++ b/astroquery/mast/tests/test_mast_remote.py
@@ -399,6 +399,20 @@ class TestMast:
         # download it
         result = mast.Observations.download_file(uri, local_path=local_path)
         assert result == ('COMPLETE', None, None)
+        assert os.path.exists(Path(os.getcwd(), filename))
+        Path.unlink(filename)  # clean up file
+
+        # download with directory as local_path parameter
+        local_path = Path(tmp_path, filename)
+        result = mast.Observations.download_file(uri, local_path=tmp_path)
+        assert result == ('COMPLETE', None, None)
+        assert os.path.exists(local_path)
+
+        # download with filename as local_path parameter
+        local_path_file = Path(tmp_path, "test.fits")
+        result = mast.Observations.download_file(uri, local_path=local_path_file)
+        assert result == ('COMPLETE', None, None)
+        assert os.path.exists(local_path_file)
 
     @pytest.mark.parametrize("test_data_uri, expected_cloud_uri", [
         ("mast:HST/product/u24r0102t_c1f.fits",

--- a/docs/mast/mast_obsquery.rst
+++ b/docs/mast/mast_obsquery.rst
@@ -373,9 +373,9 @@ curl script that can be used to download the files at a later time.
 Downloading a Single File
 -------------------------
 
-You can download a single data product file using the `~astroquery.mast.ObservationsClass.download_file`
-method, and passing in a MAST Data URI.  The default is to download the file the current working directory,
-which can be changed with the ``local_path`` keyword argument.
+You can download a single data product file by using the `~astroquery.mast.ObservationsClass.download_file`
+method and passing in a MAST Data URI.  The default is to download the file to the current working directory, but
+you can specify the download directory or filepath with the ``local_path`` keyword argument.
 
 .. doctest-remote-data::
 


### PR DESCRIPTION
Fixes #2501 

Appends filename to a `local_path` argument to avoid `IsADirectoryError`. Also updated documentation to be a bit more clear about the function and the parameter.