### PR TITLE
GAIA: include new datalink retrieve types in the method load data

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -179,6 +179,8 @@ gaia
 
 - Fix method search_async_jobs in the class TapPlus. [#2967]
 
+- New retrieval types for datalink (Gaia DR4 release). [#3110]
+
 jplhorizons
 ^^^^^^^^^^^
 

--- a/astroquery/gaia/__init__.py
+++ b/astroquery/gaia/__init__.py
@@ -35,15 +35,21 @@ class Conf(_config.ConfigNamespace):
                                       'RV_EPOCH_SINGLE',
                                       'RV_EPOCH_DOUBLE',
                                       'RVS_EPOCH',
-                                      'RVS_TRANSIT']
+                                      'RVS_TRANSIT',
+                                      'EPOCH_ASTROMETRY_CROWDED_FIELD',
+                                      'EPOCH_IMAGE',
+                                      'EPOCH_PHOTOMETRY_CCD',
+                                      'XP_EPOCH_SPECTRUM_SSO',
+                                      'XP_EPOCH_CROWDING',
+                                      'XP_MEAN_SPECTRUM',
+                                      'XP_EPOCH_SPECTRUM',
+                                      'CROWDED_FIELD_IMAGE']
 
     VALID_LINKING_PARAMETERS = {'SOURCE_ID', 'TRANSIT_ID', 'IMAGE_ID'}
 
 
 conf = Conf()
 
-
 from .core import Gaia, GaiaClass
-
 
 __all__ = ['Gaia', 'GaiaClass', 'Conf', 'conf']

--- a/astroquery/gaia/core.py
+++ b/astroquery/gaia/core.py
@@ -197,8 +197,8 @@ class GaiaClass(TapPlus):
             'RVS_TRANSIT', 'EPOCH_ASTROMETRY_CROWDED_FIELD', 'EPOCH_IMAGE', 'EPOCH_PHOTOMETRY_CCD',
             'XP_EPOCH_SPECTRUM_SSO', 'XP_EPOCH_CROWDING', 'XP_MEAN_SPECTRUM', 'XP_EPOCH_SPECTRUM',
             'CROWDED_FIELD_IMAGE']. Note that for 'CROWDED_FIELD_IMAGE' only the format 'fits' can be used,
-            and that its image in the principal header will not be available. Set 'output_file' to retrieve all data:
-            image + tables.
+            and that its image, in the principal header, will not be available in the returned dictionary. Set
+            'output_file' to retrieve all data: image + tables.
         linking_parameter : str, optional, default SOURCE_ID, valid values: SOURCE_ID, TRANSIT_ID, IMAGE_ID
             By default, all the identifiers are considered as source_id
             SOURCE_ID: the identifiers are considered as source_id

--- a/astroquery/gaia/core.py
+++ b/astroquery/gaia/core.py
@@ -194,7 +194,11 @@ class GaiaClass(TapPlus):
             'MCMC_GSPPHOT' or 'MCMC_MSC']
             For GAIA DR4, possible values will be ['EPOCH_PHOTOMETRY', 'RVS', 'XP_CONTINUOUS', 'XP_SAMPLED',
             'MCMC_GSPPHOT', 'MCMC_MSC', 'EPOCH_ASTROMETRY', 'RV_EPOCH_SINGLE', 'RV_EPOCH_DOUBLE', 'RVS_EPOCH' or
-            'RVS_TRANSIT']
+            'RVS_TRANSIT', 'EPOCH_ASTROMETRY_CROWDED_FIELD', 'EPOCH_IMAGE', 'EPOCH_PHOTOMETRY_CCD',
+            'XP_EPOCH_SPECTRUM_SSO', 'XP_EPOCH_CROWDING', 'XP_MEAN_SPECTRUM', 'XP_EPOCH_SPECTRUM',
+            'CROWDED_FIELD_IMAGE']. Note that for 'CROWDED_FIELD_IMAGE' only the format 'fits' can be used,
+            and that its image in the principal header will not be available. Set 'output_file' to retrieve all data:
+            image + tables.
         linking_parameter : str, optional, default SOURCE_ID, valid values: SOURCE_ID, TRANSIT_ID, IMAGE_ID
             By default, all the identifiers are considered as source_id
             SOURCE_ID: the identifiers are considered as source_id


### PR DESCRIPTION
Due to the products that will be available  in the next Gaia DR4 release, through the datalink service at ESAC, we would like to include the following new retrieval types


'EPOCH_ASTROMETRY_CROWDED_FIELD', 
 'EPOCH_IMAGE',
'EPOCH_PHOTOMETRY_CCD',
'XP_EPOCH_SPECTRUM_SSO', 
 'XP_EPOCH_CROWDING', 
 'XP_MEAN_SPECTRUM',
 'XP_EPOCH_SPECTRUM',
 'CROWDED_FIELD_IMAGE'

This change would only affect the method load_data.


cc @esdc-esac-esa-int

jira: GAIAMNGT-1760