### PR TITLE
MAINT: adding Python 3.13 to CI

### DIFF
--- a/.github/workflows/ci_devtests.yml
+++ b/.github/workflows/ci_devtests.yml
@@ -36,6 +36,12 @@ jobs:
             toxenv: py312-test-alldeps-devdeps-cov
             toxargs: -v
 
+          - name: Python 3.13
+            os: ubuntu-latest
+            python: '3.13-dev'
+            toxenv: py313-test
+            toxargs: -v
+
     steps:
     - name: Checkout code
       uses: actions/checkout@v4

--- a/astroquery/utils/tests/test_utils.py
+++ b/astroquery/utils/tests/test_utils.py
@@ -45,7 +45,9 @@ def test_class_or_instance():
     assert SimpleQueryClass.query() == "class"
     U = SimpleQueryClass()
     assert U.query() == "instance"
-    assert SimpleQueryClass.query.__doc__ == " docstring "
+    # Indent changes in Python 3.13 thus cannot equate
+    # See https://github.com/python/cpython/issues/81283
+    assert "docstring" in SimpleQueryClass.query.__doc__
 
 
 @pytest.mark.parametrize(('coordinates'),

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 envlist =
-    py{39,310,311,312}-test{,-alldeps,-oldestdeps,-devdeps,-predeps}{,-online}{,-cov}
+    py{39,310,311,312,313}-test{,-alldeps,-oldestdeps,-devdeps,-predeps}{,-online}{,-cov}
     codestyle
     linkcheck
     build_docs
@@ -24,6 +24,8 @@ setenv =
     PYTEST_ARGS = ''
     online: PYTEST_ARGS = --remote-data=any --reruns=1 --reruns-delay 10 -m "not bigdata"
     devdeps: PIP_EXTRA_INDEX_URL =  https://pypi.anaconda.org/scientific-python-nightly-wheels/simple https://pypi.anaconda.org/astropy/simple https://pypi.anaconda.org/liberfa/simple
+    # astropy doesn't yet have a 3.13 compatible release
+    py313: PIP_EXTRA_INDEX_URL = https://pypi.anaconda.org/astropy/simple https://pypi.anaconda.org/liberfa/simple
 
 deps =
     devdeps: numpy>=0.0.dev0
@@ -31,6 +33,9 @@ deps =
     devdeps: astropy>=0.0.dev0
     devdeps: pyerfa>=0.0.dev0
     devdeps: git+https://github.com/astropy/pyvo.git#egg=pyvo
+
+    # astropy doesn't yet have a 3.13 compatible release
+    py313: astropy>0.0dev0
 
 # mpl while not a dependency, it's required for the tests, and would pull up a newer numpy version if not pinned.
 # And pillow should be pinned as well, otherwise a too new version is pulled that is not compatible with old np.


### PR DESCRIPTION
If we're compatible out of the box then no changelog entry will be needed...

(locally I see one doctesting whitespace issue, it may actually be an upstream doctestplus issue)