### PR TITLE
Gaia: update the output file name built by the method load_data to include microsecond resolution

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -185,6 +185,8 @@ gaia
 
 - New retrieval types for datalink (Gaia DR4 release). [#3110]
 
+- The output file name built by the method load_data, includes microsecond resolution. This is based on the previous PR [#3014]. [#3130]
+
 
 jplhorizons
 ^^^^^^^^^^^

--- a/astroquery/gaia/core.py
+++ b/astroquery/gaia/core.py
@@ -258,7 +258,7 @@ class GaiaClass(TapPlus):
 
         log.debug(f"Directory where the data will be saved: {path}")
 
-        if path != '':
+        if path:
             if not os.path.isdir(path):
                 try:
                     os.mkdir(path)

--- a/astroquery/gaia/core.py
+++ b/astroquery/gaia/core.py
@@ -239,13 +239,13 @@ class GaiaClass(TapPlus):
 
         now = datetime.datetime.now(datetime.timezone.utc)
         if not dump_to_file:
-            now_formatted = now.strftime("%Y%m%d_%H%M%S")
+            now_formatted = now.strftime("%Y%m%d_%H%M%S.%f")
             temp_dirname = "temp_" + now_formatted
             downloadname_formated = "download_" + now_formatted
             output_file = os.path.join(os.getcwd(), temp_dirname, downloadname_formated)
 
         else:
-            output_file = 'datalink_output_' + now.strftime("%Y%m%dT%H%M%S") + '.zip'
+            output_file = 'datalink_output_' + now.strftime("%Y%m%dT%H%M%S.%f") + '.zip'
             output_file_specified = True
             output_file = os.path.abspath(output_file)
             log.info(f"DataLink products will be stored in the {output_file} file")

--- a/astroquery/gaia/core.py
+++ b/astroquery/gaia/core.py
@@ -224,7 +224,7 @@ class GaiaClass(TapPlus):
         dump_to_file: boolean, optional, default False.
             If it is true, a compressed directory named "datalink_output_<time_stamp>.zip" with all the DataLink
             files is made in the current working directory. The <time_stamp> format follows the ISO 8601 standard:
-            "yyyymmddThhmmss".
+            "YYYYMMDD_HHMMSS.mmmmmm".
         overwrite_output_file : boolean, optional, default False
             To overwrite the output file ("datalink_output.zip") if it already exists.
         verbose : bool, optional, default 'False'

--- a/astroquery/gaia/tests/test_gaiatap.py
+++ b/astroquery/gaia/tests/test_gaiatap.py
@@ -87,7 +87,7 @@ ids_designator = ['Gaia DR3 1104405489608579584', 'Gaia DR3 1104405489608579584,
 RADIUS = 1 * u.deg
 SKYCOORD = SkyCoord(ra=19 * u.deg, dec=20 * u.deg, frame="icrs")
 
-FAKE_TIME = datetime.datetime(2024, 1, 1, 0, 0, 59)
+FAKE_TIME = datetime.datetime(2024, 1, 1, 0, 0, 59, 1)
 
 
 @pytest.fixture
@@ -999,9 +999,12 @@ def test_datalink_querier_load_data_fits(mock_datalink_querier_fits):
     assert not os.path.exists(datalink_output)
 
 
-def test_load_data_vot(monkeypatch, tmp_path, tmp_path_factory):
+def test_load_data_vot(monkeypatch, tmp_path, tmp_path_factory, patch_datetime_now):
+
+    assert datetime.datetime.now(datetime.timezone.utc) == FAKE_TIME
+
     now = datetime.datetime.now(datetime.timezone.utc)
-    output_file = 'datalink_output_' + now.strftime("%Y%m%dT%H%M%S") + '.zip'
+    output_file = 'datalink_output_' + now.strftime("%Y%m%dT%H%M%S.%f") + '.zip'
 
     path = Path(os.getcwd(), output_file)
 
@@ -1076,9 +1079,12 @@ def test_load_data_fits(monkeypatch, tmp_path, tmp_path_factory):
     path.unlink()
 
 
-def test_load_data_csv(monkeypatch, tmp_path, tmp_path_factory):
+def test_load_data_csv(monkeypatch, tmp_path, tmp_path_factory, patch_datetime_now):
+
+    assert datetime.datetime.now(datetime.timezone.utc) == FAKE_TIME
+
     now = datetime.datetime.now(datetime.timezone.utc)
-    output_file = 'datalink_output_' + now.strftime("%Y%m%dT%H%M%S") + '.zip'
+    output_file = 'datalink_output_' + now.strftime("%Y%m%dT%H%M%S.%f") + '.zip'
 
     path = Path(os.getcwd(), output_file)
 
@@ -1112,9 +1118,12 @@ def test_load_data_csv(monkeypatch, tmp_path, tmp_path_factory):
     path.unlink()
 
 
-def test_load_data_ecsv(monkeypatch, tmp_path, tmp_path_factory):
+def test_load_data_ecsv(monkeypatch, tmp_path, tmp_path_factory, patch_datetime_now):
+
+    assert datetime.datetime.now(datetime.timezone.utc) == FAKE_TIME
+
     now = datetime.datetime.now(datetime.timezone.utc)
-    output_file = 'datalink_output_' + now.strftime("%Y%m%dT%H%M%S") + '.zip'
+    output_file = 'datalink_output_' + now.strftime("%Y%m%dT%H%M%S.%f") + '.zip'
 
     path = Path(os.getcwd(), output_file)
 
@@ -1148,9 +1157,12 @@ def test_load_data_ecsv(monkeypatch, tmp_path, tmp_path_factory):
     path.unlink()
 
 
-def test_load_data_linking_parameter(monkeypatch, tmp_path):
+def test_load_data_linking_parameter(monkeypatch, tmp_path, patch_datetime_now):
+
+    assert datetime.datetime.now(datetime.timezone.utc) == FAKE_TIME
+
     now = datetime.datetime.now(datetime.timezone.utc)
-    output_file = 'datalink_output_' + now.strftime("%Y%m%dT%H%M%S") + '.zip'
+    output_file = 'datalink_output_' + now.strftime("%Y%m%dT%H%M%S.%f") + '.zip'
 
     path = Path(os.getcwd(), output_file)
 
@@ -1185,9 +1197,12 @@ def test_load_data_linking_parameter(monkeypatch, tmp_path):
 
 
 @pytest.mark.parametrize("linking_param", ['TRANSIT_ID', 'IMAGE_ID'])
-def test_load_data_linking_parameter_with_values(monkeypatch, tmp_path, linking_param):
+def test_load_data_linking_parameter_with_values(monkeypatch, tmp_path, linking_param, patch_datetime_now):
+
+    assert datetime.datetime.now(datetime.timezone.utc) == FAKE_TIME
+
     now = datetime.datetime.now(datetime.timezone.utc)
-    output_file = 'datalink_output_' + now.strftime("%Y%m%dT%H%M%S") + '.zip'
+    output_file = 'datalink_output_' + now.strftime("%Y%m%dT%H%M%S.%f") + '.zip'
 
     path = Path(os.getcwd(), output_file)
 


### PR DESCRIPTION
In https://github.com/astropy/astroquery/issues/3128 describes the requirement to include the microsecond resolution in the output file name built by the method load_data.

Units tests were updated.

cc @esdc-esac-esa-int

jira: GAIAPCR-1331