### PR TITLE
Reduce running time for MAST doctests

### DIFF
--- a/docs/mast/mast_catalog.rst
+++ b/docs/mast/mast_catalog.rst
@@ -53,7 +53,9 @@ the user that they might be getting a subset of the true result set.
 
    >>> from astroquery.mast import Catalogs
    ...
-   >>> catalog_data = Catalogs.query_region("322.49324 12.16683", catalog="HSC", magtype=2)  # doctest: +SHOW_WARNINGS
+   >>> catalog_data = Catalogs.query_region("322.49324 12.16683", 
+   ...                                      catalog="HSC", 
+   ...                                      magtype=2)  # doctest: +SHOW_WARNINGS
    InputWarning: Coordinate string is being interpreted as an ICRS coordinate provided in degrees.
    MaxResultsWarning: Maximum catalog results returned, may not include all sources within radius.
    >>> print(catalog_data[:10])
@@ -259,7 +261,10 @@ Given an HSC Match ID, return all catalog results.
 
    >>> from astroquery.mast import Catalogs
    ...
-   >>> catalog_data = Catalogs.query_object("M10", radius=.02, catalog="HSC")
+   >>> catalog_data = Catalogs.query_object("M10", 
+   ...                                      radius=.001,
+   ...                                      catalog="HSC", 
+   ...                                      magtype=1)
    >>> matchid = catalog_data[0]["MatchID"]
    >>> print(matchid)
    7542452

--- a/docs/mast/mast_catalog.rst
+++ b/docs/mast/mast_catalog.rst
@@ -117,8 +117,11 @@ The table to query is a required parameter.
 
 .. doctest-remote-data::
 
-   >>> catalog_data = Catalogs.query_region("158.47924 -7.30962", radius=0.1,
-   ...                                       catalog="Panstarrs", data_release="dr1", table="mean")
+   >>> catalog_data = Catalogs.query_region("158.47924 -7.30962", 
+   ...                                      radius=0.1,
+   ...                                      catalog="Panstarrs", 
+   ...                                      data_release="dr1", 
+   ...                                      table="mean")
    >>> print("Number of results:",len(catalog_data))
    Number of results: 7007
    >>> print(catalog_data[:10])     # doctest: +IGNORE_OUTPUT
@@ -168,7 +171,9 @@ The TESS Input Catalog (TIC), Disk Detective Catalog, and PanSTARRS Catalog can 
    >>> from astroquery.mast import Catalogs
    ...
    >>> catalog_data = Catalogs.query_criteria(catalog="Ctl",
-   ...                                        objectname='M101', radius=1, Tmag=[10.75,11])
+   ...                                        objectname='M101', 
+   ...                                        radius=1, 
+   ...                                        Tmag=[10.75,11])
    >>> print(catalog_data)
        ID    version  HIP     TYC      ... raddflag wdflag   objID
    --------- -------- --- ------------ ... -------- ------ ---------
@@ -187,7 +192,9 @@ The TESS Input Catalog (TIC), Disk Detective Catalog, and PanSTARRS Catalog can 
    >>> from astroquery.mast import Catalogs
    ...
    >>> catalog_data = Catalogs.query_criteria(catalog="DiskDetective",
-   ...                                        objectname="M10",radius=2,state="complete")
+   ...                                        objectname="M10",
+   ...                                        radius=2,
+   ...                                        state="complete")
    >>> print(catalog_data)      # doctest: +IGNORE_OUTPUT
        designation     ...                    ZooniverseURL
    ------------------- ... ----------------------------------------------------
@@ -232,11 +239,15 @@ tuples of criteria decorator (min, gte, gt, max, lte, lt, like, contains) and va
 
 .. doctest-remote-data::
 
-   >>> catalog_data = Catalogs.query_criteria(coordinates="5.97754 32.53617", radius=0.01,
-   ...                                        catalog="PANSTARRS", table="mean", data_release="dr2",
+   >>> catalog_data = Catalogs.query_criteria(coordinates="5.97754 32.53617", 
+   ...                                        radius=0.01,
+   ...                                        catalog="PANSTARRS", 
+   ...                                        table="mean", 
+   ...                                        data_release="dr2",
    ...                                        nStackDetections=[("gte", 2)],
    ...                                        columns=["objName", "objID", "nStackDetections", "distance"],
-   ...                                        sort_by=[("desc", "distance")], pagesize=15)
+   ...                                        sort_by=[("desc", "distance")], 
+   ...                                        pagesize=15)
    >>> print(catalog_data[:10])   # doctest: +IGNORE_OUTPUT
           objName              objID        nStackDetections        distance
    --------------------- ------------------ ---------------- ---------------------

