### PR TITLE
GAIA: Update DR4 retrieval_type names and include the new one EPOCH_ASTROMETRY_BRIGHT

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -16,6 +16,11 @@ simbad
 Service fixes and enhancements
 ------------------------------
 
+gaia
+^^^^
+
+- Update DR4 retrieval_type names and include the new one EPOCH_ASTROMETRY_BRIGHT [#3207]
+
 ipac.nexsci.nasa_exoplanet_archive
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 

--- a/astroquery/gaia/__init__.py
+++ b/astroquery/gaia/__init__.py
@@ -28,13 +28,13 @@ class Conf(_config.ConfigNamespace):
     VALID_DATALINK_RETRIEVAL_TYPES = ['EPOCH_PHOTOMETRY',
                                       'XP_CONTINUOUS',
                                       'XP_SAMPLED',
-                                      'RVS',
+                                      'RVS_MEAN_SPECTRUM',
                                       'MCMC_GSPPHOT',
                                       'MCMC_MSC',
                                       'EPOCH_ASTROMETRY',
-                                      'RV_EPOCH_SINGLE',
-                                      'RV_EPOCH_DOUBLE',
-                                      'RVS_EPOCH',
+                                      'RVS_EPOCH_DATA_SINGLE',
+                                      'RVS_EPOCH_DATA_DOUBLE',
+                                      'RVS_EPOCH_SPECTRUM',
                                       'RVS_TRANSIT',
                                       'EPOCH_ASTROMETRY_CROWDED_FIELD',
                                       'EPOCH_IMAGE',
@@ -43,7 +43,8 @@ class Conf(_config.ConfigNamespace):
                                       'XP_EPOCH_CROWDING',
                                       'XP_MEAN_SPECTRUM',
                                       'XP_EPOCH_SPECTRUM',
-                                      'CROWDED_FIELD_IMAGE']
+                                      'CROWDED_FIELD_IMAGE',
+                                      'EPOCH_ASTROMETRY_BRIGHT']
 
     VALID_LINKING_PARAMETERS = {'SOURCE_ID', 'TRANSIT_ID', 'IMAGE_ID'}
 

--- a/astroquery/gaia/core.py
+++ b/astroquery/gaia/core.py
@@ -194,7 +194,7 @@ class GaiaClass(TapPlus):
             retrieval type identifier. For GAIA DR2 possible values are ['EPOCH_PHOTOMETRY']
             For GAIA DR3, possible values are ['EPOCH_PHOTOMETRY', 'RVS', 'XP_CONTINUOUS', 'XP_SAMPLED',
             'MCMC_GSPPHOT' or 'MCMC_MSC']
-             For GAIA DR4, possible values will be ['EPOCH_PHOTOMETRY', 'RVS', 'XP_CONTINUOUS', 'XP_SAMPLED',
+            For GAIA DR4, possible values will be ['EPOCH_PHOTOMETRY', 'RVS', 'XP_CONTINUOUS', 'XP_SAMPLED',
             'MCMC_GSPPHOT', 'MCMC_MSC', 'EPOCH_ASTROMETRY', 'RVS_EPOCH_DATA_SINGLE',
             'RVS_EPOCH_DATA_DOUBLE','RVS_EPOCH_SPECTRUM', 'RVS_TRANSIT', 'EPOCH_ASTROMETRY_CROWDED_FIELD',
             'EPOCH_IMAGE', 'EPOCH_PHOTOMETRY_CCD', 'XP_EPOCH_SPECTRUM_SSO', 'XP_EPOCH_CROWDING', 'XP_MEAN_SPECTRUM',

--- a/astroquery/gaia/core.py
+++ b/astroquery/gaia/core.py
@@ -198,10 +198,9 @@ class GaiaClass(TapPlus):
             'MCMC_GSPPHOT', 'MCMC_MSC', 'EPOCH_ASTROMETRY', 'RVS_EPOCH_DATA_SINGLE',
             'RVS_EPOCH_DATA_DOUBLE','RVS_EPOCH_SPECTRUM', 'RVS_TRANSIT', 'EPOCH_ASTROMETRY_CROWDED_FIELD',
             'EPOCH_IMAGE', 'EPOCH_PHOTOMETRY_CCD', 'XP_EPOCH_SPECTRUM_SSO', 'XP_EPOCH_CROWDING', 'XP_MEAN_SPECTRUM',
-            'XP_EPOCH_SPECTRUM', 'CROWDED_FIELD_IMAGE', 'EPOCH_ASTROMETRY_BRIGHT'].. Note that for
-            'CROWDED_FIELD_IMAGE' only the format 'fits' can be used,
-            and that its image, in the principal header, will not be available in the returned dictionary. Set
-            'output_file' to retrieve all data: image + tables.
+            'XP_EPOCH_SPECTRUM', 'CROWDED_FIELD_IMAGE', 'EPOCH_ASTROMETRY_BRIGHT']. Note that for
+            'CROWDED_FIELD_IMAGE' only the format 'fits' can be used, and that its image, in the principal header, will
+            not be available in the returned dictionary. Set 'output_file' to retrieve all data: image + tables.
         linking_parameter : str, optional, default SOURCE_ID, valid values: SOURCE_ID, TRANSIT_ID, IMAGE_ID
             By default, all the identifiers are considered as source_id
             SOURCE_ID: the identifiers are considered as source_id

