### PR TITLE
ENH: adding async mode to IRSA TAP based queries

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -27,6 +27,9 @@ ipac.irsa
 - Adding the "servicetype" kwarg to ``list_collections`` to be able to list SIA
   and SSA collections separately. [#3200]
 
+- Adding support for asynchronous queries using the new ``async_job``
+  keyword. [#3201]
+
 ipac.nexsci.nasa_exoplanet_archive
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 

--- a/astroquery/ipac/irsa/core.py
+++ b/astroquery/ipac/irsa/core.py
@@ -47,7 +47,7 @@ class IrsaClass(BaseVOQuery):
             self._tap = TAPService(baseurl=self.tap_url, session=self._session)
         return self._tap
 
-    def query_tap(self, query, *, async_mode=False, maxrec=None):
+    def query_tap(self, query, *, async_job=False, maxrec=None):
         """
         Send query to IRSA TAP. Results in `~pyvo.dal.TAPResults` format.
         result.to_qtable in `~astropy.table.QTable` format
@@ -56,8 +56,8 @@ class IrsaClass(BaseVOQuery):
         ----------
         query : str
             ADQL query to be executed
-        async_mode : bool, optional
-            if True query is run as an async job
+        async_job : bool, optional
+            if True query is run in asynchronous mode
         maxrec : int, optional
             maximum number of records to return
 
@@ -71,9 +71,9 @@ class IrsaClass(BaseVOQuery):
             TAP query result as `~astropy.table.QTable`
 
         """
-        log.debug(f'Query is run in async mode: {async_mode}\n TAP query: {query}')
+        log.debug(f'Query is run in async mode: {async_job}\n TAP query: {query}')
 
-        if async_mode:
+        if async_job:
             return self.tap.run_async(query, language='ADQL', maxrec=maxrec)
         else:
             return self.tap.run_sync(query, language='ADQL', maxrec=maxrec)
@@ -161,7 +161,7 @@ class IrsaClass(BaseVOQuery):
     @deprecated_renamed_argument(("selcols", "cache", "verbose"), ("columns", None, None), since="0.4.7")
     def query_region(self, coordinates=None, *, catalog=None, spatial='Cone',
                      radius=10 * u.arcsec, width=None, polygon=None,
-                     get_query_payload=False, columns='*', async_mode=False,
+                     get_query_payload=False, columns='*', async_job=False,
                      verbose=False, cache=True):
         """
         Queries the IRSA TAP server around a coordinate and returns a `~astropy.table.Table` object.
@@ -196,8 +196,8 @@ class IrsaClass(BaseVOQuery):
             Defaults to `False`.
         columns : str, optional
             Target column list with value separated by a comma(,)
-        async_mode : bool, optional
-            if True query is run as an async job
+        async_job : bool, optional
+            if True query is run in asynchronous mode
 
         Returns
         -------
@@ -247,7 +247,7 @@ class IrsaClass(BaseVOQuery):
 
         if get_query_payload:
             return adql
-        response = self.query_tap(query=adql, async_mode=async_mode)
+        response = self.query_tap(query=adql, async_job=async_job)
 
         return response.to_table()
 

--- a/astroquery/ipac/irsa/core.py
+++ b/astroquery/ipac/irsa/core.py
@@ -56,7 +56,9 @@ class IrsaClass(BaseVOQuery):
         ----------
         query : str
             ADQL query to be executed
-        maxrec : int
+        async_mode : bool, optional
+            if True query is run as an async job
+        maxrec : int, optional
             maximum number of records to return
 
         Returns
@@ -159,7 +161,7 @@ class IrsaClass(BaseVOQuery):
     @deprecated_renamed_argument(("selcols", "cache", "verbose"), ("columns", None, None), since="0.4.7")
     def query_region(self, coordinates=None, *, catalog=None, spatial='Cone',
                      radius=10 * u.arcsec, width=None, polygon=None,
-                     get_query_payload=False, columns='*',
+                     get_query_payload=False, columns='*', async_mode=False,
                      verbose=False, cache=True):
         """
         Queries the IRSA TAP server around a coordinate and returns a `~astropy.table.Table` object.
@@ -194,6 +196,8 @@ class IrsaClass(BaseVOQuery):
             Defaults to `False`.
         columns : str, optional
             Target column list with value separated by a comma(,)
+        async_mode : bool, optional
+            if True query is run as an async job
 
         Returns
         -------
@@ -243,7 +247,7 @@ class IrsaClass(BaseVOQuery):
 
         if get_query_payload:
             return adql
-        response = self.query_tap(query=adql)
+        response = self.query_tap(query=adql, async_mode=async_mode)
 
         return response.to_table()
 

--- a/astroquery/ipac/irsa/core.py
+++ b/astroquery/ipac/irsa/core.py
@@ -47,7 +47,7 @@ class IrsaClass(BaseVOQuery):
             self._tap = TAPService(baseurl=self.tap_url, session=self._session)
         return self._tap
 
-    def query_tap(self, query, *, maxrec=None):
+    def query_tap(self, query, *, async_mode=False, maxrec=None):
         """
         Send query to IRSA TAP. Results in `~pyvo.dal.TAPResults` format.
         result.to_qtable in `~astropy.table.QTable` format
@@ -69,8 +69,12 @@ class IrsaClass(BaseVOQuery):
             TAP query result as `~astropy.table.QTable`
 
         """
-        log.debug(f'TAP query: {query}')
-        return self.tap.search(query, language='ADQL', maxrec=maxrec)
+        log.debug(f'Query is run in async mode: {async_mode}\n TAP query: {query}')
+
+        if async_mode:
+            return self.tap.run_async(query, language='ADQL', maxrec=maxrec)
+        else:
+            return self.tap.run_sync(query, language='ADQL', maxrec=maxrec)
 
     def query_sia(self, *, pos=None, band=None, time=None, pol=None,
                   field_of_view=None, spatial_resolution=None,

--- a/docs/ipac/irsa/irsa.rst
+++ b/docs/ipac/irsa/irsa.rst
@@ -186,13 +186,13 @@ star HIP 12 with just the ra, dec and w1mpro columns would be:
 Async queries
 --------------
 
-For bigger queries it is recommended using the ``async_mode`` keyword option. When used,
-the query is send in asyncronous mode.
+For bigger queries it is recommended using the ``async_job`` keyword option. When used,
+the query is send in asynchronous mode.
 
 .. doctest-remote-data::
 
     >>> from astroquery.ipac.irsa import Irsa
-    >>> table = Irsa.query_region("HIP 12", catalog="allwise_p3as_psd", spatial="Cone", async_mode=True)
+    >>> table = Irsa.query_region("HIP 12", catalog="allwise_p3as_psd", spatial="Cone", async_job=True)
     >>> print(table)
         designation         ra        dec     sigra  ...         y                   z           spt_ind      htm20    
                            deg        deg     arcsec ...                                                               

--- a/docs/ipac/irsa/irsa.rst
+++ b/docs/ipac/irsa/irsa.rst
@@ -183,6 +183,21 @@ star HIP 12 with just the ra, dec and w1mpro columns would be:
     --------- ----------- ------
     0.0407905 -35.9602605  4.837
 
+Async queries
+--------------
+
+For bigger queries it is recommended using the ``async_mode`` keyword option. When used,
+the query is send in asyncronous mode.
+
+.. doctest-remote-data::
+
+    >>> from astroquery.ipac.irsa import Irsa
+    >>> table = Irsa.query_region("HIP 12", catalog="allwise_p3as_psd", spatial="Cone", async_mode=True)
+    >>> print(table)
+        designation         ra        dec     sigra  ...         y                   z           spt_ind      htm20    
+                           deg        deg     arcsec ...                                                               
+    ------------------- --------- ----------- ------ ... ------------------ ------------------- --------- -------------
+    J000009.78-355736.9 0.0407905 -35.9602605 0.0454 ... 0.0005762523295116 -0.5872239888098030 100102010 8873706189183
 
 Direct TAP query to the IRSA server
 -----------------------------------


### PR DESCRIPTION
Currently ``query_tap`` and ``query_region`` has the new ``async_mode`` bool kwarg. 

I was testing with the query listed in https://github.com/astropy/pyvo/issues/629 which times out with the sync mode, but works as expected and fast! with async. I don't really understand why this latter behaviour, but it doesn't matter much either as we leave it to the user to decide which mode to use rather than building in a heuristic in astroquery. 


Closes https://github.com/astropy/astroquery/issues/3143 


Prior discussion about changing the API approach from the duplication of methods and favouring a keyword based future: https://github.com/astropy/astroquery/issues/2598