### PR TITLE
ENH: adding SSA method for IRSA

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -24,6 +24,8 @@ gaia
 ipac.irsa
 ^^^^^^^^^
 
+- Method to run Simple Spectral Access (SSA) VO queries, ``query_ssa``, is added. [#3076]
+
 - Adding the "servicetype" kwarg to ``list_collections`` to be able to list SIA
   and SSA collections separately. [#3200]
 

--- a/astroquery/ipac/irsa/__init__.py
+++ b/astroquery/ipac/irsa/__init__.py
@@ -28,6 +28,7 @@ class Conf(_config.ConfigNamespace):
         60,
         'Time limit for connecting to the IRSA server.')
     sia_url = _config.ConfigItem('https://irsa.ipac.caltech.edu/SIA', 'IRSA SIA URL')
+    ssa_url = _config.ConfigItem('https://irsa.ipac.caltech.edu/SSA', 'IRSA SSA URL')
     tap_url = _config.ConfigItem('https://irsa.ipac.caltech.edu/TAP', 'IRSA TAP URL')
 
 

--- a/astroquery/ipac/irsa/core.py
+++ b/astroquery/ipac/irsa/core.py
@@ -12,10 +12,8 @@ from astropy.coordinates import SkyCoord, Angle
 from astropy import units as u
 from astropy.utils.decorators import deprecated_renamed_argument
 
-from pyvo.dal import TAPService
-
-from pyvo.dal.sia2 import SIA2Service, SIA2_PARAMETERS_DESC
-
+from pyvo.dal import TAPService, SIA2Service, SSAService
+from pyvo.dal.sia2 import SIA2_PARAMETERS_DESC
 from astroquery import log
 from astroquery.query import BaseVOQuery
 from astroquery.utils.commons import parse_coordinates
@@ -31,8 +29,10 @@ class IrsaClass(BaseVOQuery):
     def __init__(self):
         super().__init__()
         self.sia_url = conf.sia_url
+        self.ssa_url = conf.ssa_url
         self.tap_url = conf.tap_url
         self._sia = None
+        self._ssa = None
         self._tap = None
 
     @property
@@ -40,6 +40,12 @@ class IrsaClass(BaseVOQuery):
         if not self._sia:
             self._sia = SIA2Service(baseurl=self.sia_url, session=self._session)
         return self._sia
+
+    @property
+    def ssa(self):
+        if not self._ssa:
+            self._ssa = SSAService(baseurl=self.sia_url, session=self._session)
+        return self._ssa
 
     @property
     def tap(self):
@@ -121,6 +127,44 @@ class IrsaClass(BaseVOQuery):
             **kwargs)
 
     query_sia.__doc__ = query_sia.__doc__.replace('_SIA2_PARAMETERS', SIA2_PARAMETERS_DESC)
