### PR TITLE
Move cloud functions into Observations, fix for docs and test

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -218,6 +218,9 @@ mast
 - Added function ``mast.Observations.get_unique_product_list`` to return the unique data products associated with
   given observations. [#3096]
 
+- Deprecate ``enable_cloud_dataset`` and ``disable_cloud_dataset`` in classes where they
+  are non-operational. [#3113]
+
 mpc
 ^^^
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -218,8 +218,8 @@ mast
 - Added function ``mast.Observations.get_unique_product_list`` to return the unique data products associated with
   given observations. [#3096]
 
-- Deprecate ``enable_cloud_dataset`` and ``disable_cloud_dataset`` in classes where they
-  are non-operational. [#3113]
+- Deprecated ``enable_cloud_dataset`` and ``disable_cloud_dataset`` in classes where they
+  are non-operational. They will be removed in a future release. [#3113]
 
 mpc
 ^^^

--- a/astroquery/mast/core.py
+++ b/astroquery/mast/core.py
@@ -11,7 +11,6 @@ from astropy.utils.exceptions import AstropyDeprecationWarning
 from ..query import QueryWithLogin
 from . import utils
 from .auth import MastAuth
-from .cloud import CloudAccess
 from .discovery_portal import PortalAPI
 from .services import ServiceAPI
 
@@ -89,20 +88,16 @@ class MastQueryWithLogin(QueryWithLogin):
         """
         .. deprecated:: 0.4.8
            This function is non-operational and has been deprecated.
-
-        :raises AstropyDeprecationWarning: This function is deprecated and should not be used.
         """
-        warnings.warn('This function is non-operational and will be removed in a future release.', 
+        warnings.warn('This function is non-operational and will be removed in a future release.',
                       AstropyDeprecationWarning)
 
     def disable_cloud_dataset(self):
         """
         .. deprecated:: 0.4.8
            This function is non-operational and has been deprecated.
-
-        :raises AstropyDeprecationWarning: This function is deprecated and should not be used.
         """
-        warnings.warn('This function is non-operational and will be removed in a future release.', 
+        warnings.warn('This function is non-operational and will be removed in a future release.',
                       AstropyDeprecationWarning)
 
     def resolve_object(self, objectname):

--- a/astroquery/mast/core.py
+++ b/astroquery/mast/core.py
@@ -5,9 +5,7 @@ MAST Core
 
 This the base class for MAST queries.
 """
-import warnings
-
-from astropy.utils.exceptions import AstropyDeprecationWarning
+from astropy.utils import deprecated
 from ..query import QueryWithLogin
 from . import utils
 from .auth import MastAuth
@@ -84,21 +82,33 @@ class MastQueryWithLogin(QueryWithLogin):
         self._auth_obj.logout()
         self._authenticated = False
 
+    @deprecated(since='v0.4.8',
+                message=('This function is non-operational and will be removed in a future release.'))
     def enable_cloud_dataset(self, provider="AWS", profile=None, verbose=True):
         """
-        .. deprecated:: 0.4.8
-           This function is non-operational and has been deprecated.
-        """
-        warnings.warn('This function is non-operational and will be removed in a future release.',
-                      AstropyDeprecationWarning)
+        Enable downloading public files from S3 instead of MAST.
+        Requires the boto3 library to function.
 
+        Parameters
+        ----------
+        provider : str
+            Which cloud data provider to use.  We may in the future support multiple providers,
+            though at the moment this argument is ignored.
+        profile : str
+            Profile to use to identify yourself to the cloud provider (usually in ~/.aws/config).
+        verbose : bool
+            Default True.
+            Logger to display extra info and warning.
+        """
+        pass
+
+    @deprecated(since='v0.4.8',
+                message=('This function is non-operational and will be removed in a future release.'))
     def disable_cloud_dataset(self):
         """
-        .. deprecated:: 0.4.8
-           This function is non-operational and has been deprecated.
+        Disables downloading public files from S3 instead of MAST.
         """
-        warnings.warn('This function is non-operational and will be removed in a future release.',
-                      AstropyDeprecationWarning)
+        pass
 
     def resolve_object(self, objectname):
         """

--- a/astroquery/mast/core.py
+++ b/astroquery/mast/core.py
@@ -8,7 +8,6 @@ This the base class for MAST queries.
 from ..query import QueryWithLogin
 from . import utils
 from .auth import MastAuth
-from .cloud import CloudAccess
 from .discovery_portal import PortalAPI
 from .services import ServiceAPI
 
@@ -81,31 +80,6 @@ class MastQueryWithLogin(QueryWithLogin):
         """
         self._auth_obj.logout()
         self._authenticated = False
-
-    def enable_cloud_dataset(self, provider="AWS", profile=None, verbose=True):
-        """
-        Enable downloading public files from S3 instead of MAST.
-        Requires the boto3 library to function.
-
-        Parameters
-        ----------
-        provider : str
-            Which cloud data provider to use.  We may in the future support multiple providers,
-            though at the moment this argument is ignored.
-        profile : str
-            Profile to use to identify yourself to the cloud provider (usually in ~/.aws/config).
-        verbose : bool
-            Default True.
-            Logger to display extra info and warning.
-        """
-
-        self._cloud_connection = CloudAccess(provider, profile, verbose)
-
-    def disable_cloud_dataset(self):
-        """
-        Disables downloading public files from S3 instead of MAST
-        """
-        self._cloud_connection = None
 
     def resolve_object(self, objectname):
         """

--- a/astroquery/mast/core.py
+++ b/astroquery/mast/core.py
@@ -5,9 +5,13 @@ MAST Core
 
 This the base class for MAST queries.
 """
+import warnings
+
+from astropy.utils.exceptions import AstropyDeprecationWarning
 from ..query import QueryWithLogin
 from . import utils
 from .auth import MastAuth
+from .cloud import CloudAccess
 from .discovery_portal import PortalAPI
 from .services import ServiceAPI
 
@@ -80,6 +84,26 @@ class MastQueryWithLogin(QueryWithLogin):
         """
         self._auth_obj.logout()
         self._authenticated = False
+
+    def enable_cloud_dataset(self, provider="AWS", profile=None, verbose=True):
+        """
+        .. deprecated:: 0.4.8
+           This function is non-operational and has been deprecated.
+
+        :raises AstropyDeprecationWarning: This function is deprecated and should not be used.
+        """
+        warnings.warn('This function is non-operational and will be removed in a future release.', 
+                      AstropyDeprecationWarning)
+
+    def disable_cloud_dataset(self):
+        """
+        .. deprecated:: 0.4.8
+           This function is non-operational and has been deprecated.
+
+        :raises AstropyDeprecationWarning: This function is deprecated and should not be used.
+        """
+        warnings.warn('This function is non-operational and will be removed in a future release.', 
+                      AstropyDeprecationWarning)
 
     def resolve_object(self, objectname):
         """

--- a/astroquery/mast/observations.py
+++ b/astroquery/mast/observations.py
@@ -21,6 +21,7 @@ import astropy.coordinates as coord
 
 from astropy.table import Table, Row, unique, vstack
 from astroquery import log
+from astroquery.mast.cloud import CloudAccess
 
 from ..utils import commons, async_to_sync
 from ..utils.class_or_instance import class_or_instance
@@ -170,6 +171,30 @@ class ObservationsClass(MastQueryWithLogin):
             position = ', '.join([str(x) for x in (coordinates.ra.deg, coordinates.dec.deg, radius.deg)])
 
         return position, mashup_filters
+
+    def enable_cloud_dataset(self, provider="AWS", profile=None, verbose=True):
+        """
+        Enable downloading public files from S3 instead of MAST.
+        Requires the boto3 library to function.
+
+        Parameters
+        ----------
+        provider : str
+            Which cloud data provider to use.  We may in the future support multiple providers,
+            though at the moment this argument is ignored.
+        profile : str
+            Profile to use to identify yourself to the cloud provider (usually in ~/.aws/config).
+        verbose : bool
+            Default True.
+            Logger to display extra info and warning.
+        """
+        self._cloud_connection = CloudAccess(provider, profile, verbose)
+
+    def disable_cloud_dataset(self):
+        """
+        Disables downloading public files from S3 instead of MAST
+        """
+        self._cloud_connection = None
 
     @class_or_instance
     def query_region_async(self, coordinates, *, radius=0.2*u.deg, pagesize=None, page=None):

--- a/astroquery/mast/observations.py
+++ b/astroquery/mast/observations.py
@@ -192,7 +192,7 @@ class ObservationsClass(MastQueryWithLogin):
 
     def disable_cloud_dataset(self):
         """
-        Disables downloading public files from S3 instead of MAST
+        Disables downloading public files from S3 instead of MAST.
         """
         self._cloud_connection = None
 

--- a/astroquery/mast/tests/test_mast_remote.py
+++ b/astroquery/mast/tests/test_mast_remote.py
@@ -499,11 +499,8 @@ class TestMast:
         # enable access to public AWS S3 bucket
         Observations.enable_cloud_dataset(provider='AWS')
 
-        # Check for cloud URIs.  Accept a NoResultsWarning if AWS S3
-        # doesn't have the file.  It doesn't matter as we're only checking
-        # that the duplicate products have been culled to a single one.
-        with pytest.warns(NoResultsWarning):
-            uris = Observations.get_cloud_uris(products)
+        # Check that only one URI is returned
+        uris = Observations.get_cloud_uris(products)
         assert len(uris) == 1
 
     def test_observations_download_file(self, tmp_path):


### PR DESCRIPTION
Closes #3097 

After talking with others at MAST, it looks like `enable_cloud_dataset` and `disable_cloud_dataset` are only applicable for `Observations` and no other classes (as of now). To minimize complexity, I decided to move the functions into `Observations` so as to not make them available to other classes that inherit from `MastQueryWithLogin`. This fixes the documentation issue as well.

There was also a problem with one of our tests that I fixed, so the test suite is passing now.