### PR TITLE
BUG: better handling the optional dependency required for functionality

### DIFF
--- a/astroquery/alma/core.py
+++ b/astroquery/alma/core.py
@@ -218,6 +218,7 @@ def get_enhanced_table(result):
         print(
             "Could not import astropy-regions, which is a requirement for get_enhanced_table function in alma."
             "Please refer to http://astropy-regions.readthedocs.io/en/latest/installation.html for how to install it.")
+        raise
 
     def _parse_stcs_string(input):
         csys = 'icrs'

--- a/astroquery/alma/tests/test_alma_remote.py
+++ b/astroquery/alma/tests/test_alma_remote.py
@@ -16,6 +16,13 @@ from pyvo.dal.exceptions import DALOverflowWarning
 from astroquery.exceptions import CorruptDataWarning
 from astroquery.alma import Alma, get_enhanced_table
 
+try:
+    import regions
+
+    HAS_REGIONS = True
+except ImportError:
+    HAS_REGIONS = False
+
 # ALMA tests involving staging take too long, leading to travis timeouts
 # TODO: make this a configuration item
 SKIP_SLOW = True
@@ -62,11 +69,10 @@ class TestAlma:
         for row in results:
             assert row['data_rights'] == 'Proprietary'
 
+    @pytest.mark.skipif(not HAS_REGIONS, reason="regions is required")
     @pytest.mark.filterwarnings(
         "ignore::astropy.utils.exceptions.AstropyUserWarning")
     def test_s_region(self, alma):
-        pytest.importorskip('regions')
-        import regions  # to silence checkstyle
         alma.help_tap()
         result = alma.query_tap("select top 3 s_region from ivoa.obscore")
         enhanced_result = get_enhanced_table(result)
@@ -75,6 +81,7 @@ class TestAlma:
                                                 regions.PolygonSkyRegion,
                                                 regions.CompoundSkyRegion))
 
+    @pytest.mark.skipif(not HAS_REGIONS, reason="regions is required")
     @pytest.mark.filterwarnings(
         "ignore::astropy.utils.exceptions.AstropyUserWarning")
     def test_SgrAstar(self, tmp_path, alma):


### PR DESCRIPTION
One of the remote tests were failing when `regions` wasn't installed, which highlighted the case that we didn't handle the missing dependency well in the function too (e.g. the module should not fail if it's missing, but it should fail rather than just print a message when someone tries to use the method).