+
+    def query_ssa(self, *, pos=None, diameter=None, band=None, time=None, format=None, **kwargs):
+        """
+        Use standard SSA attributes to query the IRSA SSA service.
+
+        Parameters
+        ----------
+        pos : `~astropy.coordinates.SkyCoord` class or sequence of two floats
+            the position of the center of the circular search region.
+            assuming icrs decimal degrees if unit is not specified.
+        diameter : `~astropy.units.Quantity` class or scalar float
+            the diameter of the circular region around pos in which to search.
+            assuming icrs decimal degrees if unit is not specified.
+        band : `~astropy.units.Quantity` class or sequence of two floats
+            the bandwidth range the observations belong to.
+            assuming meters if unit is not specified.
+        time : `~astropy.time.Time` class or sequence of two strings
+            the datetime range the observations were made in.
+            assuming iso 8601 if format is not specified.
+        format : str
+           the image format(s) of interest.  "all" indicates
+           all available formats; "graphic" indicates
+           graphical images (e.g. jpeg, png, gif; not FITS);
+           "metadata" indicates that no images should be
+           returned--only an empty table with complete metadata.
+        **kwargs :
+           additional case insensitive parameters can be given via arbitrary
+           case insensitive keyword arguments. Where there is overlap
+           with the parameters set by the other arguments to
+           this function, these keywords will override.
+
+        Returns
+        -------
+        Results in `pyvo.dal.SSAResults` format.
+        result.table in Astropy table format
+        """
+        return self.ssa.search(pos=pos, diameter=diameter, band=band, time=time,
+                               format=format, **kwargs)
 
     def list_collections(self, servicetype=None):
         """

--- a/astroquery/ipac/irsa/core.py
+++ b/astroquery/ipac/irsa/core.py
@@ -159,7 +159,7 @@ class IrsaClass(BaseVOQuery):
             diameter = None
         else:
             diameter = 2 * radius
-            
+
         return self.ssa.search(pos=pos, diameter=diameter, band=band, time=time,
                                format='all', collection=collection)
 

--- a/astroquery/ipac/irsa/core.py
+++ b/astroquery/ipac/irsa/core.py
@@ -128,7 +128,8 @@ class IrsaClass(BaseVOQuery):
 
     query_sia.__doc__ = query_sia.__doc__.replace('_SIA2_PARAMETERS', SIA2_PARAMETERS_DESC)
 
-    def query_ssa(self, *, pos=None, diameter=None, band=None, time=None, format=None, **kwargs):
+    def query_ssa(self, *, pos=None, diameter=None, band=None, time=None, format=None,
+                  collection=None):
         """
         Use standard SSA attributes to query the IRSA SSA service.
 
@@ -146,17 +147,14 @@ class IrsaClass(BaseVOQuery):
         time : `~astropy.time.Time` class or sequence of two strings
             the datetime range the observations were made in.
             assuming iso 8601 if format is not specified.
+        collection : str
+           Name of the collection that the data belongs to.
         format : str
            the image format(s) of interest.  "all" indicates
            all available formats; "graphic" indicates
            graphical images (e.g. jpeg, png, gif; not FITS);
            "metadata" indicates that no images should be
            returned--only an empty table with complete metadata.
-        **kwargs :
-           additional case insensitive parameters can be given via arbitrary
-           case insensitive keyword arguments. Where there is overlap
-           with the parameters set by the other arguments to
-           this function, these keywords will override.
 
         Returns
         -------
@@ -164,7 +162,7 @@ class IrsaClass(BaseVOQuery):
         result.table in Astropy table format
         """
         return self.ssa.search(pos=pos, diameter=diameter, band=band, time=time,
-                               format=format, **kwargs)
+                               format=format, collection=collection)
 
     def list_collections(self, servicetype=None):
         """

--- a/astroquery/ipac/irsa/core.py
+++ b/astroquery/ipac/irsa/core.py
@@ -44,7 +44,7 @@ class IrsaClass(BaseVOQuery):
     @property
     def ssa(self):
         if not self._ssa:
-            self._ssa = SSAService(baseurl=self.sia_url, session=self._session)
+            self._ssa = SSAService(baseurl=self.ssa_url, session=self._session)
         return self._ssa
 
     @property

--- a/astroquery/ipac/irsa/core.py
+++ b/astroquery/ipac/irsa/core.py
@@ -128,8 +128,7 @@ class IrsaClass(BaseVOQuery):
 
     query_sia.__doc__ = query_sia.__doc__.replace('_SIA2_PARAMETERS', SIA2_PARAMETERS_DESC)
 
-    def query_ssa(self, *, pos=None, diameter=None, band=None, time=None, format=None,
-                  collection=None):
+    def query_ssa(self, *, pos=None, radius=None, band=None, time=None, collection=None):
         """
         Use standard SSA attributes to query the IRSA SSA service.
 
@@ -138,8 +137,8 @@ class IrsaClass(BaseVOQuery):
         pos : `~astropy.coordinates.SkyCoord` class or sequence of two floats
             the position of the center of the circular search region.
             assuming icrs decimal degrees if unit is not specified.
-        diameter : `~astropy.units.Quantity` class or scalar float
-            the diameter of the circular region around pos in which to search.
+        raidus : `~astropy.units.Quantity` class or scalar float
+            the radius of the circular region around pos in which to search.
             assuming icrs decimal degrees if unit is not specified.
         band : `~astropy.units.Quantity` class or sequence of two floats
             the bandwidth range the observations belong to.
@@ -149,20 +148,20 @@ class IrsaClass(BaseVOQuery):
             assuming iso 8601 if format is not specified.
         collection : str
            Name of the collection that the data belongs to.
-        format : str
-           the image format(s) of interest.  "all" indicates
-           all available formats; "graphic" indicates
-           graphical images (e.g. jpeg, png, gif; not FITS);
-           "metadata" indicates that no images should be
-           returned--only an empty table with complete metadata.
 
         Returns
         -------
         Results in `pyvo.dal.SSAResults` format.
-        result.table in Astropy table format
+        result.to_table() in Astropy table format
         """
