### PR TITLE
Fix issue 2949: nasa_exoplanet_archive transit duration unit fix

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -227,7 +227,7 @@ mast
 
 - Present users with an error when nonexistent query criteria are used in ``mast.MastMissions`` query functions. [#3126]
 
-- Present users with an error when nonexistent query criteria are used in ``mast.Catalogs.query_region`` and 
+- Present users with an error when nonexistent query criteria are used in ``mast.Catalogs.query_region`` and
   ``mast.Catalogs.query_object``. [#3126]
 
 - Handle HLSP data products in ``Observations.get_cloud_uris``. [#3126]
@@ -476,6 +476,8 @@ ipac.nexsci.nasa_exoplanet_archive
 
 - Stability improvements to ``query_aliases`` to address bug that made
   method retrieve no aliases for multiple star systems. [#2506]
+
+- Fix unit inconsistency in ``pl_trandur`` from day(s) to hour(s). [#3137]
 
 jplhorizons
 ^^^^^^^^^^^
@@ -728,8 +730,6 @@ ipac.nexsci.nasa_exoplanet_archive
 
 - Fixes to alias query, and regularize keyword removed from deprecated
   ``query_star`` method. [#2264]
-
-- ``pl_trandur`` unit updated from day(s) to hour(s) in TAP, and hour added to dictionary mapping unit strings to astropy units in core.py. [#3137]
 
 mast
 ^^^^

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -729,6 +729,8 @@ ipac.nexsci.nasa_exoplanet_archive
 - Fixes to alias query, and regularize keyword removed from deprecated
   ``query_star`` method. [#2264]
 
+- ``pl_trandur`` unit updated from day(s) to hour(s) in TAP, and hour added to dictionary mapping unit strings to astropy units in core.py. [#3137]
+
 mast
 ^^^^
 

--- a/astroquery/ipac/nexsci/nasa_exoplanet_archive/core.py
+++ b/astroquery/ipac/nexsci/nasa_exoplanet_archive/core.py
@@ -65,6 +65,7 @@ UNIT_MAPPER = {
     "degrees": u.deg,
     "dexincgs": u.dex(u.cm / u.s ** 2),
     "hours": u.hr,
+    "hour": u.hr,
     "hrs": u.hr,
     "kelvin": u.K,
     "logLsun": u.dex(u.L_sun),


### PR DESCRIPTION
`pl_trandur` unit updated from day(s) to hour(s) in TAP, and hour added to dictionary mapping unit strings to astropy units in core.py

fixes #2949 