### PR TITLE
Update download URLs for SDSS DR18

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -42,6 +42,11 @@ vizier
 - Change the type of raised error when the catalog is not found in ``Vizier.get_catalog_metadata``
   from ``IndexError`` to ``EmptyResponseError`` [#2980]
 
+sdss
+^^^^
+
+- Support new SDSS-V DR18 access URLs. [#3017]
+
 simbad
 ^^^^^^
 

--- a/astroquery/sdss/field_names.py
+++ b/astroquery/sdss/field_names.py
@@ -6,8 +6,8 @@ from astropy.table import Table
 from astropy.utils.data import get_pkg_data_contents
 from astropy.utils.exceptions import AstropyUserWarning
 
-from . import conf
-from ..utils.mocks import MockResponse
+from astroquery.sdss import conf
+from astroquery.utils.mocks import MockResponse
 
 __all__ = ['get_field_info', 'photoobj_defs', 'specobj_defs', 'crossid_defs']
 


### PR DESCRIPTION
This PR closes #3011.

Background: SDSS-V has changed the paths used to access data files. Both imaging and spectroscopic data are affected. As of SDSS-V/DR18, the SQL access does not appear to have changed. Updating these URLs may continue to work throughout SDSS-V, but that is not guaranteed.  The SDSS-V data team recommends using [sdss-access](https://pypi.org/project/sdss-access/).

- [X] Update URL for imaging.
- [x] Double-check that 5-digit `plate` numbers do work.
- [x] Update URL for SDSS-IV and earlier spectroscopy.
- [x] Would existing queries in `astroquery.sdss` ever return a SDSS-V spectrum?
- [x] Update URL for SDSS-V spectroscopy, `fieldID-MJD-fiberID` instead of `plate-MJD-fiberID`.
- [x] Update tests.