+
+        if radius is None:
+            diameter = None
+        else:
+            diameter = 2 * radius
+            
         return self.ssa.search(pos=pos, diameter=diameter, band=band, time=time,
-                               format=format, collection=collection)
+                               format='all', collection=collection)
 
     def list_collections(self, servicetype=None):
         """

--- a/astroquery/ipac/irsa/tests/test_irsa_remote.py
+++ b/astroquery/ipac/irsa/tests/test_irsa_remote.py
@@ -2,7 +2,7 @@
 
 import pytest
 import astropy.units as u
-from astropy.table import Table, unique
+from astropy.table import Table
 from astropy.coordinates import SkyCoord
 from astropy.utils.exceptions import AstropyDeprecationWarning
 

--- a/astroquery/ipac/irsa/tests/test_irsa_remote.py
+++ b/astroquery/ipac/irsa/tests/test_irsa_remote.py
@@ -92,5 +92,5 @@ class TestIrsa:
         coord = SkyCoord.from_name("Eta Carina")
         result = Irsa.query_ssa(pos=coord)
         assert len(result) > 260
-        collections = set(unique(result.to_table(), keys='dataid_collection')['dataid_collection'])
+        collections = set(result.to_table()['dataid_collection'])
         assert {'champ', 'iso_sws', 'sofia_forcast', 'sofia_great', 'spitzer_sha'}.issubset(collections)

--- a/astroquery/ipac/irsa/tests/test_irsa_remote.py
+++ b/astroquery/ipac/irsa/tests/test_irsa_remote.py
@@ -2,7 +2,7 @@
 
 import pytest
 import astropy.units as u
-from astropy.table import Table
+from astropy.table import Table, unique
 from astropy.coordinates import SkyCoord
 from astropy.utils.exceptions import AstropyDeprecationWarning
 
@@ -87,3 +87,10 @@ class TestIrsa:
             result = Irsa.query_tap(query=query)
         assert len(result) == 5
         assert result.to_table().colnames == ['ra', 'dec']
+
+    def test_ssa(self):
+        coord = SkyCoord.from_name("Eta Carina")
+        result = Irsa.query_ssa(pos=coord)
+        assert len(result) > 260
+        collections = set(unique(result.to_table(), keys='dataid_collection')['dataid_collection'])
+        assert {'champ', 'iso_sws', 'sofia_forcast', 'sofia_great', 'spitzer_sha'}.issubset(collections)

--- a/docs/ipac/irsa/irsa.rst
+++ b/docs/ipac/irsa/irsa.rst
@@ -334,7 +334,7 @@ Enhanced Imaging products in the centre of the COSMOS field as an `~astropy.tabl
    >>> arp220_spectra = Irsa.query_ssa(pos=coord).to_table()
 
 Without specifying the collection, the query returns results from multiple
-collections. For example this target has spectra from Sofia as well as from
+collections. For example this target has spectra from SOFIA as well as from
 Spitzer.
 
 .. doctest-remote-data::

--- a/docs/ipac/irsa/irsa.rst
+++ b/docs/ipac/irsa/irsa.rst
@@ -337,6 +337,8 @@ Without specifying the collection, the query returns results from multiple
 collections. For example this target has spectra from Sofia as well as from
 Spitzer.
 
+.. doctest-remote-data::
+
    >>> from astropy.table import unique
    >>> unique(arp220_spectra, keys='dataid_collection')['dataid_collection']
    <MaskedColumn name='dataid_collection' dtype='object' description='IVOA Identifier of collection' length=4>

--- a/docs/ipac/irsa/irsa.rst
+++ b/docs/ipac/irsa/irsa.rst
@@ -194,8 +194,8 @@ the query is send in asynchronous mode.
     >>> from astroquery.ipac.irsa import Irsa
     >>> table = Irsa.query_region("HIP 12", catalog="allwise_p3as_psd", spatial="Cone", async_job=True)
     >>> print(table)
-        designation         ra        dec     sigra  ...         y                   z           spt_ind      htm20    
-                           deg        deg     arcsec ...                                                               
+        designation         ra        dec     sigra  ...         y                   z           spt_ind      htm20
+                           deg        deg     arcsec ...
     ------------------- --------- ----------- ------ ... ------------------ ------------------- --------- -------------
     J000009.78-355736.9 0.0407905 -35.9602605 0.0454 ... 0.0005762523295116 -0.5872239888098030 100102010 8873706189183
 
@@ -314,6 +314,85 @@ Now plot the cutout.
    u.arcmin, wcs=WCS(hdul[0].header))
    plt.imshow(cutout.data, cmap='grey')
    plt.show()
+
+
+
+Simple spectral access queries
+------------------------------
+
+`~astroquery.ipac.irsa.IrsaClass.query_ssa` provides a way to access IRSA's Simple
+Spectral Access VO service. In the following example we are looking for Spitzer
+Enhanced Imaging products in the centre of the COSMOS field as an `~astropy.table.Table`.
+
+.. doctest-remote-data::
+
+   >>> from astroquery.ipac.irsa import Irsa
+   >>> from astropy.coordinates import SkyCoord
+   >>> from astropy import units as u
+   >>>
+   >>> coord = pos = SkyCoord.from_name('Arp 220')
+   >>> arp220_spectra = Irsa.query_ssa(pos=coord).to_table()
+
+Without specifying the collection, the query returns results from multiple
+collections. For example this target has spectra from Sofia as well as from
+Spitzer.
+
+   >>> from astropy.table import unique
+   >>> unique(arp220_spectra, keys='dataid_collection')['dataid_collection']
+   <MaskedColumn name='dataid_collection' dtype='object' description='IVOA Identifier of collection' length=4>
+            goals
+     sofia_fifils
+   spitzer_irsenh
+      spitzer_sha
+
+
+To list available collections for SSA queries, the
+`~astroquery.ipac.irsa.IrsaClass.list_collections` method is provided, and
+will return a `~astropy.table.Table`.
+
+.. doctest-remote-data::
+
+   >>> from astroquery.ipac.irsa import Irsa
+   >>> Irsa.list_collections(servicetype='SSA')
+   <Table length=35>
+          collection
+            object
+   ------------------------
+                      champ
+                      goals
+          herschel_gotcplus
+             herschel_hexos
+         herschel_hifistars
+               herschel_hop
+              herschel_hops
+    herschel_magcloudscplus
+           herschel_ppdisks
+           herschel_prismas
+              herschel_sag4
+             herschel_shpdp
+           herschel_v838mon
+              herschel_vngs
+                irtf_mearth
+                       irts
+                    iso_sws
+                 sofia_exes
+               sofia_fifils
+             sofia_flitecam
+              sofia_forcast
+                sofia_great
+             spitzer_5muses
+                spitzer_c2d
+   spitzer_disks_sh_spectra
+               spitzer_feps
+            spitzer_irs_std
+             spitzer_irsenh
+             spitzer_m83m33
+                 spitzer_s5
+               spitzer_sage
+               spitzer_sass
+                spitzer_sha
+              spitzer_sings
+              spitzer_ssgss
 
 
 Other Configurations


### PR DESCRIPTION
Addig SSA access to spectral holdings. The `query_ssa` method is a very thin wrapper of pyvo, so while any issues recovered with it is appreciated, we may ultimately need to propagate those upstream rather than adding workaround for the PR.

closes #3061 