### PR TITLE
fix: use the real column names rather than the IDs that astropy generates

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -163,6 +163,9 @@ vizier
 
 - Fixed search by UCD -- they were ignored. [#3147]
 
+- Fixed column names -- some characters were replaced by ``_`` instead of keeping
+  the original name [#3153]
+
 vsa
 ^^^
 

--- a/astroquery/vizier/core.py
+++ b/astroquery/vizier/core.py
@@ -844,7 +844,7 @@ def _parse_vizier_votable(data, *, verbose=False, invalid='warn',
                     name = t.name
                 if name not in table_dict.keys():
                     table_dict[name] = []
-                table_dict[name] += [t.to_table()]
+                table_dict[name] += [t.to_table(use_names_over_ids=True)]
         for name in table_dict.keys():
             if len(table_dict[name]) > 1:
                 table_dict[name] = tbl.vstack(table_dict[name])

--- a/astroquery/vizier/tests/test_vizier_remote.py
+++ b/astroquery/vizier/tests/test_vizier_remote.py
@@ -72,6 +72,13 @@ class TestVizierRemote:
         for table in result:
             assert 'Bmag' not in table.columns
 
+    def test_vizier_column_exotic_characters(self):
+        # column names can contain any ascii characters. This checks that they are not
+        # replaced by underscores, see issue #3124
+        result = Vizier(columns=["r'mag"],
+                        row_limit=1).get_catalogs(catalog="II/336/apass9")[0]
+        assert "r'mag" in result.colnames
+
     @pytest.mark.parametrize('all', ('all', '*'))
     def test_alls_withaddition(self, all):
         # Check that all the expected columns are there plus the _r

--- a/docs/vizier/vizier.rst
+++ b/docs/vizier/vizier.rst
@@ -14,6 +14,13 @@ radius. Similar to the VizieR web interface, the queries may be further
 constrained by specifying a choice of catalogs, keywords as well as filters on
 individual columns before retrieving the results.
 
+.. note::
+    In earlier versions of astroquery (<0.4.8), columns with special characters like 
+    ``r'mag`` were renamed into ``r_mag`` and columns starting with a number like
+    ``2MASS`` were prepended with an underscore ``_2MASS``.
+    In astroquery >=0.4.8, the column names are the same in VizieR's webpages and in
+    the tables received (for the two examples: you'll see ``r'mag`` and ``2MASS``).
+
 Table Discover
 --------------
 

--- a/docs/vizier/vizier.rst
+++ b/docs/vizier/vizier.rst
@@ -182,7 +182,7 @@ To access an individual table from the `~astroquery.utils.TableList` object:
 
     >>> interesting_table = result['IX/8/catalog']
     >>> print(interesting_table)
-      _2XRS     RAB1950      DEB1950    Xname ... Int   _RA.icrs     _DE.icrs  
+       2XRS     RAB1950      DEB1950    Xname ... Int   _RA.icrs     _DE.icrs   
                                               ... uJy                          
     --------- ------------ ------------ ----- ... --- ------------ ------------
     06429-166 06 42 54.000 -16 39 00.00       ...  -- 06 45 08.088 -16 42 11.29
@@ -347,7 +347,7 @@ the ``"+"`` in front of ``"_r"``.
     >>> vizier = Vizier(columns=["*", "+_r"], catalog="II/246")
     >>> result = vizier.query_region("HD 226868", radius="20s")
     >>> print(result[0])
-      _r    RAJ2000    DEJ2000        _2MASS       Jmag  ... Bflg Cflg Xflg Aflg
+      _r    RAJ2000    DEJ2000        2MASS        Jmag  ... Bflg Cflg Xflg Aflg
               deg        deg                       mag   ...                    
     ------ ---------- ---------- ---------------- ------ ... ---- ---- ---- ----
      0.134 299.590280  35.201599 19582166+3512057  6.872 ...  111  000    0    0
@@ -395,8 +395,8 @@ index to the ``agn`` table (not the 0-based python convention).
 
     >>> guide = Vizier(catalog="II/246", column_filters={"Kmag":"<9.0"}).query_region(agn, radius="30s", inner_radius="2s")[0]
     >>> guide.pprint()
-     _q  RAJ2000    DEJ2000        _2MASS       Jmag  ... Rflg Bflg Cflg Xflg Aflg
-           deg        deg                       mag   ...
+     _q  RAJ2000    DEJ2000        2MASS        Jmag  ... Rflg Bflg Cflg Xflg Aflg
+           deg        deg                       mag   ...                         
     --- ---------- ---------- ---------------- ------ ... ---- ---- ---- ---- ----
       1  10.686015  41.269630 00424464+4116106  9.399 ...   20   20  0c0    2    0
       1  10.685657  41.269550 00424455+4116103 10.773 ...  200  200  c00    2    0


### PR DESCRIPTION
Hello astroquery maintainers :slightly_smiling_face: 

This PR fixes #3124

The issue was not in the votable parser in astropy, but in the conversion from votable to astropy table where for vizier the option "use_names_overs_ids" should be preferred, as vizier does not write IDs for its fields but uses names instead. 

The IDs that we saw in the issue report are generated by the votable parser when a field has no ID.

See MRE for this:

```python
from astropy.io.votable.tree import VOTableFile, Resource, TableElement, Field
votable = VOTableFile()
table = TableElement(votable)
resource = Resource()
votable.resources.append(resource)
resource.tables.append(table)
table.fields.extend([Field(votable, name="filename(myname", datatype="char", arraysize="*")])
```

```
WARNING: W03: ?:?:?: W03: Implicitly generating an ID from a name 'filename(myname' -> 'filename_myname' [astropy.io.votable.xmlutil]
```

So switching from ID to name for the names of the columns in the conversion from votable to astropy table did the trick.

This is a bit of a breaking change, as people will start to see the real column names rather than the underscore ones. It also appeared from the narrative docs that this strange option was adding some underscores at the beginning of some column names event when no unconventional characters are present.

Edit: the underscore at the beginning is added when the column name starts with a letter... ~something forbidden by the standard that vizier still does :cold_sweat: (and I don't think we can change this upstream)~ 

Edit bis: no, starting with a number is valid. I was confused by the text of the standard, but from reading the xsd at the bottom, the name should be of type ``xsd:token``, which is defined here: https://www.w3.org/TR/xmlschema11-2/#token 
Looks like the xsd:token can be ``2MASS`` without issues :slightly_smiling_face: 