### PR TITLE
Accept MAST URIs as input to get_cloud_uris()

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,8 +4,17 @@
 New Tools and Services
 ----------------------
 
+
 API changes
 -----------
+
+mast
+^^^^
+
+- Handle coordinates that are not in the ICRS frame in query functions. [#3164]
+
+- Handle a MAST URI string as input for ``Observations.get_cloud_uri`` and a list of MAST URIs as input for
+  ``Observations.get_cloud_uris``. [#3193]
 
 simbad
 ^^^^^^
@@ -25,6 +34,13 @@ ipac.nexsci.nasa_exoplanet_archive
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 - Fixed InvalidTableError for DI_STARS_EXEP and TD tables. [#3189]
+
+mast
+^^^^
+
+- Bugfix where users are unnecessarily warned about a query limit while fetching products in ``MastMissions.get_product_list``. [#3193]
+
+- Bugfix where ``Observations.get_cloud_uri`` and ``Observations.get_cloud_uris`` fail if the MAST relative path is not found. [#3193]
 
 simbad
 ^^^^^^

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -11,8 +11,6 @@ API changes
 mast
 ^^^^
 
-- Handle coordinates that are not in the ICRS frame in query functions. [#3164]
-
 - Handle a MAST URI string as input for ``Observations.get_cloud_uri`` and a list of MAST URIs as input for
   ``Observations.get_cloud_uris``. [#3193]
 

--- a/astroquery/mast/missions.py
+++ b/astroquery/mast/missions.py
@@ -99,13 +99,14 @@ class MastMissionsClass(MastQueryWithLogin):
 
         if self.service == self._search:
             results = self._service_api_connection._parse_result(response, verbose, data_key='results')
+
+            # Warn if maximum results are returned
+            if len(results) >= self.limit:
+                warnings.warn("Maximum results returned, may not include all sources within radius.",
+                              MaxResultsWarning)
         elif self.service == self._list_products:
             # Results from post_list_products endpoint need to be handled differently
             results = Table(response.json()['products'])
-
-        if len(results) >= self.limit:
-            warnings.warn("Maximum results returned, may not include all sources within radius.",
-                          MaxResultsWarning)
 
         return results
 

--- a/astroquery/mast/tests/data/README.rst
+++ b/astroquery/mast/tests/data/README.rst
@@ -36,3 +36,15 @@ To generate `~astroquery.mast.tests.data.mission_products.json`, use the followi
     >>> resp = utils._simple_request('https://mast.stsci.edu/search/hst/api/v0.1/list_products', {'dataset_ids': 'Z14Z0104T'})
     >>> with open('panstarrs_columns.json', 'w') as file:
     ...     json.dump(resp.json(), file, indent=4)  # doctest: +SKIP
+
+To generate `~astroquery.mast.tests.data.mast_relative_path.json`, use the following:
+
+.. doctest-remote-data::
+
+    >>> import json
+    >>> from astroquery.mast import utils
+    ...
+    >>> resp = utils._simple_request('https://mast.stsci.edu/api/v0.1/path_lookup/',
+    ...                              {'uri': ['mast:HST/product/u9o40504m_c3m.fits', 'mast:HST/product/does_not_exist.fits']})
+    >>> with open('mast_relative_path.json', 'w') as file:
+    ...     json.dump(resp.json(), file, indent=4)  # doctest: +SKIP

--- a/astroquery/mast/tests/data/mast_relative_path.json
+++ b/astroquery/mast/tests/data/mast_relative_path.json
@@ -1,0 +1,10 @@
+{
+    "mast:HST/product/u9o40504m_c3m.fits": {
+        "status_code": 200,
+        "path": "/hst/public/u9o4/u9o40504m/u9o40504m_c3m.fits"
+    },
+    "mast:HST/product/does_not_exist.fits": {
+        "status_code": 404,
+        "path": null
+    }
+}

--- a/astroquery/mast/tests/test_mast_remote.py
+++ b/astroquery/mast/tests/test_mast_remote.py
@@ -805,6 +805,7 @@ class TestMast:
                                         extension='png')
 
     def test_observations_get_cloud_uris_list_input(self):
+        pytest.importorskip("boto3")
         uri_list = ['mast:HST/product/u24r0102t_c1f.fits',
                     'mast:PS1/product/rings.v3.skycell.1334.061.stk.r.unconv.exp.fits']
         expected = ['s3://stpubdata/hst/public/u24r/u24r0102t/u24r0102t_c1f.fits',
@@ -851,6 +852,8 @@ class TestMast:
             Observations.get_cloud_uris(target_name=234295611)
 
     def test_observations_get_cloud_uris_no_duplicates(self, msa_product_table):
+        pytest.importorskip("boto3")
+
         # Get a product list with 6 duplicate JWST MSA config files
         products = msa_product_table
 

--- a/astroquery/mast/tests/test_mast_remote.py
+++ b/astroquery/mast/tests/test_mast_remote.py
@@ -812,6 +812,9 @@ class TestMast:
                     's3://stpubdata/panstarrs/ps1/public/rings.v3.skycell/1334/061/rings.v3.skycell.1334.'
                     '061.stk.r.unconv.exp.fits']
 
+        # enable access to public AWS S3 bucket
+        Observations.enable_cloud_dataset()
+
         # list of URI strings as input
         uris = Observations.get_cloud_uris(uri_list)
         assert len(uris) > 0, f'Products for URI list {uri_list} were not found in the cloud.'

--- a/astroquery/mast/tests/test_mast_remote.py
+++ b/astroquery/mast/tests/test_mast_remote.py
@@ -692,20 +692,6 @@ class TestMast:
         with caplog.at_level("INFO", logger="astroquery"):
             assert "products were duplicates" in caplog.text
 
-    def test_observations_get_cloud_uris_no_duplicates(self, msa_product_table):
-
-        # Get a product list with 6 duplicate JWST MSA config files
-        products = msa_product_table
-
-        assert len(products) == 6
-
-        # enable access to public AWS S3 bucket
-        Observations.enable_cloud_dataset(provider='AWS')
-
-        # Check that only one URI is returned
-        uris = Observations.get_cloud_uris(products)
-        assert len(uris) == 1
-
     def test_observations_download_file(self, tmp_path):
 
         def check_result(result, path):
@@ -776,7 +762,7 @@ class TestMast:
          "s3://stpubdata/panstarrs/ps1/public/rings.v3.skycell/1334/061/"
          "rings.v3.skycell.1334.061.stk.r.unconv.exp.fits")
     ])
-    def test_get_cloud_uri(self, test_data_uri, expected_cloud_uri):
+    def test_observations_get_cloud_uri(self, test_data_uri, expected_cloud_uri):
         pytest.importorskip("boto3")
         # get a product list
         product = Table()
@@ -790,13 +776,17 @@ class TestMast:
         assert len(uri) > 0, f'Product for dataURI {test_data_uri} was not found in the cloud.'
         assert uri == expected_cloud_uri, f'Cloud URI does not match expected. ({uri} != {expected_cloud_uri})'
 
+        # pass the URI as a string
+        uri = Observations.get_cloud_uri(test_data_uri)
+        assert uri == expected_cloud_uri, f'Cloud URI does not match expected. ({uri} != {expected_cloud_uri})'
+
     @pytest.mark.parametrize("test_obs_id", ["25568122", "31411", "107604081"])
-    def test_get_cloud_uris(self, test_obs_id):
+    def test_observations_get_cloud_uris(self, test_obs_id):
         pytest.importorskip("boto3")
 
         # get a product list
         index = 24 if test_obs_id == '25568122' else 0
-        products = Observations.get_product_list(test_obs_id)[index:]
+        products = Observations.get_product_list(test_obs_id)[index:index + 2]
 
         assert len(products) > 0, (f'No products found for OBSID {test_obs_id}. '
                                    'Unable to move forward with getting URIs from the cloud.')
@@ -814,7 +804,28 @@ class TestMast:
             Observations.get_cloud_uris(products,
                                         extension='png')
 
-    def test_get_cloud_uris_query(self):
+    def test_observations_get_cloud_uris_list_input(self):
+        uri_list = ['mast:HST/product/u24r0102t_c1f.fits',
+                    'mast:PS1/product/rings.v3.skycell.1334.061.stk.r.unconv.exp.fits']
+        expected = ['s3://stpubdata/hst/public/u24r/u24r0102t/u24r0102t_c1f.fits',
+                    's3://stpubdata/panstarrs/ps1/public/rings.v3.skycell/1334/061/rings.v3.skycell.1334.'
+                    '061.stk.r.unconv.exp.fits']
+
+        # list of URI strings as input
+        uris = Observations.get_cloud_uris(uri_list)
+        assert len(uris) > 0, f'Products for URI list {uri_list} were not found in the cloud.'
+        assert uris == expected
+
+        # check for warning if filters are provided with list input
+        with pytest.warns(InputWarning, match='Filtering is not supported'):
+            Observations.get_cloud_uris(uri_list,
+                                        extension='png')
+
+        # check for warning if one of the URIs is not found
+        with pytest.warns(NoResultsWarning, match='Failed to retrieve MAST relative path'):
+            Observations.get_cloud_uris(['mast:HST/product/does_not_exist.fits'])
+
+    def test_observations_get_cloud_uris_query(self):
         pytest.importorskip("boto3")
 
         # enable access to public AWS S3 bucket
@@ -838,6 +849,19 @@ class TestMast:
         # check for warning if query returns no observations
         with pytest.warns(NoResultsWarning):
             Observations.get_cloud_uris(target_name=234295611)
+
+    def test_observations_get_cloud_uris_no_duplicates(self, msa_product_table):
+        # Get a product list with 6 duplicate JWST MSA config files
+        products = msa_product_table
+
+        assert len(products) == 6
+
+        # enable access to public AWS S3 bucket
+        Observations.enable_cloud_dataset(provider='AWS')
+
+        # Check that only one URI is returned
+        uris = Observations.get_cloud_uris(products)
+        assert len(uris) == 1
 
     ######################
     # CatalogClass tests #

--- a/astroquery/mast/utils.py
+++ b/astroquery/mast/utils.py
@@ -185,7 +185,8 @@ def mast_relative_path(mast_uri):
     result = []
     for chunk in uri_list_chunks:
         response = _simple_request("https://mast.stsci.edu/api/v0.1/path_lookup/",
-                                   {"uri": chunk})
+                                   {"uri": [mast_uri[1] for mast_uri in chunk]})
+
         json_response = response.json()
 
         for uri in chunk:

--- a/astroquery/mast/utils.py
+++ b/astroquery/mast/utils.py
@@ -6,6 +6,7 @@ MAST Utils
 Miscellaneous functions used throughout the MAST module.
 """
 
+import warnings
 import numpy as np
 
 import requests
@@ -14,11 +15,11 @@ import platform
 from urllib import parse
 
 import astropy.coordinates as coord
-from astropy.table import unique
+from astropy.table import unique, Table
 
 from .. import log
 from ..version import version
-from ..exceptions import ResolverError, InvalidQueryError
+from ..exceptions import NoResultsWarning, ResolverError, InvalidQueryError
 from ..utils import commons
 
 from . import conf
@@ -192,6 +193,9 @@ def mast_relative_path(mast_uri):
             # ("uri", "/path/to/product")
             # so we index for path (index=1)
             path = json_response.get(uri[1])["path"]
+            if path is None:
+                warnings.warn(f"Failed to retrieve MAST relative path for {uri[1]}. Skipping...", NoResultsWarning)
+                continue
             if 'galex' in path:
                 path = path.lstrip("/mast/")
             elif '/ps1/' in path:
@@ -218,19 +222,31 @@ def _split_list_into_chunks(input_list, chunk_size):
 def remove_duplicate_products(data_products, uri_key):
     """
     Removes duplicate data products that have the same data URI.
+
     Parameters
     ----------
-    data_products : `~astropy.table.Table`
-        Table containing products to be checked for duplicates.
+    data_products : `~astropy.table.Table`, list
+        Table containing products or list of URIs to be checked for duplicates.
     uri_key : str
         Column name representing the URI of a product.
+
     Returns
     -------
     unique_products : `~astropy.table.Table`
         Table containing products with unique dataURIs.
     """
+    # Get unique products based on input type
+    if isinstance(data_products, Table):
+        unique_products = unique(data_products, keys=uri_key)
+    else:  # data_products is a list
+        seen = set()
+        unique_products = []
+        for uri in data_products:
+            if uri not in seen:
+                seen.add(uri)
+                unique_products.append(uri)
+
     number = len(data_products)
-    unique_products = unique(data_products, keys=uri_key)
     number_unique = len(unique_products)
     if number_unique < number:
         log.info(f"{number - number_unique} of {number} products were duplicates. "

--- a/setup.cfg
+++ b/setup.cfg
@@ -87,6 +87,8 @@ filterwarnings =
     ignore:The upstream SHA API has been changed:UserWarning
 # CDMS triggers this, but we don't use it directly
     ignore: The 'strip_cdata' option of HTMLParser:DeprecationWarning
+# Datetime deprecation warnings
+    ignore::DeprecationWarning:datetime\.datetime
 
 markers =
     bigdata: marks tests that are expected to trigger a large download (deselect with '-m "not bigdata"')

--- a/setup.cfg
+++ b/setup.cfg
@@ -87,8 +87,8 @@ filterwarnings =
     ignore:The upstream SHA API has been changed:UserWarning
 # CDMS triggers this, but we don't use it directly
     ignore: The 'strip_cdata' option of HTMLParser:DeprecationWarning
-# Datetime deprecation warnings
-    ignore::DeprecationWarning:datetime\.datetime
+# Triggered in mast, likely boto related
+    ignore:datetime.datetime.utcnow\(\) is deprecated:DeprecationWarning
 
 markers =
     bigdata: marks tests that are expected to trigger a large download (deselect with '-m "not bigdata"')


### PR DESCRIPTION
This PR does the following:

- Allows users to input a MAST URI string as input for `Observations.get_cloud_uri`.
- Allows users to input a list of MAST URI strings as input for `Observations.get_cloud_uris`. Logs a warning if the user tries to provide filter criteria as well, since this won't be possible without a `Table`.
- Bugfix where users where unnecessarily warned about a query result limit while trying to fetch products in `MastMissions`.
- Bugfix where the functions to get cloud URIs fail if the MAST relative path cannot be returned. Now, it logs a warning and skips that particular data product.
- Added JWST to the list of cloud-hosted missions.
- Added both non-remote and remote test cases to increase coverage.