### PR TITLE
MAINT: skip bigdata tests in CI

### DIFF
--- a/astroquery/alma/tests/test_alma_remote.py
+++ b/astroquery/alma/tests/test_alma_remote.py
@@ -165,6 +165,7 @@ class TestAlma:
         with pytest.raises(AttributeError):
             alma.is_proprietary('uid://NON/EXI/STING')
 
+    @pytest.mark.bigdata
     def test_retrieve_data(self, tmp_path, alma):
         """
         Regression test for issue 2490 (the retrieval step will simply fail if

--- a/tox.ini
+++ b/tox.ini
@@ -22,7 +22,7 @@ description = run tests
 
 setenv =
     PYTEST_ARGS = ''
-    online: PYTEST_ARGS = --remote-data=any --reruns=1 --reruns-delay 10
+    online: PYTEST_ARGS = --remote-data=any --reruns=1 --reruns-delay 10 -m "not bigdata"
     devdeps: PIP_EXTRA_INDEX_URL =  https://pypi.anaconda.org/scientific-python-nightly-wheels/simple https://pypi.anaconda.org/astropy/simple https://pypi.anaconda.org/liberfa/simple
 
 deps =


### PR DESCRIPTION
This should close #3032, but I keep both the related alma and esasky issues open to see if there are any non-bigdata solutions to test the functionalities.