--- a/docs/mast/mast_cut.rst
+++ b/docs/mast/mast_cut.rst
@@ -125,7 +125,10 @@ parameter will result in an error when set to 'TICA'.
 
    >>> from astroquery.mast import Tesscut
    ...
-   >>> hdulist = Tesscut.get_cutouts(objectname="Eleonora", product='tica', moving_target=True, size=5, sector=6)
+   >>> hdulist = Tesscut.get_cutouts(objectname="Eleonora", 
+   ...                               product='tica', 
+   ...                               moving_target=True, 
+   ...                               sector=6)
    Traceback (most recent call last):
    ...
    astroquery.exceptions.InvalidQueryError: Only SPOC is available for moving targets queries.
@@ -145,7 +148,9 @@ pixel file will be produced for each one.
    >>> import astropy.units as u
    ...
    >>> cutout_coord = SkyCoord(107.18696, -70.50919, unit="deg")
-   >>> manifest = Tesscut.download_cutouts(coordinates=cutout_coord, size=[5, 5]*u.arcmin, sector=9) # doctest: +IGNORE_OUTPUT
+   >>> manifest = Tesscut.download_cutouts(coordinates=cutout_coord, 
+   ...                                     size=[5, 5]*u.arcmin,
+   ...                                     sector=9) # doctest: +IGNORE_OUTPUT
    Downloading URL https://mast.stsci.edu/tesscut/api/v0.1/astrocut?ra=107.18696&dec=-70.50919&y=0.08333333333333333&x=0.11666666666666667&units=d&sector=9 to ./tesscut_20210716150026.zip ... [Done]
    >>> print(manifest)  # doctest: +IGNORE_OUTPUT
                         Local Path
@@ -163,7 +168,10 @@ and because the TICA products are not available for sectors 1-26, we request cut
    >>> import astropy.units as u
    ...
    >>> cutout_coord = SkyCoord(107.18696, -70.50919, unit="deg")
-   >>> manifest = Tesscut.download_cutouts(coordinates=cutout_coord, product='tica', size=[5, 7]*u.arcmin, sector=27) # doctest: +IGNORE_OUTPUT
+   >>> manifest = Tesscut.download_cutouts(coordinates=cutout_coord, 
+   ...                                     product='tica', 
+   ...                                     size=[5, 7]*u.arcmin, 
+   ...                                     sector=27) # doctest: +IGNORE_OUTPUT
    Downloading URL https://mast.stsci.edu/tesscut/api/v0.1/astrocut?ra=107.18696&dec=-70.50919&y=0.08333333333333333&x=0.11666666666666667&units=d&product=TICA&sector=27 to ./tesscut_20230214150644.zip ... [Done]
    >>> print(manifest)  # doctest: +IGNORE_OUTPUT
                         Local Path

--- a/docs/mast/mast_cut.rst
+++ b/docs/mast/mast_cut.rst
@@ -53,13 +53,13 @@ not explicitly called for TICA.
    >>> from astropy.coordinates import SkyCoord
    ...
    >>> cutout_coord = SkyCoord(107.18696, -70.50919, unit="deg")
-   >>> hdulist = Tesscut.get_cutouts(coordinates=cutout_coord)
+   >>> hdulist = Tesscut.get_cutouts(coordinates=cutout_coord, sector=33)
    >>> hdulist[0].info()  # doctest: +IGNORE_OUTPUT
    Filename: <class '_io.BytesIO'>
    No.    Name      Ver    Type      Cards   Dimensions   Format
-     0  PRIMARY       1 PrimaryHDU      56   ()
-     1  PIXELS        1 BinTableHDU    280   1196R x 12C   [D, E, J, 25J, 25E, 25E, 25E, 25E, J, E, E, 38A]
-     2  APERTURE      1 ImageHDU        81   (5, 5)   int32
+   0  PRIMARY       1 PrimaryHDU      57   ()      
+   1  PIXELS        1 BinTableHDU    281   3495R x 12C   [D, E, J, 25J, 25E, 25E, 25E, 25E, J, E, E, 38A]   
+   2  APERTURE      1 ImageHDU        82   (5, 5)   int32  
 
 
 For users with time-sensitive targets who would like cutouts from the latest observations,
