### PR TITLE
Escape MAST Download URIs

### DIFF
--- a/astroquery/mast/observations.py
+++ b/astroquery/mast/observations.py
@@ -10,6 +10,7 @@ from pathlib import Path
 import warnings
 import time
 import os
+from urllib.parse import quote
 
 import numpy as np
 
@@ -534,6 +535,7 @@ class ObservationsClass(MastQueryWithLogin):
         # create the full data URL
         base_url = base_url if base_url else self._portal_api_connection.MAST_DOWNLOAD_URL
         data_url = base_url + "?uri=" + uri
+        escaped_url = base_url + "?uri=" + quote(uri, safe=":/")
 
         # parse a local file path from local_path parameter.  Use current directory as default.
         filename = os.path.basename(uri)
@@ -565,11 +567,11 @@ class ObservationsClass(MastQueryWithLogin):
                         status = "SKIPPED"
                     else:
                         log.warning("Falling back to mast download...")
-                        self._download_file(data_url, local_path,
+                        self._download_file(escaped_url, local_path,
                                             cache=cache, head_safe=True, continuation=False,
                                             verbose=verbose)
             else:
-                self._download_file(data_url, local_path,
+                self._download_file(escaped_url, local_path,
                                     cache=cache, head_safe=True, continuation=False,
                                     verbose=verbose)
 

--- a/astroquery/mast/tests/test_mast_remote.py
+++ b/astroquery/mast/tests/test_mast_remote.py
@@ -508,7 +508,7 @@ class TestMast:
         assert Path(tmp_path, filename).exists()
 
         # check that downloaded file is a valid FITS file
-        f = fits.open(filename)
+        f = fits.open(Path(tmp_path, filename))
         f.close()
 
     @pytest.mark.parametrize("test_data_uri, expected_cloud_uri", [

--- a/astroquery/mast/tests/test_mast_remote.py
+++ b/astroquery/mast/tests/test_mast_remote.py
@@ -498,6 +498,19 @@ class TestMast:
         assert result == ('COMPLETE', None, None)
         assert Path(tmp_path, filename).exists()
 
+    def test_observations_download_file_escaped(self, tmp_path):
+        # test that `download_file` correctly escapes a URI
+        in_uri = 'mast:HLA/url/cgi-bin/fitscut.cgi?' \
+                 'red=hst_04819_65_wfpc2_f814w_pc&blue=hst_04819_65_wfpc2_f555w_pc&size=ALL&format=fits'
+        filename = Path(in_uri).name
+        result = Observations.download_file(uri=in_uri, local_path=tmp_path)
+        assert result == ('COMPLETE', None, None)
+        assert Path(tmp_path, filename).exists()
+
+        # check that downloaded file is a valid FITS file
+        f = fits.open(filename)
+        f.close()
+
     @pytest.mark.parametrize("test_data_uri, expected_cloud_uri", [
         ("mast:HST/product/u24r0102t_c1f.fits",
          "s3://stpubdata/hst/public/u24r/u24r0102t/u24r0102t_c1f.fits"),

--- a/astroquery/mast/tests/test_mast_remote.py
+++ b/astroquery/mast/tests/test_mast_remote.py
@@ -150,10 +150,6 @@ class TestMast:
         assert isinstance(responses, list)
 
     def test_mast_service_request(self):
-
-        # clear columns config
-        Mast._column_configs = dict()
-
         service = 'Mast.Caom.Cone'
         params = {'ra': 184.3,
                   'dec': 54.5,
@@ -174,9 +170,6 @@ class TestMast:
         assert len(result[np.where(result["obs_id"] == "6374399093149532160")]) == 2
 
     def test_mast_query(self):
-        # clear columns config
-        Mast._column_configs = dict()
-
         result = Mast.mast_query('Mast.Caom.Cone', ra=184.3, dec=54.5, radius=0.2)
 
         # Is result in the right format
@@ -225,9 +218,6 @@ class TestMast:
         assert isinstance(responses, list)
 
     def test_observations_query_region(self):
-        # clear columns config
-        Observations._column_configs = dict()
-
         result = Observations.query_region("322.49324 12.16683", radius="0.005 deg")
         assert isinstance(result, Table)
         assert len(result) > 500
@@ -243,9 +233,6 @@ class TestMast:
         assert isinstance(responses, list)
 
     def test_observations_query_object(self):
-        # clear columns config
-        Observations._column_configs = dict()
-
         result = Observations.query_object("M8", radius=".04 deg")
         assert isinstance(result, Table)
         assert len(result) > 150
@@ -264,10 +251,6 @@ class TestMast:
         assert isinstance(responses, list)
 
     def test_observations_query_criteria(self):
-
-        # clear columns config
-        Observations._column_configs = dict()
-
         # without position
         result = Observations.query_criteria(instrument_name="*WFPC2*",
                                              proposal_id=8169,
@@ -333,10 +316,6 @@ class TestMast:
         assert isinstance(responses, list)
 
     def test_observations_get_product_list(self):
-
-        # clear columns config
-        Observations._column_configs = dict()
-
         observations = Observations.query_object("M8", radius=".04 deg")
         test_obs_id = str(observations[0]['obsid'])
         mult_obs_ids = str(observations[0]['obsid']) + ',' + str(observations[1]['obsid'])
@@ -618,10 +597,7 @@ class TestMast:
             for k, v in exp_values.items():
                 assert result[row][k] == v
 
-        # clear columns config
-        Catalogs._column_configs = dict()
         in_radius = 0.1 * u.deg
-
         result = Catalogs.query_region("158.47924 -7.30962",
                                        radius=in_radius,
                                        catalog="Gaia")
@@ -716,9 +692,6 @@ class TestMast:
             assert isinstance(result, Table)
             for k, v in exp_values.items():
                 assert v in result[k]
-
-        # clear columns config
-        Catalogs._column_configs = dict()
 
         result = Catalogs.query_object("M10",
                                        radius=.001,
@@ -819,9 +792,6 @@ class TestMast:
             for k, v in exp_vals.items():
                 assert v in result[k]
 
-        # clear columns config
-        Catalogs._column_configs = dict()
-
         # without position
         result = Catalogs.query_criteria(catalog="Tic",
                                          Bmag=[30, 50],
@@ -897,10 +867,6 @@ class TestMast:
         assert isinstance(responses, list)
 
     def test_catalogs_query_hsc_matchid(self):
-
-        # clear columns config
-        Catalogs._column_configs = dict()
-
         catalogData = Catalogs.query_object("M10",
                                             radius=.001,
                                             catalog="HSC",
@@ -921,10 +887,6 @@ class TestMast:
         assert isinstance(responses, list)
 
     def test_catalogs_get_hsc_spectra(self):
-
-        # clear columns config
-        Catalogs._column_configs = dict()
-
         result = Catalogs.get_hsc_spectra()
         assert isinstance(result, Table)
         assert result[np.where(result['MatchID'] == '19657846')]


### PR DESCRIPTION
Fixes an issue with downloading URIs that include URL parameters. This PR escapes URIs before sending them to the MAST download service so that URIs are not unexpectedly truncated.

Also removes lines from the test suite that were not serving an apparent purpose.

Adding a test case for this particular change would add ~1 minute to test execution time, so I was planning to add that to our internal, backend test suite.