### PR TITLE
Bugfix in get_cloud_uri_list, added test case

### DIFF
--- a/astroquery/mast/cloud.py
+++ b/astroquery/mast/cloud.py
@@ -160,6 +160,8 @@ class CloudAccess:  # pragma:no-cover
                     elif full_url:
                         path = "http://s3.amazonaws.com/{}/{}".format(self.pubdata_bucket, path)
                         uri_list.append(path)
+                    else:
+                        uri_list.append(path)
                 except self.botocore.exceptions.ClientError as e:
                     if e.response['Error']['Code'] != "404":
                         raise
@@ -192,7 +194,7 @@ class CloudAccess:  # pragma:no-cover
             warnings.simplefilter("ignore")
             bucket_path = self.get_cloud_uri(data_product, False)
         if not bucket_path:
-            raise Exception("Unable to locate file {}.".format(data_product['productFilename']))
+            raise Exception("Unable to locate file {}.".format(data_product['dataURI']))
 
         # Ask the webserver (in this case S3) what the expected content length is and use that.
         info_lookup = s3_client.head_object(Bucket=self.pubdata_bucket, Key=bucket_path)

--- a/astroquery/mast/tests/test_mast_remote.py
+++ b/astroquery/mast/tests/test_mast_remote.py
@@ -505,6 +505,20 @@ class TestMast:
         result = Observations.download_file(uri, local_path=local_path_file)
         check_result(result, local_path_file)
 
+    @pytest.mark.parametrize("in_uri", [
+        'mast:HLA/url/cgi-bin/getdata.cgi?download=1&filename=hst_05206_01_wfpc2_f375n_wf_daophot_trm.cat',
+        'mast:HST/product/u24r0102t_c3m.fits'
+    ])
+    def test_observations_download_file_cloud(self, tmp_path, in_uri):
+        pytest.importorskip("boto3")
+
+        Observations.enable_cloud_dataset()
+
+        filename = Path(in_uri).name
+        result = Observations.download_file(uri=in_uri, cloud_only=True, local_path=tmp_path)
+        assert result == ('COMPLETE', None, None)
+        assert Path(tmp_path, filename).exists()
+
     @pytest.mark.parametrize("test_data_uri, expected_cloud_uri", [
         ("mast:HST/product/u24r0102t_c1f.fits",
          "s3://stpubdata/hst/public/u24r/u24r0102t/u24r0102t_c1f.fits"),


### PR DESCRIPTION
This is to fix a small bug in the last PR that was merged for MAST. 

I also fixed a `KeyError` so that error messages give necessary information, and I added a test case for downloading files from the cloud so that we catch similar bugs in the future.