### PR TITLE
Fix #3135 - `TestEso.test_each_survey_and_SgrAstar` fails

### DIFF
--- a/astroquery/eso/tests/test_eso_remote.py
+++ b/astroquery/eso/tests/test_eso_remote.py
@@ -17,6 +17,7 @@ instrument_list = [u'fors1', u'fors2', u'sphere', u'vimos', u'omegacam',
 SKIP_SLOW = True
 
 SGRA_SURVEYS = ['195.B-0283', 'GIRAFFE', 'HARPS', 'HAWKI', 'KMOS',
+                'ERIS-SPIFFIER',
                 'MW-BULGE-PSFPHOT', 'VPHASplus', 'VVV', 'VVVX', 'XSHOOTER']
 
 


### PR DESCRIPTION
Fix #3135 - TestEso.test_each_survey_and_SgrAstar fails

# Changelog

 - Added `ERIS-SPIFFIER` to `SGRA_SURVEYS`