@@ -72,7 +72,9 @@ this example shows a request for TICA cutouts:
    >>> from astropy.coordinates import SkyCoord
    ...
    >>> cutout_coord = SkyCoord(107.18696, -70.50919, unit="deg")
-   >>> hdulist = Tesscut.get_cutouts(coordinates=cutout_coord, product='tica')
+   >>> hdulist = Tesscut.get_cutouts(coordinates=cutout_coord, 
+   ...                               product='tica',
+   ...                               sector=28)
    >>> hdulist[0][0].header['FFI_TYPE']  # doctest: +IGNORE_OUTPUT
    'TICA'
 
@@ -83,7 +85,7 @@ than a set of coordinates.
 
    >>> from astroquery.mast import Tesscut
    ...
-   >>> hdulist = Tesscut.get_cutouts(objectname="TIC 32449963")
+   >>> hdulist = Tesscut.get_cutouts(objectname="TIC 32449963", sector=37)
    >>> hdulist[0].info()  # doctest: +IGNORE_OUTPUT
    Filename: <class '_io.BytesIO'>
    No.    Name      Ver    Type      Cards   Dimensions   Format
@@ -106,7 +108,9 @@ simply with either the objectname or coordinates.
 
    >>> from astroquery.mast import Tesscut
    ...
-   >>> hdulist = Tesscut.get_cutouts(objectname="Eleonora", moving_target=True, size=5, sector=6)
+   >>> hdulist = Tesscut.get_cutouts(objectname="Eleonora",
+   ...                               moving_target=True,
+   ...                               sector=6)
    >>> hdulist[0].info()  # doctest: +IGNORE_OUTPUT
    Filename: <class '_io.BytesIO'>
    No.    Name      Ver    Type      Cards   Dimensions   Format
@@ -141,12 +145,12 @@ pixel file will be produced for each one.
    >>> import astropy.units as u
    ...
    >>> cutout_coord = SkyCoord(107.18696, -70.50919, unit="deg")
-   >>> manifest = Tesscut.download_cutouts(coordinates=cutout_coord, size=[5, 7]*u.arcmin, sector=9) # doctest: +IGNORE_OUTPUT
+   >>> manifest = Tesscut.download_cutouts(coordinates=cutout_coord, size=[5, 5]*u.arcmin, sector=9) # doctest: +IGNORE_OUTPUT
    Downloading URL https://mast.stsci.edu/tesscut/api/v0.1/astrocut?ra=107.18696&dec=-70.50919&y=0.08333333333333333&x=0.11666666666666667&units=d&sector=9 to ./tesscut_20210716150026.zip ... [Done]
    >>> print(manifest)  # doctest: +IGNORE_OUTPUT
                         Local Path
    ----------------------------------------------------------
-   ./tess-s0009-4-1_107.186960_-70.509190_21x15_astrocut.fits
+   ./tess-s0009-4-1_107.186960_-70.509190_15x15_astrocut.fits
 
 The query from the example above defaults to downloading cutouts from SPOC. The following example is a query for
 the same target from above, but with the product argument passed as TICA to explicitly request for TICA cutouts,
@@ -234,17 +238,6 @@ The following example requests SPOC cutouts for a moving target.
 Note that the moving targets functionality is not currently available for TICA,
 so the query will always default to SPOC.
 
-.. doctest-remote-data::
-
-   >>> from astroquery.mast import Tesscut
-   ...
-   >>> sector_table = Tesscut.get_sectors(objectname="Ceres", moving_target=True)
-   >>> print(sector_table)
-     sectorName   sector camera ccd
-   -------------- ------ ------ ---
-   tess-s0029-1-4     29      1   4
-   tess-s0043-3-3     43      3   3
-   tess-s0044-2-4     44      2   4
 
 Zcut
 ====
@@ -270,7 +263,7 @@ If the given coordinate appears in more than one Zcut survey, a FITS file will b
    >>> from astropy.coordinates import SkyCoord
    ...
    >>> cutout_coord = SkyCoord(189.49206, 62.20615, unit="deg")
