### PR TITLE
CDMS: fix `MOLWT` column starting position

### DIFF
--- a/astroquery/linelists/cdms/core.py
+++ b/astroquery/linelists/cdms/core.py
@@ -225,7 +225,7 @@ class CDMSClass(BaseQuery):
                   'DR': 36,
                   'ELO': 38,
                   'GUP': 47,
-                  'MOLWT': 51,
+                  'MOLWT': 50,
                   'TAG': 54,
                   'QNFMT': 58,
                   'Ju': 61,

--- a/astroquery/linelists/cdms/core.py
+++ b/astroquery/linelists/cdms/core.py
@@ -220,14 +220,14 @@ class CDMSClass(BaseQuery):
         text = soup.find('pre').text
 
         starts = {'FREQ': 0,
-                  'ERR': 14,
-                  'LGINT': 25,
-                  'DR': 36,
-                  'ELO': 38,
+                  'ERR': 13,
+                  'LGINT': 24,
+                  'DR': 35,
+                  'ELO': 37,
                   'GUP': 47,
                   'MOLWT': 50,
-                  'TAG': 54,
-                  'QNFMT': 58,
+                  'TAG': 53,
+                  'QNFMT': 57,
                   'Ju': 61,
                   'Ku': 63,
                   'vu': 65,
@@ -240,7 +240,7 @@ class CDMSClass(BaseQuery):
                   'F1l': 79,
                   'F2l': 81,
                   'F3l': 83,
-                  'name': 89}
+                  'name': 85}
 
         result = ascii.read(text, header_start=None, data_start=0,
                             comment=r'THIS|^\s{12,14}\d{4,6}.*',


### PR DESCRIPTION
Now the molecule tag `100501` and others work. Earlier they were crashing with 
```python
ValueError: invalid literal for int() with base 10: '13-'
```
Because that `-` is part of the signed `TAG`.