### PR TITLE
MAINT: fixing broken and redirected links

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1374,7 +1374,7 @@ casda
 dace
 ^^^^
 
-- Added DACE Service. See https://dace.unige.ch/ for details. [#1370]
+- Added DACE Service. See DACE website for details. [#1370]
 
 gemini
 ^^^^^^
@@ -1831,8 +1831,8 @@ Infrastructure, Utility and Other Changes and Additions
 - Fix NASA ADS, which had an internal syntax error [#602]
 - Bugfix in NRAO queries: telescope config was parsed incorrectly [#629]
 - IBE - added new module for locating data from PTF, WISE, and 2MASS from IRSA.
-  See <http://irsa.ipac.caltech.edu/ibe/> for more information about IBE and
-  <http://www.ptf.caltech.edu/page/ibe> for more information about PTF survey
+  See <https://irsa.ipac.caltech.edu:443/ibe/> for more information about IBE and
+  <https://www.ptf.caltech.edu/page/ibe> for more information about PTF survey
   data in particular. [#450]
 
 0.3.0 (2015-10-26)

--- a/astroquery/alma/core.py
+++ b/astroquery/alma/core.py
@@ -217,7 +217,7 @@ def get_enhanced_table(result):
     except ImportError:
         print(
             "Could not import astropy-regions, which is a requirement for get_enhanced_table function in alma."
-            "Please refer to http://astropy-regions.readthedocs.io/en/latest/installation.html for how to install it.")
+            "Please refer to https://astropy-regions.readthedocs.io/en/latest/installation.html for how to install it.")
         raise
 
     def _parse_stcs_string(input):
@@ -1143,7 +1143,7 @@ class AlmaClass(QueryWithLogin):
         List the file contents of a UID from Cycle 0.  Will raise an error
         if the UID is from cycle 1+, since those data have been released in
         a different and more consistent format.  See
-        https://almascience.org/documents-and-tools/cycle-2/ALMAQA2Productsv1.01.pdf
+        https://almascience.nrao.edu/documents-and-tools/cycle-2/ALMAQA2Productsv1.01.pdf
         for details.
         """
 

--- a/astroquery/astrometry_net/core.py
+++ b/astroquery/astrometry_net/core.py
@@ -346,7 +346,7 @@ class AstrometryNetClass(BaseQuery):
         """
         Plate solve from an image, either by uploading the image to
         astrometry.net or by finding sources locally using
-        `photutils <https://photutils.rtfd.io>`_ and solving with source
+        `photutils <https://photutils.readthedocs.io/en/stable/>`_ and solving with source
         locations.
 
         Parameters

--- a/astroquery/gama/__init__.py
+++ b/astroquery/gama/__init__.py
@@ -3,7 +3,7 @@
 gama
 ----
 Access to GAMA (Galaxy And Mass Assembly) data, via the DR2 SQL query form.
-http://www.gama-survey.org/dr3/query/
+https://www.gama-survey.org/dr3/query/
 
 :author: James T. Allen <james.thomas.allen@gmail.com>
 """

--- a/astroquery/hitran/__init__.py
+++ b/astroquery/hitran/__init__.py
@@ -13,7 +13,7 @@ class Conf(_config.ConfigNamespace):
     """
     Configuration parameters for `astroquery.hitran`.
     """
-    query_url = _config.ConfigItem('http://hitran.org/lbl/api',
+    query_url = _config.ConfigItem('https://hitran.org/lbl/api',
                                    'HITRAN web interface URL.')
     timeout = _config.ConfigItem(60,
                                  'Time limit for connecting to HITRAN server.')

--- a/astroquery/hitran/core.py
+++ b/astroquery/hitran/core.py
@@ -19,7 +19,7 @@ class HitranClass(BaseQuery):
                  'mol_name': 4}
 
 # Copied from the hapi.py code (Academic Free License)
-# http://hitran.org/static/hapi/hapi.py
+# https://hitran.org/static/hapi/hapi.py
 # M I id iso_name abundance mass mol_name
     ISO = {
         (1, 1): [1, 'H2(16O)', 0.997317, 18.010565, 'H2O'],

--- a/astroquery/imcce/core.py
+++ b/astroquery/imcce/core.py
@@ -396,7 +396,7 @@ Miriade = MiriadeClass()
 @async_to_sync
 class SkybotClass(BaseQuery):
     """A class for querying the `IMCCE SkyBoT
-    <http://vo.imcce.fr/webservices/skybot>`_ service.
+    <https://vo.imcce.fr/webservices/skybot/>`_ service.
     """
     _uri = None  # query uri
     _get_raw_response = False

--- a/astroquery/ipac/irsa/ibe/__init__.py
+++ b/astroquery/ipac/irsa/ibe/__init__.py
@@ -24,12 +24,10 @@ class Conf(_config.ConfigNamespace):
 
     dataset = _config.ConfigItem(
         'images',
-        ('Default data set. See, for example, '
-         'https://irsa.ipac.caltech.edu/ibe/search/ptf for options.'))
+        ('Default data set.'))
     table = _config.ConfigItem(
         'level1',
-        ('Default table. See, for example, '
-         'https://irsa.ipac.caltech.edu/ibe/search/ptf/images for options.'))
+        ('Default table.'))
     timeout = _config.ConfigItem(
         120,
         'Time limit for connecting to the IRSA server.')

--- a/astroquery/jplhorizons/core.py
+++ b/astroquery/jplhorizons/core.py
@@ -236,7 +236,7 @@ class HorizonsClass(BaseQuery):
         The following tables list the values queried, their definitions, data
         types, units, and original Horizons designations (where available). For
         more information on the definitions of these quantities, please refer to
-        the `Horizons User Manual <https://ssd.jpl.nasa.gov/?horizons_doc>`_.
+        the `Horizons User Manual <https://ssd.jpl.nasa.gov/horizons/manual.html>`_.
 
         +------------------+-----------------------------------------------+
         | Column Name      | Definition                                    |
@@ -561,12 +561,12 @@ class HorizonsClass(BaseQuery):
             corresponding to all the quantities to be queried from JPL Horizons
             using the coding according to the `JPL Horizons User Manual
             Definition of Observer Table Quantities
-            <https://ssd.jpl.nasa.gov/?horizons_doc#table_quantities>`_;
+            <https://ssd.jpl.nasa.gov/horizons/manual.html#obsquan>`_;
             default: all quantities
 
         optional_settings: dict, optional
             key-value based dictionary to inject some additional optional settings
-            See `Optional observer-table settings" <https://ssd.jpl.nasa.gov/horizons.cgi?s_tset=1>`_;
+            See `Optional observer-table settings" <https://ssd.jpl.nasa.gov/horizons/app.html>`_;
             default: empty optional setting
 
         get_query_payload : boolean, optional
@@ -744,7 +744,7 @@ class HorizonsClass(BaseQuery):
         The following table lists the values queried, their definitions, data
         types, units, and original Horizons designations (where available). For
         more information on the definitions of these quantities, please refer to
-        the `Horizons User Manual <https://ssd.jpl.nasa.gov/?horizons_doc>`_.
+        the `Horizons User Manual <https://ssd.jpl.nasa.gov/horizons/manual.html>`_.
 
         +------------------+-----------------------------------------------+
         | Column Name      | Definition                                    |
@@ -974,7 +974,7 @@ class HorizonsClass(BaseQuery):
         The following table lists the values queried, their definitions, data
         types, units, and original Horizons designations (where available). For
         more information on the definitions of these quantities, please refer to
-        the `Horizons User Manual <https://ssd.jpl.nasa.gov/?horizons_doc>`_.
+        the `Horizons User Manual <https://ssd.jpl.nasa.gov/horizons/manual.html>`_.
 
         +------------------+-----------------------------------------------+
         | Column Name      | Definition                                    |

--- a/astroquery/jplsbdb/core.py
+++ b/astroquery/jplsbdb/core.py
@@ -18,7 +18,7 @@ class SBDBClass(BaseQuery):
 
     """
     A class for querying the `JPL Small-Body Database Browser
-    <https://ssd.jpl.nasa.gov/sbdb.cgi>`_ service.
+    <https://ssd.jpl.nasa.gov/tools/sbdb_lookup.html>`_ service.
     """
 
     # internal flag whether to return the raw reponse
@@ -46,7 +46,7 @@ class SBDBClass(BaseQuery):
                     cache=True):
         """
         This method queries the `JPL Small-Body Database Browser
-        <https://ssd.jpl.nasa.gov/sbdb.cgi>`_ and returns an
+        <https://ssd.jpl.nasa.gov/tools/sbdb_lookup.html>`_ and returns an
         `~collections.OrderedDict` with all queried information.
 
         Parameters
@@ -94,7 +94,7 @@ class SBDBClass(BaseQuery):
         virtual_impactor: boolean, optional
             Provide information on a potential virtual impactor nature of the
             target from the `JPL Sentry system
-            <http://cneos.jpl.nasa.gov/sentry/>`_. Default: ``False``
+            <https://cneos.jpl.nasa.gov/sentry/>`_. Default: ``False``
         discovery: boolean, optional
             Output discovery circumstances and IAU name citation data.
             Default: ``False``

--- a/astroquery/lamda/__init__.py
+++ b/astroquery/lamda/__init__.py
@@ -6,7 +6,7 @@ LAMDA Query Tool
 :Author: Brian Svoboda (svobodb@email.arizona.edu)
 
 This package is for querying the Leiden Atomic and Molecular Database (LAMDA)
-hosted at: http://home.strw.leidenuniv.nl/~moldata/.
+hosted at: https://home.strw.leidenuniv.nl/~moldata/.
 
 Note:
   If you use the data files from LAMDA in your research work please refer to

--- a/astroquery/mast/auth.py
+++ b/astroquery/mast/auth.py
@@ -48,7 +48,7 @@ class MastAuth:
             Default is None.
             The token to authenticate the user.
             This can be generated at
-            https://auth.mast.stsci.edu/token?suggested_name=Astroquery&suggested_scope=mast:exclusive_access.
+            https://ssoportal.stsci.edu/idp/profile/SAML2/Redirect/SSO?execution=e1s1
             If not supplied, it will be prompted for if not in the keyring or set via $MAST_API_TOKEN
         store_token : bool, optional
             Default False.

--- a/astroquery/mast/core.py
+++ b/astroquery/mast/core.py
@@ -46,7 +46,7 @@ class MastQueryWithLogin(QueryWithLogin):
             Default is None.
             The token to authenticate the user.
             This can be generated at
-            https://auth.mast.stsci.edu/token?suggested_name=Astroquery&suggested_scope=mast:exclusive_access.
+            https://ssoportal.stsci.edu/idp/profile/SAML2/Redirect/SSO?execution=e1s1
             If not supplied, it will be prompted for if not in the keyring or set via $MAST_API_TOKEN
         store_token : bool, optional
             Default False.

--- a/astroquery/mast/cutouts.py
+++ b/astroquery/mast/cutouts.py
@@ -138,7 +138,7 @@ class TesscutClass(MastQueryWithLogin):
         objectname : str, optional
             The target around which to search, by name (objectname="M104")
             or TIC ID (objectname="TIC 141914082"). If moving_target is True, input must be the name or ID
-            (as understood by the `JPL ephemerides service <https://ssd.jpl.nasa.gov/horizons.cgi>`__)
+            (as understood by the `JPL ephemerides service <https://ssd.jpl.nasa.gov/horizons/app.html>`__)
             of a moving target such as an asteroid or comet.
 
             NOTE: If coordinates is supplied, this argument cannot be used.
@@ -173,7 +173,7 @@ class TesscutClass(MastQueryWithLogin):
 
             if not objectname:
                 raise InvalidQueryError("Please specify the object name or ID (as understood by the "
-                                        "`JPL ephemerides service <https://ssd.jpl.nasa.gov/horizons.cgi>`__) "
+                                        "`JPL ephemerides service <https://ssd.jpl.nasa.gov/horizons/app.html>`__) "
                                         "of a moving target such as an asteroid or comet.")
 
             params = {"product": product.upper(), "obj_id": objectname}
@@ -266,7 +266,7 @@ class TesscutClass(MastQueryWithLogin):
         objectname : str, optional
             The target around which to search, by name (objectname="M104")
             or TIC ID (objectname="TIC 141914082"). If moving_target is True, input must be the name or ID
-            (as understood by the `JPL ephemerides service <https://ssd.jpl.nasa.gov/horizons.cgi>`__)
+            (as understood by the `JPL ephemerides service <https://ssd.jpl.nasa.gov/horizons/app.html>`__)
             of a moving target such as an asteroid or comet.
 
             NOTE: If coordinates is supplied, this argument cannot be used.
@@ -300,7 +300,7 @@ class TesscutClass(MastQueryWithLogin):
 
             if not objectname:
                 raise InvalidQueryError("Please specify the object name or ID (as understood by the "
-                                        "`JPL ephemerides service <https://ssd.jpl.nasa.gov/horizons.cgi>`__) "
+                                        "`JPL ephemerides service <https://ssd.jpl.nasa.gov/horizons/app.html>`__) "
                                         "of a moving target such as an asteroid or comet.")
 
             astrocut_request = f"moving_target/astrocut?obj_id={objectname}&product={product.upper()}"
@@ -394,7 +394,7 @@ class TesscutClass(MastQueryWithLogin):
         objectname : str, optional
             The target around which to search, by name (objectname="M104")
             or TIC ID (objectname="TIC 141914082"). If moving_target is True, input must be the name or ID
-            (as understood by the `JPL ephemerides service <https://ssd.jpl.nasa.gov/horizons.cgi>`__)
+            (as understood by the `JPL ephemerides service <https://ssd.jpl.nasa.gov/horizons/app.html>`__)
             of a moving target such as an asteroid or comet.
 
             NOTE: If coordinates is supplied, this argument cannot be used.
@@ -437,7 +437,7 @@ class TesscutClass(MastQueryWithLogin):
 
             if not objectname:
                 raise InvalidQueryError("Please specify the object name or ID (as understood by the "
-                                        "`JPL ephemerides service <https://ssd.jpl.nasa.gov/horizons.cgi>`__) "
+                                        "`JPL ephemerides service <https://ssd.jpl.nasa.gov/horizons/app.html>`__) "
                                         "of a moving target such as an asteroid or comet.")
 
             param_dict["obj_id"] = objectname

--- a/astroquery/mocserver/core.py
+++ b/astroquery/mocserver/core.py
@@ -24,7 +24,7 @@ try:
     from regions import CircleSkyRegion, PolygonSkyRegion
 except ImportError:
     print("Could not import astropy-regions, which is a requirement for the CDS service."
-          "Please refer to http://astropy-regions.readthedocs.io/en/latest/installation.html for how to install it.")
+          "Please refer to https://astropy-regions.readthedocs.io/en/latest/installation.html for how to install it.")
 
 __all__ = ['MOCServerClass', 'MOCServer']
 

--- a/astroquery/open_exoplanet_catalogue/__init__.py
+++ b/astroquery/open_exoplanet_catalogue/__init__.py
@@ -3,9 +3,9 @@
 Access to the Open Exoplanet Catalogue.
 Hanno Rein 2013
 
-https://github.com/hannorein/open_exoplanet_catalogue
-https://github.com/hannorein/oec_meta
-http://openexoplanetcatalogue.com
+https://github.com/OpenExoplanetCatalogue/open_exoplanet_catalogue
+https://github.com/OpenExoplanetCatalogue/oec_meta
+https://openexoplanetcatalogue.com
 """
 from .oec_query import xml_element_to_dict, findvalue, get_catalogue
 

--- a/astroquery/skyview/core.py
+++ b/astroquery/skyview/core.py
@@ -178,7 +178,7 @@ class SkyViewClass(BaseQuery):
 
         References
         ----------
-        .. [1] http://skyview.gsfc.nasa.gov/current/help/fields.html
+        .. [1] https://skyview.gsfc.nasa.gov/current/help/fields.html
 
         Examples
         --------

--- a/astroquery/template_module/__init__.py
+++ b/astroquery/template_module/__init__.py
@@ -8,7 +8,7 @@
 """
 
 # Make the URL of the server, timeout and other items configurable
-# See <http://docs.astropy.org/en/latest/config/index.html#developer-usage>
+# See <https://docs.astropy.org/en/latest/config/index.html#developer-usage>
 # for docs and examples on how to do this
 # Below is a common use case
 from astropy import config as _config

--- a/astroquery/vo_conesearch/conesearch.py
+++ b/astroquery/vo_conesearch/conesearch.py
@@ -402,7 +402,7 @@ def predict_search(url, *args, **kwargs):
 
     plot : bool
         If `True`, plot will be displayed.
-        Plotting uses `matplotlib <http://matplotlib.sourceforge.net/>`_.
+        Plotting uses matplotlib.
 
     args, kwargs
         See :meth:`astroquery.vo_conesearch.core.ConeSearchClass.query_region`.

--- a/astroquery/wfau/core.py
+++ b/astroquery/wfau/core.py
@@ -26,7 +26,7 @@ class BaseWFAUClass(QueryWithLogin):
     """
     The BaseWFAUQuery class.  This is intended to be inherited by other classes
     that implement specific interfaces to Wide-Field Astronomy Unit
-    (http://www.roe.ac.uk/ifa/wfau/) archives
+    (https://www.roe.ac.uk/ifa/wfau/) archives
     """
     BASE_URL = ""
     LOGIN_URL = BASE_URL + "DBLogin"

--- a/docs/alma/alma.rst
+++ b/docs/alma/alma.rst
@@ -104,7 +104,7 @@ via the ALMA OIDC (OpenID Connect) service, Keycloak.
     Successfully logged in to asa.alma.cl
 
 Your password will be stored by the `keyring
-<https://pypi.python.org/pypi/keyring>`_ module.
+<https://pypi.org/project/keyring>`_ module.
 You can choose not to store your password by passing the argument
 ``store_password=False`` to ``Alma.login``.  You can delete your password later
 with the command ``keyring.delete_password('astroquery:asa.alma.cl',

--- a/docs/astrometry_net/astrometry_net.rst
+++ b/docs/astrometry_net/astrometry_net.rst
@@ -47,7 +47,7 @@ For more information about `astropy.config`, see: https://docs.astropy.org/en/st
 
 Using keyring to store API key
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-You can use the `keyring <https://pypi.python.org/pypi/keyring>`_ module to store your API key.
+You can use the `keyring <https://pypi.org/project/keyring>`_ library to store your API key.
 
 .. code-block:: python
 
@@ -56,7 +56,7 @@ You can use the `keyring <https://pypi.python.org/pypi/keyring>`_ module to stor
 
 If you have multiple users and keys you can change ``None`` to another name to assign usernames to different keys.
 
-Now you can include the `keyring <https://pypi.python.org/pypi/keyring>`_ module to set your API key.
+Now you can include the ``keyring`` module to set your API key.
 
 .. code-block:: python
 
@@ -76,7 +76,7 @@ For multiple users, replace the empty argument with the desired username.
 .. code-block:: python
 
     >>> ast.api_key = keyring.get_password('astroquery:astrometry_net', 'username')
-    
+
 .. note::
 
     Be aware that some information you submit to `astrometry.net`_ is publicly
@@ -404,4 +404,4 @@ Reference/API
     :no-inheritance-diagram:
 
 .. _astrometry.net: https://astrometry.net/
-.. _photutils: https://photutils.readthedocs.io
+.. _photutils: https://photutils.readthedocs.io/en/stable/

--- a/docs/atomic/atomic.rst
+++ b/docs/atomic/atomic.rst
@@ -13,7 +13,7 @@ parameters of which all are optional. In the example below, only a
 restricted set of the available parameters is used to keep it simple:
 ``wavelength_range``, ``wavelength_type``, ``wavelength_accuracy`` and
 ``element_spectrum``.  The respective web form for Atomic Line List can be
-found at http://www.pa.uky.edu/~peter/atomic/. As can be seen there, the
+found at https://linelist.pa.uky.edu/atomic/. As can be seen there, the
 first form fields are "Wavelength range" and "Unit". Because astroquery
 encourages the usage of AstroPy units, the expected type for the parameter
 ``wavelength_range`` is a tuple with two AstroPy quantities in it. This has
@@ -50,7 +50,7 @@ If you are repeatedly getting failed queries, or bad/out-of-date results, try cl
     >>> from astroquery.atomic import AtomicLineList
     >>> AtomicLineList.clear_cache()
 
-If this function is unavailable, upgrade your version of astroquery. 
+If this function is unavailable, upgrade your version of astroquery.
 The ``clear_cache`` function was introduced in version 0.4.7.dev8479.
 
 
@@ -60,4 +60,4 @@ Reference/API
 .. automodapi:: astroquery.atomic
     :no-inheritance-diagram:
 
-.. _source: http://www.pa.uky.edu/~peter/atomic/documentation.html
+.. _source: https://linelist.pa.uky.edu/atomic/documentation.html

--- a/docs/cadc/cadc.rst
+++ b/docs/cadc/cadc.rst
@@ -238,7 +238,7 @@ TAP provides two operation modes:
 The functions can be run as an authenticated user, the
 `~astroquery.cadc.CadcClass.list_async_jobs` function will error if
 not authenticated. For authentication you need an account with the
-CADC, go to http://www.cadc-ccda.hia-iha.nrc-cnrc.gc.ca/, choose a
+CADC, go to https://www.cadc-ccda.hia-iha.nrc-cnrc.gc.ca/, choose a
 language, click on Login in the top right area, click on the Request
 an Account link, enter your information and wait for confirmation of
 your account creation.

--- a/docs/casda/casda.rst
+++ b/docs/casda/casda.rst
@@ -5,9 +5,9 @@ CASDA Queries (`astroquery.casda`)
 **********************************
 
 The CSIRO ASKAP Science Data Archive (CASDA) provides access to science-ready data products
-from observations at the `Australian Square Kilometre Array Pathfinder (ASKAP) <https://www.atnf.csiro.au/projects/askap/index.html>`_ telescope.
+from observations at the `Australian Square Kilometre Array Pathfinder (ASKAP) <https://www.csiro.au/en/about/facilities-collections/atnf/askap-radio-telescope>`_ telescope.
 These data products include source catalogues, images, spectral line and polarisation cubes, spectra and visbilities.
-This package allows querying of the data products available in CASDA (`<https://casda.csiro.au/>`_).
+This package allows querying of the data products available in CASDA (`<https://research.csiro.au/casda>`_).
 
 Listing Data Products
 =====================
@@ -204,7 +204,7 @@ If you are repeatedly getting failed queries, or bad/out-of-date results, try cl
     >>> from astroquery.casda import Casda
     >>> Casda.clear_cache()
 
-If this function is unavailable, upgrade your version of astroquery. 
+If this function is unavailable, upgrade your version of astroquery.
 The ``clear_cache`` function was introduced in version 0.4.7.dev8479.
 
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -198,3 +198,14 @@ if eval(setup_cfg.get('edit_on_github')):
 
 nitpicky = True
 nitpick_ignore = [('py:class', 'astroquery.mast.core.MastQueryWithLogin')]
+
+
+# -- Linkcheck builder options ----------------------------------------------
+#
+
+# These anchors don't resolve with the linkchecker, but work well from the browser
+linkcheck_ignore = ['https://mast.stsci.edu/search/ui/#/jwst',
+                    'https://mast.stsci.edu/search/ui/#/hst',
+                    'https://nxsa.esac.esa.int/nxsa-web/#aio',
+                    'https://ssd.jpl.nasa.gov/horizons/manual.html#center',
+                    'https://splatalogue.online/#/basic']

--- a/docs/esa/hubble/hubble.rst
+++ b/docs/esa/hubble/hubble.rst
@@ -14,7 +14,7 @@ important science projects ever, with over 500 000 observations of more than
 30000 targets available for retrieval from the Archive.
 
 This package allows the access to the `European Space Agency Hubble Archive
-<http://hst.esac.esa.int/ehst/>`__. All the HST observations available
+<https://hst.esac.esa.int/ehst/>`__. All the HST observations available
 in the EHST are synchronised with the MAST services for HST reprocessed
 public data and corresponding metadata.  Therefore, excluding proprietary
 data, all HST data in the EHST are identical to those in MAST.

--- a/docs/esa/iso/iso.rst
+++ b/docs/esa/iso/iso.rst
@@ -12,7 +12,7 @@ jointly covered wavelengths from 2.5 to around 240 microns with spatial resoluti
 arcseconds (at the shortest wavelengths) to 90 arcseconds (at the longer wavelengths). Its 60 cm diameter
 telescope was cooled by superfluid liquid helium to temperatures of 2-4 K.
 
-This package allows the access to the `ISO Data Archive <http://nida.esac.esa.int/nida-cl-web/>`__.
+This package allows the access to the `ISO Data Archive <https://nida.esac.esa.int/nida-cl-web/>`__.
 It has been developed by the ESAC Science Data Centre (ESDC) with requirements provided by the
 ESA experts at ESAC.
 
@@ -120,7 +120,7 @@ There are two valid values for 'retrieval_type': OBSERVATION and STANDALONE. OBS
 used commonly to download data from the archive and STANDALONE returns a Virtual Observatory
 product (if any).
 
-For more info on the data products, please check 'http://nida.esac.esa.int/nida-cl-web/',
+For more info on the data products, please check 'https://nida.esac.esa.int/nida-cl-web/',
 "IDA USERS GUIDE" section.
 
 Both query and download methods are designed to be used in coordination. For example, we can query
@@ -248,7 +248,7 @@ All these tables can be queried using the TAP interface and allow geometrical qu
   >>> result_table = Simbad.query_object("M31")
   >>> print(result_table)    # doctest: +IGNORE_OUTPUT
   main_id         ra                dec         ...     coo_bibcode     matched_id
-                 deg                deg         ...                               
+                 deg                deg         ...
   ------- ------------------ ------------------ ... ------------------- ----------
     M  31 10.684708333333333 41.268750000000004 ... 2006AJ....131.1163S      M  31
   >>> c = SkyCoord(result_table['ra'], result_table['dec'], unit=(u.deg, u.deg),

--- a/docs/esa/xmm_newton/xmm_newton.rst
+++ b/docs/esa/xmm_newton/xmm_newton.rst
@@ -9,7 +9,7 @@ The X-ray Multi-Mirror Mission, XMM-Newton, is an ESA X-ray observatory launched
 It carries 3 high-throughput X-ray telescopes with unprecedented effective area and an Optical Monitor,
 the first flown on an X-ray observatory.
 
-This package allows the access to the `XMM-Newton Science Archive <http://nxsa.esac.esa.int/nxsa-web/>`__.
+This package allows the access to the `XMM-Newton Science Archive <https://nxsa.esac.esa.int/nxsa-web/>`__.
 It has been developed by the ESAC Science Data Centre (ESDC) with requirements provided by the
 XMM-Newton Science Operations Centre.
 
@@ -35,7 +35,7 @@ This will download all PPS files for the observation '0505720401' and instrument
 it will store them in a tar called 'result0505720401.tar'. The parameters available are detailed in the API.
 
 For more details of the parameters check the section 3.4 at:
-		'http://nxsa.esac.esa.int/nxsa-web/#aio'
+		'https://nxsa.esac.esa.int/nxsa-web/#aio'
 
 --------------------------------------
 2. Getting XMM-Newton proprietary data

--- a/docs/esasky/esasky.rst
+++ b/docs/esasky/esasky.rst
@@ -14,13 +14,13 @@ ESASky Queries (`astroquery.esasky`)
 Getting started
 ===============
 
-This is a python interface for querying the `ESASky web service <http://www.cosmos.esa.int/web/esdc/esasky>`__.
+This is a python interface for querying the `ESASky web service <https://www.cosmos.esa.int/web/esdc/esasky-how-to>`__.
 This module supports cone searches and download of data products from all missions available in ESASky. You can also use
 the ESASky Solar System Object crossmatch methods to get all observations (both targeted and serendipitous) of a solar
 system object.
 
 There are 4 categories of methods, based on the type of data: catalogs, observations, spectra, and SSO. `Documentation
-on the ESASky web service can be found here. <http://www.cosmos.esa.int/web/esdc/esasky-help>`__
+on the ESASky web service can be found here. <https://www.cosmos.esa.int/web/esdc/esasky-help>`__
 
 Get the available catalog names
 -------------------------------

--- a/docs/eso/eso.rst
+++ b/docs/eso/eso.rst
@@ -78,7 +78,7 @@ Automatic password
 ------------------
 
 As shown above, your password can be stored by the `keyring
-<https://pypi.python.org/pypi/keyring>`_ module, if you
+<https://pypi.org/project/keyring>`_ module, if you
 pass the argument ``store_password=True`` to ``Eso.login()``.
 For security reason, storing the password is turned off by default.
 
@@ -92,7 +92,7 @@ Automatic login
 
 You can further automate the authentication process by configuring a default username.
 The astroquery configuration file, which can be found following the procedure
-detailed in `astropy.config <http://docs.astropy.org/en/stable/config/index.html>`_,
+detailed in `astropy.config <https://docs.astropy.org/en/stable/config/index.html>`_,
 needs to be edited by adding ``username = ICONDOR`` in the ``[eso]`` section.
 
 When configured, the username in the ``login()`` method call can be omitted
@@ -393,7 +393,7 @@ If you are repeatedly getting failed queries, or bad/out-of-date results, try cl
     >>> from astroquery.eso import Eso
     >>> Eso.clear_cache()
 
-If this function is unavailable, upgrade your version of astroquery. 
+If this function is unavailable, upgrade your version of astroquery.
 The ``clear_cache`` function was introduced in version 0.4.7.dev8479.
 
 

--- a/docs/gaia/gaia.rst
+++ b/docs/gaia/gaia.rst
@@ -279,7 +279,7 @@ time of the query exceeds time execution limit; see here archive_tips_ for detai
 of the synchronous queries is limited to 2000 rows. If you need more than that, you must use
 asynchronous queries.
 
-.. _archive_tips: https://www.cosmos.esa.int/web/gaia/archive-tips
+.. _archive_tips: https://www.cosmos.esa.int/web/gaia/faqs
 
 The results can be saved in memory (default) or in a file.
 

--- a/docs/gama/gama.rst
+++ b/docs/gama/gama.rst
@@ -71,4 +71,4 @@ Reference/API
 .. automodapi:: astroquery.gama
     :no-inheritance-diagram:
 
-.. _astropy.table.Table: http://docs.astropy.org/en/latest/table/index.html
+.. _astropy.table.Table: https://docs.astropy.org/en/latest/table/index.html

--- a/docs/gemini/gemini.rst
+++ b/docs/gemini/gemini.rst
@@ -24,7 +24,7 @@ Positional queries can be based on a sky position.  Radius is an optional parame
                >>> coord = coordinates.SkyCoord(210.80242917, 54.34875, unit="deg")
                >>> data = Observations.query_region(coordinates=coord, radius=0.3*units.deg)
                >>> print(data[0:5])
-               exposure_time detector_roi_setting ...  release         dec      
+               exposure_time detector_roi_setting ...  release         dec
                ------------- -------------------- ... ---------- ---------------
                   119.998583           Full Frame ... 2008-08-21  54.34877772501
                   119.998312           Full Frame ... 2008-09-25 54.376194395654
@@ -43,7 +43,7 @@ You may also do a query by the name of the object you are interested in.
                 >>> from astroquery.gemini import Observations
                 >>> data = Observations.query_object(objectname='m101')
                 >>> print(data[0:5])
-                exposure_time detector_roi_setting ...  release         dec      
+                exposure_time detector_roi_setting ...  release         dec
                 ------------- -------------------- ... ---------- ---------------
                            --            Undefined ... 2013-12-21              --
                            --            Undefined ... 2013-12-21              --
@@ -133,7 +133,7 @@ Authenticated Sessions
 ----------------------
 
 The Gemini module allows for authenticated sessions using your GOA account.  This is the same account you login
-with on the GOA homepage at `<https://archive.gemini.edu/>`__.  The `astroquery.gemini.ObservationsClass.login`
+with on the GOA homepage at `<https://archive.gemini.edu/searchform>`__.  The `astroquery.gemini.ObservationsClass.login`
 method returns `True` if successful.
 
 .. doctest-skip::

--- a/docs/hitran/hitran.rst
+++ b/docs/hitran/hitran.rst
@@ -65,4 +65,4 @@ Reference/API
 .. automodapi:: astroquery.hitran
     :no-inheritance-diagram:
 
-.. _HITRAN: http://hitran.org
+.. _HITRAN: https://hitran.org

--- a/docs/imcce/imcce.rst
+++ b/docs/imcce/imcce.rst
@@ -463,7 +463,7 @@ This submodule makes use of IMCCE's `SkyBoT
 Miriade service
 <https://ssp.imcce.fr/webservices/miriade//>`_. Additional information on
 SkyBoT can be obtained from `Berthier et al. 2006
-<https://adsabs.harvard.edu/abs/2006ASPC..351..367B>`_.
+<https://ui.adsabs.harvard.edu/abs/2006ASPC..351..367B/abstract>`_.
 
 Please consider the following notes from IMCCE:
 
@@ -471,7 +471,7 @@ Please consider the following notes from IMCCE:
   acknowledgment would be appreciated: "*This research has made use of
   IMCCE's SkyBoT VO tool*", or cite the following article
   `2006ASPC..351..367B
-  <https://adsabs.harvard.edu/abs/2006ASPC..351..367B>`_.
+  <https://ui.adsabs.harvard.edu/abs/2006ASPC..351..367B/abstract>`_.
 * If Miriade was helpful for your research work, the following
   acknowledgment would be appreciated: "*This research has made use of
   IMCCE's Miriade VO tool*"

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -2,7 +2,7 @@ Astroquery
 ==========
 
 This is the documentation for the Astroquery coordinated package of `astropy
-<http://www.astropy.org>`__.
+<https://www.astropy.org>`__.
 
 Code and issue tracker are on `GitHub <https://github.com/astropy/astroquery>`_.
 
@@ -99,24 +99,24 @@ Astroquery works with Python 3.9 or later.
 
 The following packages are required for astroquery installation & use:
 
-* `numpy <http://www.numpy.org>`_ >= 1.20
-* `astropy <http://www.astropy.org>`__ (>=5.0)
+* `numpy <https://numpy.org>`_ >= 1.20
+* `astropy <https://www.astropy.org>`__ (>=5.0)
 * `pyVO`_ (>=1.5)
 * `requests <https://requests.readthedocs.io/en/latest/>`_
-* `keyring <https://pypi.python.org/pypi/keyring>`_
+* `keyring <https://pypi.org/project/keyring>`_
 * `Beautiful Soup <https://www.crummy.com/software/BeautifulSoup/>`_
-* `html5lib <https://pypi.python.org/pypi/html5lib>`_
+* `html5lib <https://pypi.org/project/html5lib>`_
 
 and for running the tests:
 
-* `curl <https://curl.haxx.se/>`__
+* `curl <https://curl.se/>`__
 * `pytest-astropy <https://github.com/astropy/pytest-astropy>`__
 * `pytest-rerunfailures <https://github.com/pytest-dev/pytest-rerunfailures>`__
 
 The following packages are optional dependencies and are required for the
 full functionality of the `~astroquery.mocserver`, `~astroquery.alma`, and `~astroquery.xmatch` modules:
 
-* `astropy-healpix <http://astropy-healpix.readthedocs.io/en/latest/>`_
+* `astropy-healpix <https://astropy-healpix.readthedocs.io/en/latest/>`_
 * `regions <https://astropy-regions.readthedocs.io/en/latest/>`_
 * `mocpy <https://cds-astro.github.io/mocpy/>`_ >= 0.9
 
@@ -128,7 +128,7 @@ For the `~astroquery.vamdc` module:
 The following packages are optional dependencies and are required for the
 full functionality of the `~astroquery.mast` module:
 
-* `boto3 <https://boto3.readthedocs.io/>`_
+* `boto3 <https://boto3.amazonaws.com/v1/documentation/api/latest/index.html>`_
 
 Using astroquery
 ----------------

--- a/docs/ipac/irsa/irsa.rst
+++ b/docs/ipac/irsa/irsa.rst
@@ -183,10 +183,6 @@ star HIP 12 with just the ra, dec and w1mpro columns would be:
     --------- ----------- ------
     0.0407905 -35.9602605  4.837
 
-A list of available columns for each catalog can be found at
-https://irsa.ipac.caltech.edu/holdings/catalogs.html. The "Long Form" button
-at the top of the column names table must be clicked to access a full list
-of all available columns.
 
 Direct TAP query to the IRSA server
 -----------------------------------

--- a/docs/ipac/irsa/irsa_dust/irsa_dust.rst
+++ b/docs/ipac/irsa/irsa_dust/irsa_dust.rst
@@ -186,5 +186,5 @@ Reference/API
 .. automodapi:: astroquery.ipac.irsa.irsa_dust
     :no-inheritance-diagram:
 
-.. _IRSA Dust Extinction Service: http://irsa.ipac.caltech.edu/applications/DUST/index.html
-.. _IRSA DUST coordinates description page: http://irsa.ipac.caltech.edu/applications/DUST/docs/coordinate.html
+.. _IRSA Dust Extinction Service: https://irsa.ipac.caltech.edu:443/applications/DUST/index.html
+.. _IRSA DUST coordinates description page: https://irsa.ipac.caltech.edu:443/applications/DUST/docs/coordinate.html

--- a/docs/jplsbdb/jplsbdb.rst
+++ b/docs/jplsbdb/jplsbdb.rst
@@ -10,7 +10,7 @@ Overview
 
 The :class:`~astroquery.jplsbdb.SBDBClass` class provides
 an interface to the `Small-Body Database Browser
-<https://ssd.jpl.nasa.gov/sbdb.cgi>`_ (SBDB) maintained by the `JPL
+<https://ssd.jpl.nasa.gov/tools/sbdb_lookup.html>`_ (SBDB) maintained by the `JPL
 Solar System Dynamics group <https://ssd.jpl.nasa.gov/>`_.
 
 The SBDB provides detailed information on a specific known small body,
@@ -279,7 +279,7 @@ Acknowledgements
 ================
 
 This submodule makes use of the `JPL Horizons
-<https://ssd.jpl.nasa.gov/sbdb.cgi>`_ system.
+<https://ssd.jpl.nasa.gov/tools/sbdb_lookup.html>`_ system.
 
 The development of this submodule is funded through NASA PDART
 Grant No. 80NSSC18K0987 to the `sbpy project <https://sbpy.org>`_.
@@ -295,7 +295,7 @@ If you are repeatedly getting failed queries, or bad/out-of-date results, try cl
     >>> from astroquery.jplsbdb import SBDB
     >>> SBDB.clear_cache()
 
-If this function is unavailable, upgrade your version of astroquery. 
+If this function is unavailable, upgrade your version of astroquery.
 The ``clear_cache`` function was introduced in version 0.4.7.dev8479.
 
 

--- a/docs/lamda/lamda.rst
+++ b/docs/lamda/lamda.rst
@@ -34,7 +34,7 @@ want to reload the cache, clear the cache and remove the molecule dictionary as 
     >>> Lamda.clear_cache()
     >>> os.remove(Lamda.moldict_path)
 
-If this function is unavailable, upgrade your version of astroquery. 
+If this function is unavailable, upgrade your version of astroquery.
 The ``clear_cache`` function was introduced in version 0.4.7.dev8479.
 
 You can query for any molecule in that dictionary.
@@ -54,4 +54,4 @@ Reference/API
 .. automodapi:: astroquery.lamda
     :no-inheritance-diagram:
 
-.. _LAMDA: http://home.strw.leidenuniv.nl/~moldata/
+.. _LAMDA: https://home.strw.leidenuniv.nl/~moldata/

--- a/docs/mast/mast.rst
+++ b/docs/mast/mast.rst
@@ -54,7 +54,7 @@ or by initializing a class instance with credentials.
 
 If a token is not supplied, the user will be prompted to enter one.
 
-To view tokens accessible through your account, visit https://auth.mast.stsci.edu
+To view tokens accessible through your account, visit https://auth.mast.stsci.edu/info
 
 .. doctest-skip::
 

--- a/docs/mast/mast_cut.rst
+++ b/docs/mast/mast_cut.rst
@@ -57,9 +57,9 @@ not explicitly called for TICA.
    >>> hdulist[0].info()  # doctest: +IGNORE_OUTPUT
    Filename: <class '_io.BytesIO'>
    No.    Name      Ver    Type      Cards   Dimensions   Format
-   0  PRIMARY       1 PrimaryHDU      57   ()      
-   1  PIXELS        1 BinTableHDU    281   3495R x 12C   [D, E, J, 25J, 25E, 25E, 25E, 25E, J, E, E, 38A]   
-   2  APERTURE      1 ImageHDU        82   (5, 5)   int32  
+   0  PRIMARY       1 PrimaryHDU      57   ()
+   1  PIXELS        1 BinTableHDU    281   3495R x 12C   [D, E, J, 25J, 25E, 25E, 25E, 25E, J, E, E, 38A]
+   2  APERTURE      1 ImageHDU        82   (5, 5)   int32
 
 
 For users with time-sensitive targets who would like cutouts from the latest observations,
@@ -72,7 +72,7 @@ this example shows a request for TICA cutouts:
    >>> from astropy.coordinates import SkyCoord
    ...
    >>> cutout_coord = SkyCoord(107.18696, -70.50919, unit="deg")
-   >>> hdulist = Tesscut.get_cutouts(coordinates=cutout_coord, 
+   >>> hdulist = Tesscut.get_cutouts(coordinates=cutout_coord,
    ...                               product='tica',
    ...                               sector=28)
    >>> hdulist[0][0].header['FFI_TYPE']  # doctest: +IGNORE_OUTPUT
@@ -100,7 +100,7 @@ and returns a target pixel file, with format described
 `here <https://astrocut.readthedocs.io/en/latest/astrocut/file_formats.html#path-focused-target-pixel-files>`__.
 The moving_target is an optional bool argument where `True` signifies that the accompanying ``objectname``
 input is the object name or ID understood by the
-`JPL Horizon ephemerades interface <https://ssd.jpl.nasa.gov/horizons.cgi>`__.
+`JPL Horizon ephemerades interface <https://ssd.jpl.nasa.gov/horizons/app.html>`__.
 The default value for moving_target is set to False. Therefore, a non-moving target can be input
 simply with either the objectname or coordinates.
 
@@ -125,9 +125,9 @@ parameter will result in an error when set to 'TICA'.
 
    >>> from astroquery.mast import Tesscut
    ...
-   >>> hdulist = Tesscut.get_cutouts(objectname="Eleonora", 
-   ...                               product='tica', 
-   ...                               moving_target=True, 
+   >>> hdulist = Tesscut.get_cutouts(objectname="Eleonora",
+   ...                               product='tica',
+   ...                               moving_target=True,
    ...                               sector=6)
    Traceback (most recent call last):
    ...
@@ -148,7 +148,7 @@ pixel file will be produced for each one.
    >>> import astropy.units as u
    ...
    >>> cutout_coord = SkyCoord(107.18696, -70.50919, unit="deg")
-   >>> manifest = Tesscut.download_cutouts(coordinates=cutout_coord, 
+   >>> manifest = Tesscut.download_cutouts(coordinates=cutout_coord,
    ...                                     size=[5, 5]*u.arcmin,
    ...                                     sector=9) # doctest: +IGNORE_OUTPUT
    Downloading URL https://mast.stsci.edu/tesscut/api/v0.1/astrocut?ra=107.18696&dec=-70.50919&y=0.08333333333333333&x=0.11666666666666667&units=d&sector=9 to ./tesscut_20210716150026.zip ... [Done]
@@ -168,9 +168,9 @@ and because the TICA products are not available for sectors 1-26, we request cut
    >>> import astropy.units as u
    ...
    >>> cutout_coord = SkyCoord(107.18696, -70.50919, unit="deg")
-   >>> manifest = Tesscut.download_cutouts(coordinates=cutout_coord, 
-   ...                                     product='tica', 
-   ...                                     size=[5, 7]*u.arcmin, 
+   >>> manifest = Tesscut.download_cutouts(coordinates=cutout_coord,
+   ...                                     product='tica',
+   ...                                     size=[5, 7]*u.arcmin,
    ...                                     sector=27) # doctest: +IGNORE_OUTPUT
    Downloading URL https://mast.stsci.edu/tesscut/api/v0.1/astrocut?ra=107.18696&dec=-70.50919&y=0.08333333333333333&x=0.11666666666666667&units=d&product=TICA&sector=27 to ./tesscut_20230214150644.zip ... [Done]
    >>> print(manifest)  # doctest: +IGNORE_OUTPUT
@@ -293,9 +293,9 @@ If a given coordinate appears in more than one Zcut survey, a cutout will be pro
    >>> from astropy.coordinates import SkyCoord
    ...
    >>> cutout_coord = SkyCoord(189.49206, 62.20615, unit="deg")
-   >>> manifest = Zcut.download_cutouts(coordinates=cutout_coord, 
-   ...                                  size=[5, 10], 
-   ...                                  units="px", 
+   >>> manifest = Zcut.download_cutouts(coordinates=cutout_coord,
+   ...                                  size=[5, 10],
+   ...                                  units="px",
    ...                                  survey="3dhst_goods-n")  # doctest: +IGNORE_OUTPUT
    Downloading URL https://mast.stsci.edu/zcut/api/v0.1/astrocut?ra=189.49206&dec=62.20615&y=200&x=300&units=px&format=fits to ./zcut_20210125155545.zip ... [Done]
    Inflating...
@@ -304,15 +304,15 @@ If a given coordinate appears in more than one Zcut survey, a cutout will be pro
                                  Local Path
    -------------------------------------------------------------------------
    ./candels_gn_30mas_189.492060_62.206150_300.0pix-x-200.0pix_astrocut.fits
-   >>> manifest = Zcut.download_cutouts(coordinates=cutout_coord, 
-   ...                                  size=[5, 10], 
-   ...                                  units="px", 
+   >>> manifest = Zcut.download_cutouts(coordinates=cutout_coord,
+   ...                                  size=[5, 10],
+   ...                                  units="px",
    ...                                  survey="3dhst_goods-n",
    ...                                  cutout_format="jpg")  # doctest: +IGNORE_OUTPUT
    Downloading URL https://mast.stsci.edu/zcut/api/v0.1/astrocut?ra=189.49206&dec=62.20615&y=200&x=300&units=px&format=jpg to ./zcut_20201202132453.zip ... [Done]
    ...
    >>> print(manifest)
-                                                Local Path                                             
+                                                Local Path
    -----------------------------------------------------------------------------------------------------
       ./hlsp_3dhst_spitzer_irac_goods-n_irac1_v4.0_sc_189.492060_62.206150_10.0pix-x-5.0pix_astrocut.jpg
    ./hlsp_3dhst_spitzer_irac_goods-n-s2_irac3_v4.0_sc_189.492060_62.206150_10.0pix-x-5.0pix_astrocut.jpg

--- a/docs/mast/mast_mastquery.rst
+++ b/docs/mast/mast_mastquery.rst
@@ -7,7 +7,7 @@ The Mast class provides more direct access to the MAST interface.  It requires
 more knowledge of the inner workings of the MAST API, and should be rarely
 needed.  However in the case of new functionality not yet implemented in
 astroquery, this class does allow access.  See the
-`MAST api documentation <https://mast.stsci.edu/api>`__ for more
+`MAST api documentation <https://mast.stsci.edu/api/v0/>`__ for more
 information.
 
 The basic MAST query function allows users to query through the following
@@ -69,7 +69,7 @@ Valid parameters for TIC and CTL services are detailed in the
    >>> observations = Mast.mast_query('Mast.Catalogs.Filtered.Tic.Rows',
    ...                                columns='id',
    ...                                dec=[{'min': -90, 'max': -30}],
-   ...                                Teff=[{'min': 4250, 'max': 4500}], 
+   ...                                Teff=[{'min': 4250, 'max': 4500}],
    ...                                logg=[{'min': 4.5, 'max': 5.0}],
    ...                                Tmag=[{'min': 8, 'max': 10}])
    >>> print(observations) # doctest: +IGNORE_OUTPUT
@@ -102,7 +102,7 @@ not mask the output tables using the columns parameter. Additionally, using a
    >>> observations = Mast.mast_query('Mast.Catalogs.Filtered.Tic.Rows',
    ...                                columns = 'COUNT_BIG(*)',
    ...                                dec=[{'min': -90, 'max': -30}],
-   ...                                Teff=[{'min': 4250, 'max': 4500}], 
+   ...                                Teff=[{'min': 4250, 'max': 4500}],
    ...                                logg=[{'min': 4.5, 'max': 5.0}],
    ...                                Tmag=[{'min': 8, 'max': 10}])
    Traceback (most recent call last):
@@ -163,7 +163,7 @@ for more information on valid service parameters.
    ...
    >>> observations = Mast.mast_query('Mast.Caom.Cone',
    ...                                columns='ra',
-   ...                                Teff=[{'min': 4250, 'max': 4500}], 
+   ...                                Teff=[{'min': 4250, 'max': 4500}],
    ...                                logg=[{'min': 4.5, 'max': 5.0}])
    Traceback (most recent call last):
    ...

--- a/docs/mocserver/mocserver.rst
+++ b/docs/mocserver/mocserver.rst
@@ -19,7 +19,7 @@ For those wanting to know more about MOCs, please refer to this `IVOA paper
 <http://ivoa.net/documents/MOC/20140602/REC-MOC-1.0-20140602.pdf>`_ and the `MOCPy's documentation
 <https://github.com/cds-astro/mocpy>`_ developed by the CDS.
 
-CDS has set up a server known as the `MOCServer <http://alasky.unistra.fr/MocServer/query?>`_ storing data-set names
+CDS has set up a server known as the `MOCServer <http://alasky.unistra.fr/MocServer/query>`_ storing data-set names
 each associated with a MOC spatial coverage and some meta-datas giving a more detailed explanation of the data-set.
 
 The MOCServer aims at returning the data-sets having at least one source lying in a specific sky region defined by the
@@ -448,6 +448,6 @@ Reference/API
 
 .. _CDS MOCServer: http://alasky.unistra.fr/MocServer/query
 .. _IVOA standard: http://ivoa.net/documents/MOC/20140602/REC-MOC-1.0-20140602.pdf
-.. _astropy-healpix: http://astropy-healpix.readthedocs.io/en/latest/
+.. _astropy-healpix: https://astropy-healpix.readthedocs.io/en/latest/
 .. _regions: https://github.com/astropy/regions
 .. _mocpy: https://github.com/cds-astro/mocpy

--- a/docs/ogle/ogle.rst
+++ b/docs/ogle/ogle.rst
@@ -49,7 +49,7 @@ If you are repeatedly getting failed queries, or bad/out-of-date results, try cl
     >>> from astroquery.ogle import Ogle
     >>> Ogle.clear_cache()
 
-If this function is unavailable, upgrade your version of astroquery. 
+If this function is unavailable, upgrade your version of astroquery.
 The ``clear_cache`` function was introduced in version 0.4.7.dev8479.
 
 
@@ -59,4 +59,4 @@ Reference/API
 .. automodapi:: astroquery.ogle
     :no-inheritance-diagram:
 
-.. _calculator: http://ogle.astrouw.edu.pl/
+.. _calculator: https://ogle.astrouw.edu.pl/

--- a/docs/skyview/skyview.rst
+++ b/docs/skyview/skyview.rst
@@ -7,7 +7,7 @@ Skyview Queries (`astroquery.skyview`)
 Getting started
 ===============
 
-The `SkyView <https://skyview.gsfc.nasa.gov/>`_ service offers a cutout service for a
+The `SkyView <https://skyview.gsfc.nasa.gov/current/cgi/titlepage.pl>`_ service offers a cutout service for a
 number of imaging surveys.
 
 To see the list of surveys, use the `~astroquery.skyview.SkyViewClass.list_surveys` method.
@@ -237,7 +237,7 @@ If you are repeatedly getting failed queries, or bad/out-of-date results, try cl
     >>> from astroquery.skyview import SkyView
     >>> SkyView.clear_cache()
 
-If this function is unavailable, upgrade your version of astroquery. 
+If this function is unavailable, upgrade your version of astroquery.
 The ``clear_cache`` function was introduced in version 0.4.7.dev8479.
 
 

--- a/docs/splatalogue/splatalogue.rst
+++ b/docs/splatalogue/splatalogue.rst
@@ -129,7 +129,7 @@ size of the printout and assist with doctests; it is not needed as the default
           1370                                             CH<sub>3</sub>O<sup>13</sup>CHO (TopModel)                       Methyl Formate ...                        None             0
          21026                                                                   CH3O13CHO, vt = 0, 1 Methyl formate, v<sub>t</sub> = 0, 1 ...                        None             0
           1314                     H<sub>2</sub>NCH<sub>2</sub>COOH - II <font color="red">v=1</font>                              Glycine ...                        None             0
-          1284                                   cis-CH<sub>2</sub>OHCHO <font color="red">v=3</font>                       Glycolaldehyde ...                        None             0          
+          1284                                   cis-CH<sub>2</sub>OHCHO <font color="red">v=3</font>                       Glycolaldehyde ...                        None             0
 
 Querying just by frequency isn't particularly effective; a nicer approach is to
 use both frequency and chemical name.  If you can remember that CO 2-1 is approximately
@@ -260,10 +260,10 @@ If you are repeatedly getting failed queries, or bad/out-of-date results, try cl
     >>> from astroquery.splatalogue import Splatalogue
     >>> Splatalogue.clear_cache()
 
-If this function is unavailable, upgrade your version of astroquery. 
+If this function is unavailable, upgrade your version of astroquery.
 The ``clear_cache`` function was introduced in version 0.4.7.dev8479.
 
-       
+
 Reference/API
 =============
 
@@ -272,4 +272,4 @@ Reference/API
 
 .. _Splatalogue: https://www.splatalogue.online
 .. _Splatalogue web service: https://splatalogue.online/
-.. _query interface: https://splatalogue.online//b.php
+.. _query interface: https://splatalogue.online/#/basic

--- a/docs/vamdc/vamdc.rst
+++ b/docs/vamdc/vamdc.rst
@@ -41,4 +41,4 @@ Reference/API
 .. automodapi:: astroquery.vamdc
     :no-inheritance-diagram:
 
-.. _vamdclib: http://vamdclib.readthedocs.io/en/latest/
+.. _vamdclib: https://vamdclib.readthedocs.io/en/latest/

--- a/docs/vo_conesearch/vo_conesearch.rst
+++ b/docs/vo_conesearch/vo_conesearch.rst
@@ -193,7 +193,7 @@ The one that a typical user needs is the :ref:`vo-sec-client-scs` component
 See Also
 ========
 
-- `Simple Cone Search Version 1.03, IVOA Recommendation (22 February 2008) <http://www.ivoa.net/Documents/REC/DAL/ConeSearch-20080222.html>`_
+- `Simple Cone Search Version 1.03, IVOA Recommendation (22 February 2008) <http://www.ivoa.net/documents/REC/DAL/ConeSearch-20080222.html>`_
 
 - `STScI VAO Registry <http://vao.stsci.edu/directory/NVORegInt.asmx?op=VOTCapabilityPredOpt>`_
 
@@ -210,10 +210,10 @@ If you are repeatedly getting failed queries, or bad/out-of-date results, try cl
     >>> from astroquery.vo_conesearch import ConeSearch
     >>> ConeSearch.clear_cache()
 
-If this function is unavailable, upgrade your version of astroquery. 
+If this function is unavailable, upgrade your version of astroquery.
 The ``clear_cache`` function was introduced in version 0.4.7.dev8479.
 
-  
+
 Reference/API
 =============
 


### PR DESCRIPTION
In preparation for the release I went ahead and fixed the broken links and redirects. One redirect remains for IRSA as the old alias now points to a really long TAP query that looks ugly in a docstring. And somehow the ignore is not respected for a jplhorizons' anchor. 