### PR TITLE
Update VSA url

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -41,6 +41,11 @@ skyview
 - Overlay arguments ``lut``, ``grid``, and ``gridlabel`` are removed, as they
   only apply to output types not returned by Astroquery [#2979]
 
+vsa
+^^^
+
+- Updating base URL to fix 404 responses. [#3033]
+
 
 Infrastructure, Utility and Other Changes and Additions
 -------------------------------------------------------

--- a/astroquery/vsa/core.py
+++ b/astroquery/vsa/core.py
@@ -65,7 +65,7 @@ class VsaClass(BaseWFAUClass):
                                        community=community,
                                        password=password)
 
-        self.BASE_URL = 'http://horus.roe.ac.uk:8080/vdfs/'
+        self.BASE_URL = "http://vsa.roe.ac.uk:8080/vdfs/"
         self.LOGIN_URL = self.BASE_URL + "DBLogin"
         self.IMAGE_URL = self.BASE_URL + "GetImage"
         self.ARCHIVE_URL = self.BASE_URL + "ImageList"

--- a/astroquery/vsa/tests/test_vista_remote.py
+++ b/astroquery/vsa/tests/test_vista_remote.py
@@ -19,7 +19,7 @@ class TestVista:
     @pytest.mark.dependency(name='vsa_up')
     def test_is_vsa_up(self):
         try:
-            vista._request("GET", "http://horus.roe.ac.uk:8080/vdfs/VgetImage_form.jsp")
+            vista._request("GET", "http://vsa.roe.ac.uk:8080/vdfs/VgetImage_form.jsp")
         except Exception as ex:
             pytest.fail("VISTA appears to be down.  Exception was: {0}".format(ex))
 


### PR DESCRIPTION
The VSA url seems to be outdated (`horus.roe.ac.uk` rather than `vsa.roe.ac.uk`). I'm not sure when exactly the URL changed, but navigating in a browser to http://horus.roe.ac.uk will redirect to the new `vsa.roe.ac.uk` page. At a guess, I'd say this URL change is also why the VSA tests stopped working (#2828).

Anyway, this PR just updates the URL to the new one. Having tested locally, the queries etc now work as expected with the new URL.