### PR TITLE
DEP: refactored out runtime dependency on setuptools

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -136,6 +136,8 @@ Infrastructure, Utility and Other Changes and Additions
 
 - Versions of PyVO <1.5 are no longer supported. [#3002]
 
+- Dropped ``setuptools`` as a runtime dependency. [#3071]
+
 utils.tap
 ^^^^^^^^^
 

--- a/astroquery/alma/core.py
+++ b/astroquery/alma/core.py
@@ -8,8 +8,8 @@ import tarfile
 import string
 import requests
 import warnings
+import importlib.resources as importlib_resources
 
-from pkg_resources import resource_filename
 from bs4 import BeautifulSoup
 import pyvo
 from urllib.parse import urljoin
@@ -1183,10 +1183,9 @@ class AlmaClass(QueryWithLogin):
         Stoehr.
         """
         if not hasattr(self, '_cycle0_table'):
-            filename = resource_filename(
-                'astroquery.alma', 'data/cycle0_delivery_asdm_mapping.txt')
-
-            self._cycle0_table = Table.read(filename, format='ascii.no_header')
+            ref = importlib_resources.files('astroquery.alma') / 'data' / 'cycle0_delivery_asdm_mapping.txt'
+            with importlib_resources.as_file(ref) as path:
+                self._cycle0_table = Table.read(path, format='ascii.no_header')
             self._cycle0_table.rename_column('col1', 'ID')
             self._cycle0_table.rename_column('col2', 'uid')
         return self._cycle0_table

--- a/astroquery/ipac/nexsci/nasa_exoplanet_archive/tests/test_nasa_exoplanet_archive.py
+++ b/astroquery/ipac/nexsci/nasa_exoplanet_archive/tests/test_nasa_exoplanet_archive.py
@@ -5,7 +5,6 @@ import sys
 from urllib.parse import urlencode
 
 import astropy.units as u
-import pkg_resources
 import pytest
 import requests
 
@@ -17,8 +16,7 @@ try:
 except ImportError:
     pytest.skip("Install mock for the nasa_exoplanet_archive tests.", allow_module_level=True)
 
-MAIN_DATA = pkg_resources.resource_filename("astroquery.ipac.nexsci.nasa_exoplanet_archive", "data")
-TEST_DATA = pkg_resources.resource_filename(__name__, "data")
+TEST_DATA = os.path.abspath(os.path.join(os.path.dirname(__file__), "data"))
 RESPONSE_FILE = os.path.join(TEST_DATA, "responses.json")
 
 # API accessible tables will gradually transition to TAP service


### PR DESCRIPTION
Context:
- `pkg_resources`, which is part of `setuptools`, is de facto a runtime dependency of `astroquery`
- it is not declared as such: I suspect the reason this has not been a problem (yet) in CI is that some test dependency (likely pytest-doctestplus via pytest-astropy) pulls it in. I'm working on eliminating this dependency from the stack, see https://github.com/scientific-python/pytest-doctestplus/pull/258
- `pkg_resources` is also deprecated as an API (see https://setuptools.pypa.io/en/latest/pkg_resources.html)

I followed the upstream [migration guide](https://importlib-resources.readthedocs.io/en/latest/migration.html#pkg-resources-resource-filename) here.
