### PR TITLE
DEP: pinning pillow version for oldest deps CI job

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -33,10 +33,12 @@ deps =
     devdeps: git+https://github.com/astropy/pyvo.git#egg=pyvo
 
 # mpl while not a dependency, it's required for the tests, and would pull up a newer numpy version if not pinned.
+# And pillow should be pinned as well, otherwise a too new version is pulled that is not compatible with old np.
 
     oldestdeps: astropy==5.0.0
     oldestdeps: numpy==1.20
     oldestdeps: matplotlib==3.4.*
+    oldestdeps: pillow==10.0.0
     oldestdeps: pyvo==1.5
     oldestdeps: pytest-doctestplus==0.13
     oldestdeps: requests==2.25


### PR DESCRIPTION
This should fix the failing CI on `main`.