### PR TITLE
Update MPC query to parse 3 digit precision motion columns

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -12,8 +12,8 @@ mpc
 ^^^
 
 - Parse star catalog information when querying observations database [#2957]
-- Parse ephemeris with sky motion with three digit precision [#3019]
-- Raise NoResultWarining when empty ephemeris reponse is returned [#3019]
+- Parse ephemeris with sky motion with three digit precision [#3026]
+- Raise EmptyResponseError when empty ephemeris reponse is returned [#3026]
 
 linelists.cdms
 ^^^^^^^^^^^^^^

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -12,6 +12,8 @@ mpc
 ^^^
 
 - Parse star catalog information when querying observations database [#2957]
+- Parse ephemeris with sky motion with three digit precision [#3019]
+- Raise NoResultWarining when empty ephemeris reponse is returned [#3019]
 
 linelists.cdms
 ^^^^^^^^^^^^^^

--- a/astroquery/mpc/core.py
+++ b/astroquery/mpc/core.py
@@ -1033,7 +1033,7 @@ class MPCClass(BaseQuery):
                     s = np.nan
                 else:
                     s = float(s)
-
+        
                 rows.append((line[:3], lon, c, s, line[30:]))
 
             tab = Table(rows=rows,
@@ -1088,17 +1088,19 @@ class MPCClass(BaseQuery):
                 elif 's=s' in result.request.body:  # sky Motion
                     names += ('dRA cos(Dec)', 'dDec')
                     units += ('arcsec/h', 'arcsec/h')
-                col_starts += (73, 81)
-                col_ends += (80, 89)
+                # Correct start and end for Motion columns if the results have 3 digit precision.
+                col_starts += (73, 82)
+                col_ends += (81, 91)
 
                 if 'Moon' in columns:
                     # table includes Alt, Az, Sun and Moon geometry
                     names += ('Azimuth', 'Altitude', 'Sun altitude', 'Moon phase',
                               'Moon distance', 'Moon altitude')
+                    # Modified column start and end as motion column can have 3 digit precision.
                     col_starts += tuple((col_ends[-1] + offset for offset in
-                                         (2, 9, 14, 20, 27, 33)))
+                                        (1, 8, 13, 19, 26, 32)))
                     col_ends += tuple((col_ends[-1] + offset for offset in
-                                       (8, 13, 19, 26, 32, 37)))
+                                      (7, 12, 18, 25, 31, 36)))
                     units += ('deg', 'deg', 'deg', None, 'deg', 'deg')
                 if 'Uncertainty' in columns:
                     names += ('Uncertainty 3sig', 'Unc. P.A.')

--- a/astroquery/mpc/core.py
+++ b/astroquery/mpc/core.py
@@ -1061,12 +1061,20 @@ class MPCClass(BaseQuery):
             # find column headings
             if SKY:
                 # slurp to newline after "h m s"
-                i = text_table.index('\n', text_table.index('h m s')) + 1
+                # raise EmptyResponseError if no ephemeris lines are found in the query response
+                try:
+                    i = text_table.index('\n', text_table.index('h m s')) + 1
+                except ValueError as e:
+                    raise EmptyResponseError(content)
                 columns = text_table[:i]
                 data_start = columns.count('\n') - 1
             else:
                 # slurp to newline after "JD_TT"
-                i = text_table.index('\n', text_table.index('JD_TT')) + 1
+                # raise EmptyResponseError if no ephemeris lines are found in the query response
+                try:
+                    i = text_table.index('\n', text_table.index('JD_TT')) + 1
+                except ValueError as e:
+                    raise EmptyResponseError(content)
                 columns = text_table[:i]
                 data_start = columns.count('\n') - 1
 

--- a/astroquery/mpc/core.py
+++ b/astroquery/mpc/core.py
@@ -16,8 +16,7 @@ from erfa import ErfaWarning
 from ..query import BaseQuery
 from . import conf
 from ..utils import async_to_sync, class_or_instance
-from ..exceptions import InvalidQueryError, EmptyResponseError
-
+from ..exceptions import InvalidQueryError, EmptyResponseError, NoResultsWarning
 
 __all__ = ['MPCClass']
 
@@ -1064,7 +1063,7 @@ class MPCClass(BaseQuery):
                 try:
                     i = text_table.index('\n', text_table.index('h m s')) + 1
                 except ValueError as e:
-                    raise EmptyResponseError(content)
+                    raise NoResultsWarning(content)
                 columns = text_table[:i]
                 data_start = columns.count('\n') - 1
             else:
@@ -1073,7 +1072,7 @@ class MPCClass(BaseQuery):
                 try:
                     i = text_table.index('\n', text_table.index('JD_TT')) + 1
                 except ValueError as e:
-                    raise EmptyResponseError(content)
+                    raise NoResultsWarning(content)
                 columns = text_table[:i]
                 data_start = columns.count('\n') - 1
 
@@ -1181,7 +1180,6 @@ class MPCClass(BaseQuery):
             else:
                 # convert from MPES string to Time
                 tab['JD'] = Time(tab['JD'], format='jd', scale='tt')
-            print(tab)
             return tab
 
         elif self.query_type == 'observations':

--- a/astroquery/mpc/core.py
+++ b/astroquery/mpc/core.py
@@ -1094,7 +1094,6 @@ class MPCClass(BaseQuery):
                 elif 's=s' in result.request.body:  # sky Motion
                     names += ('dRA cos(Dec)', 'dDec')
                     units += ('arcsec/h', 'arcsec/h')
-                # Correct start and end for Motion columns if the results have 3 digit precision.
                 col_starts += (73, 82)
                 col_ends += (81, 91)
 
@@ -1102,7 +1101,6 @@ class MPCClass(BaseQuery):
                     # table includes Alt, Az, Sun and Moon geometry
                     names += ('Azimuth', 'Altitude', 'Sun altitude', 'Moon phase',
                               'Moon distance', 'Moon altitude')
-                    # Modified column start and end as motion column can have 3 digit precision.
                     col_starts += tuple((col_ends[-1] + offset for offset in
                                         (1, 8, 13, 19, 26, 32)))
                     col_ends += tuple((col_ends[-1] + offset for offset in
@@ -1110,7 +1108,6 @@ class MPCClass(BaseQuery):
                     units += ('deg', 'deg', 'deg', None, 'deg', 'deg')
                 if 'Uncertainty' in columns:
                     names += ('Uncertainty 3sig', 'Unc. P.A.')
-                    # Modified column start and end as motion column can have 3 digit precision.
                     col_starts += tuple((col_ends[-1] + offset for offset in
                                          (1, 10)))
                     col_ends += tuple((col_ends[-1] + offset for offset in

--- a/astroquery/mpc/core.py
+++ b/astroquery/mpc/core.py
@@ -16,7 +16,7 @@ from erfa import ErfaWarning
 from ..query import BaseQuery
 from . import conf
 from ..utils import async_to_sync, class_or_instance
-from ..exceptions import InvalidQueryError, EmptyResponseError, NoResultsWarning
+from ..exceptions import InvalidQueryError, EmptyResponseError
 
 __all__ = ['MPCClass']
 
@@ -1063,7 +1063,7 @@ class MPCClass(BaseQuery):
                 try:
                     i = text_table.index('\n', text_table.index('h m s')) + 1
                 except ValueError as e:
-                    raise NoResultsWarning(content)
+                    raise EmptyResponseError(content)
                 columns = text_table[:i]
                 data_start = columns.count('\n') - 1
             else:
@@ -1072,7 +1072,7 @@ class MPCClass(BaseQuery):
                 try:
                     i = text_table.index('\n', text_table.index('JD_TT')) + 1
                 except ValueError as e:
-                    raise NoResultsWarning(content)
+                    raise EmptyResponseError(content)
                 columns = text_table[:i]
                 data_start = columns.count('\n') - 1
 

--- a/astroquery/mpc/core.py
+++ b/astroquery/mpc/core.py
@@ -1062,7 +1062,7 @@ class MPCClass(BaseQuery):
                 # raise EmptyResponseError if no ephemeris lines are found in the query response
                 try:
                     i = text_table.index('\n', text_table.index('h m s')) + 1
-                except ValueError as e:
+                except ValueError:
                     raise EmptyResponseError(content)
                 columns = text_table[:i]
                 data_start = columns.count('\n') - 1
@@ -1071,7 +1071,7 @@ class MPCClass(BaseQuery):
                 # raise EmptyResponseError if no ephemeris lines are found in the query response
                 try:
                     i = text_table.index('\n', text_table.index('JD_TT')) + 1
-                except ValueError as e:
+                except ValueError:
                     raise EmptyResponseError(content)
                 columns = text_table[:i]
                 data_start = columns.count('\n') - 1

--- a/astroquery/mpc/core.py
+++ b/astroquery/mpc/core.py
@@ -1052,7 +1052,6 @@ class MPCClass(BaseQuery):
                 raise InvalidQueryError(content)
             table_end = content.find('</pre>')
             text_table = content[table_start + 5:table_end]
-
             SKY = 'raty=a' in result.request.body
             HELIOCENTRIC = 'raty=s' in result.request.body
             GEOCENTRIC = 'raty=G' in result.request.body
@@ -1112,10 +1111,11 @@ class MPCClass(BaseQuery):
                     units += ('deg', 'deg', 'deg', None, 'deg', 'deg')
                 if 'Uncertainty' in columns:
                     names += ('Uncertainty 3sig', 'Unc. P.A.')
+                    # Modified column start and end as motion column can have 3 digit precision.
                     col_starts += tuple((col_ends[-1] + offset for offset in
-                                         (2, 11)))
+                                         (1, 10)))
                     col_ends += tuple((col_ends[-1] + offset for offset in
-                                       (10, 16)))
+                                       (9, 15)))
                     units += ('arcsec', 'deg')
                 if ">Map</a>" in first_row and self._unc_links:
                     names += ('Unc. map', 'Unc. offsets')
@@ -1181,7 +1181,7 @@ class MPCClass(BaseQuery):
             else:
                 # convert from MPES string to Time
                 tab['JD'] = Time(tab['JD'], format='jd', scale='tt')
-
+            print(tab)
             return tab
 
         elif self.query_type == 'observations':

--- a/astroquery/mpc/core.py
+++ b/astroquery/mpc/core.py
@@ -1033,7 +1033,7 @@ class MPCClass(BaseQuery):
                     s = np.nan
                 else:
                     s = float(s)
-        
+
                 rows.append((line[:3], lon, c, s, line[30:]))
 
             tab = Table(rows=rows,

--- a/astroquery/mpc/tests/data/2024AA_ephemeris_500-a-t.html
+++ b/astroquery/mpc/tests/data/2024AA_ephemeris_500-a-t.html
@@ -1,0 +1,75 @@
+ <!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN">
+ <html>
+ <head>
+ <META HTTP-EQUIV="Content-Type" CONTENT="text/html; charset=ISO-8859-1">
+ <title>Minor Planet Ephemeris Service: Query Results</title>
+ </head>
+ <body>
+ <h1>Minor Planet Ephemeris Service: Query Results</h1>
+ Below are the results of your request from the Minor Planet Center's
+ Minor Planet Ephemeris Service.
+ <p>
+   Newly designated objects may take up to 1 day to show up in this service.
+ </p>
+ <p>
+   Orbits and ephemerides of unnumbered NEOs are up-to-date. Other orbits are in
+  the process of being refreshed.
+ </p>
+ <p>
+   The current system is not completely reliable in the case of objects
+   with very-close approaches with the Earth.
+   <br></br> We are working on a completely new system,
+   but for the time being we encourage the users to double check
+   the results with other ephemeris generators when the object is very close to 
+ Earth.
+ </p>
+ Ephemerides are for
+ the geocenter.
+ <p><hr><p>
+ <p>
+ <b>2024 AA</b>
+<p> Number of variant orbits available:     11</p>
+ <p>Perturbed ephemeris below is based on
+   1-day-arc
+ unperturbed elements from 
+ <i>MPO</i> 793554.
+ Last observed on  2024 Jan. 2.
+<p><a href="https://www.minorplanetcenter.net/iau/info/FurtherObs.html">Further observations?</a>  Useful for orbit improvement.
+ <p><pre>
+     K24A00A       [H=27.41]
+Date       UT      R.A. (J2000) Decl.    Delta     r     El.    Ph.   V      Sky Motion       Uncertainty info
+            h m s                                                            "/min    "/min   3-sig/" P.A.
+2024 06 15 000000 23 28 41.6 -05 17 07   1.451   1.819   93.3  33.9  30.9   +0.17    +0.006       169 063.5 / <a href="https://cgi.minorplanetcenter.net/cgi-bin/uncertaintymap.cgi?Obj=K24A00A&JD=2460476.50000&Ext=VAR2">Map</a> / <a href="https://cgi.minorplanetcenter.net/cgi-bin/uncertaintymap.cgi?Obj=K24A00A&JD=2460476.50000&Ext=VAR2&Form=Y&OC=500">Offsets</a>
+2024 06 16 000000 23 28 56.7 -05 17 05   1.447   1.829   94.2  33.6  30.9   +0.15    -0.003       172 063.5 / <a href="https://cgi.minorplanetcenter.net/cgi-bin/uncertaintymap.cgi?Obj=K24A00A&JD=2460477.50000&Ext=VAR2">Map</a> / <a href="https://cgi.minorplanetcenter.net/cgi-bin/uncertaintymap.cgi?Obj=K24A00A&JD=2460477.50000&Ext=VAR2&Form=Y&OC=500">Offsets</a>
+2024 06 17 000000 23 29 09.8 -05 17 16   1.444   1.838   95.1  33.4  30.9   +0.13    -0.013       175 063.6 / <a href="https://cgi.minorplanetcenter.net/cgi-bin/uncertaintymap.cgi?Obj=K24A00A&JD=2460478.50000&Ext=VAR2">Map</a> / <a href="https://cgi.minorplanetcenter.net/cgi-bin/uncertaintymap.cgi?Obj=K24A00A&JD=2460478.50000&Ext=VAR2&Form=Y&OC=500">Offsets</a>
+2024 06 18 000000 23 29 20.8 -05 17 41   1.440   1.848   96.1  33.1  30.9   +0.10    -0.022       178 063.6 / <a href="https://cgi.minorplanetcenter.net/cgi-bin/uncertaintymap.cgi?Obj=K24A00A&JD=2460479.50000&Ext=VAR2">Map</a> / <a href="https://cgi.minorplanetcenter.net/cgi-bin/uncertaintymap.cgi?Obj=K24A00A&JD=2460479.50000&Ext=VAR2&Form=Y&OC=500">Offsets</a>
+2024 06 19 000000 23 29 29.9 -05 18 19   1.437   1.858   97.0  32.9  30.9   +0.083   -0.031       181 063.6 / <a href="https://cgi.minorplanetcenter.net/cgi-bin/uncertaintymap.cgi?Obj=K24A00A&JD=2460480.50000&Ext=VAR2">Map</a> / <a href="https://cgi.minorplanetcenter.net/cgi-bin/uncertaintymap.cgi?Obj=K24A00A&JD=2460480.50000&Ext=VAR2&Form=Y&OC=500">Offsets</a>
+2024 06 20 000000 23 29 36.9 -05 19 11   1.433   1.867   97.9  32.6  30.9   +0.062   -0.041       184 063.7 / <a href="https://cgi.minorplanetcenter.net/cgi-bin/uncertaintymap.cgi?Obj=K24A00A&JD=2460481.50000&Ext=VAR2">Map</a> / <a href="https://cgi.minorplanetcenter.net/cgi-bin/uncertaintymap.cgi?Obj=K24A00A&JD=2460481.50000&Ext=VAR2&Form=Y&OC=500">Offsets</a>
+2024 06 21 000000 23 29 41.8 -05 20 16   1.429   1.877   98.8  32.3  30.9   +0.040   -0.050       187 063.7 / <a href="https://cgi.minorplanetcenter.net/cgi-bin/uncertaintymap.cgi?Obj=K24A00A&JD=2460482.50000&Ext=VAR2">Map</a> / <a href="https://cgi.minorplanetcenter.net/cgi-bin/uncertaintymap.cgi?Obj=K24A00A&JD=2460482.50000&Ext=VAR2&Form=Y&OC=500">Offsets</a>
+2024 06 22 000000 23 29 44.6 -05 21 35   1.425   1.886   99.8  32.1  30.9   +0.019   -0.059       190 063.7 / <a href="https://cgi.minorplanetcenter.net/cgi-bin/uncertaintymap.cgi?Obj=K24A00A&JD=2460483.50000&Ext=VAR2">Map</a> / <a href="https://cgi.minorplanetcenter.net/cgi-bin/uncertaintymap.cgi?Obj=K24A00A&JD=2460483.50000&Ext=VAR2&Form=Y&OC=500">Offsets</a>
+2024 06 23 000000 23 29 45.4 -05 23 07   1.422   1.896  100.8  31.8  30.9   -0.003   -0.069       193 063.8 / <a href="https://cgi.minorplanetcenter.net/cgi-bin/uncertaintymap.cgi?Obj=K24A00A&JD=2460484.50000&Ext=VAR2">Map</a> / <a href="https://cgi.minorplanetcenter.net/cgi-bin/uncertaintymap.cgi?Obj=K24A00A&JD=2460484.50000&Ext=VAR2&Form=Y&OC=500">Offsets</a>
+2024 06 24 000000 23 29 44.0 -05 24 54   1.418   1.905  101.7  31.5  30.9   -0.025   -0.079       196 063.8 / <a href="https://cgi.minorplanetcenter.net/cgi-bin/uncertaintymap.cgi?Obj=K24A00A&JD=2460485.50000&Ext=VAR2">Map</a> / <a href="https://cgi.minorplanetcenter.net/cgi-bin/uncertaintymap.cgi?Obj=K24A00A&JD=2460485.50000&Ext=VAR2&Form=Y&OC=500">Offsets</a>
+2024 06 25 000000 23 29 40.5 -05 26 54   1.414   1.914  102.7  31.2  30.9   -0.048   -0.088       199 063.8 / <a href="https://cgi.minorplanetcenter.net/cgi-bin/uncertaintymap.cgi?Obj=K24A00A&JD=2460486.50000&Ext=VAR2">Map</a> / <a href="https://cgi.minorplanetcenter.net/cgi-bin/uncertaintymap.cgi?Obj=K24A00A&JD=2460486.50000&Ext=VAR2&Form=Y&OC=500">Offsets</a>
+2024 06 26 000000 23 29 34.8 -05 29 08   1.410   1.924  103.7  30.9  30.9   -0.070   -0.098       202 063.9 / <a href="https://cgi.minorplanetcenter.net/cgi-bin/uncertaintymap.cgi?Obj=K24A00A&JD=2460487.50000&Ext=VAR2">Map</a> / <a href="https://cgi.minorplanetcenter.net/cgi-bin/uncertaintymap.cgi?Obj=K24A00A&JD=2460487.50000&Ext=VAR2&Form=Y&OC=500">Offsets</a>
+2024 06 27 000000 23 29 27.0 -05 31 37   1.406   1.933  104.7  30.6  30.9   -0.093   -0.11       205 063.9 /  <a href="https://cgi.minorplanetcenter.net/cgi-bin/uncertaintymap.cgi?Obj=K24A00A&JD=2460488.50000&Ext=VAR2">Map</a> / <a href="https://cgi.minorplanetcenter.net/cgi-bin/uncertaintymap.cgi?Obj=K24A00A&JD=2460488.50000&Ext=VAR2&Form=Y&OC=500">Offsets</a>
+2024 06 28 000000 23 29 16.9 -05 34 20   1.403   1.942  105.7  30.3  30.9   -0.12    -0.12       208 064.0 /  <a href="https://cgi.minorplanetcenter.net/cgi-bin/uncertaintymap.cgi?Obj=K24A00A&JD=2460489.50000&Ext=VAR2">Map</a> / <a href="https://cgi.minorplanetcenter.net/cgi-bin/uncertaintymap.cgi?Obj=K24A00A&JD=2460489.50000&Ext=VAR2&Form=Y&OC=500">Offsets</a>
+2024 06 29 000000 23 29 04.7 -05 37 17   1.399   1.952  106.7  29.9  30.9   -0.14    -0.13       211 064.0 /  <a href="https://cgi.minorplanetcenter.net/cgi-bin/uncertaintymap.cgi?Obj=K24A00A&JD=2460490.50000&Ext=VAR2">Map</a> / <a href="https://cgi.minorplanetcenter.net/cgi-bin/uncertaintymap.cgi?Obj=K24A00A&JD=2460490.50000&Ext=VAR2&Form=Y&OC=500">Offsets</a>
+2024 06 30 000000 23 28 50.2 -05 40 28   1.395   1.961  107.8  29.6  30.9   -0.16    -0.14       214 064.0 /  <a href="https://cgi.minorplanetcenter.net/cgi-bin/uncertaintymap.cgi?Obj=K24A00A&JD=2460491.50000&Ext=VAR2">Map</a> / <a href="https://cgi.minorplanetcenter.net/cgi-bin/uncertaintymap.cgi?Obj=K24A00A&JD=2460491.50000&Ext=VAR2&Form=Y&OC=500">Offsets</a>
+2024 07 01 000000 23 28 33.5 -05 43 54   1.391   1.970  108.8  29.2  30.9   -0.18    -0.15       217 064.1 /  <a href="https://cgi.minorplanetcenter.net/cgi-bin/uncertaintymap.cgi?Obj=K24A00A&JD=2460492.50000&Ext=VAR2">Map</a> / <a href="https://cgi.minorplanetcenter.net/cgi-bin/uncertaintymap.cgi?Obj=K24A00A&JD=2460492.50000&Ext=VAR2&Form=Y&OC=500">Offsets</a>
+2024 07 02 000000 23 28 14.5 -05 47 34   1.387   1.979  109.8  28.9  30.9   -0.21    -0.16       220 064.1 /  <a href="https://cgi.minorplanetcenter.net/cgi-bin/uncertaintymap.cgi?Obj=K24A00A&JD=2460493.50000&Ext=VAR2">Map</a> / <a href="https://cgi.minorplanetcenter.net/cgi-bin/uncertaintymap.cgi?Obj=K24A00A&JD=2460493.50000&Ext=VAR2&Form=Y&OC=500">Offsets</a>
+2024 07 03 000000 23 27 53.3 -05 51 29   1.384   1.988  110.9  28.5  30.9   -0.23    -0.17       223 064.2 /  <a href="https://cgi.minorplanetcenter.net/cgi-bin/uncertaintymap.cgi?Obj=K24A00A&JD=2460494.50000&Ext=VAR2">Map</a> / <a href="https://cgi.minorplanetcenter.net/cgi-bin/uncertaintymap.cgi?Obj=K24A00A&JD=2460494.50000&Ext=VAR2&Form=Y&OC=500">Offsets</a>
+2024 07 04 000000 23 27 29.7 -05 55 38   1.380   1.997  112.0  28.2  30.9   -0.26    -0.18       226 064.2 /  <a href="https://cgi.minorplanetcenter.net/cgi-bin/uncertaintymap.cgi?Obj=K24A00A&JD=2460495.50000&Ext=VAR2">Map</a> / <a href="https://cgi.minorplanetcenter.net/cgi-bin/uncertaintymap.cgi?Obj=K24A00A&JD=2460495.50000&Ext=VAR2&Form=Y&OC=500">Offsets</a>
+2024 07 05 000000 23 27 03.9 -06 00 02   1.376   2.006  113.0  27.8  30.9   -0.28    -0.19       229 064.2 /  <a href="https://cgi.minorplanetcenter.net/cgi-bin/uncertaintymap.cgi?Obj=K24A00A&JD=2460496.50000&Ext=VAR2">Map</a> / <a href="https://cgi.minorplanetcenter.net/cgi-bin/uncertaintymap.cgi?Obj=K24A00A&JD=2460496.50000&Ext=VAR2&Form=Y&OC=500">Offsets</a>
+</pre>
+ <p><hr><p>
+ These calculations have been performed on the
+ <a href="http://www.minorplanetcenter.net/iau/Ack/TamkinFoundation.html">Tamkin
+ Foundation Computing Network</a>.
+ <p><hr>
+ <p>
+       <a href="http://validator.w3.org/check?uri=referer"><img border="0"
+           src="http://www.w3.org/Icons/valid-html401"
+           alt="Valid HTML 4.01!" height="31" width="88"></a>
+ </p>
+ </body>
+ </html>

--- a/astroquery/mpc/tests/data/2024AA_ephemeris_G37-a-t.html
+++ b/astroquery/mpc/tests/data/2024AA_ephemeris_G37-a-t.html
@@ -1,0 +1,75 @@
+ <!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN">
+ <html>
+ <head>
+ <META HTTP-EQUIV="Content-Type" CONTENT="text/html; charset=ISO-8859-1">
+ <title>Minor Planet Ephemeris Service: Query Results</title>
+ </head>
+ <body>
+ <h1>Minor Planet Ephemeris Service: Query Results</h1>
+ Below are the results of your request from the Minor Planet Center's
+ Minor Planet Ephemeris Service.
+ <p>
+   Newly designated objects may take up to 1 day to show up in this service.
+ </p>
+ <p>
+   Orbits and ephemerides of unnumbered NEOs are up-to-date. Other orbits are in
+  the process of being refreshed.
+ </p>
+ <p>
+   The current system is not completely reliable in the case of objects
+   with very-close approaches with the Earth.
+   <br></br> We are working on a completely new system,
+   but for the time being we encourage the users to double check
+   the results with other ephemeris generators when the object is very close to 
+ Earth.
+ </p>
+ Ephemerides are for
+ observatory code G37.
+ <p><hr><p>
+ <p>
+ <b>2024 AA</b>
+<p> Number of variant orbits available:     11</p>
+ <p>Perturbed ephemeris below is based on
+   1-day-arc
+ unperturbed elements from 
+ <i>MPO</i> 793554.
+ Last observed on  2024 Jan. 2.
+<p><a href="https://www.minorplanetcenter.net/iau/info/FurtherObs.html">Further observations?</a>  Useful for orbit improvement.
+ <p><pre>
+     K24A00A       [H=27.41]
+Date       UT      R.A. (J2000) Decl.    Delta     r     El.    Ph.   V      Sky Motion        Object    Sun   Moon                Uncertainty info
+            h m s                                                            "/min    "/min   Azi. Alt.  Alt.  Phase Dist. Alt.    3-sig/" P.A.
+2024 06 15 000000 23 28 41.4 -05 17 10   1.451   1.819   93.3  33.9  30.9   +0.19    +0.006   323  -55   +30   0.57   168  +45       169 063.5 / <a href="https://cgi.minorplanetcenter.net/cgi-bin/uncertaintymap.cgi?Obj=K24A00A&JD=2460476.50000&Ext=VAR2">Map</a> / <a href="https://cgi.minorplanetcenter.net/cgi-bin/uncertaintymap.cgi?Obj=K24A00A&JD=2460476.50000&Ext=VAR2&Form=Y&OC=500">Offsets</a>
+2024 06 16 000000 23 28 56.6 -05 17 08   1.447   1.829   94.2  33.6  30.9   +0.17    -0.003   325  -56   +30   0.67   156  +35       172 063.5 / <a href="https://cgi.minorplanetcenter.net/cgi-bin/uncertaintymap.cgi?Obj=K24A00A&JD=2460477.50000&Ext=VAR2">Map</a> / <a href="https://cgi.minorplanetcenter.net/cgi-bin/uncertaintymap.cgi?Obj=K24A00A&JD=2460477.50000&Ext=VAR2&Form=Y&OC=500">Offsets</a>
+2024 06 17 000000 23 29 09.7 -05 17 19   1.444   1.838   95.1  33.4  30.9   +0.15    -0.012   326  -56   +30   0.75   144  +25       175 063.6 / <a href="https://cgi.minorplanetcenter.net/cgi-bin/uncertaintymap.cgi?Obj=K24A00A&JD=2460478.50000&Ext=VAR2">Map</a> / <a href="https://cgi.minorplanetcenter.net/cgi-bin/uncertaintymap.cgi?Obj=K24A00A&JD=2460478.50000&Ext=VAR2&Form=Y&OC=500">Offsets</a>
+2024 06 18 000000 23 29 20.7 -05 17 44   1.440   1.848   96.1  33.1  30.9   +0.13    -0.021   328  -57   +30   0.83   132  +14       178 063.6 / <a href="https://cgi.minorplanetcenter.net/cgi-bin/uncertaintymap.cgi?Obj=K24A00A&JD=2460479.50000&Ext=VAR2">Map</a> / <a href="https://cgi.minorplanetcenter.net/cgi-bin/uncertaintymap.cgi?Obj=K24A00A&JD=2460479.50000&Ext=VAR2&Form=Y&OC=500">Offsets</a>
+2024 06 19 000000 23 29 29.8 -05 18 22   1.437   1.858   97.0  32.9  30.9   +0.10    -0.031   329  -57   +30   0.90   120  +03       181 063.6 / <a href="https://cgi.minorplanetcenter.net/cgi-bin/uncertaintymap.cgi?Obj=K24A00A&JD=2460480.50000&Ext=VAR2">Map</a> / <a href="https://cgi.minorplanetcenter.net/cgi-bin/uncertaintymap.cgi?Obj=K24A00A&JD=2460480.50000&Ext=VAR2&Form=Y&OC=500">Offsets</a>
+2024 06 20 000000 23 29 36.8 -05 19 14   1.433   1.867   97.9  32.6  30.9   +0.083   -0.040   331  -58   +30   0.95   107  -08       184 063.7 / <a href="https://cgi.minorplanetcenter.net/cgi-bin/uncertaintymap.cgi?Obj=K24A00A&JD=2460481.50000&Ext=VAR2">Map</a> / <a href="https://cgi.minorplanetcenter.net/cgi-bin/uncertaintymap.cgi?Obj=K24A00A&JD=2460481.50000&Ext=VAR2&Form=Y&OC=500">Offsets</a>
+2024 06 21 000000 23 29 41.7 -05 20 19   1.429   1.877   98.8  32.3  30.9   +0.062   -0.049   333  -58   +30   0.99   094  -20       187 063.7 / <a href="https://cgi.minorplanetcenter.net/cgi-bin/uncertaintymap.cgi?Obj=K24A00A&JD=2460482.50000&Ext=VAR2">Map</a> / <a href="https://cgi.minorplanetcenter.net/cgi-bin/uncertaintymap.cgi?Obj=K24A00A&JD=2460482.50000&Ext=VAR2&Form=Y&OC=500">Offsets</a>
+2024 06 22 000000 23 29 44.6 -05 21 38   1.425   1.886   99.8  32.1  30.9   +0.040   -0.059   334  -58   +30   1.00   081  -31       190 063.7 / <a href="https://cgi.minorplanetcenter.net/cgi-bin/uncertaintymap.cgi?Obj=K24A00A&JD=2460483.50000&Ext=VAR2">Map</a> / <a href="https://cgi.minorplanetcenter.net/cgi-bin/uncertaintymap.cgi?Obj=K24A00A&JD=2460483.50000&Ext=VAR2&Form=Y&OC=500">Offsets</a>
+2024 06 23 000000 23 29 45.3 -05 23 10   1.422   1.896  100.8  31.8  30.9   +0.018   -0.069   336  -59   +30   0.99   067  -43       193 063.8 / <a href="https://cgi.minorplanetcenter.net/cgi-bin/uncertaintymap.cgi?Obj=K24A00A&JD=2460484.50000&Ext=VAR2">Map</a> / <a href="https://cgi.minorplanetcenter.net/cgi-bin/uncertaintymap.cgi?Obj=K24A00A&JD=2460484.50000&Ext=VAR2&Form=Y&OC=500">Offsets</a>
+2024 06 24 000000 23 29 43.9 -05 24 57   1.418   1.905  101.7  31.5  30.9   -0.003   -0.078   338  -59   +30   0.95   053  -54       196 063.8 / <a href="https://cgi.minorplanetcenter.net/cgi-bin/uncertaintymap.cgi?Obj=K24A00A&JD=2460485.50000&Ext=VAR2">Map</a> / <a href="https://cgi.minorplanetcenter.net/cgi-bin/uncertaintymap.cgi?Obj=K24A00A&JD=2460485.50000&Ext=VAR2&Form=Y&OC=500">Offsets</a>
+2024 06 25 000000 23 29 40.4 -05 26 57   1.414   1.914  102.7  31.2  30.9   -0.026   -0.088   340  -59   +30   0.89   039  -63       199 063.8 / <a href="https://cgi.minorplanetcenter.net/cgi-bin/uncertaintymap.cgi?Obj=K24A00A&JD=2460486.50000&Ext=VAR2">Map</a> / <a href="https://cgi.minorplanetcenter.net/cgi-bin/uncertaintymap.cgi?Obj=K24A00A&JD=2460486.50000&Ext=VAR2&Form=Y&OC=500">Offsets</a>
+2024 06 26 000000 23 29 34.8 -05 29 12   1.410   1.924  103.7  30.9  30.9   -0.048   -0.098   342  -60   +30   0.81   025  -68       202 063.9 / <a href="https://cgi.minorplanetcenter.net/cgi-bin/uncertaintymap.cgi?Obj=K24A00A&JD=2460487.50000&Ext=VAR2">Map</a> / <a href="https://cgi.minorplanetcenter.net/cgi-bin/uncertaintymap.cgi?Obj=K24A00A&JD=2460487.50000&Ext=VAR2&Form=Y&OC=500">Offsets</a>
+2024 06 27 000000 23 29 26.9 -05 31 40   1.406   1.933  104.7  30.6  30.9   -0.070   -0.11    344  -60   +30   0.72   011  -65       205 063.9 / <a href="https://cgi.minorplanetcenter.net/cgi-bin/uncertaintymap.cgi?Obj=K24A00A&JD=2460488.50000&Ext=VAR2">Map</a> / <a href="https://cgi.minorplanetcenter.net/cgi-bin/uncertaintymap.cgi?Obj=K24A00A&JD=2460488.50000&Ext=VAR2&Form=Y&OC=500">Offsets</a>
+2024 06 28 000000 23 29 16.9 -05 34 23   1.403   1.942  105.7  30.3  30.9   -0.093   -0.12    346  -60   +30   0.61   004  -58       208 064.0 / <a href="https://cgi.minorplanetcenter.net/cgi-bin/uncertaintymap.cgi?Obj=K24A00A&JD=2460489.50000&Ext=VAR2">Map</a> / <a href="https://cgi.minorplanetcenter.net/cgi-bin/uncertaintymap.cgi?Obj=K24A00A&JD=2460489.50000&Ext=VAR2&Form=Y&OC=500">Offsets</a>
+2024 06 29 000000 23 29 04.6 -05 37 20   1.399   1.952  106.7  29.9  30.9   -0.12    -0.13    348  -61   +30   0.49   018  -47       211 064.0 / <a href="https://cgi.minorplanetcenter.net/cgi-bin/uncertaintymap.cgi?Obj=K24A00A&JD=2460490.50000&Ext=VAR2">Map</a> / <a href="https://cgi.minorplanetcenter.net/cgi-bin/uncertaintymap.cgi?Obj=K24A00A&JD=2460490.50000&Ext=VAR2&Form=Y&OC=500">Offsets</a>
+2024 06 30 000000 23 28 50.2 -05 40 31   1.395   1.961  107.8  29.6  30.9   -0.14    -0.14    350  -61   +30   0.38   032  -36       214 064.0 / <a href="https://cgi.minorplanetcenter.net/cgi-bin/uncertaintymap.cgi?Obj=K24A00A&JD=2460491.50000&Ext=VAR2">Map</a> / <a href="https://cgi.minorplanetcenter.net/cgi-bin/uncertaintymap.cgi?Obj=K24A00A&JD=2460491.50000&Ext=VAR2&Form=Y&OC=500">Offsets</a>
+2024 07 01 000000 23 28 33.4 -05 43 57   1.391   1.970  108.8  29.2  30.9   -0.16    -0.15    352  -61   +30   0.27   046  -24       217 064.1 / <a href="https://cgi.minorplanetcenter.net/cgi-bin/uncertaintymap.cgi?Obj=K24A00A&JD=2460492.50000&Ext=VAR2">Map</a> / <a href="https://cgi.minorplanetcenter.net/cgi-bin/uncertaintymap.cgi?Obj=K24A00A&JD=2460492.50000&Ext=VAR2&Form=Y&OC=500">Offsets</a>
+2024 07 02 000000 23 28 14.5 -05 47 37   1.388   1.979  109.8  28.9  30.9   -0.19    -0.16    354  -61   +30   0.18   060  -12       220 064.1 / <a href="https://cgi.minorplanetcenter.net/cgi-bin/uncertaintymap.cgi?Obj=K24A00A&JD=2460493.50000&Ext=VAR2">Map</a> / <a href="https://cgi.minorplanetcenter.net/cgi-bin/uncertaintymap.cgi?Obj=K24A00A&JD=2460493.50000&Ext=VAR2&Form=Y&OC=500">Offsets</a>
+2024 07 03 000000 23 27 53.2 -05 51 32   1.384   1.988  110.9  28.5  30.9   -0.21    -0.17    356  -61   +30   0.10   074  +00       223 064.2 / <a href="https://cgi.minorplanetcenter.net/cgi-bin/uncertaintymap.cgi?Obj=K24A00A&JD=2460494.50000&Ext=VAR2">Map</a> / <a href="https://cgi.minorplanetcenter.net/cgi-bin/uncertaintymap.cgi?Obj=K24A00A&JD=2460494.50000&Ext=VAR2&Form=Y&OC=500">Offsets</a>
+2024 07 04 000000 23 27 29.7 -05 55 41   1.380   1.997  112.0  28.2  30.9   -0.23    -0.18    358  -61   +30   0.04   088  +11       226 064.2 / <a href="https://cgi.minorplanetcenter.net/cgi-bin/uncertaintymap.cgi?Obj=K24A00A&JD=2460495.50000&Ext=VAR2">Map</a> / <a href="https://cgi.minorplanetcenter.net/cgi-bin/uncertaintymap.cgi?Obj=K24A00A&JD=2460495.50000&Ext=VAR2&Form=Y&OC=500">Offsets</a>
+2024 07 05 000000 23 27 03.9 -06 00 05   1.377   2.006  113.0  27.8  30.9   -0.26    -0.19    001  -61   +30   0.01   101  +22       229 064.2 / <a href="https://cgi.minorplanetcenter.net/cgi-bin/uncertaintymap.cgi?Obj=K24A00A&JD=2460496.50000&Ext=VAR2">Map</a> / <a href="https://cgi.minorplanetcenter.net/cgi-bin/uncertaintymap.cgi?Obj=K24A00A&JD=2460496.50000&Ext=VAR2&Form=Y&OC=500">Offsets</a>
+</pre>
+ <p><hr><p>
+ These calculations have been performed on the
+ <a href="http://www.minorplanetcenter.net/iau/Ack/TamkinFoundation.html">Tamkin
+ Foundation Computing Network</a>.
+ <p><hr>
+ <p>
+       <a href="http://validator.w3.org/check?uri=referer"><img border="0"
+           src="http://www.w3.org/Icons/valid-html401"
+           alt="Valid HTML 4.01!" height="31" width="88"></a>
+ </p>
+ </body>
+ </html>

--- a/astroquery/mpc/tests/data/340P_ephemeris_G37-a-t.html
+++ b/astroquery/mpc/tests/data/340P_ephemeris_G37-a-t.html
@@ -1,0 +1,49 @@
+ <!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN">
+ <html>
+ <head>
+ <META HTTP-EQUIV="Content-Type" CONTENT="text/html; charset=ISO-8859-1">
+ <title>Minor Planet Ephemeris Service: Query Results</title>
+ </head>
+ <body>
+ <h1>Minor Planet Ephemeris Service: Query Results</h1>
+ Below are the results of your request from the Minor Planet Center's
+ Minor Planet Ephemeris Service.
+ <p>
+   Newly designated objects may take up to 1 day to show up in this service.
+ </p>
+ <p>
+   Orbits and ephemerides of unnumbered NEOs are up-to-date. Other orbits are in
+  the process of being refreshed.
+ </p>
+ <p>
+   The current system is not completely reliable in the case of objects
+   with very-close approaches with the Earth.
+   <br></br> We are working on a completely new system,
+   but for the time being we encourage the users to double check
+   the results with other ephemeris generators when the object is very close to 
+ Earth.
+ </p>
+ Ephemerides are for
+ observatory code 106.
+ <p><hr><p>
+ <b> 340P/Boattini</b>
+ <p>Perturbed ephemeris below is based on
+ unperturbed elements from 
+ <i>MPC</i> 133426.
+ <p>
+ <p><pre>
+0340P
+Date       UT      R.A. (J2000) Decl.    Delta     r     El.    Ph.   m1     Sky Motion        Object    Sun   Moon
+            h m s                                                            "/min    "/min   Azi. Alt.  Alt.  Phase Dist. Alt.</pre>
+ <p><hr><p>
+ These calculations have been performed on the
+ <a href="http://www.minorplanetcenter.net/iau/Ack/TamkinFoundation.html">Tamkin
+ Foundation Computing Network</a>.
+ <p><hr>
+ <p>
+       <a href="http://validator.w3.org/check?uri=referer"><img border="0"
+           src="http://www.w3.org/Icons/valid-html401"
+           alt="Valid HTML 4.01!" height="31" width="88"></a>
+ </p>
+ </body>
+ </html>

--- a/astroquery/mpc/tests/test_mpc.py
+++ b/astroquery/mpc/tests/test_mpc.py
@@ -190,7 +190,7 @@ def test_get_ephemeris_Moon_phase_and_Uncertainty(patch_post):
 
 
 def test_get_ephemeris_by_name_empty(patch_post):
-    with pytest.raises(NoResultsWarning):
+    with pytest.raises(EmptyResponseError):
         mpc.core.MPC.get_ephemeris('340P', location='G37')
 
 

--- a/astroquery/mpc/tests/test_mpc.py
+++ b/astroquery/mpc/tests/test_mpc.py
@@ -64,7 +64,7 @@ import astropy.units as u
 from astropy.coordinates import EarthLocation, Angle
 from astropy.time import Time
 
-from ...exceptions import EmptyResponseError, InvalidQueryError, NoResultsWarning
+from ...exceptions import EmptyResponseError, InvalidQueryError
 from ... import mpc
 from astroquery.utils.mocks import MockResponse
 from requests import Request

--- a/astroquery/mpc/tests/test_mpc.py
+++ b/astroquery/mpc/tests/test_mpc.py
@@ -64,7 +64,7 @@ import astropy.units as u
 from astropy.coordinates import EarthLocation, Angle
 from astropy.time import Time
 
-from ...exceptions import EmptyResponseError, InvalidQueryError
+from ...exceptions import EmptyResponseError, InvalidQueryError, NoResultsWarning
 from ... import mpc
 from astroquery.utils.mocks import MockResponse
 from requests import Request
@@ -190,7 +190,7 @@ def test_get_ephemeris_Moon_phase_and_Uncertainty(patch_post):
 
 
 def test_get_ephemeris_by_name_fail(patch_post):
-    with pytest.raises(EmptyResponseError):
+    with pytest.raises(NoResultsWarning):
         mpc.core.MPC.get_ephemeris('340P', location='G37')
 
 

--- a/astroquery/mpc/tests/test_mpc.py
+++ b/astroquery/mpc/tests/test_mpc.py
@@ -64,7 +64,7 @@ import astropy.units as u
 from astropy.coordinates import EarthLocation, Angle
 from astropy.time import Time
 
-from ...exceptions import InvalidQueryError
+from ...exceptions import EmptyResponseError, InvalidQueryError
 from ... import mpc
 from astroquery.utils.mocks import MockResponse
 from requests import Request
@@ -178,18 +178,23 @@ def test_get_ephemeris_Moon_phase(patch_post):
 
 def test_get_ephemeris_Uncertainty(patch_post):
     # this test requires an object with uncertainties != N/A
-    result = mpc.core.MPC.get_ephemeris('1994 XG')
+    result = mpc.core.MPC.get_ephemeris('2024 AA')
     assert result['Uncertainty 3sig'].quantity[0] > 0 * u.arcsec
 
 
 def test_get_ephemeris_Moon_phase_and_Uncertainty(patch_post):
     # this test requires an object with uncertainties != N/A
-    result = mpc.core.MPC.get_ephemeris('1994 XG', location='G37')
+    result = mpc.core.MPC.get_ephemeris('2024 AA', location='G37')
     assert result['Moon phase'][0] >= 0
     assert result['Uncertainty 3sig'].quantity[0] > 0 * u.arcsec
 
 
 def test_get_ephemeris_by_name_fail(patch_post):
+    with pytest.raises(EmptyResponseError):
+        mpc.core.MPC.get_ephemeris('340P', location='G37')
+
+
+def test_get_ephemeris_by_name_empty(patch_post):
     with pytest.raises(InvalidQueryError):
         mpc.core.MPC.get_ephemeris('test fail')
 

--- a/astroquery/mpc/tests/test_mpc.py
+++ b/astroquery/mpc/tests/test_mpc.py
@@ -189,12 +189,12 @@ def test_get_ephemeris_Moon_phase_and_Uncertainty(patch_post):
     assert result['Uncertainty 3sig'].quantity[0] > 0 * u.arcsec
 
 
-def test_get_ephemeris_by_name_fail(patch_post):
+def test_get_ephemeris_by_name_empty(patch_post):
     with pytest.raises(NoResultsWarning):
         mpc.core.MPC.get_ephemeris('340P', location='G37')
 
 
-def test_get_ephemeris_by_name_empty(patch_post):
+def test_get_ephemeris_by_name_fail(patch_post):
     with pytest.raises(InvalidQueryError):
         mpc.core.MPC.get_ephemeris('test fail')
 

--- a/astroquery/mpc/tests/test_mpc_remote.py
+++ b/astroquery/mpc/tests/test_mpc_remote.py
@@ -1,7 +1,7 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 import requests
 import pytest
-
+import astropy.units as u
 from astroquery.exceptions import InvalidQueryError
 from astroquery import mpc
 
@@ -77,6 +77,21 @@ class TestMPC:
         # test that query succeeded
         response = mpc.MPC.get_ephemeris(target)
         assert len(response) > 0
+
+    def test_get_ephemeris_Moon_phase(self):
+        result = mpc.core.MPC.get_ephemeris('2P', location='G37')
+        assert result['Moon phase'][0] >= 0
+
+    def test_get_ephemeris_Uncertainty(self):
+        # this test requires an object with uncertainties != N/A
+        result = mpc.core.MPC.get_ephemeris('2024 AA', start='2024-06-15')
+        assert result['Uncertainty 3sig'].quantity[0] > 0 * u.arcsec
+
+    def test_get_ephemeris_Moon_phase_and_Uncertainty(self):
+        # this test requires an object with uncertainties != N/A
+        result = mpc.core.MPC.get_ephemeris('2024 AA', location='G37', start='2024-06-15')
+        assert result['Moon phase'][0] >= 0
+        assert result['Uncertainty 3sig'].quantity[0] > 0 * u.arcsec
 
     def test_get_ephemeris_target_fail(self):
         # test that query failed


### PR DESCRIPTION
#3019 update of the MPC parse_results to correctly parse 3 digit precision motion columns
#3022 update of the MPC parse_results to raise EmptyResponseError if no table lines are parsed