--- a/astroquery/gaia/core.py
+++ b/astroquery/gaia/core.py
@@ -198,7 +198,8 @@ class GaiaClass(TapPlus):
             'MCMC_GSPPHOT', 'MCMC_MSC', 'EPOCH_ASTROMETRY', 'RVS_EPOCH_DATA_SINGLE',
             'RVS_EPOCH_DATA_DOUBLE','RVS_EPOCH_SPECTRUM', 'RVS_TRANSIT', 'EPOCH_ASTROMETRY_CROWDED_FIELD',
             'EPOCH_IMAGE', 'EPOCH_PHOTOMETRY_CCD', 'XP_EPOCH_SPECTRUM_SSO', 'XP_EPOCH_CROWDING', 'XP_MEAN_SPECTRUM',
-            'XP_EPOCH_SPECTRUM', 'CROWDED_FIELD_IMAGE', 'EPOCH_ASTROMETRY_BRIGHT'].. Note that for 'CROWDED_FIELD_IMAGE' only the format 'fits' can be used,
+            'XP_EPOCH_SPECTRUM', 'CROWDED_FIELD_IMAGE', 'EPOCH_ASTROMETRY_BRIGHT'].. Note that for
+            'CROWDED_FIELD_IMAGE' only the format 'fits' can be used,
             and that its image, in the principal header, will not be available in the returned dictionary. Set
             'output_file' to retrieve all data: image + tables.
         linking_parameter : str, optional, default SOURCE_ID, valid values: SOURCE_ID, TRANSIT_ID, IMAGE_ID

--- a/astroquery/gaia/core.py
+++ b/astroquery/gaia/core.py
@@ -194,11 +194,11 @@ class GaiaClass(TapPlus):
             retrieval type identifier. For GAIA DR2 possible values are ['EPOCH_PHOTOMETRY']
             For GAIA DR3, possible values are ['EPOCH_PHOTOMETRY', 'RVS', 'XP_CONTINUOUS', 'XP_SAMPLED',
             'MCMC_GSPPHOT' or 'MCMC_MSC']
-            For GAIA DR4, possible values will be ['EPOCH_PHOTOMETRY', 'RVS', 'XP_CONTINUOUS', 'XP_SAMPLED',
-            'MCMC_GSPPHOT', 'MCMC_MSC', 'EPOCH_ASTROMETRY', 'RV_EPOCH_SINGLE', 'RV_EPOCH_DOUBLE', 'RVS_EPOCH' or
-            'RVS_TRANSIT', 'EPOCH_ASTROMETRY_CROWDED_FIELD', 'EPOCH_IMAGE', 'EPOCH_PHOTOMETRY_CCD',
-            'XP_EPOCH_SPECTRUM_SSO', 'XP_EPOCH_CROWDING', 'XP_MEAN_SPECTRUM', 'XP_EPOCH_SPECTRUM',
-            'CROWDED_FIELD_IMAGE']. Note that for 'CROWDED_FIELD_IMAGE' only the format 'fits' can be used,
+             For GAIA DR4, possible values will be ['EPOCH_PHOTOMETRY', 'RVS', 'XP_CONTINUOUS', 'XP_SAMPLED',
+            'MCMC_GSPPHOT', 'MCMC_MSC', 'EPOCH_ASTROMETRY', 'RVS_EPOCH_DATA_SINGLE',
+            'RVS_EPOCH_DATA_DOUBLE','RVS_EPOCH_SPECTRUM', 'RVS_TRANSIT', 'EPOCH_ASTROMETRY_CROWDED_FIELD',
+            'EPOCH_IMAGE', 'EPOCH_PHOTOMETRY_CCD', 'XP_EPOCH_SPECTRUM_SSO', 'XP_EPOCH_CROWDING', 'XP_MEAN_SPECTRUM',
+            'XP_EPOCH_SPECTRUM', 'CROWDED_FIELD_IMAGE', 'EPOCH_ASTROMETRY_BRIGHT'].. Note that for 'CROWDED_FIELD_IMAGE' only the format 'fits' can be used,
             and that its image, in the principal header, will not be available in the returned dictionary. Set
             'output_file' to retrieve all data: image + tables.
         linking_parameter : str, optional, default SOURCE_ID, valid values: SOURCE_ID, TRANSIT_ID, IMAGE_ID


### PR DESCRIPTION
Hi Astroquery team,

we'd like to rename the datalink retrieve types that can be accessed through the method _load\_data_


RVS_EPOCH --> RVS_EPOCH_SPECTRUM
RV_EPOCH_DOUBLE --> RVS_EPOCH_DATA_DOUBLE
RV_EPOCH_SINGLE --> RVS_EPOCH_DATA_SINGLE

and include the new retrieve type EPOCH_ASTROMETRY_BRIGHT.



Jira: GAIAMNGT-1828 

cc @esdc-esac-esa-int