### PR TITLE
Format MPC ephemeris error response as text (i.e., strip HTML tags).

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -89,6 +89,10 @@ mpc
 - Remove ``comettype`` parameter from ``MPC.get_observations`` without
   deprecation: it was undocumented, ignored, and had no effect.  [#3089]
 
+- When ``MPC.get_ephemeris`` raises an ``InvalidQueryError`` message, instead of
+  returning the original HTML formatted text, strip the HTML tags and return a
+  plain text message.  [#3171]
+
 nvas
 ^^^^
 

--- a/astroquery/mpc/core.py
+++ b/astroquery/mpc/core.py
@@ -1047,7 +1047,7 @@ class MPCClass(BaseQuery):
             content = result.content.decode()
             table_start = content.find('<pre>')
             if table_start == -1:
-                raise InvalidQueryError(content)
+                raise InvalidQueryError(BeautifulSoup(content, "html.parser").get_text())
             table_end = content.find('</pre>')
             text_table = content[table_start + 5:table_end]
             SKY = 'raty=a' in result.request.body


### PR DESCRIPTION
When raising an invalid query error, instead of setting the error content to:

```
<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN">
 <html>
 <head>
 <META HTTP-EQUIV="Content-Type" CONTENT="text/html; charset=ISO-8859-1">
 <title>Minor Planet Ephemeris Service: Query Results</title>
 </head>
 <body>
 <h1>Minor Planet Ephemeris Service: Query Results</h1>
 Below are the results of your request from the Minor Planet Center's
 Minor Planet Ephemeris Service.
 <p>
   Newly designated objects may take up to 1 day to show up in this service.
 </p>
 <p>
   Orbits and ephemerides of unnumbered NEOs are up-to-date. Other orbits are in
  the process of being refreshed.
 </p>
 <p>
   The current system is not completely reliable in the case of objects
   with very-close approaches with the Earth.
   <br></br> We are working on a completely new system,
   but for the time being we encourage the users to double check
   the results with other ephemeris generators when the object is very close to 
 Earth.
 </p>
 Ephemerides are for
 the geocenter.
 <p><hr><p>
No current elements found for 433P.  There may be published elements for this object; if there are, it is probably meaningless to make a current prediction of the basis of them.  However, when this  object is identified/recovered/rediscovered, elements will be available here.  If the designation refers to a recently designated object, ephemerides will generally be available on the day following assignment of the designation.
 <p><hr><p>
 These calculations have been performed on the
 <a href="http://www.minorplanetcenter.net/iau/Ack/TamkinFoundation.html">Tamkin
 Foundation Computing Network</a>.
 <p><hr>
 <p>
       <a href="http://validator.w3.org/check?uri=referer"><img border="0"
           src="http://www.w3.org/Icons/valid-html401"
           alt="Valid HTML 4.01!" height="31" width="88"></a>
 </p>
 </body>
 </html>

```

strip the HTML tags and give the user something that is easier to read:

```



Minor Planet Ephemeris Service: Query Results


Minor Planet Ephemeris Service: Query Results
 Below are the results of your request from the Minor Planet Center's
 Minor Planet Ephemeris Service.
 
   Newly designated objects may take up to 1 day to show up in this service.
 

   Orbits and ephemerides of unnumbered NEOs are up-to-date. Other orbits are in
  the process of being refreshed.
 

   The current system is not completely reliable in the case of objects
   with very-close approaches with the Earth.
    We are working on a completely new system,
   but for the time being we encourage the users to double check
   the results with other ephemeris generators when the object is very close to 
 Earth.
 
 Ephemerides are for
 the geocenter.
 
No current elements found for 433P.  There may be published elements for this object; if there are, it is probably meaningless to make a current prediction of the basis of them.  However, when this  object is identified/recovered/rediscovered, elements will be available here.  If the designation refers to a recently designated object, ephemerides will generally be available on the day following assignment of the designation.
 
 These calculations have been performed on the
 Tamkin
 Foundation Computing Network.
 

```