### PR TITLE
MAINT: back with the long description

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -114,7 +114,7 @@ looked up at the following `Zenodo page <https://doi.org/10.5281/zenodo.591669>`
 Additional Links
 ----------------
 
-Maintained by `Adam Ginsburg`_ and `Brigitta Sipocz <https://github.com/bsipocz>`_ (`astropy.astroquery@gmail.com`_)
+Maintained by `Adam Ginsburg`_ and `Brigitta Sipocz <https://github.com/bsipocz>`_
 
 
 .. _Download Development ZIP: https://github.com/astropy/astroquery/zipball/main

--- a/setup.py
+++ b/setup.py
@@ -19,4 +19,6 @@ from astropy_helpers.setup_helpers import setup
 from pathlib import Path
 this_directory = Path(__file__).parent
 
-setup(long_description="README.rst", long_description_content_type='text/x-rst')
+long_description = (this_directory / "README.rst").read_text()
+
+setup(long_description=long_description, long_description_content_type='text/x-rst')


### PR DESCRIPTION
I have run `twine check` until it passed, so it should all back to normal for the release.

This closes, potentially, #2772, but I will close the issue once the release is up on pypi and the description is back in place.