### PR TITLE
Panstarrs Bugfix

### DIFF
--- a/astroquery/mast/tests/data/README.rst
+++ b/astroquery/mast/tests/data/README.rst
@@ -13,7 +13,7 @@ To generate `~astroquery.mast.tests.data.mission_columns.json`, use the followin
     ...
     >>> resp = utils._simple_request('https://mast.stsci.edu/search/util/api/v0.1/column_list', {'mission': 'hst'})
     >>> with open('mission_columns.json', 'w') as file:
-    ...     json.dump(resp.json(), file, indent=4)
+    ...     json.dump(resp.json(), file, indent=4)  # doctest: +SKIP
 
 To generate `~astroquery.mast.tests.data.panstarrs_columns.json`, use the following:
 
@@ -24,4 +24,4 @@ To generate `~astroquery.mast.tests.data.panstarrs_columns.json`, use the follow
     ...
     >>> resp = utils._simple_request('https://catalogs.mast.stsci.edu/api/v0.1/panstarrs/dr2/mean/metadata.json')
     >>> with open('panstarrs_columns.json', 'w') as file:
-    ...     json.dump(resp.json(), file, indent=4)
+    ...     json.dump(resp.json(), file, indent=4)  # doctest: +SKIP


### PR DESCRIPTION
I mentioned in my last MR that we were having an intermittent issue with Panstarrs queries. This is a workaround for robustness so that query functions do not fail when responses have unexpected data. To get the name of the column, we now use the `column_name` key if it exists.

I also added SKIP directives to the code snippets in the data README so that extra files are not left behind when running the test suite.