### PR TITLE
Fix the failing tests getting spectra from ESA Sky

### DIFF
--- a/astroquery/esasky/tests/test_esasky_remote.py
+++ b/astroquery/esasky/tests/test_esasky_remote.py
@@ -183,7 +183,7 @@ class TestESASky:
         # - HST-IR, JWST-MID-IR and CHEOPS have no data
         # - LAMOST does not support download
         # - JWST-NEAR-IR returns a zip file with many fits files in it, unsupported
-        result = ESASky.get_spectra(position="M1", missions=mission, download_dir=tmp_path)
+        result = ESASky.get_spectra(position="M1", missions=mission, radius='15 arcsec', download_dir=tmp_path)
         assert Path(tmp_path, mission.upper()).exists()
 
         if mission != "Herschel":


### PR DESCRIPTION
This will fix the test test_esasky_get_spectra for mission HST-UV and HST-OPTICAL. I can't find anything on our end that explains why these tests started failing. We have a rather small default radius (5 arc seconds) where we look for spectra. Maybe the underlying data changed, or the M1 supernova moved slightly in the CDS name resolver?