### PR TITLE
Check for TESS/TICA FFIs when getting products for observations

### DIFF
--- a/astroquery/mast/observations.py
+++ b/astroquery/mast/observations.py
@@ -434,8 +434,7 @@ class ObservationsClass(MastQueryWithLogin):
                         "If you need a TESS image for an entire field, please see our "
                         "dedicated page for downloading larger quantities of TESS data at \n"
                         "https://archive.stsci.edu/tess/. Data products will not be fetched "
-                        "for the following observations IDs: \n"
-                        + "\n".join(tess_ffis))
+                        "for the following observations IDs: \n" + "\n".join(tess_ffis))
 
         if tica_ffis.size:
             # Warn user if TICA FFIs exist
@@ -443,8 +442,8 @@ class ObservationsClass(MastQueryWithLogin):
                         "download TICA FFI products.\n"
                         "Please see our dedicated page for downloading larger quantities of "
                         "TICA data: https://archive.stsci.edu/hlsp/tica.\n"
-                        "Data products will not be fetched for the following observation IDs: \n"
-                        + "\n".join(tica_ffis))
+                        "Data products will not be fetched for the following "
+                        "observation IDs: \n" + "\n".join(tica_ffis))
 
         # Filter out FFIs with a mask
         mask = (obs_table['target_name'] != 'TESS FFI') & (obs_table['target_name'] != 'TICA FFI')

--- a/astroquery/mast/tests/test_mast_remote.py
+++ b/astroquery/mast/tests/test_mast_remote.py
@@ -369,6 +369,20 @@ class TestMast:
         assert len(obs_collection) == 1
         assert obs_collection[0] == 'IUE'
 
+    def test_observations_get_product_list_tess_tica(self, caplog):
+        # Get observations and products with both TESS and TICA FFIs
+        obs = Observations.query_criteria(target_name=['TESS FFI', 'TICA FFI', '429031146'])
+        prods = Observations.get_product_list(obs)
+
+        # Check that WARNING messages about FFIs were logged
+        with caplog.at_level("WARNING", logger="astroquery"):
+            assert "TESS FFI products" in caplog.text
+            assert "TICA FFI products" in caplog.text
+
+        # Should only return products corresponding to target 429031146
+        assert len(prods) > 0
+        assert (np.char.find(prods['obs_id'], '429031146') != -1).all()
+
     def test_observations_filter_products(self):
         observations = Observations.query_object("M8", radius=".04 deg")
         obsLoc = np.where(observations["obs_id"] == 'ktwo200071160-c92_lc')


### PR DESCRIPTION
To try and decrease load on the MAST server, we would like to prevent Astroquery users from getting products for TESS and TICA FFIs. When a user tries to do this, they should be presented with a warning message that presents alternate methods for downloading.

Right now, this filter only works if the user passes in a `Row` or `Table` to `get_product_list`, since we need access to the `target_name` field. We're aware that this is a limitation and will explore other options if we continue to receive these type of expensive requests from Astroquery.