-   >>> hdulist = Zcut.get_cutouts(coordinates=cutout_coord, size=5)
+   >>> hdulist = Zcut.get_cutouts(coordinates=cutout_coord, survey='3dhst_goods-n')
    >>> hdulist[0].info()    # doctest: +IGNORE_OUTPUT
    Filename: <class '_io.BytesIO'>
    No.    Name      Ver    Type      Cards   Dimensions   Format
@@ -292,7 +285,10 @@ If a given coordinate appears in more than one Zcut survey, a cutout will be pro
    >>> from astropy.coordinates import SkyCoord
    ...
    >>> cutout_coord = SkyCoord(189.49206, 62.20615, unit="deg")
-   >>> manifest = Zcut.download_cutouts(coordinates=cutout_coord, size=[200, 300], units="px")    # doctest: +IGNORE_OUTPUT
+   >>> manifest = Zcut.download_cutouts(coordinates=cutout_coord, 
+   ...                                  size=[5, 10], 
+   ...                                  units="px", 
+   ...                                  survey="3dhst_goods-n")  # doctest: +IGNORE_OUTPUT
    Downloading URL https://mast.stsci.edu/zcut/api/v0.1/astrocut?ra=189.49206&dec=62.20615&y=200&x=300&units=px&format=fits to ./zcut_20210125155545.zip ... [Done]
    Inflating...
    ...
@@ -300,23 +296,26 @@ If a given coordinate appears in more than one Zcut survey, a cutout will be pro
                                  Local Path
    -------------------------------------------------------------------------
    ./candels_gn_30mas_189.492060_62.206150_300.0pix-x-200.0pix_astrocut.fits
-
-
-.. doctest-remote-data::
-
-   >>> from astroquery.mast import Zcut
-   >>> from astropy.coordinates import SkyCoord
-   ...
-   >>> cutout_coord = SkyCoord(189.49206, 62.20615, unit="deg")
-   >>> manifest = Zcut.download_cutouts(coordinates=cutout_coord, size=[200, 300], units="px", form="jpg")    # doctest: +IGNORE_OUTPUT
+   >>> manifest = Zcut.download_cutouts(coordinates=cutout_coord, 
+   ...                                  size=[5, 10], 
+   ...                                  units="px", 
+   ...                                  survey="3dhst_goods-n",
+   ...                                  cutout_format="jpg")  # doctest: +IGNORE_OUTPUT
    Downloading URL https://mast.stsci.edu/zcut/api/v0.1/astrocut?ra=189.49206&dec=62.20615&y=200&x=300&units=px&format=jpg to ./zcut_20201202132453.zip ... [Done]
    ...
-   >>> print(manifest)        # doctest: +IGNORE_OUTPUT
-                                                   Local Path
-   ---------------------------------------------------------------------------------------------------------
-    ./hlsp_candels_hst_acs_gn-tot-30mas_f606w_v1.0_drz_189.492060_62.206150_300.0pix-x-200.0pix_astrocut.jpg
-    ./hlsp_candels_hst_acs_gn-tot-30mas_f814w_v1.0_drz_189.492060_62.206150_300.0pix-x-200.0pix_astrocut.jpg
-   ./hlsp_candels_hst_acs_gn-tot-30mas_f850lp_v1.0_drz_189.492060_62.206150_300.0pix-x-200.0pix_astrocut.jpg
+   >>> print(manifest)
+                                                Local Path                                             
+   -----------------------------------------------------------------------------------------------------
+      ./hlsp_3dhst_spitzer_irac_goods-n_irac1_v4.0_sc_189.492060_62.206150_10.0pix-x-5.0pix_astrocut.jpg
+   ./hlsp_3dhst_spitzer_irac_goods-n-s2_irac3_v4.0_sc_189.492060_62.206150_10.0pix-x-5.0pix_astrocut.jpg
+   ./hlsp_3dhst_spitzer_irac_goods-n-s1_irac4_v4.0_sc_189.492060_62.206150_10.0pix-x-5.0pix_astrocut.jpg
+      ./hlsp_3dhst_spitzer_irac_goods-n_irac2_v4.0_sc_189.492060_62.206150_10.0pix-x-5.0pix_astrocut.jpg
+         ./hlsp_3dhst_mayall_mosaic_goods-n_u_v4.0_sc_189.492060_62.206150_10.0pix-x-5.0pix_astrocut.jpg
+    ./hlsp_3dhst_subaru_suprimecam_goods-n_rc_v4.0_sc_189.492060_62.206150_10.0pix-x-5.0pix_astrocut.jpg
+     ./hlsp_3dhst_subaru_suprimecam_goods-n_v_v4.0_sc_189.492060_62.206150_10.0pix-x-5.0pix_astrocut.jpg
+    ./hlsp_3dhst_subaru_suprimecam_goods-n_ic_v4.0_sc_189.492060_62.206150_10.0pix-x-5.0pix_astrocut.jpg
+    ./hlsp_3dhst_subaru_suprimecam_goods-n_zp_v4.0_sc_189.492060_62.206150_10.0pix-x-5.0pix_astrocut.jpg
+     ./hlsp_3dhst_subaru_suprimecam_goods-n_b_v4.0_sc_189.492060_62.206150_10.0pix-x-5.0pix_astrocut.jpg
 
 
 Survey information
