### PR TITLE
Fix issue 3187: Missing unit strings in UNIT_MAPPER for ipac.nexsci.nasa_exoplanet_archive

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -69,6 +69,11 @@ simbad
 
 - Fixed non existing flux filters as votable fields would fail silently [#3186]
 
+ipac.nexsci.nasa_exoplanet_archive
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+- Add missing unit strings to unit mapper. ``micron``, ``microns``, and ``uas``. [#3188]
+
 
 Infrastructure, Utility and Other Changes and Additions
 -------------------------------------------------------

--- a/astroquery/ipac/nexsci/nasa_exoplanet_archive/core.py
+++ b/astroquery/ipac/nexsci/nasa_exoplanet_archive/core.py
@@ -39,6 +39,8 @@ UNIT_MAPPER = {
     "BKJD": None,  # TODO: optionally support mapping columns to Time objects
     "D_L": u.pc,
     "D_S": u.pc,
+    "micron": u.um,
+    "microns": u.um,
     "Earth flux": u.L_sun / (4 * np.pi * u.au**2),
     "Earth Flux": u.L_sun / (4 * np.pi * u.au**2),
     "Fearth": u.L_sun / (4 * np.pi * u.au**2),
@@ -73,6 +75,7 @@ UNIT_MAPPER = {
     "log(Solar)": u.dex(u.L_sun),
     "mags": u.mag,
     "microas": u.uas,
+    "uas": u.uas,
     "perc": u.percent,
     "pi_E": None,
     "pi_EE": None,


### PR DESCRIPTION
Added units `'microns'`, `'micron'`, `'hour'`, and `'uas'` to the `UNIT_MAPPER` dict to get rid of warning thrown for unrecognized units.

fixes #3187 