### PR TITLE
Check that parameters are valid when running criteria queries

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -183,6 +183,9 @@ mast
 - Increased the speed of ``mast.Observations.get_cloud_uris`` by obtaining multiple
   URIs from MAST at once. [#3064]
 
+- Present users with an error rather than a warning when nonexistent query criteria are used in ``mast.Observations.query_criteria``
+  and ``mast.Catalogs.query_criteria``. [#3084]
+
 
 0.4.7 (2024-03-08)
 ==================

--- a/astroquery/mast/discovery_portal.py
+++ b/astroquery/mast/discovery_portal.py
@@ -407,8 +407,8 @@ class PortalAPI(BaseQuery):
             # Get the column type and separator
             col_info = caom_col_config.get(colname)
             if not col_info:
-                closest_match = difflib.get_close_matches(colname, caom_col_config.keys(), n=1)[0]
-                error_msg = f"Filter '{colname}' does not exist. Did you mean '{closest_match}'?" if closest_match \
+                closest_match = difflib.get_close_matches(colname, caom_col_config.keys(), n=1)
+                error_msg = f"Filter '{colname}' does not exist. Did you mean '{closest_match[0]}'?" if closest_match \
                     else f"Filter '{colname}' does not exist."
                 raise InvalidQueryError(error_msg)
 

--- a/astroquery/mast/tests/test_mast_remote.py
+++ b/astroquery/mast/tests/test_mast_remote.py
@@ -274,6 +274,17 @@ class TestMast:
                                              intentType="calibration")
         assert (result["intentType"] == "calibration").all()
 
+    def test_observations_query_criteria_invalid_keyword(self):
+        # attempt to make a criteria query with invalid keyword
+        with pytest.raises(InvalidQueryError) as err_no_alt:
+            Observations.query_criteria_count(not_a_keyword='TESS')
+        assert 'Filter not_a_keyword does not exist.' in str(err_no_alt.value)
+
+        # keyword is close enough for difflib to offer alternative
+        with pytest.raises(InvalidQueryError) as err_with_alt:
+            Observations.query_criteria_count(oops_collection='TESS')
+        assert 'obs_collection' in str(err_with_alt.value)
+
     # count functions
     def test_observations_query_region_count(self):
         maxRes = Observations.query_criteria_count()
@@ -880,6 +891,17 @@ class TestMast:
                                          sort_by=[("asc", "distance")])
         assert isinstance(result, Table)
         assert result['distance'][0] <= result['distance'][1]
+
+    def test_catalogs_query_criteria_invalid_keyword(self):
+        # attempt to make a criteria query with invalid keyword
+        with pytest.raises(InvalidQueryError) as err_no_alt:
+            Catalogs.query_criteria(catalog='tic', not_a_keyword='TESS')
+        assert 'Filter not_a_keyword does not exist.' in str(err_no_alt.value)
+
+        # keyword is close enough for difflib to offer alternative
+        with pytest.raises(InvalidQueryError) as err_with_alt:
+            Catalogs.query_criteria(catalog='ctl', objectType="STAR")
+        assert 'objType' in str(err_with_alt.value)
 
     def test_catalogs_query_hsc_matchid_async(self):
         catalogData = Catalogs.query_object("M10",

--- a/astroquery/mast/tests/test_mast_remote.py
+++ b/astroquery/mast/tests/test_mast_remote.py
@@ -278,7 +278,7 @@ class TestMast:
         # attempt to make a criteria query with invalid keyword
         with pytest.raises(InvalidQueryError) as err_no_alt:
             Observations.query_criteria_count(not_a_keyword='TESS')
-        assert 'Filter not_a_keyword does not exist.' in str(err_no_alt.value)
+        assert "Filter 'not_a_keyword' does not exist." in str(err_no_alt.value)
 
         # keyword is close enough for difflib to offer alternative
         with pytest.raises(InvalidQueryError) as err_with_alt:
@@ -896,7 +896,7 @@ class TestMast:
         # attempt to make a criteria query with invalid keyword
         with pytest.raises(InvalidQueryError) as err_no_alt:
             Catalogs.query_criteria(catalog='tic', not_a_keyword='TESS')
-        assert 'Filter not_a_keyword does not exist.' in str(err_no_alt.value)
+        assert "Filter 'not_a_keyword' does not exist." in str(err_no_alt.value)
 
         # keyword is close enough for difflib to offer alternative
         with pytest.raises(InvalidQueryError) as err_with_alt:


### PR DESCRIPTION
Part of our efforts at MAST to prevent very large requests from Astroquery! 

If a user attempts to use a criteria argument that doesn't exist in `Observations.query_criteria` or `Catalogs.query_criteria`, they will encounter an `InvalidQueryError`. If the provided keyword is similar to an expected keyword, the user will be prompted with the expected keyword in the error message.