@@ -387,5 +386,6 @@ If the given coordinate appears in more than one product, a cutout will be produ
                                  Local Path
    ---------------------------------------------------------------------------------
    ./hst_cutout_skycell-p2007x09y05-ra351d3478-decn28d4978_wfc3_ir_f160w_coarse.fits
+   ./hst_cutout_skycell-p2007x09y05-ra351d3478-decn28d4978_wfc3_ir_f160w.fits
    ./hst_cutout_skycell-p2007x09y05-ra351d3478-decn28d4978_wfc3_uvis_f606w.fits
    ./hst_cutout_skycell-p2007x09y05-ra351d3478-decn28d4978_wfc3_uvis_f814w.fits

--- a/docs/mast/mast_obsquery.rst
+++ b/docs/mast/mast_obsquery.rst
@@ -385,7 +385,9 @@ curl script that can be used to download the files at a later time.
    >>> single_obs = Observations.query_criteria(obs_collection="IUE", obs_id="lwp13058")
    >>> data_products = Observations.get_product_list(single_obs)
    ...
-   >>> table = Observations.download_products(data_products, productType="SCIENCE", curl_flag=True)   # doctest: +IGNORE_OUTPUT
+   >>> table = Observations.download_products(data_products, 
+   ...                                        productType="SCIENCE", 
+   ...                                        curl_flag=True)   # doctest: +IGNORE_OUTPUT
    Downloading URL https://mast.stsci.edu/portal/Download/stage/anonymous/public/514cfaa9-fdc1-4799-b043-4488b811db4f/mastDownload_20170629162916.sh to ./mastDownload_20170629162916.sh ... [Done]
 
 
@@ -463,7 +465,8 @@ To get a list of S3 URIs, use the following workflow:
    >>> import os
    >>> from astroquery.mast import Observations
    ...
-   >>> # Simply call the `enable_cloud_dataset` method from `Observations`. The default provider is `AWS`, but we will write it in manually for this example:
+   >>> # Simply call the `enable_cloud_dataset` method from `Observations`. 
+   >>> # The default provider is `AWS`, but we will write it in manually for this example:
    >>> Observations.enable_cloud_dataset(provider='AWS')
    INFO: Using the S3 STScI public dataset [astroquery.mast.core]
    ...

--- a/docs/mast/mast_obsquery.rst
+++ b/docs/mast/mast_obsquery.rst
@@ -35,7 +35,7 @@ Radius is an optional parameter and the default is 0.2 degrees.
 
    >>> from astroquery.mast import Observations
    ...
-   >>> obs_table = Observations.query_object("M8",radius=".02 deg")
+   >>> obs_table = Observations.query_object("M8", radius=".02 deg")
    >>> print(obs_table[:10])  # doctest: +IGNORE_OUTPUT
    intentType obs_collection provenance_name ... srcDen    obsid    distance
    ---------- -------------- --------------- ... ------ ----------- --------
@@ -96,22 +96,19 @@ RA and Dec must be given in decimal degrees, and datetimes in MJD.
               image           1            HST ...    science 2003520266 2023816134
               image           1            HST ...    science 2003520268 2025756935
    ...
