### PR TITLE
Remove photutils from Astroquery astrometry.net

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -8,6 +8,11 @@ New Tools and Services
 Service fixes and enhancements
 ------------------------------
 
+astrometry_net
+^^^^^^^^^^^^^^
+
+- Remove photutils from Astroquery astrometry.net [#3067]
+
 alma
 ^^^^
 

--- a/astroquery/astrometry_net/core.py
+++ b/astroquery/astrometry_net/core.py
@@ -416,7 +416,7 @@ class AstrometryNetClass(BaseQuery):
                                          files={'file': f})
         else:
             warning_msg = "Removing photutils functionality to obtain extracted positions list from " \
-                          "AstoromertyNetClass.solve_from_source_list. Users will need to " \
+                          "AstrometryNetClass.solve_from_source_list. Users will need to " \
                           "submit pre-extracted catalog positions or a fits file for https://nova.astrometry.net/ " \
                           "to extract with their algorithm."
             warnings.warn(warning_msg, category=AstropyDeprecationWarning)

--- a/astroquery/astrometry_net/core.py
+++ b/astroquery/astrometry_net/core.py
@@ -415,10 +415,10 @@ class AstrometryNetClass(BaseQuery):
                                          cache=False,
                                          files={'file': f})
         else:
-            warning_msg = "Removing photutils functionality to obtain extracted positions list from " \
-                          "AstrometryNetClass.solve_from_source_list. Users will need to " \
-                          "submit pre-extracted catalog positions or a fits file for https://nova.astrometry.net/ " \
-                          "to extract with their algorithm."
+            warning_msg = ("Removing photutils functionality to obtain extracted positions list from "
+                          "AstrometryNetClass.solve_from_source_list. Users will need to "
+                          "submit pre-extracted catalog positions or a fits file for https://nova.astrometry.net/ "
+                          "to extract with their algorithm.")
             warnings.warn(warning_msg, category=AstropyDeprecationWarning)
             # Detect sources and delegate to solve_from_source_list
             if _HAVE_CCDDATA:

--- a/astroquery/astrometry_net/core.py
+++ b/astroquery/astrometry_net/core.py
@@ -2,11 +2,12 @@
 
 
 import json
+import warnings
 
 from astropy.io import fits
 from astropy.stats import sigma_clipped_stats
 from astropy.coordinates import SkyCoord
-from astropy.utils.decorators import deprecated_renamed_argument
+from astropy.utils.decorators import AstropyDeprecationWarning, deprecated_renamed_argument
 
 try:
     from astropy.nddata import CCDData
@@ -332,7 +333,7 @@ class AstrometryNetClass(BaseQuery):
                                        verbose=verbose,
                                        return_submission_id=return_submission_id)
 
-    @deprecated_renamed_argument("force_image_upload", None, since="0.4.8")
+    @deprecated_renamed_argument(("force_image_upload", "ra_dec_units"), (None, None), since="0.4.8")
     def solve_from_image(self, image_file_path, *, force_image_upload=False,
                          ra_key=None, dec_key=None,
                          ra_dec_units=None,
@@ -414,10 +415,11 @@ class AstrometryNetClass(BaseQuery):
                                          cache=False,
                                          files={'file': f})
         else:
-            warning_msg = "Removing photutils functionality to obtain position list." \
-                          "Users can generate a coordinate list and upload to Astrometry.net" \
-                          "or a fits file that Astrometry.net will extract positions."
-            DeprecationWarning(warning_msg)
+            warning_msg = "Removing photutils functionality to obtain extracted positions list from " \
+                          "AstoromertyNetClass.solve_from_source_list. Users will need to " \
+                          "submit pre-extracted catalog positions or a fits file for https://nova.astrometry.net/ " \
+                          "to extract with their algorithm."
+            warnings.warn(warning_msg, category=AstropyDeprecationWarning)
             # Detect sources and delegate to solve_from_source_list
             if _HAVE_CCDDATA:
                 # CCDData requires a unit, so provide one. It has absolutely

--- a/astroquery/astrometry_net/core.py
+++ b/astroquery/astrometry_net/core.py
@@ -415,10 +415,13 @@ class AstrometryNetClass(BaseQuery):
                                          cache=False,
                                          files={'file': f})
         else:
-            warning_msg = ("Removing photutils functionality to obtain extracted positions list from "
-                          "AstrometryNetClass.solve_from_source_list. Users will need to "
-                          "submit pre-extracted catalog positions or a fits file for https://nova.astrometry.net/ "
-                          "to extract with their algorithm.")
+            warning_msg = (
+                "Removing photutils functionality to obtain extracted positions list from "
+                "AstrometryNetClass.solve_from_source_list. Users will need to "
+                "submit pre-extracted catalog positions or a fits file for https://nova.astrometry.net/ "
+                "to extract with their algorithm."
+            )
+
             warnings.warn(warning_msg, category=AstropyDeprecationWarning)
             # Detect sources and delegate to solve_from_source_list
             if _HAVE_CCDDATA:

--- a/astroquery/astrometry_net/core.py
+++ b/astroquery/astrometry_net/core.py
@@ -6,6 +6,7 @@ import json
 from astropy.io import fits
 from astropy.stats import sigma_clipped_stats
 from astropy.coordinates import SkyCoord
+from astropy.utils.decorators import deprecated_renamed_argument
 
 try:
     from astropy.nddata import CCDData
@@ -331,6 +332,7 @@ class AstrometryNetClass(BaseQuery):
                                        verbose=verbose,
                                        return_submission_id=return_submission_id)
 
+    @deprecated_renamed_argument("force_image_upload", None, since="0.4.8")
     def solve_from_image(self, image_file_path, *, force_image_upload=False,
                          ra_key=None, dec_key=None,
                          ra_dec_units=None,
@@ -412,6 +414,10 @@ class AstrometryNetClass(BaseQuery):
                                          cache=False,
                                          files={'file': f})
         else:
+            warning_msg = "Removing photutils functionality to obtain position list." \
+                          "Users can generate a coordinate list and upload to Astrometry.net" \
+                          "or a fits file that Astrometry.net will extract positions."
+            DeprecationWarning(warning_msg)
             # Detect sources and delegate to solve_from_source_list
             if _HAVE_CCDDATA:
                 # CCDData requires a unit, so provide one. It has absolutely


### PR DESCRIPTION
This PR addresses #2782.

Currently `astroquery/astrometry_net/core.py` tries to import `photutils.detection.DAOStarFinder` and `astropy.nddata.CCDData` and will make decisions on how sources in the fits file passed to `AstrometryNetClass` are extracted. The following additions will prepare the photutils portion of the algorithm for removal with the goal that if a source catalog is not provided, that `nova.astrometry.net` will perform the source extraction.

- Added astropy deprecation warning in code block containing `photutils`.
- Added astropy deprecation decorator for and unused parameter and parameter that allows user to bypass or allow `nova.astrometry.net` to extract sources.

Fixes: #2782.