### PR TITLE
fix: use left join when adding tables instead of inner join

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -13,6 +13,13 @@ ipac.nexsci.nasa_exoplanet_archive
 
 - Fixed InvalidTableError for DI_STARS_EXEP and TD tables. [#3189]
 
+simbad
+^^^^^^
+
+- fix: when adding a measurement table in the votable_fields, if a measurement table is
+  empty for an object, there will now be a line with masked values instead of no line in
+  the result [#3199]
+
 xmatch
 ^^^^^^
 

--- a/astroquery/simbad/core.py
+++ b/astroquery/simbad/core.py
@@ -347,7 +347,7 @@ class SimbadClass(BaseVOQuery):
         self.columns_in_output += [_Column(table, column, alias)
                                    for column, alias in zip(columns, alias)]
         self.joins += [_Join(table, _Column("basic", link["target_column"]),
-                             _Column(table, link["from_column"]))]
+                             _Column(table, link["from_column"]), "LEFT JOIN")]
 
     def add_votable_fields(self, *args):
         """Add columns to the output of a SIMBAD query.

--- a/astroquery/simbad/tests/test_simbad.py
+++ b/astroquery/simbad/tests/test_simbad.py
@@ -214,7 +214,7 @@ def test_add_table_to_output(monkeypatch):
     simbad_instance._add_table_to_output("mesDiameter")
     assert simbad.core._Join("mesdiameter",
                              simbad.core._Column("basic", "oid"),
-                             simbad.core._Column("mesdiameter", "oidref")
+                             simbad.core._Column("mesdiameter", "oidref"), "LEFT JOIN"
                              ) in simbad_instance.joins
     assert simbad.core._Column("mesdiameter", "bibcode", "mesdiameter.bibcode"
                                ) in simbad_instance.columns_in_output

--- a/docs/simbad/simbad.rst
+++ b/docs/simbad/simbad.rst
@@ -602,6 +602,72 @@ And the columns in the output can be reset to their default value with
     A detailed description on the ways to add fluxes is available in the
     :ref:`optical filters` section.
 
+Measurement fields vs. Basic fields
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Some field names start with ``mes``. These denote what SIMBAD calls a
+"measurement table". These tables store the history on past measurements of a physical
+parameter for each object.
+
+Let's look at the star ``HD 200207`` with the parallax measurements table ``mesplx``:
+
+.. doctest-remote-data::
+
+    >>> from astroquery.simbad import Simbad
+    >>> simbad = Simbad()
+    >>> simbad.add_votable_fields("mesplx")
+    >>> hd_200207 = simbad.query_object("HD 200207")
+    >>> hd_200207[["main_id", "mesplx.plx", "mesplx.plx_err", "mesplx.bibcode"]]
+    <Table length=5>
+     main_id  mesplx.plx mesplx.plx_err    mesplx.bibcode
+                 mas          mas
+      object   float32      float32            object
+    --------- ---------- -------------- -------------------
+    HD 200207     3.4084         0.0195 2020yCat.1350....0G
+    HD 200207     3.4552         0.0426 2018yCat.1345....0G
+    HD 200207       3.35           0.76 1997A&A...323L..49P
+    HD 200207       3.72           0.62 2007A&A...474..653V
+    HD 200207       3.25           0.22 2016A&A...595A...2G
+
+This field adds one line per parallax measurement: five articles have measured it
+for this star.
+
+If you are only interested in the most precise measure recorded by the SIMBAD team, some
+measurements fields have an equivalent in the basic fields. These fields only give one
+line per object with the most precise currently known value:
+
++-------------------+---------------+
+| measurement field | basic field   |
++===================+===============+
+| mesplx            | parallax      |
++-------------------+---------------+
+| mespm             | propermotions |
++-------------------+---------------+
+| messpt            | sp            |
++-------------------+---------------+
+| mesvelocities     | velocity      |
++-------------------+---------------+
+
+Here, ``mesplx`` has an equivalent in the basic fields so we could have done:
+
+.. doctest-remote-data::
+
+    >>> from astroquery.simbad import Simbad
+    >>> simbad = Simbad()
+    >>> simbad.add_votable_fields("parallax")
+    >>> hd_200207 = simbad.query_object("HD 200207")
+    >>> hd_200207[["main_id", "plx_value", "plx_err", "plx_bibcode"]]
+    <Table length=1>
+     main_id  plx_value plx_err     plx_bibcode
+                 mas      mas
+      object   float64  float32        object
+    --------- --------- ------- -------------------
+    HD 200207    3.4084  0.0195 2020yCat.1350....0G
+
+And we only have one line per object with the value selected by SIMBAD's team.
+
+Thus, choosing to add a measurement field or a basic field depends on your goal.
+
 Additional criteria
 -------------------
 


### PR DESCRIPTION
This fixes #3197 

The behavior that people expect is not the one that we get with the default inner join:

```python
from astroquery.simbad import Simbad
simbad = Simbad()
simbad.add_votable_fields("mesdistance")
simbad.query_object("vega")
```

## with inner join

No measurement --> no result

```
WARNING: NoResultsWarning: The request executed correctly, but there was no data corresponding to these criteria in SIMBAD [astroquery.simbad.core]
<Table length=0>
main_id    ra     dec   coo_err_maj coo_err_min coo_err_angle coo_wavelength coo_bibcode mesdistance.bibcode ... mesdistance.mespos mesdistance.method mesdistance.minus_err mesdistance.minus_err_prec mesdistance.plus_err mesdistance.plus_err_prec mesdistance.qual mesdistance.unit matched_id
          deg     deg       mas         mas          deg                                                     ...                                                                                                                                                                                   
 object float64 float64   float32     float32       int16          str1         object          object       ...       int16              object              float64                  int16                  float64                  int16                 str1            object        object  
------- ------- ------- ----------- ----------- ------------- -------------- ----------- ------------------- ... ------------------ ------------------ --------------------- -------------------------- -------------------- ------------------------- ---------------- ---------------- ----------
```

## with left join

No measurement --> masked data

```
<Table length=1>
 main_id         ra              dec       coo_err_maj coo_err_min coo_err_angle coo_wavelength     coo_bibcode     mesdistance.bibcode ... mesdistance.method mesdistance.minus_err mesdistance.minus_err_prec mesdistance.plus_err mesdistance.plus_err_prec mesdistance.qual mesdistance.unit matched_id
                deg              deg           mas         mas          deg                                                             ...                                                                                                                                                                
  object      float64          float64       float32     float32       int16          str1             object              object       ...       object              float64                  int16                  float64                  int16                 str1            object        object  
--------- ---------------- --------------- ----------- ----------- ------------- -------------- ------------------- ------------------- ... ------------------ --------------------- -------------------------- -------------------- ------------------------- ---------------- ---------------- ----------
* alf Lyr 279.234734787025 38.783688956244     3.51118     2.81205            90              O 2007A&A...474..653V                     ...                                       --                         --                   --                        --                                    NAME Vega
```

# Other changes

This PR also adds a new section in the documentation that tries to explain measurement tables in SIMBAD.