### PR TITLE
Streamlined method to get list of cloud URIs

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -169,8 +169,7 @@ mast
 
 - Fix bug in ``Catalogs.query_criteria()`` to use ``page`` and ``pagesize`` parameters correctly. [#3065]
 
-- Add ``mast.Observations.get_cloud_uris_query`` method so that given a set of query criteria and optional filters,
-  the user receives a list of cloud data URIs for matching data products. [#3064]
+- Modify ``mast.Observations.get_cloud_uris`` to also accept query criteria and data product filters. [#3064]
 
 
 0.4.7 (2024-03-08)

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -171,6 +171,9 @@ mast
 
 - Modify ``mast.Observations.get_cloud_uris`` to also accept query criteria and data product filters. [#3064]
 
+- Increased the speed of ``mast.Observations.get_cloud_uris`` by obtaining multiple
+  URIs from MAST at once. [#3064]
+
 
 0.4.7 (2024-03-08)
 ==================

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -169,6 +169,8 @@ mast
 
 - Fix bug in ``Catalogs.query_criteria()`` to use ``page`` and ``pagesize`` parameters correctly. [#3065]
 
+- Add ``mast.Observations.get_cloud_uris_query`` method so that given a set of query criteria and optional filters,
+  the user receives a list of cloud data URIs for matching data products. [#3064]
 
 
 0.4.7 (2024-03-08)

--- a/astroquery/mast/cloud.py
+++ b/astroquery/mast/cloud.py
@@ -158,7 +158,7 @@ class CloudAccess:  # pragma:no-cover
                         s3_path = "s3://{}/{}".format(self.pubdata_bucket, path)
                         uri_list.append(s3_path)
                     elif full_url:
-                        path = "http://s3.amazonaws.com/{}/{}".format(self._pubdata_bucket, path)
+                        path = "http://s3.amazonaws.com/{}/{}".format(self.pubdata_bucket, path)
                         uri_list.append(path)
                 except self.botocore.exceptions.ClientError as e:
                     if e.response['Error']['Code'] != "404":

--- a/astroquery/mast/cloud.py
+++ b/astroquery/mast/cloud.py
@@ -112,7 +112,7 @@ class CloudAccess:  # pragma:no-cover
         uri_list = self.get_cloud_uri_list(data_product, include_bucket=include_bucket, full_url=full_url)
 
         # Making sure we got at least 1 URI from the query above.
-        if uri_list[0] is None:
+        if not uri_list or uri_list[0] is None:
             warnings.warn("Unable to locate file {}.".format(data_product), NoResultsWarning)
         else:
             # Output from ``get_cloud_uri_list`` is always a list even when it's only 1 URI

--- a/astroquery/mast/cloud.py
+++ b/astroquery/mast/cloud.py
@@ -14,7 +14,7 @@ from astroquery import log
 from astropy.utils.console import ProgressBarOrSpinner
 from astropy.utils.exceptions import AstropyDeprecationWarning
 
-from ..exceptions import NoResultsWarning, InvalidQueryError
+from ..exceptions import NoResultsWarning
 
 from . import utils
 
@@ -109,32 +109,14 @@ class CloudAccess:  # pragma:no-cover
             found in the cloud, None is returned.
         """
 
-        s3_client = self.boto3.client('s3', config=self.config)
+        uri_list = self.get_cloud_uri_list(data_product, include_bucket=include_bucket, full_url=full_url)
 
-        path = utils.mast_relative_path(data_product["dataURI"])
-        if path is None:
-            raise InvalidQueryError("Malformed data uri {}".format(data_product['dataURI']))
-
-        if 'galex' in path:
-            path = path.lstrip("/mast/")
-        elif '/ps1/' in path:
-            path = path.replace("/ps1/", "panstarrs/ps1/public/")
+        # Making sure we got at least 1 URI from the query above.
+        if uri_list[0] is None:
+            warnings.warn("Unable to locate file {}.".format(data_product), NoResultsWarning)
         else:
-            path = path.lstrip("/")
-
-        try:
-            s3_client.head_object(Bucket=self.pubdata_bucket, Key=path)
-            if include_bucket:
-                path = "s3://{}/{}".format(self.pubdata_bucket, path)
-            elif full_url:
-                path = "http://s3.amazonaws.com/{}/{}".format(self.pubdata_bucket, path)
-            return path
-        except self.botocore.exceptions.ClientError as e:
-            if e.response['Error']['Code'] != "404":
-                raise
-
-        warnings.warn("Unable to locate file {}.".format(data_product['productFilename']), NoResultsWarning)
-        return None
+            # Output from ``get_cloud_uri_list`` is always a list even when it's only 1 URI
+            return uri_list[0]
 
     def get_cloud_uri_list(self, data_products, include_bucket=True, full_url=False):
         """
@@ -158,8 +140,33 @@ class CloudAccess:  # pragma:no-cover
             List of URIs generated from the data products, list way contain entries that are None
             if data_products includes products not found in the cloud.
         """
+        s3_client = self.boto3.client('s3', config=self.config)
 
-        return [self.get_cloud_uri(product, include_bucket, full_url) for product in data_products]
+        paths = utils.mast_relative_path(data_products["dataURI"])
+        if isinstance(paths, str):  # Handle the case where only one product was requested
+            paths = [paths]
+
+        uri_list = []
+        for path in paths:
+            if path is None:
+                uri_list.append(None)
+            else:
+                try:
+                    # Use `head_object` to verify that the product is available on S3 (not all products are)
+                    s3_client.head_object(Bucket=self.pubdata_bucket, Key=path)
+                    if include_bucket:
+                        s3_path = "s3://{}/{}".format(self.pubdata_bucket, path)
+                        uri_list.append(s3_path)
+                    elif full_url:
+                        path = "http://s3.amazonaws.com/{}/{}".format(self._pubdata_bucket, path)
+                        uri_list.append(path)
+                except self.botocore.exceptions.ClientError as e:
+                    if e.response['Error']['Code'] != "404":
+                        raise
+                    warnings.warn("Unable to locate file {}.".format(path), NoResultsWarning)
+                    uri_list.append(None)
+
+        return uri_list
 
     def download_file(self, data_product, local_path, cache=True, verbose=True):
         """

--- a/astroquery/mast/observations.py
+++ b/astroquery/mast/observations.py
@@ -784,7 +784,7 @@ class ObservationsClass(MastQueryWithLogin):
         ----------
         data_products : `~astropy.table.Table`
             Table containing products to be converted into cloud data uris. If provided, this will supercede
-            page_size, page, or any arguments passed in as **criteria.
+            page_size, page, or any keyword arguments passed in as criteria.
         include_bucket : bool
             Default True. When False, returns the path of the file relative to the
             top level cloud storage location.

--- a/astroquery/mast/tests/test_mast_remote.py
+++ b/astroquery/mast/tests/test_mast_remote.py
@@ -544,6 +544,27 @@ class TestMast:
 
         assert len(uris) > 0, f'Products for OBSID {test_obs_id} were not found in the cloud.'
 
+    def test_get_cloud_uris_query(self):
+        pytest.importorskip("boto3")
+
+        # enable access to public AWS S3 bucket
+        Observations.enable_cloud_dataset()
+
+        # get uris with other functions
+        obs = Observations.query_criteria(target_name=234295610,
+                                          provenance_name="SPOC",
+                                          sequence_number=[1, 2])
+        prod = Observations.get_product_list(obs)
+        filt = Observations.filter_products(prod, calib_level=[2])
+        s3_uris = Observations.get_cloud_uris(filt)
+
+        # get uris with streamlined function
+        uris = Observations.get_cloud_uris_query(target_name=234295610,
+                                                 provenance_name="SPOC",
+                                                 sequence_number=[1, 2],
+                                                 filter_products={'calib_level': [2]})
+        assert s3_uris == uris
+
     ######################
     # CatalogClass tests #
     ######################

--- a/astroquery/mast/tests/test_mast_remote.py
+++ b/astroquery/mast/tests/test_mast_remote.py
@@ -544,6 +544,11 @@ class TestMast:
 
         assert len(uris) > 0, f'Products for OBSID {test_obs_id} were not found in the cloud.'
 
+        # check for warning if no data products match filters
+        with pytest.warns(NoResultsWarning):
+            Observations.get_cloud_uris(products,
+                                        extension='png')
+
     def test_get_cloud_uris_query(self):
         pytest.importorskip("boto3")
 
@@ -559,11 +564,19 @@ class TestMast:
         s3_uris = Observations.get_cloud_uris(filt)
 
         # get uris with streamlined function
-        uris = Observations.get_cloud_uris_query(target_name=234295610,
-                                                 provenance_name="SPOC",
-                                                 sequence_number=[1, 2],
-                                                 filter_products={'calib_level': [2]})
+        uris = Observations.get_cloud_uris(target_name=234295610,
+                                           provenance_name="SPOC",
+                                           sequence_number=[1, 2],
+                                           filter_products={'calib_level': [2]})
         assert s3_uris == uris
+
+        # check that InvalidQueryError is thrown if neither data_products or **criteria are defined
+        with pytest.raises(InvalidQueryError):
+            Observations.get_cloud_uris(filter_products={'calib_level': [2]})
+
+        # check for warning if query returns no observations
+        with pytest.warns(NoResultsWarning):
+            Observations.get_cloud_uris(target_name=234295611)
 
     ######################
     # CatalogClass tests #

--- a/astroquery/mast/tests/test_mast_remote.py
+++ b/astroquery/mast/tests/test_mast_remote.py
@@ -526,12 +526,13 @@ class TestMast:
         assert len(uri) > 0, f'Product for dataURI {test_data_uri} was not found in the cloud.'
         assert uri == expected_cloud_uri, f'Cloud URI does not match expected. ({uri} != {expected_cloud_uri})'
 
-    def test_get_cloud_uris(self):
+    @pytest.mark.parametrize("test_obs_id", ["25568122", "31411"])
+    def test_get_cloud_uris(self, test_obs_id):
         pytest.importorskip("boto3")
-        test_obs_id = '25568122'
 
         # get a product list
-        products = Observations.get_product_list(test_obs_id)[24:]
+        index = 24 if test_obs_id == '25568122' else 0
+        products = Observations.get_product_list(test_obs_id)[index:]
 
         assert len(products) > 0, (f'No products found for OBSID {test_obs_id}. '
                                    'Unable to move forward with getting URIs from the cloud.')
@@ -556,17 +557,13 @@ class TestMast:
         Observations.enable_cloud_dataset()
 
         # get uris with other functions
-        obs = Observations.query_criteria(target_name=234295610,
-                                          provenance_name="SPOC",
-                                          sequence_number=[1, 2])
+        obs = Observations.query_criteria(target_name=234295610)
         prod = Observations.get_product_list(obs)
         filt = Observations.filter_products(prod, calib_level=[2])
         s3_uris = Observations.get_cloud_uris(filt)
 
         # get uris with streamlined function
         uris = Observations.get_cloud_uris(target_name=234295610,
-                                           provenance_name="SPOC",
-                                           sequence_number=[1, 2],
                                            filter_products={'calib_level': [2]})
         assert s3_uris == uris
 

--- a/docs/mast/mast_catalog.rst
+++ b/docs/mast/mast_catalog.rst
@@ -24,7 +24,7 @@ The returned fields vary by catalog, find the field documentation for specific c
 `here <https://mast.stsci.edu/api/v0/pages.html>`__.
 If no catalog is specified, the Hubble Source Catalog will be queried.
 
-.. doctest-remote-data::
+.. doctest-skip::
 
    >>> from astroquery.mast import Catalogs
    ...
@@ -261,19 +261,17 @@ Given an HSC Match ID, return all catalog results.
    >>> catalog_data = Catalogs.query_object("M10", radius=.02, catalog="HSC")
    >>> matchid = catalog_data[0]["MatchID"]
    >>> print(matchid)
-   63980492
+   7542452
    >>> matches = Catalogs.query_hsc_matchid(matchid)
    >>> print(matches)
-     CatID   MatchID  ...                       cd_matrix
-   --------- -------- ... ------------------------------------------------------
-   257195287 63980492 ... -1.38889e-005 -5.26157e-010 -5.26157e-010 1.38889e-005
-   257440119 63980492 ... -1.38889e-005 -5.26157e-010 -5.26157e-010 1.38889e-005
-   428373428 63980492 ...   -1.10056e-005 5.65193e-010 5.65193e-010 1.10056e-005
-   428373427 63980492 ...   -1.10056e-005 5.65193e-010 5.65193e-010 1.10056e-005
-   428373429 63980492 ...   -1.10056e-005 5.65193e-010 5.65193e-010 1.10056e-005
-   410574499 63980492 ...   -1.10056e-005 1.56577e-009 1.56577e-009 1.10056e-005
-   410574498 63980492 ...   -1.10056e-005 1.56577e-009 1.56577e-009 1.10056e-005
-   410574497 63980492 ...   -1.10056e-005 1.56577e-009 1.56577e-009 1.10056e-005
+     CatID   MatchID ...                       cd_matrix                       
+   --------- ------- ... ------------------------------------------------------
+   419094794 7542452 ...   -1.10056e-005 5.65193e-010 5.65193e-010 1.10056e-005
+   419094795 7542452 ...   -1.10056e-005 5.65193e-010 5.65193e-010 1.10056e-005
+   401289578 7542452 ...   -1.10056e-005 1.56577e-009 1.56577e-009 1.10056e-005
+   401289577 7542452 ...   -1.10056e-005 1.56577e-009 1.56577e-009 1.10056e-005
+   257194049 7542452 ... -1.38889e-005 -5.26157e-010 -5.26157e-010 1.38889e-005
+   257438887 7542452 ... -1.38889e-005 -5.26157e-010 -5.26157e-010 1.38889e-005
 
 
 HSC spectra accessed through this class as well. `~astroquery.mast.CatalogsClass.get_hsc_spectra`

--- a/docs/mast/mast_catalog.rst
+++ b/docs/mast/mast_catalog.rst
@@ -24,12 +24,13 @@ The returned fields vary by catalog, find the field documentation for specific c
 `here <https://mast.stsci.edu/api/v0/pages.html>`__.
 If no catalog is specified, the Hubble Source Catalog will be queried.
 
-.. doctest-skip::
+ 
+.. doctest-remote-data::
 
    >>> from astroquery.mast import Catalogs
    ...
    >>> catalog_data = Catalogs.query_object("158.47924 -7.30962", catalog="Galex")
-   >>> print(catalog_data[:10])
+   >>> print(catalog_data[:10])  # doctest: +IGNORE_OUTPUT
     distance_arcmin          objID        survey ... fuv_flux_aper_7 fuv_artifact
    ------------------ ------------------- ------ ... --------------- ------------
    0.3493802506329695 6382034098673685038    AIS ...     0.047751952            0

--- a/docs/mast/mast_obsquery.rst
+++ b/docs/mast/mast_obsquery.rst
@@ -284,9 +284,9 @@ with `~astroquery.mast.ObservationsClass.get_product_list`
 (see `here <https://mast.stsci.edu/api/v0/_c_a_o_mfields.html>`__ for more details).
 Using "obs_id" instead of "obsid" from the previous example will result in the following error:
 
-.. doctest-skip::
+.. doctest-remote-data::
    >>> obs_ids = obs_table[0:2]['obs_id']
-   >>> data_products_by_id = Observations.get_product_list(obs_ids)
+   >>> data_products_by_id = Observations.get_product_list(obs_ids)  # doctest: +IGNORE_OUTPUT
    Traceback (most recent call last):
    ...
    RemoteServiceError: Error converting data type varchar to bigint.
@@ -467,24 +467,23 @@ Alternatively, this workflow can be streamlined by providing the query criteria 
 This approach is recommended for code brevity. Query criteria are supplied as keyword arguments, and filters are supplied through the 
 ``filter_products`` parameter. If both ``data_products`` and query criteria are provided, ``data_products`` takes precedence.
 
-.. doctest-skip::
+.. doctest-remote-data::
 
    >>> import os
    >>> from astroquery.mast import Observations
    ...
    >>> Observations.enable_cloud_dataset(provider='AWS')
-   INFO: Using the S3 STScI public dataset [astroquery.mast.core]
-   ...
+   INFO: Using the S3 STScI public dataset [astroquery.mast.cloud]
    >>> # Getting the cloud URIs
    >>> s3_uris = Observations.get_cloud_uris(obs_collection='HST',
-                                             filters='F606W',
-                                             instrument_name='ACS/WFC',
-                                             proposal_id=['12062'],
-                                             dataRights='PUBLIC',
-                                             filter_products={'productSubGroupDescription': 'DRZ'})
+   ...                                       filters='F606W',
+   ...                                       instrument_name='ACS/WFC',
+   ...                                       proposal_id=['12062'],
+   ...                                       dataRights='PUBLIC',
+   ...                                       filter_products={'productSubGroupDescription': 'DRZ'})
+   INFO: 2 of 4 products were duplicates. Only downloading 2 unique product(s). [astroquery.mast.observations]
    >>> print(s3_uris)
    ['s3://stpubdata/hst/public/jbev/jbeveo010/jbeveo010_drz.fits', 's3://stpubdata/hst/public/jbev/jbevet010/jbevet010_drz.fits']
-   ...
    >>> Observations.disable_cloud_dataset()
 
 Downloading data products from S3:

--- a/docs/mast/mast_obsquery.rst
+++ b/docs/mast/mast_obsquery.rst
@@ -427,6 +427,8 @@ MAST until it is disabled with `~astroquery.mast.ObservationsClass.disable_cloud
 To directly access a list of cloud URIs for a given dataset, use the
 `~astroquery.mast.ObservationsClass.get_cloud_uris`
 function (Python will prompt you to enable cloud access if you haven't already).
+To return a list of cloud URIs based on query criteria and product filters, use the
+`~astroquery.mast.ObservationsClass.get_cloud_uris_query` function.
 
 When cloud access is enabled, the standard download function
 `~astroquery.mast.ObservationsClass.download_products` preferentially pulls files from AWS when they
@@ -434,7 +436,7 @@ are available. When set to `True`, the ``cloud_only`` parameter in
 `~astroquery.mast.ObservationsClass.download_products` skips all data products not available in the cloud.
 
 
-Getting a list of S3 URIs:
+To get a list of S3 URIs, use the following workflow:
 
 .. doctest-skip::
 
@@ -456,10 +458,32 @@ Getting a list of S3 URIs:
    ...                                         productSubGroupDescription='DRZ')
    >>> s3_uris = Observations.get_cloud_uris(filtered)
    >>> print(s3_uris)
-   ['s3://stpubdata/hst/public/jbev/jbeveo010/jbeveo010_drz.fits', 's3://stpubdata/hst/public/jbev/jbeveo010/jbeveo010_drz.fits', 's3://stpubdata/hst/public/jbev/jbevet010/jbevet010_drz.fits', 's3://stpubdata/hst/public/jbev/jbevet010/jbevet010_drz.fits']
+   ['s3://stpubdata/hst/public/jbev/jbeveo010/jbeveo010_drz.fits', 's3://stpubdata/hst/public/jbev/jbevet010/jbevet010_drz.fits']
    ...
    >>> Observations.disable_cloud_dataset()
 
+Alternatively, you can use the streamlined `~astroquery.mast.ObservationsClass.get_cloud_uris_query` function. This approach is recommended
+for code brevity. Query criteria are supplied as keyword arguments, and filters are supplied through the ``filter_products`` parameter.
+
+.. doctest-skip::
+
+   >>> import os
+   >>> from astroquery.mast import Observations
+   ...
+   >>> Observations.enable_cloud_dataset(provider='AWS')
+   INFO: Using the S3 STScI public dataset [astroquery.mast.core]
+   ...
+   >>> # Getting the cloud URIs
+   >>> s3_uris = Observations.get_cloud_uris_query(obs_collection='HST',
+                                                   filters='F606W',
+                                                   instrument_name='ACS/WFC',
+                                                   proposal_id=['12062'],
+                                                   dataRights='PUBLIC',
+                                                   filter_products={'productSubGroupDescription': 'DRZ'})
+   >>> print(s3_uris)
+   ['s3://stpubdata/hst/public/jbev/jbeveo010/jbeveo010_drz.fits', 's3://stpubdata/hst/public/jbev/jbevet010/jbevet010_drz.fits']
+   ...
+   >>> Observations.disable_cloud_dataset()
 
 Downloading data products from S3:
 

--- a/docs/mast/mast_obsquery.rst
+++ b/docs/mast/mast_obsquery.rst
@@ -284,7 +284,7 @@ with `~astroquery.mast.ObservationsClass.get_product_list`
 (see `here <https://mast.stsci.edu/api/v0/_c_a_o_mfields.html>`__ for more details).
 Using "obs_id" instead of "obsid" from the previous example will result in the following error:
 
-.. doctest-remote-data::
+.. doctest-skip::
    >>> obs_ids = obs_table[0:2]['obs_id']
    >>> data_products_by_id = Observations.get_product_list(obs_ids)
    Traceback (most recent call last):
@@ -325,12 +325,12 @@ Product filtering can also be applied directly to a table of products without pr
    ...
    >>> data_products = Observations.get_product_list('25588063')
    >>> print(len(data_products))
-   27
+   30
    >>> products = Observations.filter_products(data_products,
    ...                                         productType=["SCIENCE", "PREVIEW"],
    ...                                         extension="fits")
    >>> print(len(products))
-   8
+   10
 
 
 Downloading Data Products

--- a/docs/mast/mast_obsquery.rst
+++ b/docs/mast/mast_obsquery.rst
@@ -427,8 +427,9 @@ MAST until it is disabled with `~astroquery.mast.ObservationsClass.disable_cloud
 To directly access a list of cloud URIs for a given dataset, use the
 `~astroquery.mast.ObservationsClass.get_cloud_uris`
 function (Python will prompt you to enable cloud access if you haven't already).
-To return a list of cloud URIs based on query criteria and product filters, use the
-`~astroquery.mast.ObservationsClass.get_cloud_uris_query` function.
+With this function, users may specify a `~astropy.table.Table` of data products or 
+query criteria. Query criteria are supplied as keyword arguments, and product filters 
+may be supplied through the ``mrp_only``, ``extension``, and ``filter_products`` parameters.
 
 When cloud access is enabled, the standard download function
 `~astroquery.mast.ObservationsClass.download_products` preferentially pulls files from AWS when they
@@ -462,8 +463,9 @@ To get a list of S3 URIs, use the following workflow:
    ...
    >>> Observations.disable_cloud_dataset()
 
-Alternatively, you can use the streamlined `~astroquery.mast.ObservationsClass.get_cloud_uris_query` function. This approach is recommended
-for code brevity. Query criteria are supplied as keyword arguments, and filters are supplied through the ``filter_products`` parameter.
+Alternatively, this workflow can be streamlined by providing the query criteria directly to `~astroquery.mast.ObservationsClass.get_cloud_uris`.
+This approach is recommended for code brevity. Query criteria are supplied as keyword arguments, and filters are supplied through the 
+``filter_products`` parameter. If both ``data_products`` and query criteria are provided, ``data_products`` takes precedence.
 
 .. doctest-skip::
 
@@ -474,12 +476,12 @@ for code brevity. Query criteria are supplied as keyword arguments, and filters 
    INFO: Using the S3 STScI public dataset [astroquery.mast.core]
    ...
    >>> # Getting the cloud URIs
-   >>> s3_uris = Observations.get_cloud_uris_query(obs_collection='HST',
-                                                   filters='F606W',
-                                                   instrument_name='ACS/WFC',
-                                                   proposal_id=['12062'],
-                                                   dataRights='PUBLIC',
-                                                   filter_products={'productSubGroupDescription': 'DRZ'})
+   >>> s3_uris = Observations.get_cloud_uris(obs_collection='HST',
+                                             filters='F606W',
+                                             instrument_name='ACS/WFC',
+                                             proposal_id=['12062'],
+                                             dataRights='PUBLIC',
+                                             filter_products={'productSubGroupDescription': 'DRZ'})
    >>> print(s3_uris)
    ['s3://stpubdata/hst/public/jbev/jbeveo010/jbeveo010_drz.fits', 's3://stpubdata/hst/public/jbev/jbevet010/jbevet010_drz.fits']
    ...


### PR DESCRIPTION
Added `mast.Observations.get_cloud_uris_query()` method so that given a set of query criteria and optional filters, the user receives a list of cloud data URIs for matching data products.

Also added to documentation and remote unit tests.