### PR TITLE
fix: query objects

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -149,6 +149,9 @@ simbad
   A helper method was added ``astroquery.simbad.utils.CriteriaTranslator`` to
   translate between the sim-script syntax and the TAP/ADQL syntax. [#2954]
 
+- fixed ``query_objects`` that would not work in combination with the additional field
+  ``ident`` [#3149]
+
 skyview
 ^^^^^^^
 

--- a/astroquery/simbad/core.py
+++ b/astroquery/simbad/core.py
@@ -718,28 +718,29 @@ class SimbadClass(BaseVOQuery):
         Examples
         --------
 
-        Look for large galaxies in two cones
+        Look for largest galaxies in two cones
 
         >>> from astroquery.simbad import Simbad
         >>> from astropy.coordinates import SkyCoord
         >>> simbad = Simbad()
         >>> simbad.ROW_LIMIT = 5
-        >>> simbad.add_votable_fields("otype") # doctest: +REMOTE_DATA
+        >>> simbad.add_votable_fields("otype", "dim") # doctest: +REMOTE_DATA
         >>> coordinates = SkyCoord([SkyCoord(186.6, 12.7, unit=("deg", "deg")),
         ...                         SkyCoord(170.75, 23.9, unit=("deg", "deg"))])
         >>> result = simbad.query_region(coordinates, radius="2d5m",
-        ...                              criteria="otype = 'Galaxy..' AND galdim_majaxis>8") # doctest: +REMOTE_DATA
-        >>> result.sort("main_id") # doctest: +REMOTE_DATA
-        >>> result["main_id", "otype"] # doctest: +REMOTE_DATA
+        ...                              criteria="otype = 'Galaxy..' AND galdim_majaxis>8.5") # doctest: +REMOTE_DATA
+        >>> result.sort("galdim_majaxis", reverse=True) # doctest: +REMOTE_DATA
+        >>> result["main_id", "otype", "galdim_majaxis"] # doctest: +REMOTE_DATA
         <Table length=5>
-          main_id    otype
-           object    object
-        ------------ ------
-        LEDA   40577    GiG
-        LEDA   41362    GiC
-               M  86    GiG
-               M  87    AGN
-           NGC  4438    LIN
+          main_id    otype  galdim_majaxis
+                                arcmin
+           object    object    float32
+        ------------ ------ --------------
+        LEDA   41362    GiC           11.0
+               M  86    GiG          10.47
+        LEDA   40917    AG?           10.3
+               M  87    AGN           9.12
+           NGC  4438    LIN           8.91
 
         Notes
         -----
@@ -1334,7 +1335,7 @@ class SimbadClass(BaseVOQuery):
         ...                  my_table_name=letters_table) # doctest: +REMOTE_DATA
         <Table length=3>
         alphabet
-         object
+          str1
         --------
                a
                b

--- a/astroquery/simbad/tests/test_simbad.py
+++ b/astroquery/simbad/tests/test_simbad.py
@@ -408,9 +408,10 @@ def test_query_objects():
     # no wildcard and additional criteria
     adql = simbad.core.Simbad.query_objects(("m1", "m2"), criteria="otype = 'Galaxy..'",
                                             get_query_payload=True)["QUERY"]
-    expected = ('FROM TAP_UPLOAD.script_infos LEFT JOIN ident ON TAP_UPLOAD.script_infos.'
-                '"user_specified_id" = ident."id" LEFT JOIN basic ON basic."oid" = ident."oidref"'
-                ' WHERE (otype = \'Galaxy..\')')
+    expected = ('FROM TAP_UPLOAD.script_infos LEFT JOIN ident AS ident_upload '
+                'ON TAP_UPLOAD.script_infos.'
+                '"user_specified_id" = ident_upload."id" LEFT JOIN basic '
+                'ON basic."oid" = ident_upload."oidref" WHERE (otype = \'Galaxy..\')')
     assert adql.endswith(expected)
     # with wildcard
     adql = simbad.core.Simbad.query_objects(("M *", "NGC *"), wildcard=True, get_query_payload=True)["QUERY"]

--- a/astroquery/simbad/tests/test_simbad_remote.py
+++ b/astroquery/simbad/tests/test_simbad_remote.py
@@ -204,3 +204,10 @@ class TestSimbad:
         simbad_instance.add_votable_fields("u")
         result = simbad_instance.query_object("HD 147933")
         assert all(filtername in result.colnames for filtername in {"u", "U", "V"})
+
+    def test_double_ident_in_query_objects(self):
+        simbad = Simbad()
+        simbad.add_votable_fields("ident")
+        result = simbad.query_objects(['HD 1'])
+        assert len(result) > 1
+        assert all(result["main_id"] == "HD      1")

--- a/docs/simbad/query_tap.rst
+++ b/docs/simbad/query_tap.rst
@@ -195,22 +195,25 @@ that is the measurement table for rotations. Their common column is ``oidref``.
 .. doctest-remote-data::
 
     >>> from astroquery.simbad import Simbad
