### PR TITLE
doc: make XMatch prepare tables error message state the two possible causes for failure

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -286,6 +286,9 @@ xmatch
 - Fix xmatch query for two local tables. The second table was written over the first one,
   resulting in a confusing "missing cat1" error. [#3116]
 
+- Make the error message clearer about VizieR tables not available for
+  crossmatching [#3168]
+
 
 0.4.7 (2024-03-08)
 ==================

--- a/astroquery/xmatch/core.py
+++ b/astroquery/xmatch/core.py
@@ -147,7 +147,7 @@ class XMatchClass(BaseQuery):
         if not self.is_table_available(cat):
             if ((colRA is None) or (colDec is None)):
                 raise ValueError(
-                    f"'{cat}' is not available on the XMatch server.If you are "
+                    f"'{cat}' is not available on the XMatch server. If you are "
                     "using a VizieR table name, note that only tables with "
                     "coordinates are available on the XMatch server. If you are "
                     f"using a local table, the arguments 'colRA{cat_index}' and "

--- a/astroquery/xmatch/core.py
+++ b/astroquery/xmatch/core.py
@@ -146,7 +146,12 @@ class XMatchClass(BaseQuery):
 
         if not self.is_table_available(cat):
             if ((colRA is None) or (colDec is None)):
-                raise ValueError('Specify the name of the RA/Dec columns in the input table.')
+                raise ValueError(
+                    f"'{cat}' is not available on the XMatch server.If you are "
+                    "using a VizieR table name, note that only tables with "
+                    "coordinates are available on the XMatch server. If you are "
+                    f"using a local table, the arguments 'colRA{cat_index}' and "
+                    f"'colDec{cat_index}' must be provided.")
             # if `cat1` is not a VizieR table,
             # it is assumed it's either a URL or an uploaded table
             payload['colRA{0}'.format(cat_index)] = colRA

--- a/astroquery/xmatch/tests/test_xmatch.py
+++ b/astroquery/xmatch/tests/test_xmatch.py
@@ -1,5 +1,6 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 from pathlib import Path
+import re
 
 import requests
 import pytest
@@ -114,3 +115,13 @@ def test_two_local_tables():
                              max_distance=1 * arcsec,
                              get_query_payload=True)
     assert 'cat1' in payload[1]["files"] and 'cat2' in payload[1]["files"]
+
+
+def test_table_not_available(monkeypatch):
+    xm = XMatch()
+    monkeypatch.setattr(xm, '_request', request_mockreturn)
+    cat1 = "vizier:J/A+A/331/81/table2"
+    cat2 = "blabla"
+    # reproduces #1464
+    with pytest.raises(ValueError, match=f"'{re.escape(cat1)}' is not available *"):
+        xm.query_async(cat1=cat1, cat2=cat2, max_distance=5 * arcsec)


### PR DESCRIPTION
Fixes #1464 

This PR modifies the error message to reflect the two possible causes for failure:

- either the table does not exist in the XMatch server (typo in the table name, or this VizieR table has no coordinates, and thus cannot be cross matched)
- or the user needs to provide colRa and colDec (the only info that was given before)