### PR TITLE
Fix InvalidTableError for DI_STARS_EXEP and TD tables in ipac.nexsci.nasa_exoplanet_archive

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -74,6 +74,8 @@ ipac.nexsci.nasa_exoplanet_archive
 
 - Add missing unit strings to unit mapper. ``micron``, ``microns``, and ``uas``. [#3188]
 
+- Fixed InvalidTableError for DI_STARS_EXEP and TD tables. [#3189]
+
 
 Infrastructure, Utility and Other Changes and Additions
 -------------------------------------------------------

--- a/astroquery/ipac/nexsci/nasa_exoplanet_archive/core.py
+++ b/astroquery/ipac/nexsci/nasa_exoplanet_archive/core.py
@@ -233,7 +233,7 @@ class NasaExoplanetArchiveClass(BaseVOQuery, BaseQuery):
         if cache is None:
             cache = self.CACHE
 
-        if table in self.TAP_TABLES:
+        if table in [tab.lower() for tab in self.TAP_TABLES]:
             tap = pyvo.dal.tap.TAPService(baseurl=self.URL_TAP, session=self._session)
             # construct query from table and request_payload (including format)
             tap_query = self._request_to_sql(request_payload)

--- a/astroquery/ipac/nexsci/nasa_exoplanet_archive/tests/test_nasa_exoplanet_archive_remote.py
+++ b/astroquery/ipac/nexsci/nasa_exoplanet_archive/tests/test_nasa_exoplanet_archive_remote.py
@@ -185,3 +185,10 @@ def test_format():
     with pytest.raises(InvalidQueryError) as error:
         NasaExoplanetArchive.query_object("HAT-P-11 b", format="json")
     assert "json" in str(error)
+
+
+@pytest.mark.remote_data
+def test_table_case_sensivity():
+    # Regression test from #3090
+    table = NasaExoplanetArchive.query_criteria(table='DI_STARS_EXEP', select='*')
+    assert len(table) > 0


### PR DESCRIPTION
Fixes issue https://github.com/astropy/astroquery/issues/3090. Line 233 was comparing a table name already converted to lower case with a list of original table names (both upper and lower case). Now comparing lower case throughout.