### PR TITLE
Bugfix for pagesize and page parameters in catalogs.query_criteria()

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -157,6 +157,8 @@ mast
 
 - Add ``verbose`` parameter to modulate output in ``mast.observations.download_products`` method. [#3031]
 
+- Fix bug in ``Catalogs.query_criteria()`` to use ``page`` and ``pagesize`` parameters correctly. [#3065]
+
 
 
 0.4.7 (2024-03-08)

--- a/astroquery/mast/collections.py
+++ b/astroquery/mast/collections.py
@@ -225,6 +225,8 @@ class CatalogsClass(MastQueryWithLogin):
 
         Parameters
         ----------
+        catalog : str
+            The catalog to be queried.
         pagesize : int, optional
             Can be used to override the default pagesize.
             E.g. when using a slow internet connection.

--- a/astroquery/mast/services.py
+++ b/astroquery/mast/services.py
@@ -12,6 +12,7 @@ import warnings
 import numpy as np
 
 from astropy.table import Table, MaskedColumn
+from astropy.utils.decorators import deprecated_renamed_argument
 
 from ..query import BaseQuery
 from ..utils import async_to_sync
@@ -222,6 +223,7 @@ class ServiceAPI(BaseQuery):
         return result_table
 
     @class_or_instance
+    @deprecated_renamed_argument('page_size', 'pagesize', since='0.4.8')
     def service_request_async(self, service, params, pagesize=None, page=None, use_json=False, **kwargs):
         """
         Given a MAST fabric service and parameters, builds and executes a fabric microservice catalog query.

--- a/astroquery/mast/services.py
+++ b/astroquery/mast/services.py
@@ -222,7 +222,7 @@ class ServiceAPI(BaseQuery):
         return result_table
 
     @class_or_instance
-    def service_request_async(self, service, params, page_size=None, page=None, use_json=False, **kwargs):
+    def service_request_async(self, service, params, pagesize=None, page=None, use_json=False, **kwargs):
         """
         Given a MAST fabric service and parameters, builds and executes a fabric microservice catalog query.
         See documentation `here <https://catalogs.mast.stsci.edu/docs/index.html>`__
@@ -234,7 +234,7 @@ class ServiceAPI(BaseQuery):
            The MAST catalogs service to query. Should be present in self.SERVICES
         params : dict
            JSON object containing service parameters.
-        page_size : int, optional
+        pagesize : int, optional
            Default None.
            Can be used to override the default pagesize (set in configs) for this query only.
            E.g. when using a slow internet connection.
@@ -273,13 +273,13 @@ class ServiceAPI(BaseQuery):
         catalogs_request = []
         if not page:
             page = params.pop('page', None)
-        if not page_size:
-            page_size = params.pop('page_size', None)
+        if not pagesize:
+            pagesize = params.pop('pagesize', None)
 
         if page is not None:
             catalogs_request.append(('page', page))
-        if page_size is not None:
-            catalogs_request.append(('pagesize', page_size))
+        if pagesize is not None:
+            catalogs_request.append(('pagesize', pagesize))
 
         if not use_json:
             # Decompose filters, sort
@@ -331,7 +331,7 @@ class ServiceAPI(BaseQuery):
             if prop == 'format':
                 # Ignore format changes
                 continue
-            elif prop == 'page_size':
+            elif prop == 'pagesize':
                 catalog_params.extend(('pagesize', value))
             elif prop == 'sort_by':
                 # Loop through each value if list

--- a/astroquery/mast/tests/test_mast_remote.py
+++ b/astroquery/mast/tests/test_mast_remote.py
@@ -74,10 +74,13 @@ class TestMast:
                   'dec': 54.5,
                   'radius': 0.001}
 
-        result = Mast.service_request(service, params)
+        result = Mast.service_request(service, params, pagesize=10, page=2)
 
         # Is result in the right format
         assert isinstance(result, Table)
+
+        # Is result limited to ten rows
+        assert len(result) == 10
 
         # Are the GALEX observations in the results table
         assert "GALEX" in result['obs_collection']
@@ -532,15 +535,18 @@ class TestMast:
                                        radius=0.01*u.deg, catalog="panstarrs",
                                        table="mean")
         row = np.where((result['objName'] == 'PSO J322.4622+12.1920') & (result['yFlags'] == 16777496))
+        second_id = result[1]['objID']
         assert isinstance(result, Table)
         np.testing.assert_allclose(result[row]['distance'], 0.039381703406789904)
 
         result = Catalogs.query_region("322.49324 12.16683",
                                        radius=0.01*u.deg, catalog="panstarrs",
                                        table="mean",
-                                       page_size=3)
+                                       pagesize=1,
+                                       page=2)
         assert isinstance(result, Table)
-        assert len(result) == 3
+        assert len(result) == 1
+        assert second_id == result[0]['objID']
 
         result = Catalogs.query_region("158.47924 -7.30962",
                                        radius=in_radius,
@@ -588,6 +594,16 @@ class TestMast:
                                        radius=.001,
                                        catalog="TIC")
         check_result(result, {'ID': '1305764225'})
+        second_id = result[1]['ID']
+
+        result = Catalogs.query_object("M10",
+                                       radius=.001,
+                                       catalog="TIC",
+                                       pagesize=1,
+                                       page=2)
+        assert isinstance(result, Table)
+        assert len(result) == 1
+        assert second_id == result[0]['ID']
 
         result = Catalogs.query_object("M10",
                                        radius=.001,
@@ -681,6 +697,16 @@ class TestMast:
                                          Bmag=[30, 50],
                                          objType="STAR")
         check_result(result, {'ID': '81609218'})
+        second_id = result[1]['ID']
+
+        result = Catalogs.query_criteria(catalog="Tic",
+                                         Bmag=[30, 50],
+                                         objType="STAR",
+                                         pagesize=1,
+                                         page=2)
+        assert isinstance(result, Table)
+        assert len(result) == 1
+        assert second_id == result[0]['ID']
 
         result = Catalogs.query_criteria(catalog="ctl",
                                          Tmag=[10.5, 11],


### PR DESCRIPTION
Fix bug so that the `pagesize` and `page` parameters work properly for `Catalogs.query_criteria()`.

Also added to unit test cases to check that these are working properly.