### PR TITLE
[SIMBAD] Add filter names as possible votable fields 

### DIFF
--- a/astroquery/simbad/tests/data/simbad_output_options.xml
+++ b/astroquery/simbad/tests/data/simbad_output_options.xml
@@ -1,17 +1,17 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- Produced with astropy.io.votable version 6.0.0
+<!-- Produced with astropy.io.votable version 6.1.0
      http://www.astropy.org/ -->
 <VOTABLE version="1.4" xmlns="http://www.ivoa.net/xml/VOTable/v1.3" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.ivoa.net/xml/VOTable/v1.3 http://www.ivoa.net/xml/VOTable/VOTable-1.4.xsd">
  <RESOURCE type="results">
-  <TABLE ID="result_S1711533763224" name="result_S1711533763224">
-   <FIELD ID="name" arraysize="*" datatype="char" name="name">
+  <TABLE ID="result_S1719407661907" name="result_S1719407661907">
+   <FIELD ID="name" arraysize="*" datatype="char" name="name" ucd="instr.filter">
     <DESCRIPTION>
-     column name
+     flux filter name
     </DESCRIPTION>
    </FIELD>
-   <FIELD ID="description" arraysize="*" datatype="char" name="description">
+   <FIELD ID="description" arraysize="*" datatype="unicodeChar" name="description" ucd="meta.note;instr.filter">
     <DESCRIPTION>
-     brief description of column
+     flux filter description
     </DESCRIPTION>
    </FIELD>
    <FIELD ID="type" arraysize="*" datatype="unicodeChar" name="type"/>
@@ -506,6 +506,91 @@
       <TD>velocity</TD>
       <TD>all fields related with radial velocity and redshift</TD>
       <TD>bundle of basic columns</TD>
+     </TR>
+     <TR>
+      <TD>U</TD>
+      <TD>Magnitude U</TD>
+      <TD>filter name</TD>
+     </TR>
+     <TR>
+      <TD>B</TD>
+      <TD>Magnitude B</TD>
+      <TD>filter name</TD>
+     </TR>
+     <TR>
+      <TD>V</TD>
+      <TD>Magnitude V</TD>
+      <TD>filter name</TD>
+     </TR>
+     <TR>
+      <TD>R</TD>
+      <TD>Magnitude R</TD>
+      <TD>filter name</TD>
+     </TR>
+     <TR>
+      <TD>I</TD>
+      <TD>Magnitude I</TD>
+      <TD>filter name</TD>
+     </TR>
+     <TR>
+      <TD>J</TD>
+      <TD>Magnitude J</TD>
+      <TD>filter name</TD>
+     </TR>
+     <TR>
+      <TD>H</TD>
+      <TD>Magnitude H</TD>
+      <TD>filter name</TD>
+     </TR>
+     <TR>
+      <TD>K</TD>
+      <TD>Magnitude K</TD>
+      <TD>filter name</TD>
+     </TR>
+     <TR>
+      <TD>u</TD>
+      <TD>Magnitude SDSS u</TD>
+      <TD>filter name</TD>
+     </TR>
+     <TR>
+      <TD>g</TD>
+      <TD>Magnitude SDSS g</TD>
+      <TD>filter name</TD>
+     </TR>
+     <TR>
+      <TD>r</TD>
+      <TD>Magnitude SDSS r</TD>
+      <TD>filter name</TD>
+     </TR>
+     <TR>
+      <TD>i</TD>
+      <TD>Magnitude SDSS i</TD>
+      <TD>filter name</TD>
+     </TR>
+     <TR>
+      <TD>z</TD>
+      <TD>Magnitude SDSS z</TD>
+      <TD>filter name</TD>
+     </TR>
+     <TR>
+      <TD>G</TD>
+      <TD>Magnitude Gaia G</TD>
+      <TD>filter name</TD>
+     </TR>
+     <TR>
+      <TD>F150W</TD>
+      <TD>JWST NIRCam F150W</TD>
+      <TD>filter name</TD>
+     </TR>
+     <TR>
+      <TD>F200W</TD>
+      <TD>JWST NIRCam F200W</TD>
+      <TD>filter name</TD>
+     </TR>
+     <TR>
+      <TD>F444W</TD>
+      <TD>JWST NIRCan F444W</TD>
+      <TD>filter name</TD>
      </TR>
     </TABLEDATA>
    </DATA>

--- a/astroquery/simbad/tests/test_simbad_remote.py
+++ b/astroquery/simbad/tests/test_simbad_remote.py
@@ -129,7 +129,7 @@ class TestSimbad:
                   "      c       3")
         assert expect == str(result)
         # Test query_tap raised errors
-        with pytest.raises(DALOverflowWarning, match="Partial result set *"):
+        with pytest.warns(DALOverflowWarning, match="Partial result set *"):
             truncated_result = Simbad.query_tap("SELECT * from basic", maxrec=2)
             assert len(truncated_result) == 2
         with pytest.raises(ValueError, match="The maximum number of records cannot exceed 2000000."):

--- a/astroquery/simbad/tests/test_simbad_remote.py
+++ b/astroquery/simbad/tests/test_simbad_remote.py
@@ -173,12 +173,12 @@ class TestSimbad:
         assert len(simbad_instance.columns_in_output) == 8
         assert _Column("basic", "galdim_majaxis") in simbad_instance.columns_in_output
 
