### PR TITLE
Maintenance for the VizieR module

### DIFF
--- a/astroquery/vizier/tests/test_vizier.py
+++ b/astroquery/vizier/tests/test_vizier.py
@@ -55,7 +55,7 @@ def post_mockreturn(self, method, url, data=None, timeout=10, files=None,
         filename = data_path(VO_DATA[datad['-source']])
     elif '-words' in datad:
         # a find_catalog request/only metadata
-        filename = data_path(VO_DATA['find_' + datad['-words']])
+        filename = data_path(VO_DATA['find_' + datad['-words'].split("&")[0]])
 
     with open(filename, 'rb') as infile:
         content = infile.read()

--- a/astroquery/vizier/tests/test_vizier_remote.py
+++ b/astroquery/vizier/tests/test_vizier_remote.py
@@ -94,7 +94,7 @@ class TestVizierRemote:
         v = vizier.core.Vizier(
             columns=['_RAJ2000', 'DEJ2000', 'B-V', 'Vmag', 'Plx'],
             column_filters={"Vmag": ">10"}, keywords=["optical", "radio"])
-
+        v.ROW_LIMIT = 1
         v.query_object('M 31')
 
     def test_regressiontest_invalidtable(self):
@@ -127,22 +127,17 @@ class TestVizierRemote:
 
     def test_findcatalog_maxcatalog(self):
         V = vizier.core.Vizier()
-        cats = V.find_catalogs('eclipsing binary', max_catalogs=5000)
-        assert len(cats) >= 468
-
-        # with pytest.raises(ValueError) as exc:
-        #    V.find_catalogs('eclipsing binary')
-        # assert str(exc.value)==("Maximum number of catalogs exceeded."
-        #                        "  Try setting max_catalogs "
-        #                        "to a large number and try again")
+        cats = V.find_catalogs('eclipsing binary planets', max_catalogs=5000)
+        assert len(cats) >= 39  # as of 2024
 
     def test_findcatalog_ucd(self):
+        # this fails for VizieR 7.33.3, should work in next releases
         V = vizier.core.Vizier()
-        ucdresult = V(ucd='time.age*').find_catalogs('eclipsing binary', max_catalogs=5000)
-        result = V.find_catalogs('eclipsing binary', max_catalogs=5000)
+        ucdresult = V(ucd='phys.albedo').find_catalogs('mars', max_catalogs=5000)
+        result = V.find_catalogs('mars', max_catalogs=5000)
 
-        assert len(ucdresult) >= 12  # count as of 1/15/2018
-        assert len(result) >= 628
+        assert len(ucdresult) >= 1
+        assert len(result) >= 11
         # important part: we're testing that UCD is parsed and some catalogs are ruled out
         assert len(ucdresult) < len(result)
 

--- a/astroquery/vizier/tests/test_vizier_remote.py
+++ b/astroquery/vizier/tests/test_vizier_remote.py
@@ -5,7 +5,7 @@ import numpy as np
 import astropy.units as u
 from astropy.coordinates import SkyCoord
 
-from astroquery import vizier
+from astroquery.vizier import Vizier
 from astroquery.utils import commons
 from .conftest import scalar_skycoord, vector_skycoord
 
@@ -14,61 +14,61 @@ from .conftest import scalar_skycoord, vector_skycoord
 class TestVizierRemote:
 
     def test_query_object(self):
-        result = vizier.core.Vizier.query_object(
+        result = Vizier.query_object(
             "HD 226868", catalog=["NOMAD", "UCAC"])
 
         assert isinstance(result, commons.TableList)
 
     def test_query_another_object(self):
-        result = vizier.core.Vizier.query_region(
+        result = Vizier.query_region(
             "AFGL 2591", radius='0d5m', catalog="B/iram/pdbi")
         assert isinstance(result, commons.TableList)
 
     def test_query_object_async(self):
-        response = vizier.core.Vizier.query_object_async(
+        response = Vizier.query_object_async(
             "HD 226868", catalog=["NOMAD", "UCAC"])
         assert response is not None
 
     def test_query_region(self):
-        result = vizier.core.Vizier.query_region(
+        result = Vizier.query_region(
             scalar_skycoord, radius=5 * u.deg, catalog=["HIP", "NOMAD", "UCAC"])
 
         assert isinstance(result, commons.TableList)
 
     def test_query_region_async(self):
-        response = vizier.core.Vizier.query_region_async(
+        response = Vizier.query_region_async(
             scalar_skycoord, radius=5 * u.deg, catalog=["HIP", "NOMAD", "UCAC"])
         assert response is not None
 
     def test_query_region_async_galactic(self):
-        response = vizier.core.Vizier.query_region_async(
+        response = Vizier.query_region_async(
             scalar_skycoord, radius=0.5 * u.deg, catalog="HIP", frame="galactic")
         assert response is not None
-        payload = vizier.core.Vizier.query_region_async(
+        payload = Vizier.query_region_async(
             scalar_skycoord, radius=0.5 * u.deg, catalog="HIP",
             frame="galactic", get_query_payload=True)
         assert "-c=G" in payload
 
     def test_query_Vizier_instance(self):
         with pytest.warns(UserWarning, match="xry : No such keyword"):
-            v = vizier.core.Vizier(
+            vizier = Vizier(
                 columns=['_RAJ2000', 'DEJ2000', 'B-V', 'Vmag', 'Plx'],
                 column_filters={"Vmag": ">10"}, keywords=["optical", "xry"])
 
-        result = v.query_object("HD 226868", catalog=["NOMAD", "UCAC"])
+        result = vizier.query_object("HD 226868", catalog=["NOMAD", "UCAC"])
         assert isinstance(result, commons.TableList)
-        result = v.query_region(
+        result = vizier.query_region(
             scalar_skycoord, width="5d0m0s", height="3d0m0s", catalog=["NOMAD", "UCAC"])
         assert isinstance(result, commons.TableList)
 
     def test_vizier_column_restriction(self):
         # Check that the column restriction worked.  At least some of these
         # catalogs include Bmag's
-        v = vizier.core.Vizier(
+        vizier = Vizier(
             columns=['_RAJ2000', 'DEJ2000', 'B-V', 'Vmag', 'Plx'],
             column_filters={"Vmag": ">10"}, keywords=["optical", "X-ray"])
 
-        result = v.query_object("HD 226868", catalog=["NOMAD", "UCAC"])
+        result = vizier.query_object("HD 226868", catalog=["NOMAD", "UCAC"])
         for table in result:
             assert 'Bmag' not in table.columns
 
@@ -76,38 +76,38 @@ class TestVizierRemote:
     def test_alls_withaddition(self, all):
         # Check that all the expected columns are there plus the _r
         # (radius from target) that we've added
-        v = vizier.core.Vizier(columns=[all, "+_r"], catalog="II/246")
-        result = v.query_region("HD 226868", radius="20s")
+        vizier = Vizier(columns=[all, "+_r"], catalog="II/246")
+        result = vizier.query_region("HD 226868", radius="20s")
         table = result['II/246/out']
         assert 'Jmag' in table.columns
         assert '_r' in table.columns
 
     def test_get_catalogs(self):
-        result = vizier.core.Vizier.get_catalogs('J/ApJ/706/83')
+        result = Vizier.get_catalogs('J/ApJ/706/83')
         assert isinstance(result, commons.TableList)
 
     def test_get_catalog_metadata(self):
-        meta = vizier.core.Vizier(catalog="I/324").get_catalog_metadata()
+        meta = Vizier(catalog="I/324").get_catalog_metadata()
         assert meta['title'] == "The Initial Gaia Source List (IGSL)"
 
     def test_query_two_wavelengths(self):
-        v = vizier.core.Vizier(
+        vizier = Vizier(
             columns=['_RAJ2000', 'DEJ2000', 'B-V', 'Vmag', 'Plx'],
             column_filters={"Vmag": ">10"}, keywords=["optical", "radio"])
-        v.ROW_LIMIT = 1
-        v.query_object('M 31')
+        vizier.ROW_LIMIT = 1
+        vizier.query_object('M 31')
 
     def test_regressiontest_invalidtable(self):
-        V = vizier.core.Vizier(
+        vizier = Vizier(
             columns=['all'], ucd='(spect.dopplerVeloc*|phys.veloc*)',
             keywords=['Radio', 'IR'], row_limit=5000)
-        C = SkyCoord(359.61687 * u.deg, -0.242457 * u.deg, frame="galactic")
+        coordinate = SkyCoord(359.61687 * u.deg, -0.242457 * u.deg, frame="galactic")
 
         # With newer versions UnitsWarning may be issued as well
-        with pytest.warns() as w:
-            V.query_region(C, radius=2 * u.arcmin)
+        with pytest.warns() as warnings:
+            vizier.query_region(coordinate, radius=2 * u.arcmin)
 
-        for i in w:
+        for i in warnings:
             message = str(i.message)
             assert ("VOTABLE parsing raised exception" in message or "not supported by the VOUnit standard" in message)
 
@@ -115,9 +115,9 @@ class TestVizierRemote:
 
         # Regression test: the columns of the default should never
         # be modified from default
-        assert vizier.core.Vizier.columns == ['*']
+        assert Vizier.columns == ['*']
         # Coordinate selection is entirely arbitrary
-        result = vizier.core.Vizier.query_region(
+        result = Vizier.query_region(
             vector_skycoord, radius=10 * u.arcsec, catalog=["HIP", "NOMAD", "UCAC"])
 
         assert len(result) >= 5
@@ -126,15 +126,15 @@ class TestVizierRemote:
         assert result['I/239/hip_main']['HIP'] == 98298
 
     def test_findcatalog_maxcatalog(self):
-        V = vizier.core.Vizier()
-        cats = V.find_catalogs('eclipsing binary planets', max_catalogs=5000)
+        vizier = Vizier()
+        cats = vizier.find_catalogs('eclipsing binary planets', max_catalogs=5000)
         assert len(cats) >= 39  # as of 2024
 
     def test_findcatalog_ucd(self):
         # this fails for VizieR 7.33.3, should work in next releases
-        V = vizier.core.Vizier()
-        ucdresult = V(ucd='phys.albedo').find_catalogs('mars', max_catalogs=5000)
-        result = V.find_catalogs('mars', max_catalogs=5000)
+        vizier = Vizier()
+        ucdresult = vizier(ucd='phys.albedo').find_catalogs('mars', max_catalogs=5000)
+        result = vizier.find_catalogs('mars', max_catalogs=5000)
 
         assert len(ucdresult) >= 1
         assert len(result) >= 11
@@ -142,15 +142,15 @@ class TestVizierRemote:
         assert len(ucdresult) < len(result)
 
     def test_asu_tsv_return_type(self):
-        V = vizier.core.Vizier()
-        result = V.query_object("HD 226868", catalog=["NOMAD", "UCAC"], return_type='asu-tsv', cache=False)
+        vizier = Vizier()
+        result = vizier.query_object("HD 226868", catalog=["NOMAD", "UCAC"], return_type='asu-tsv', cache=False)
 
         assert isinstance(result, list)
         assert len(result) == 3
 
     def test_query_constraints(self):
-        V = vizier.core.Vizier(row_limit=3)
-        result = V.query_constraints(catalog="I/130/main", mB2="=14.7")[0]
+        vizier = Vizier(row_limit=3)
+        result = vizier.query_constraints(catalog="I/130/main", mB2="=14.7")[0]
         # row_limit is taken in account
         assert len(result) == 3
         # the criteria is respected

--- a/docs/vizier/vizier.rst
+++ b/docs/vizier/vizier.rst
@@ -1,5 +1,3 @@
-.. doctest-skip-all
-
 .. _astroquery.vizier:
 
 ************************************
@@ -22,13 +20,16 @@ Table Discover
 If you want to search for a set of tables, e.g. based on author name or other keywords,
 the :meth:`~astroquery.vizier.VizierClass.find_catalogs` tool can be used:
 
-.. code-block:: python
+.. doctest-remote-data::
 
     >>> from astroquery.vizier import Vizier
-    >>> catalog_list = Vizier.find_catalogs('Kang W51')
-    >>> print({k:v.description for k,v in catalog_list.items()})
-    {'J/ApJS/191/232': 'CO survey of W51 molecular cloud (Bieging+, 2010)',
-     'J/ApJ/706/83': 'Embedded YSO candidates in W51 (Kang+, 2009)'}
+    >>> catalog_list = Vizier.find_catalogs('hot jupiter exoplanet transit')
+    >>> for k, v in catalog_list.items():
+    ...     print(k, ":", v.description)
+    J/A+A/635/A205 : Ultra-hot Jupiter WASP-121b transits (Bourrier+, 2020)
+    J/ApJ/788/39 : Hot Jupiter exoplanets host stars EW and abundances (Teske+, 2014)
+    J/AJ/157/217 : Transit times of five hot Jupiter WASP exoplanets (Bouma+, 2019)
+    J/A+A/635/A122 : CoRoT-30b and CoRoT-31b radial velocity curves (Border+, 2020)
 
 From this result, you could either get any of these as a complete catalog or
 query them for individual objects or regions.
@@ -41,49 +42,77 @@ If you know the name of the catalog you wish to retrieve, e.g. from doing a
 :meth:`~astroquery.vizier.VizierClass.find_catalogs` search as above, you can then grab
 the complete contents of those catalogs:
 
-.. code-block:: python
+.. doctest-remote-data::
 
     >>> catalogs = Vizier.get_catalogs(catalog_list.keys())
     >>> print(catalogs)
-    TableList with 3 tables:
-       '0:J/ApJ/706/83/ysos' with 22 column(s) and 50 row(s)
-       '1:J/ApJS/191/232/table1' with 13 column(s) and 50 row(s)
-       '2:J/ApJS/191/232/map' with 2 column(s) and 2 row(s)
+    TableList with 10 tables:
+      '0:J/A+A/635/A205/20140119' with 7 column(s) and 50 row(s) 
+       '1:J/A+A/635/A205/20140123' with 7 column(s) and 50 row(s) 
+       '2:J/A+A/635/A205/20171231' with 7 column(s) and 50 row(s) 
+       '3:J/A+A/635/A205/20180114' with 7 column(s) and 50 row(s) 
+       '4:J/A+A/635/A205/ccf-mask' with 3 column(s) and 50 row(s) 
+       '5:J/ApJ/788/39/stars' with 7 column(s) and 17 row(s) 
+       '6:J/ApJ/788/39/table4' with 48 column(s) and 50 row(s) 
+       '7:J/AJ/157/217/transits' with 8 column(s) and 50 row(s) 
+       '8:J/A+A/635/A122/table2' with 4 column(s) and 18 row(s) 
+       '9:J/A+A/635/A122/table3' with 4 column(s) and 17 row(s) 
 
 Similarly, the ``Resource`` objects (the values of the dictionary resulting from
 :meth:`~astroquery.vizier.VizierClass.find_catalogs`) can be used in the same
 way:
 
-.. code-block:: python
+.. doctest-remote-data::
 
     >>> catalogs = Vizier.get_catalogs(catalog_list.values())
     >>> print(catalogs)
-    TableList with 3 tables:
-       '0:J/ApJ/706/83/ysos' with 22 column(s) and 50 row(s)
-       '1:J/ApJS/191/232/table1' with 13 column(s) and 50 row(s)
-       '2:J/ApJS/191/232/map' with 2 column(s) and 2 row(s)
+    TableList with 10 tables:
+       '0:J/A+A/635/A205/20140119' with 7 column(s) and 50 row(s) 
+       '1:J/A+A/635/A205/20140123' with 7 column(s) and 50 row(s) 
+       '2:J/A+A/635/A205/20171231' with 7 column(s) and 50 row(s) 
+       '3:J/A+A/635/A205/20180114' with 7 column(s) and 50 row(s) 
+       '4:J/A+A/635/A205/ccf-mask' with 3 column(s) and 50 row(s) 
+       '5:J/ApJ/788/39/stars' with 7 column(s) and 17 row(s) 
+       '6:J/ApJ/788/39/table4' with 48 column(s) and 50 row(s) 
+       '7:J/AJ/157/217/transits' with 8 column(s) and 50 row(s) 
+       '8:J/A+A/635/A122/table2' with 4 column(s) and 18 row(s) 
+       '9:J/A+A/635/A122/table3' with 4 column(s) and 17 row(s) 
 
-.. code-block:: python
+.. doctest-remote-data::
 
-   >>> catalogs = Vizier.get_catalogs(catalog_list.keys())
-   >>> print(catalogs)
-   TableList with 3 tables:
-      '0:J/ApJ/706/83/ysos' with 22 column(s) and 50 row(s)
-      '1:J/ApJS/191/232/table1' with 13 column(s) and 50 row(s)
-      '2:J/ApJS/191/232/map' with 2 column(s) and 2 row(s)
+    >>> catalogs = Vizier.get_catalogs(catalog_list.keys())
+    >>> print(catalogs)
+    TableList with 10 tables:
+       '0:J/A+A/635/A205/20140119' with 7 column(s) and 50 row(s) 
+       '1:J/A+A/635/A205/20140123' with 7 column(s) and 50 row(s) 
+       '2:J/A+A/635/A205/20171231' with 7 column(s) and 50 row(s) 
+       '3:J/A+A/635/A205/20180114' with 7 column(s) and 50 row(s) 
+       '4:J/A+A/635/A205/ccf-mask' with 3 column(s) and 50 row(s) 
+       '5:J/ApJ/788/39/stars' with 7 column(s) and 17 row(s) 
+       '6:J/ApJ/788/39/table4' with 48 column(s) and 50 row(s) 
+       '7:J/AJ/157/217/transits' with 8 column(s) and 50 row(s) 
+       '8:J/A+A/635/A122/table2' with 4 column(s) and 18 row(s) 
+       '9:J/A+A/635/A122/table3' with 4 column(s) and 17 row(s) 
 
 Note that the row limit is set to 50 by default, so if you want to get a truly
 complete catalog, you need to change that:
 
-.. code-block:: python
+.. doctest-remote-data::
 
     >>> Vizier.ROW_LIMIT = -1
     >>> catalogs = Vizier.get_catalogs(catalog_list.keys())
     >>> print(catalogs)
-    TableList with 3 tables:
-       '0:J/ApJ/706/83/ysos' with 22 column(s) and 737 row(s)
-       '1:J/ApJS/191/232/table1' with 13 column(s) and 218 row(s)
-       '2:J/ApJS/191/232/map' with 2 column(s) and 2 row(s)
+    TableList with 10 tables:
+       '0:J/A+A/635/A205/20140119' with 7 column(s) and 235 row(s) 
+       '1:J/A+A/635/A205/20140123' with 7 column(s) and 195 row(s) 
+       '2:J/A+A/635/A205/20171231' with 7 column(s) and 248 row(s) 
+       '3:J/A+A/635/A205/20180114' with 7 column(s) and 307 row(s) 
+       '4:J/A+A/635/A205/ccf-mask' with 3 column(s) and 1828 row(s) 
+       '5:J/ApJ/788/39/stars' with 7 column(s) and 17 row(s) 
+       '6:J/ApJ/788/39/table4' with 48 column(s) and 106 row(s) 
+       '7:J/AJ/157/217/transits' with 8 column(s) and 236 row(s) 
+       '8:J/A+A/635/A122/table2' with 4 column(s) and 18 row(s) 
+       '9:J/A+A/635/A122/table3' with 4 column(s) and 17 row(s) 
     >>> Vizier.ROW_LIMIT = 50
 
 Get a catalog's associated metadata
@@ -119,7 +148,7 @@ about VizieR's catalogs. It returns a table with the following columns:
               title            authors  ... waveband  doi  
               object            object  ...  object  object
     -------------------------- -------- ... -------- ------
-    Atlas of Peculiar Galaxies Arp H.C. ...  optical
+    Atlas of Peculiar Galaxies Arp H.C. ...  optical     --
       
 
 Query an object
@@ -128,15 +157,16 @@ Query an object
 
 For instance to query Sirius across all catalogs:
 
-.. code-block:: python
+.. doctest-remote-data::
 
     >>> from astroquery.vizier import Vizier
-    >>> result = Vizier.query_object("sirius")
+    >>> vizier = Vizier()
+    >>> result = vizier.query_object("sirius")
     >>> print(result)
-    TableList with 275 tables:
-       '0:METAobj' with 5 column(s) and 5 row(s)
-       '1:ReadMeObj' with 5 column(s) and 5 row(s)
-       '2:I/34/greenw2a' with 16 column(s) and 1 row(s)
+    TableList with 416 tables:
+       '0:METAobj' with 5 column(s) and 7 row(s) 
+       '1:ReadMeObj' with 5 column(s) and 7 row(s) 
+       '2:I/34/greenw2a' with 16 column(s) and 1 row(s) 
        ...
 
 All the results are returned as a `~astroquery.utils.TableList` object. This
@@ -146,22 +176,21 @@ against its name.
 
 To access an individual table from the `~astroquery.utils.TableList` object:
 
-.. code-block:: python
+.. doctest-remote-data::
 
-    >>> interesting_table = result['IX/10A/cor_ros']
+    >>> interesting_table = result['IX/8/catalog']
     >>> print(interesting_table)
-         _1RXS       Rank        sourceID       RAJ2000  DEJ2000  Sep
-                                                  deg      deg    arcs
-    ---------------- ---- --------------------- -------- -------- ----
-    J064509.3-164241    2 1RXH J064509.2-164242 101.2885 -16.7119    2
-    J064509.3-164241   14 1RXP J0645 8.4-164302 101.2854 -16.7174   24
-    J064509.3-164241   20 1RXH J064515.7-164402 101.3156 -16.7339  123
+      _2XRS     RAB1950      DEB1950    Xname ... Int   _RA.icrs     _DE.icrs  
+                                              ... uJy                          
+    --------- ------------ ------------ ----- ... --- ------------ ------------
+    06429-166 06 42 54.000 -16 39 00.00       ...  -- 06 45 08.088 -16 42 11.29
+    06429-166 06 42 54.000 -16 39 00.00       ...  -- 06 45 08.088 -16 42 11.29
 
 To do some common processing to all the tables in the returned
 `~astroquery.utils.TableList` object, do just what you would do for a python
 dictionary:
 
-.. code-block:: python
+.. doctest-remote-data::
 
     >>> for table_name in result.keys():
     ...     table = result[table_name]
@@ -177,7 +206,7 @@ query should be specified along with the value for the radius (or height/width
 for a box) of the region. For instance to query a large region around the
 quasar 3C 273:
 
-.. code-block:: python
+.. doctest-remote-data::
 
     >>> from astroquery.vizier import Vizier
     >>> from astropy.coordinates import Angle
@@ -187,33 +216,35 @@ Note that the radius may also be specified as a string in the format
 expected by `~astropy.coordinates.Angle`. So the above query may also
 be written as:
 
-.. code-block:: python
+.. doctest-remote-data::
 
     >>> result = Vizier.query_region("3C 273", radius="0d6m0s", catalog='GSC')
 
 Or using angular units and quantities from `astropy.units`:
 
-.. code-block:: python
+.. doctest-remote-data::
 
     >>> import astropy.units as u
     >>> result = Vizier.query_region("3C 273", radius=0.1*u.deg, catalog='GSC')
 
 To see the result:
 
-.. code-block:: python
+.. doctest-remote-data::
 
     >>> print(result)
-    TableList with 3 tables:
-       '0:I/254/out' with 10 column(s) and 17 row(s)
-       '1:I/271/out' with 11 column(s) and 50 row(s)
-       '2:I/305/out' with 11 column(s) and 50 row(s)
+    TableList with 5 tables:
+       '0:I/254/out' with 10 column(s) and 17 row(s) 
+       '1:I/255/out' with 9 column(s) and 17 row(s) 
+       '2:I/271/out' with 11 column(s) and 50 row(s) 
+       '3:I/305/out' with 11 column(s) and 50 row(s) 
+       '4:I/353/gsc242' with 35 column(s) and 50 row(s) 
 
 As mentioned earlier, the region may also be mentioned by specifying the height
 and width of a box. If only one of the height or width is mentioned, then the
 region is treated to be a square having sides equal to the specified
 dimension.
 
-.. code-block:: python
+.. doctest-remote-data::
 
     >>> from astroquery.vizier import Vizier
     >>> import astropy.units as u
@@ -224,10 +255,11 @@ dimension.
     ...                         width="30m",
     ...                         catalog=["NOMAD", "UCAC"])
     >>> print(result)
-    TableList with 3 tables:
-       '0:I/297/out' with 19 column(s) and 50 row(s)
-       '1:I/289/out' with 13 column(s) and 50 row(s)
-       '2:I/322A/out' with 24 column(s) and 50 row(s)
+    TableList with 4 tables:
+       '0:I/297/out' with 19 column(s) and 50 row(s) 
+       '1:I/289/out' with 13 column(s) and 50 row(s) 
+       '2:I/322A/out' with 24 column(s) and 50 row(s) 
+       '3:I/340/ucac5' with 20 column(s) and 50 row(s)
 
 
 One more thing to note in the above example is that the coordinates may be
@@ -242,15 +274,15 @@ coordinate. Finally the ``catalog`` keyword argument may be passed in either
 Last but not least, :meth:`~astroquery.vizier.VizierClass.query_region` also supports
 constraints on the columns of the returned tables by mean of the ``column_filters`` keyword.
 
-.. code-block:: python
+.. doctest-remote-data::
 
     >>> from astroquery.vizier import Vizier
     >>> import astropy.units as u
     >>> from astropy.coordinates import SkyCoord
     >>> result = Vizier.query_region(SkyCoord.from_name('M81'),
-                                     radius=10*u.arcmin,
-                                     catalog='I/345/gaia2',
-                                     column_filters={'Gmag': '<19'})
+    ...                              radius=10*u.arcmin,
+    ...                              catalog='I/345/gaia2',
+    ...                              column_filters={'Gmag': '<19'})
     >>> print(result[0]['Gmag'].max())
     18.9508
 
@@ -262,11 +294,10 @@ columns, an instance of the `~astroquery.vizier.VizierClass` class specifying th
 created. All further queries may then be performed on this instance rather than
 on the Vizier class.
 
-.. code-block:: python
+.. doctest-remote-data::
 
     >>> v = Vizier(columns=['_RAJ2000', '_DEJ2000','B-V', 'Vmag', 'Plx'],
-    ...            column_filters={"Vmag":">10"}, keywords=["optical", "xry"])
-    WARNING: xry : No such keyword [astroquery.vizier.core]
+    ...            column_filters={"Vmag":">10"}, keywords=["optical", "xry"])  # doctest: +IGNORE_WARNINGS
 
 Note that whenever an unknown keyword is specified, a warning is emitted and
 that keyword is discarded from further consideration. The behavior for
@@ -274,29 +305,31 @@ searching with these keywords is the same as defined for the web
 interface (`for details see here`_). Now we call the different query methods on
 this Vizier instance:
 
-.. code-block:: python
+.. doctest-remote-data::
 
+    >>> v = Vizier(columns=['_RAJ2000', '_DEJ2000','B-V', 'Vmag', 'Plx'],
+    ...            column_filters={"Vmag":">10"}, keywords=["optical", "xry"])  # doctest: +IGNORE_WARNINGS
     >>> result = v.query_object("HD 226868", catalog=["NOMAD", "UCAC"])
     >>> print(result)
-    TableList with 3 tables:
-        '0:I/297/out' with 3 column(s) and 50 row(s)
-        '1:I/289/out' with 3 column(s) and 18 row(s)
-        '2:I/322A/out' with 3 column(s) and 10 row(s)
-
+    TableList with 4 tables:
+       '0:I/297/out' with 3 column(s) and 50 row(s) 
+       '1:I/289/out' with 2 column(s) and 18 row(s) 
+       '2:I/322A/out' with 3 column(s) and 10 row(s) 
+       '3:I/340/ucac5' with 2 column(s) and 26 row(s) 
     >>> print(result['I/322A/out'])
-     _RAJ2000   _DEJ2000   Vmag
-       deg        deg      mag
-    ---------- ---------- ------
-    299.572419  35.194234 15.986
-    299.580291  35.176889 13.274
-    299.582571  35.185225 14.863
-    299.594172  35.179995 14.690
-    299.601402  35.198108 14.644
-    299.617669  35.186999 14.394
-    299.561498  35.201693 15.687
-    299.570217  35.225663 14.878
-    299.601081  35.233338 13.170
-    299.617995  35.205864 13.946
+       _RAJ2000      _DEJ2000    Vmag 
+         deg           deg       mag  
+    ------------- ------------- ------
+    299.572418900  35.194234200 15.986
+    299.580291200  35.176888900 13.274
+    299.582571200  35.185225300 14.863
+    299.594171800  35.179994800 14.690
+    299.601402100  35.198107800 14.644
+    299.617668600  35.186998700 14.394
+    299.561497700  35.201692800 15.687
+    299.570216500  35.225663400 14.878
+    299.601080600  35.233337800 13.170
+    299.617995000  35.205863700 13.946
 
 When specifying the columns of the query, sorting of the returned table can be
 requested by adding ``+`` (or ``-`` for reverse sorting order) in front of the column
@@ -305,19 +338,19 @@ distance column (``"_r"``) of the 2MASS catalog (II/246) are queried, 20 arcsec
 around HD 226868. The result is sorted in increasing distance, as requested with
 the ``"+"`` in front of ``"_r"``.
 
-.. code-block:: python
+.. doctest-remote-data::
 
     >>> v = Vizier(columns=["*", "+_r"], catalog="II/246")
     >>> result = v.query_region("HD 226868", radius="20s")
     >>> print(result[0])
       _r    RAJ2000    DEJ2000        _2MASS       Jmag  ... Bflg Cflg Xflg Aflg
-     arcs     deg        deg                       mag   ...
+              deg        deg                       mag   ...                    
     ------ ---------- ---------- ---------------- ------ ... ---- ---- ---- ----
      0.134 299.590280  35.201599 19582166+3512057  6.872 ...  111  000    0    0
-    10.141 299.587491  35.203217 19582099+3512115 10.285 ...  111  c00    0    0
-    11.163 299.588599  35.198849 19582126+3511558 13.111 ...  002  00c    0    0
-    12.289 299.586356  35.200542 19582072+3512019 14.553 ...  111  ccc    0    0
-    17.688 299.586254  35.197994 19582070+3511527 16.413 ...  100  c00    0    0
+    10.135 299.587491  35.203217 19582099+3512115 10.285 ...  111  c00    0    0
+    11.167 299.588599  35.198849 19582126+3511558 13.111 ...  002  00c    0    0
+    12.288 299.586356  35.200542 19582072+3512019 14.553 ...  111  ccc    0    0
+    17.691 299.586254  35.197994 19582070+3511527 16.413 ...  100  c00    0    0
 
 Note: The special column ``"*"`` requests just the default columns of a
 catalog; ``"**"`` would request all the columns.
@@ -333,26 +366,28 @@ stars with a ``Kmag`` brighter than 9.0 are looked for, with a separation
 between 2 and 30 arcsec. The column ``_q`` in the ``guide`` table is a 1-based
 index to the ``agn`` table (not the 0-based python convention).
 
-.. code-block:: python
+.. doctest-remote-data::
 
     >>> agn = Vizier(catalog="VII/258/vv10",
     ...              columns=['*', '_RAJ2000', '_DEJ2000']).query_constraints(Vmag="10.0..11.0")[0]
     >>> print(agn)
-    _RAJ2000 _DEJ2000  Cl  nR      Name     ...  Sp  n_Vmag  Vmag  B-V  r_z
-      deg      deg                          ...              mag   mag
-    -------- -------- --- --- ------------- ... ---- ------ ----- ----- ----
-     10.6846  41.2694   Q              M 31 ...   S2        10.57  1.08 1936
-     60.2779 -16.1108   Q     NPM1G-16.0168 ...           R 10.16    --  988
-     27.2387   5.9067   A   *      NGC  676 ...   S2        10.50    -- 1034
-     40.6696  -0.0131   A          NGC 1068 ...  S1h        10.83  0.87   58
-    139.7596  26.2697   A          NGC 2824 ...   S?        10.88    -- 2528
-    147.5921  72.2792   A          NGC 2985 ... S1.9        10.61  0.76 1033
-    173.1442  53.0678   A          NGC 3718 ...  S3b        10.61  0.74 1033
-    184.9608  29.6139   A         UGC  7377 ...   S3        10.47  0.99 2500
-    185.0287  29.2808   A          NGC 4278 ...  S3b        10.87  0.98 1033
-    186.4537  33.5467   A          NGC 4395 ... S1.8        10.27  0.53 1033
-    192.7196  41.1194   A          NGC 4736 ...    S        10.85  0.85 1032
-    208.3612  40.2831   A          NGC 5353 ...   S?      R 10.91    --  368
+     _RAJ2000   _DEJ2000   Cl  nR      Name     ...  Sp  n_Vmag  Vmag  B-V  r_z 
+       deg        deg                           ...              mag   mag      
+    ---------- ---------- --- --- ------------- ... ---- ------ ----- ----- ----
+     10.684583  41.269444   Q              M 31 ...   S2        10.57  1.08 1936
+     60.277917 -16.110833   Q     NPM1G-16.0168 ...           R 10.16    --  988
+     27.238750   5.906667   A   *      NGC  676 ...   S2        10.50    -- 1034
+     40.669583  -0.013056   A          NGC 1068 ...  S1h        10.83  0.87   58
+    139.759583  26.269722   A          NGC 2824 ...   S?        10.88    -- 2528
+    147.592083  72.279167   A          NGC 2985 ... S1.9        10.61  0.76 1033
+    173.144167  53.067778   A          NGC 3718 ...  S3b        10.61  0.74 1033
+    184.960833  29.613889   A         UGC  7377 ...   S3        10.47  0.99 2500
+    185.028750  29.280833   A          NGC 4278 ...  S3b        10.87  0.98 1033
+    186.453750  33.546667   A          NGC 4395 ... S1.8        10.27  0.53 1033
+    192.719583  41.119444   A          NGC 4736 ...    S        10.85  0.85 1032
+    208.361250  40.283056   A          NGC 5353 ...   S?      R 10.91    --  368
+
+.. doctest-remote-data::
 
     >>> guide = Vizier(catalog="II/246", column_filters={"Kmag":"<9.0"}).query_region(agn, radius="30s", inner_radius="2s")[0]
     >>> guide.pprint()


### PR DESCRIPTION
Hi astroquery,

## What the PR does

This is just a maintenance PR. It does: 
- allow the tests to run in the documentation
- switch from `-meta.all` to `-meta` in `find_catalogs` (the extended information is not in the `<RESOURCE>` tag anyway, so it is not used by the method). This increases the speed of this method and reduces the size of the downloaded information **a lot**
-  update the remote tests with examples that return less results to make them a bit faster, and reduce the impact on VizieR's servers

Internally, to use the `-meta` option that has no value (a weird thing of the ASU protocol) I had to change the post request in find_catalog. This has the added benefit that we can now use the `-obsolete` option rather than filtering afterwards.

There is no change to the API.

## On the ucd test failure

This is also there on main. It is an upstream issue with the votable output (discovered thanks to this PR), most likely introduced in VizieR v7.33.3 . It is already solved in the beta version of VizieR, so the fix will be here automatically with the next release upstream.