-   >>> obs_table = Observations.query_criteria(filters=["*UV","Kepler"],objectname="M101")
+   >>> obs_table = Observations.query_criteria(filters=["*UV","Kepler"],
+   ...                                         objectname="M10",
+   ...                                         obs_collection="GALEX")
    >>> print(obs_table)  # doctest: +IGNORE_OUTPUT
-   dataproduct_type calib_level obs_collection ...   objID1        distance
-   ---------------- ----------- -------------- ... ---------- ------------------
-              image           2          GALEX ... 1000045952                0.0
-              image           2          GALEX ... 1000001327 371.71837196246395
-              image           2          GALEX ... 1000016641                0.0
-              image           2          GALEX ... 1000016644 229.81061601101433
-              image           2          GALEX ... 1000001326                0.0
-              image           2          GALEX ... 1000004203                0.0
-              image           2          GALEX ... 1000004937 3.8329068532314046
-              image           2          GALEX ... 1000045953 371.71837196246395
-              image           2          GALEX ... 1000048357                0.0
-              image           2          GALEX ... 1000048943 3.8329068532314046
-              image           2          GALEX ... 1000055044                0.0
-              image           2          GALEX ... 1000055047 229.81061601101433
+   intentType obs_collection provenance_name ... objID objID1 distance
+   ---------- -------------- --------------- ... ----- ------ --------
+      science          GALEX             GII ...  7022   7022      0.0
+      science          GALEX             GII ...  7023   7023      0.0
+      science          GALEX             AIS ... 61673  61673      0.0
+      science          GALEX             AIS ... 61674  61674      0.0
+      science          GALEX             AIS ... 61675  61675      0.0
+      science          GALEX             AIS ... 61676  61676      0.0
+      science          GALEX             GII ... 78941  78941      0.0
 
 We encourage the use of wildcards particularly when querying for JWST instruments
 with the instrument_name criteria. This is because of the varying instrument names
@@ -138,17 +135,14 @@ This can be useful if trying to decide whether the available memory is sufficien
 
    >>> from astroquery.mast import Observations
    ...
-   >>> print(Observations.query_region_count("322.49324 12.16683"))  # doctest: +IGNORE_OUTPUT
-   2364
+   >>> print(Observations.query_region_count("322.49324 12.16683", radius=0.001))  # doctest: +IGNORE_OUTPUT
+   6338
    ...
    >>> print(Observations.query_object_count("M8",radius=".02 deg"))  # doctest: +IGNORE_OUTPUT
    469
    ...
-   >>> print(Observations.query_criteria_count(dataproduct_type="image",
-   ...                                         filters=["NUV","FUV"],
-   ...                                         t_max=[52264.4586,54452.8914]))  # doctest: +IGNORE_OUTPUT
-   59033
-
+   >>> print(Observations.query_criteria_count(proposal_id=8880))  # doctest: +IGNORE_OUTPUT
+   8
 
 
 Metadata Queries
@@ -162,7 +156,7 @@ use the `~astroquery.mast.ObservationsClass.list_missions` function.
    >>> from astroquery.mast import Observations
    ...
    >>> print(Observations.list_missions())
-   ['BEFS', 'EUVE', 'FIMS-SPEAR', 'FUSE', 'GALEX', 'HLA', 'HLSP', 'HST', 'HUT', 'IUE', 'JWST', 'K2', 'K2FFI', 'Kepler', 'KeplerFFI', 'OPO', 'PS1', 'SPITZER_SHA', 'SWIFT', 'TESS', 'TUES', 'WUPPE']
+   ['BEFS', 'EUVE', 'FIMS-SPEAR', 'FUSE', 'GALEX', 'HLA', 'HLSP', 'HST', 'HUT', 'IUE', 'JWST', 'K2', 'K2FFI', 'Kepler', 'KeplerFFI', 'OPO', 'PS1', 'SDSS', 'SPITZER_SHA', 'SWIFT', 'TESS', 'TUES', 'WUPPE']
 
 To get a table of metadata associated with observation or product lists use the
 `~astroquery.mast.ObservationsClass.get_metadata` function.


### PR DESCRIPTION
Adjusted some of the queries in MAST documentation to reduce the running time of the doctests. Reduced from ~9.5 minutes to ~3 minutes.

I also reformatted some of the queries to be more readable and updated outputs.