### PR TITLE
MAINT: fix OGLE url

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -25,6 +25,12 @@ linelists.cdms
 
 - Fix result parsing incompatibility with astropy 6.1 on Windows systems. [#3008]
 
+ogle
+^^^^
+
+- Change URL to https and thus making the module functional again. [#3048]
+
+
 splatalogue
 ^^^^^^^^^^^
 

--- a/astroquery/ogle/__init__.py
+++ b/astroquery/ogle/__init__.py
@@ -7,7 +7,7 @@ OGLE Query Tool
 
 This package is for querying interstellar extinction toward the Galactic bulge
 from OGLE-III data
-`hosted at. <http://ogle.astrouw.edu.pl/cgi-ogle/getext.py>`_
+`hosted at. <https://ogle.astrouw.edu.pl/cgi-ogle/getext.py>`_
 
 Note:
   If you use the data from OGLE please refer to the publication by Nataf et al.
@@ -21,7 +21,7 @@ class Conf(_config.ConfigNamespace):
     Configuration parameters for `astroquery.ogle`.
     """
     server = _config.ConfigItem(
-        ['http://ogle.astrouw.edu.pl/cgi-ogle/getext.py'],
+        ['https://ogle.astrouw.edu.pl/cgi-ogle/getext.py'],
         'Name of the OGLE mirror to use.')
     timeout = _config.ConfigItem(
         60,


### PR DESCRIPTION
Digging into the responses from the CI failures was a rabbit hole, apparently this was a one character fix...

fixes #2805 