### PR TITLE
Support case-insensitive query criteria

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -188,6 +188,9 @@ mast
 - Present users with an error rather than a warning when nonexistent query criteria are used in ``mast.Observations.query_criteria``
   and ``mast.Catalogs.query_criteria``. [#3084]
 
+- Support for case-insensitive criteria keyword arguments in ``mast.Observations.query_criteria`` and 
+  ``mast.Catalogs.query_criteria``. [#3085]
+
 
 0.4.7 (2024-03-08)
 ==================

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -189,7 +189,7 @@ mast
   and ``mast.Catalogs.query_criteria``. [#3084]
 
 - Support for case-insensitive criteria keyword arguments in ``mast.Observations.query_criteria`` and 
-  ``mast.Catalogs.query_criteria``. [#3085]
+  ``mast.Catalogs.query_criteria``. [#3087]
 
 
 0.4.7 (2024-03-08)

--- a/astroquery/mast/discovery_portal.py
+++ b/astroquery/mast/discovery_portal.py
@@ -404,8 +404,8 @@ class PortalAPI(BaseQuery):
             if np.isscalar(value,):
                 value = [value]
 
-            # Get the column type and separator
-            col_info = caom_col_config.get(colname)
+            # Get the column type and separator with case-insensitive lookup
+            col_info = next((v for k, v in caom_col_config.items() if k.lower() == colname.lower()), None)
             if not col_info:
                 closest_match = difflib.get_close_matches(colname, caom_col_config.keys(), n=1)
                 error_msg = f"Filter '{colname}' does not exist. Did you mean '{closest_match[0]}'?" if closest_match \

--- a/astroquery/mast/tests/test_mast_remote.py
+++ b/astroquery/mast/tests/test_mast_remote.py
@@ -274,6 +274,13 @@ class TestMast:
                                              intentType="calibration")
         assert (result["intentType"] == "calibration").all()
 
+        # with case-insensitive keyword arguments
+        result = Observations.query_criteria(Instrument_Name="*WFPC2*",
+                                             proposal_ID=8169,
+                                             T_min=[51361, 51362])
+        assert isinstance(result, Table)
+        assert len(result) == 13
+
     def test_observations_query_criteria_invalid_keyword(self):
         # attempt to make a criteria query with invalid keyword
         with pytest.raises(InvalidQueryError) as err_no_alt:
@@ -891,6 +898,18 @@ class TestMast:
                                          sort_by=[("asc", "distance")])
         assert isinstance(result, Table)
         assert result['distance'][0] <= result['distance'][1]
+
+        # with case-insensitive keyword arguments
+        result = Catalogs.query_criteria(catalog="Tic",
+                                         bMAG=[30, 50],
+                                         objtype="STAR")
+        check_result(result, {'ID': '81609218'})
+
+        result = Catalogs.query_criteria(catalog="DiskDetective",
+                                         STATE=["inactive", "disabled"],
+                                         oVaL=[8, 10],
+                                         Multi=[3, 7])
+        check_result(result, {'designation': 'J003920.04-300132.4'})
 
     def test_catalogs_query_criteria_invalid_keyword(self):
         # attempt to make a criteria query with invalid keyword

--- a/astroquery/mast/tests/test_mast_remote.py
+++ b/astroquery/mast/tests/test_mast_remote.py
@@ -686,18 +686,8 @@ class TestMast:
                                        radius=0.01*u.deg, catalog="panstarrs",
                                        table="mean")
         row = np.where((result['objName'] == 'PSO J322.4622+12.1920') & (result['yFlags'] == 16777496))
-        second_id = result[1]['objID']
         assert isinstance(result, Table)
         np.testing.assert_allclose(result[row]['distance'], 0.039381703406789904)
-
-        result = Catalogs.query_region("322.49324 12.16683",
-                                       radius=0.01*u.deg, catalog="panstarrs",
-                                       table="mean",
-                                       pagesize=1,
-                                       page=2)
-        assert isinstance(result, Table)
-        assert len(result) == 1
-        assert second_id == result[0]['objID']
 
         result = Catalogs.query_region("158.47924 -7.30962",
                                        radius=in_radius,
@@ -711,8 +701,18 @@ class TestMast:
                                        radius=in_radius,
                                        catalog="tic")
         row = np.where(result['ID'] == '841736289')
+        second_id = result[1]['ID']
         check_result(result, row, {'gaiaqflag': 1})
         np.testing.assert_allclose(result[row]['RA_orig'], 158.475246786483)
+
+        result = Catalogs.query_region("158.47924 -7.30962",
+                                       radius=in_radius,
+                                       catalog="tic",
+                                       pagesize=1,
+                                       page=2)
+        assert isinstance(result, Table)
+        assert len(result) == 1
+        assert second_id == result[0]['ID']
 
         result = Catalogs.query_region("158.47924 -7.30962",
                                        radius=in_radius,


### PR DESCRIPTION
`Observations.query_criteria` and `Catalogs.query_criteria` now support case insensitivity for criteria keyword arguments. For example, the argument `objtype` is treated the same as `objType`. 