### PR TITLE
[XMatch] fix: upload of two local tables is now possible

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -217,6 +217,12 @@ mpc
 - Rename ``MPC.get_mpc_object_endpoint`` to ``MPC._get_mpc_object_endpoint`` to
   indicate that it is a private method. [#3089]
 
+xmatch
+^^^^^^
+
+- Fix xmatch query for two local tables. The second table was written over the first one,
+  resulting in a confusing "missing cat1" error. [#3116]
+
 
 0.4.7 (2024-03-08)
 ==================

--- a/astroquery/xmatch/tests/test_xmatch.py
+++ b/astroquery/xmatch/tests/test_xmatch.py
@@ -104,3 +104,13 @@ def test_xmatch_query_cat1_table_local(monkeypatch):
         'errHalfMaj', 'errHalfMin', 'errPosAng', 'Jmag', 'Hmag', 'Kmag',
         'e_Jmag', 'e_Hmag', 'e_Kmag', 'Qfl', 'Rfl', 'X', 'MeasureJD']
     assert len(table) == 11
+
+
+def test_two_local_tables():
+    table1 = Table({'a': [1], 'b': [1], 'c': [1]})
+    table2 = Table({'a': [1], 'b': [1], 'c': [1]})
+    payload = XMatch().query(cat1=table1, cat2=table2,
+                             colRA1="a", colDec1="b", colRA2="a", colDec2="b",
+                             max_distance=1 * arcsec,
+                             get_query_payload=True)
+    assert 'cat1' in payload[1]["files"] and 'cat2' in payload[1]["files"]


### PR DESCRIPTION
Hello astroquery :slightly_smiling_face: 

In the files dictionary sent to XMatch, the second table was written over the first one, resulting in a confusing "missing cat1" error even if the user did give a cat1. This fixes #3115 , closes #1687 and closes #1786

I did not add a remote test, only a local one. Is it ok?