### PR TITLE
ENH: IRSA: adding servicetype to list_collections

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -21,6 +21,12 @@ gaia
 
 - Update DR4 retrieval_type names and include the new one EPOCH_ASTROMETRY_BRIGHT [#3207]
 
+ipac.irsa
+^^^^^^^^^
+
+- Adding the "servicetype" kwarg to ``list_collections`` to be able to list SIA
+  and SSA collections separately. [#3200]
+
 ipac.nexsci.nasa_exoplanet_archive
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 

--- a/astroquery/ipac/irsa/core.py
+++ b/astroquery/ipac/irsa/core.py
@@ -132,22 +132,22 @@ class IrsaClass(BaseVOQuery):
             A table listing all the possible collections for IRSA SIA queries.
         """
 
-        servicetype = servicetype.upper()
-
         if not servicetype:
             query = "SELECT DISTINCT collection from caom.observation ORDER by collection"
-        elif servicetype == 'SIA':
-            query = ("SELECT DISTINCT o.collection FROM caom.observation o "
-                     "JOIN caom.plane p ON o.obsid = p.obsid "
-                     "WHERE (p.dataproducttype = 'image' OR p.dataproducttype = 'cube') "
-                     "order by collection")
-        elif servicetype == 'SSA':
-            query = ("SELECT DISTINCT o.collection FROM caom.observation o "
-                     "JOIN caom.plane p ON o.obsid = p.obsid "
-                     "WHERE (p.dataproducttype = 'spectrum' OR p.dataproducttype = 'cube') "
-                     "order by collection")
         else:
-            raise ValueError("if specified, servicetype should be 'SIA' or 'SSA'")
+            servicetype = servicetype.upper()
+            if servicetype == 'SIA':
+                query = ("SELECT DISTINCT o.collection FROM caom.observation o "
+                         "JOIN caom.plane p ON o.obsid = p.obsid "
+                         "WHERE (p.dataproducttype = 'image' OR p.dataproducttype = 'cube') "
+                         "order by collection")
+            elif servicetype == 'SSA':
+                query = ("SELECT DISTINCT o.collection FROM caom.observation o "
+                         "JOIN caom.plane p ON o.obsid = p.obsid "
+                         "WHERE (p.dataproducttype = 'spectrum' OR p.dataproducttype = 'cube') "
+                         "order by collection")
+            else:
+                raise ValueError("if specified, servicetype should be 'SIA' or 'SSA'")
 
         collections = self.query_tap(query=query)
         return collections.to_table()

--- a/astroquery/ipac/irsa/core.py
+++ b/astroquery/ipac/irsa/core.py
@@ -116,15 +116,15 @@ class IrsaClass(BaseVOQuery):
 
     query_sia.__doc__ = query_sia.__doc__.replace('_SIA2_PARAMETERS', SIA2_PARAMETERS_DESC)
 
-    def list_collections(self, servicetype='sia'):
+    def list_collections(self, servicetype=None):
         """
         Return information of available IRSA SIAv2 collections to be used in ``query_sia`` queries.
 
         Parameters
         ----------
         servicetype : str or None
-            Service type to list collections for.
-            Currently supported ones are: 'SIA'.
+            Service type to list collections for. Returns all collections when not provided.
+            Currently supported service types are: 'SIA', 'SSA'.
 
         Returns
         -------
@@ -134,10 +134,20 @@ class IrsaClass(BaseVOQuery):
 
         servicetype = servicetype.upper()
 
-        if servicetype == 'SIA':
+        if not servicetype:
             query = "SELECT DISTINCT collection from caom.observation ORDER by collection"
+        elif servicetype == 'SIA':
+            query = ("SELECT DISTINCT o.collection FROM caom.observation o "
+                     "JOIN caom.plane p ON o.obsid = p.obsid "
+                     "WHERE (p.dataproducttype = 'image' OR p.dataproducttype = 'cube') "
+                     "order by collection")
+        elif servicetype == 'SSA':
+            query = ("SELECT DISTINCT o.collection FROM caom.observation o "
+                     "JOIN caom.plane p ON o.obsid = p.obsid "
+                     "WHERE (p.dataproducttype = 'spectrum' OR p.dataproducttype = 'cube') "
+                     "order by collection")
         else:
-            raise ValueError("servicetype should be 'sia'")
+            raise ValueError("if specified, servicetype should be 'SIA' or 'SSA'")
 
         collections = self.query_tap(query=query)
         return collections.to_table()

--- a/astroquery/ipac/irsa/core.py
+++ b/astroquery/ipac/irsa/core.py
@@ -116,16 +116,29 @@ class IrsaClass(BaseVOQuery):
 
     query_sia.__doc__ = query_sia.__doc__.replace('_SIA2_PARAMETERS', SIA2_PARAMETERS_DESC)
 
-    def list_collections(self):
+    def list_collections(self, servicetype='sia'):
         """
         Return information of available IRSA SIAv2 collections to be used in ``query_sia`` queries.
+
+        Parameters
+        ----------
+        servicetype : str or None
+            Service type to list collections for.
+            Currently supported ones are: 'SIA'.
 
         Returns
         -------
         collections : A `~astropy.table.Table` object.
             A table listing all the possible collections for IRSA SIA queries.
         """
-        query = "SELECT DISTINCT collection from caom.observation ORDER by collection"
+
+        servicetype = servicetype.upper()
+
+        if servicetype == 'SIA':
+            query = "SELECT DISTINCT collection from caom.observation ORDER by collection"
+        else:
+            raise ValueError("servicetype should be 'sia'")
+
         collections = self.query_tap(query=query)
         return collections.to_table()
 

--- a/astroquery/ipac/irsa/tests/test_irsa_remote.py
+++ b/astroquery/ipac/irsa/tests/test_irsa_remote.py
@@ -67,13 +67,18 @@ class TestIrsa:
         # (at the time of writing there are 933 tables in the list).
         assert len(catalogs) > 900
 
-    def test_list_collections(self):
-        collections = Irsa.list_collections()
+    @pytest.mark.parametrize('servicetype', (None, 'sia', 'ssa'))
+    def test_list_collections(self, servicetype):
+        collections = Irsa.list_collections(servicetype=servicetype)
         # Number of available collections may change over time, test only for significant drop.
-        # (at the time of writing there are 110 collections in the list).
-        assert len(collections) > 100
-        assert 'spitzer_seip' in collections['collection']
-        assert 'wise_allwise' in collections['collection']
+        # (at the time of writing there are 104 SIA and 35 SSA collections in the list).
+        if servicetype == 'ssa':
+            assert len(collections) > 30
+            assert 'sofia_exes' in collections['collection']
+        else:
+            assert len(collections) > 100
+            assert 'spitzer_seip' in collections['collection']
+            assert 'wise_allwise' in collections['collection']
 
     def test_tap(self):
         query = "SELECT TOP 5 ra,dec FROM cosmos2015"

--- a/docs/ipac/irsa/irsa.rst
+++ b/docs/ipac/irsa/irsa.rst
@@ -234,13 +234,15 @@ Enhanced Imaging products in the centre of the COSMOS field as an `~astropy.tabl
 
 To list available collections for SIA queries, the
 `~astroquery.ipac.irsa.IrsaClass.list_collections` method is provided, and
-will return a `~astropy.table.Table`:
+will return a `~astropy.table.Table`. You can use the ``servicetype``
+argument to filter for image or spectral collections using ``'SIA'`` or
+``'SSA'`` respectively:
 
 .. doctest-remote-data::
 
    >>> from astroquery.ipac.irsa import Irsa
-   >>> Irsa.list_collections()
-   <Table length=124>
+   >>> Irsa.list_collections(servicetype='SIA')
+   <Table length=104>
          collection
            object
    ---------------------


### PR DESCRIPTION
We have cached two collection listing queries to help separating out image vs spectral services. This doesn't have to wait until all the issues are sorted upstream for the SSA PR.

closes https://github.com/astropy/astroquery/issues/3077