-    def test_add_table_to_output(self):
+    def test_add_votable_fields(self):
         simbad_instance = Simbad()
         # empty before the test
         simbad_instance.columns_in_output = []
         simbad_instance.add_votable_fields("otypes")
-        assert _Column("otypes", "otype", '"otypes.otype"') in simbad_instance.columns_in_output
+        assert _Column("otypes", "otype", 'otypes.otype') in simbad_instance.columns_in_output
         # tables also require a join
         assert _Join("otypes",
                      _Column("basic", "oid"),
@@ -191,3 +191,10 @@ class TestSimbad:
         # mixed columns bundles and tables
         simbad_instance.add_votable_fields("flux", "velocity", "update_date")
         assert len(simbad_instance.columns_in_output) == 19
+
+        # add fluxes by their filter names
+        simbad_instance = Simbad()
+        simbad_instance.add_votable_fields("U", "V")
+        simbad_instance.add_votable_fields("u")
+        result = simbad_instance.query_object("HD 147933")
+        assert all(filtername in result.colnames for filtername in {"u", "U", "V"})

--- a/docs/simbad/simbad.rst
+++ b/docs/simbad/simbad.rst
@@ -466,30 +466,30 @@ with:
 
     >>> from astroquery.simbad import Simbad
     >>> Simbad.list_votable_fields()[["name", "description"]]
-    <Table length=98>
-          name                            description                      
-         object                              object                        
-    --------------- -------------------------------------------------------
-        mesDiameter                        Collection of stellar diameters.
-              mesPM                           Collection of proper motions.
-             mesISO         Infrared Space Observatory (ISO) observing log.
-             mesSpT                           Collection of spectral types.
-          allfluxes        all flux/magnitudes U,B,V,I,J,H,K,u_,g_,r_,i_,z_
-              ident                   Identifiers of an astronomical object
-               flux Magnitude/Flux information about an astronomical object
-             mesPLX                 Collection of trigonometric parallaxes.
-           otypedef          all names and definitions for the object types
-                ...                                                     ...
-           vlsr_min          Minimum for the mean value of the LSR velocity
-    vlsr_wavelength     Wavelength class for the origin of the LSR velocity
-        coordinates                     all fields related with coordinates
-                dim             major and minor axis, angle and inclination
-         dimensions                 all fields related to object dimensions
-          morphtype            all fields related to the morphological type
-           parallax                        all fields related to parallaxes
-      propermotions              all fields related with the proper motions
-                 sp               all fields related with the spectral type
-           velocity    all fields related with radial velocity and redshift
+    <Table length=115>
+        name                          description                      
+       object                            object                        
+    ----------- -------------------------------------------------------
+    mesDiameter                        Collection of stellar diameters.
+          mesPM                           Collection of proper motions.
+         mesISO         Infrared Space Observatory (ISO) observing log.
+         mesSpT                           Collection of spectral types.
+      allfluxes        all flux/magnitudes U,B,V,I,J,H,K,u_,g_,r_,i_,z_
+          ident                   Identifiers of an astronomical object
+           flux Magnitude/Flux information about an astronomical object
+         mesPLX                 Collection of trigonometric parallaxes.
+       otypedef          all names and definitions for the object types
+            ...                                                     ...
+              K                                             Magnitude K
+              u                                        Magnitude SDSS u
+              g                                        Magnitude SDSS g
+              r                                        Magnitude SDSS r
+              i                                        Magnitude SDSS i
+              z                                        Magnitude SDSS z
+              G                                        Magnitude Gaia G
+          F150W                                       JWST NIRCam F150W
+          F200W                                       JWST NIRCam F200W
+          F444W                                       JWST NIRCan F444W
 
 You can also access a single field description with 
 `~astroquery.simbad.SimbadClass.get_field_description`
@@ -502,6 +502,11 @@ You can also access a single field description with
 
 And the columns in the output can be reset to their default value with
 `~astroquery.simbad.SimbadClass.reset_votable_fields`.
+
+.. Note::
+
+    A detailed description on the ways to add fluxes is available in the
+    :ref:`optical filters` section.
 
 Additional criteria
 -------------------


### PR DESCRIPTION
I'd like to tweak a bit the way I handled the fluxes votable fields deprecations in the SIMBAD rework.

In the current version, this:

```python
from astroquery.simbad import Simbad
simbad = Simbad()
simbad.add_votable_fields("flux(u)")
```
works with a warning that does not say how this should be replaced. 

This PR adds new votable fields for the SIMBAD's filters. And thus we can provide a clearer warning that points to this new replacement. This uses the `allfluxes` table from SIMBAD's relational schema (http://simbad.cds.unistra.fr/simbad/tap/tapsearch.html) that only contains the magnitude value.

There is also a clearer error message for the  deprecated `flux_**()`  votable fields that were falling in the generic error message for unknown fields. There is now a message that says that the replacement is the votable field `flux` which adds the whole `flux` table with every information covered by these former votable fields.

--- 

In addition, the `allfluxes` votable field was broken 

```python
from astroquery.simbad import Simbad
simbad = Simbad()
simbad.add_votable_fields("allfluxes")
```

would make every query fail because the names of the columns are casefolded while this table **is** an exception in the database and is case-sensitive. This is fixed in this PR.