### PR TITLE
fix: turn detailed membership on by default

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,14 @@
 New Tools and Services
 ----------------------
 
+API changes
+-----------
+
+simbad
+^^^^^^
+
+- The detailed hierarchy is now returned by default in ``query_hierarchy``
+  (it was hidden by default in the previous versions) [#3195]
 
 Service fixes and enhancements
 ------------------------------
@@ -18,7 +26,6 @@ xmatch
 
 - the API is more flexible: you can now ommit the ``vizier:`` before the catalog name
   when crossmatching with a vizier table [#3194]
-
 
 Infrastructure, Utility and Other Changes and Additions
 -------------------------------------------------------

--- a/astroquery/simbad/core.py
+++ b/astroquery/simbad/core.py
@@ -868,7 +868,7 @@ class SimbadClass(BaseVOQuery):
                            get_query_payload=get_query_payload)
 
     def query_hierarchy(self, name, hierarchy, *,
-                        detailed_hierarchy=False,
+                        detailed_hierarchy=True,
                         criteria=None, get_query_payload=False):
         """Query either the parents or the children of the object.
 
@@ -906,6 +906,7 @@ class SimbadClass(BaseVOQuery):
         --------
         >>> from astroquery.simbad import Simbad
         >>> parent = Simbad.query_hierarchy("2MASS J18511048-0615470",
+        ...                                 detailed_hierarchy=False,
         ...                                 hierarchy="parents")  # doctest: +REMOTE_DATA
         >>> parent[["main_id", "ra", "dec"]] # doctest: +REMOTE_DATA
         <Table length=1>

--- a/astroquery/simbad/tests/test_simbad.py
+++ b/astroquery/simbad/tests/test_simbad.py
@@ -390,6 +390,7 @@ def test_query_hierarchy():
     assert detailed in adql
     adql = simbad_instance.query_hierarchy("test", hierarchy="children",
                                            criteria="test=test",
+                                           detailed_hierarchy=False,
                                            get_query_payload=True)["QUERY"]
     assert "h_link.parent = name.oidref" in adql
     assert "test=test" in adql

--- a/docs/simbad/simbad.rst
+++ b/docs/simbad/simbad.rst
@@ -181,7 +181,7 @@ assessments, they are translated in SIMBAD as follows:
 | non member        | 0                      |
 +-------------------+------------------------+
 
-For gravitational lens systems, double stars, and blends (superimposition of two
+For gravitational lens systems, double stars, and blends (superposition of two
 non-physically linked objects), the SIMBAD team does not assign a probability
 value (this will be a ``None``).
 
@@ -303,7 +303,7 @@ Here, we see that the link between ``V* V787 Cep`` and the open cluster ``NGC 18
 opened for debate: the only way to build an opinion is to read the four articles.
 This information would be hidden if we did not print the detailed hierarchy report.
 
-These somewhat contradicting results are an inherent part of SIMBAD, which simply
+These somewhat contradictory results are an inherent part of SIMBAD, which simply
 translates the literature into a database.
 
 Query a region


### PR DESCRIPTION
I got feedback that having `detailed_membership` turned off by default leads to big interpretation errors.

This PR changes the default behavior, but also adds a more detailed documentation on the meaning of `membership_certainty` in the hope that this will help the interpretation of the results of the method `query_hierarchy`.