-    >>> query = """SELECT bibcode AS "Rotation Measurements Bibcodes"
+    >>> query = """SELECT DISTINCT bibcode AS "Rotation Measurements Bibcodes"
     ...     FROM ident JOIN mesrot USING(oidref)
     ...     WHERE id = 'Sirius';
     ...     """
-    >>> Simbad.query_tap(query)
-    <Table length=7>
+    >>> bibcodes = Simbad.query_tap(query)
+    >>> bibcodes.sort("Rotation Measurements Bibcodes")
+    >>> bibcodes
+    <Table length=8>
     Rotation Measurements Bibcodes
-                object
+                object            
     ------------------------------
-               2023ApJS..266...11B
-               2016A&A...589A..83G
-               2002A&A...393..897R
-               1995ApJS...99..135A
-               1970CoKwa.189....0U
                1970CoAsi.239....1B
+               1970CoKwa.189....0U
+               1995ApJS...99..135A
+               2002A&A...393..897R
+               2005yCat.3244....0G
                2011A&A...531A.143D
+               2016A&A...589A..83G
+               2023ApJS..266...11B
 
 This returns six papers in which the SIMBAD team found rotation data for Sirius.
 

--- a/docs/simbad/simbad.rst
+++ b/docs/simbad/simbad.rst
@@ -66,7 +66,7 @@ to query the messier object M1:
     main_id    ra     dec   ... coo_wavelength     coo_bibcode     matched_id
               deg     deg   ...
     ------- ------- ------- ... -------------- ------------------- ----------
-      M   1 83.6287 22.0147 ...              R 1995AuJPh..48..143S      M   1
+      M   1 83.6324 22.0174 ...              X 2022A&A...661A..38P      M   1
 
 `Wildcards`_ are supported. Note that this makes the query case-sensitive.
 This allows, for instance, to query messier objects from 1 through 9:
@@ -203,12 +203,12 @@ If the center is defined by coordinates, then the best solution is to use a
     >>> Simbad.query_region(SkyCoord(31.0087, 14.0627, unit=(u.deg, u.deg),
     ...                     frame='galactic'), radius=2 * u.arcsec)
     <Table length=2>
-          main_id               ra        ... coo_wavelength     coo_bibcode
-                               deg        ...
-           object            float64      ...      str1             object
-    ------------------- ----------------- ... -------------- -------------------
-               GJ 699 b 269.4520769586187 ...              O 2020yCat.1350....0G
-    NAME Barnard's star 269.4520769586187 ...              O 2020yCat.1350....0G
+           main_id                ra        ... coo_wavelength     coo_bibcode    
+                                 deg        ...                                   
+            object             float64      ...      str1             object      
+    --------------------- ----------------- ... -------------- -------------------
+    NAME Barnard's Star b 269.4520769586187 ...              O 2020yCat.1350....0G
+      NAME Barnard's star 269.4520769586187 ...              O 2020yCat.1350....0G
 
 .. Note::
 
@@ -466,7 +466,7 @@ with:
 
     >>> from astroquery.simbad import Simbad
     >>> Simbad.list_votable_fields()[["name", "description"]]
-    <Table length=115>
+    <Table length=...>
         name                          description                      
        object                            object                        
     ----------- -------------------------------------------------------
@@ -584,11 +584,12 @@ constraint on the first character of the ``mespm.bibcode`` column
     >>> simbad.add_votable_fields("mesPM", "otype")
     >>> pm_measurements = simbad.query_object("BD+30  2512", criteria=criteria)
     >>> pm_measurements[["main_id", "mespm.pmra", "mespm.pmde", "mespm.bibcode"]]
-    <Table length=6>
+    <Table length=7>
       main_id   mespm.pmra mespm.pmde    mespm.bibcode
                  mas / yr   mas / yr
        object    float32    float32          object
     ----------- ---------- ---------- -------------------
+    BD+30  2512     -631.6     -289.5 2016ApJ...817..112S
     BD+30  2512   -631.662   -308.469 2020yCat.1350....0G
     BD+30  2512     -631.6     -289.5 2016ApJS..224...36K
     BD+30  2512   -631.625   -308.495 2018yCat.1345....0G


### PR DESCRIPTION
Hi astroquery maintainers :slightly_smiling_face: 

This PR fixes a rare corner case where the `query_objects` method would not work if the people added the votable field `ident` beforehand.

## MRE:

```python
from astroquery.simbad import Simbad
simbad = Simbad()
simbad.add_votable_fields("ident")
result = simbad.query_objects(['HD 1'])
```
It's solved by adding the possibility to give aliases to joined tables and using and alias for one of the `ident` tables in this specific case. I don't think an alias is needed anywhere else. Here the need for one of the ident to be added with a  LEFT JOIN and the one from add_votable_fields should be added with a normal JOIN is very specific to this method.