### PR TITLE
Astrometry.net: reduce number of calls when polling for job status

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -13,6 +13,8 @@ astrometry_net
 
 - Remove photutils from Astroquery astrometry.net [#3067]
 
+- Reduce the number of API calls when polling for job status [#3078]
+
 alma
 ^^^^
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -13,7 +13,7 @@ astrometry_net
 
 - Remove photutils from Astroquery astrometry.net [#3067]
 
-- Reduce the number of API calls when polling for job status [#3078]
+- Reduce the number of API calls when polling for job status [#3079]
 
 alma
 ^^^^

--- a/astroquery/astrometry_net/core.py
+++ b/astroquery/astrometry_net/core.py
@@ -246,11 +246,12 @@ class AstrometryNetClass(BaseQuery):
         status = ''
         while not has_completed:
             time.sleep(1)
-            sub_stat_url = url_helpers.join(self.API_URL, 'submissions', str(submission_id))
-            sub_stat = self._request('GET', sub_stat_url, cache=False)
-            jobs = sub_stat.json()['jobs']
-            if jobs:
-                job_id = jobs[0]
+            if job_id is None:
+                sub_stat_url = url_helpers.join(self.API_URL, 'submissions', str(submission_id))
+                sub_stat = self._request('GET', sub_stat_url, cache=False)
+                jobs = sub_stat.json()['jobs']
+                if jobs:
+                    job_id = jobs[0]
             if job_id:
                 job_stat_url = url_helpers.join(self.API_URL, 'jobs',
                                                 str(job_id), 'info')


### PR DESCRIPTION
Only query for job id once, rather than each time through the job-status polling loop

closes #3078 