### PR TITLE
INFO message when removing duplicate products should give the correct number of products based on filters

### DIFF
--- a/astroquery/mast/observations.py
+++ b/astroquery/mast/observations.py
@@ -740,11 +740,11 @@ class ObservationsClass(MastQueryWithLogin):
 
             products = vstack(product_lists)
 
-        # Remove duplicate products
-        products = self._remove_duplicate_products(products)
-
         # apply filters
         products = self.filter_products(products, mrp_only=mrp_only, **filters)
+
+        # remove duplicate products
+        products = self._remove_duplicate_products(products)
 
         if not len(products):
             warnings.warn("No products to download.", NoResultsWarning)


### PR DESCRIPTION
Related to #2496 and #2497

Quick fix so that the number of products given in the INFO message in `_remove_duplicate_products` reflects any filters that were applied to the products. I did this by switching the order of the calls in `download_products` so that filters are applied to the product list before duplicates are removed.