### PR TITLE
BUG: ESAHubble.get_member_observations now always return lists

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -31,10 +31,13 @@ casda
 
 - Support jobs which are in the SUSPENDED state (used when copying data) [#3134]
 
-ehst
-^^^^
+esa.hubble
+^^^^^^^^^^
 
 - Include warning in get_datalabs_path method for ehst when the data volume is not mounted in DataLabs [#3059]
+
+- Fix an inconsistency, ``get_member_observations`` now return a list for
+  both simple and composite observations. [#3157]
 
 gama
 ^^^^

--- a/astroquery/esa/hubble/core.py
+++ b/astroquery/esa/hubble/core.py
@@ -299,7 +299,7 @@ class ESAHubbleClass(BaseQuery):
     def _select_related_composite(self, observation_id):
         query = f"select observation_id from ehst.observation where members like '%{observation_id}%'"
         job = self.query_tap(query=query)
-        oids = job["observation_id"]
+        oids = job["observation_id"].tolist()
         return oids
 
     def __validate_product_type(self, product_type):

--- a/astroquery/esa/hubble/tests/test_esa_hubble_remote.py
+++ b/astroquery/esa/hubble/tests/test_esa_hubble_remote.py
@@ -103,7 +103,9 @@ class TestEsaHubbleRemoteData:
 
     def test_hap_simple_to_hap_composite(self):
         result = esa_hubble.get_member_observations(observation_id='hst_16316_71_acs_sbc_f150lp_jec071i9')
-        assert result == ['hst_16316_71_acs_sbc_f150lp_jec071']
+        assert result == ['hst_16316_71_acs_sbc_f150lp_jec071',
+                          'hst_16316_71_acs_sbc_total_jec071',
+                          'hst_skycell-p2478x15y09_acs_sbc_f150lp_all']
 
     def test_hap_simple_to_hst_simple(self):
         result = esa_hubble.get_hap_hst_link(observation_id='hst_16316_71_acs_sbc_f150lp_jec071i9')


### PR DESCRIPTION
I was clearing up remote test failures in prep for the release when noticed this bug. It was quicker to fix it myself than to report it in an issue.

I suspect that previously only one result was returned thus the test didn't pick up this inconsistency when the composite returned a MaskedColumn rather than a list.