### PR TITLE
ENH: making `spatial` case insensitive

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -37,6 +37,8 @@ ipac.irsa
 - Adding support for asynchronous queries using the new ``async_job``
   keyword. [#3201]
 
+- Making ``'spatial'`` keyword in ``query_region`` case insensitive. [#3224]
+
 ipac.nexsci.nasa_exoplanet_archive
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 

--- a/astroquery/ipac/irsa/core.py
+++ b/astroquery/ipac/irsa/core.py
@@ -208,9 +208,11 @@ class IrsaClass(BaseVOQuery):
 
         adql = f'SELECT {columns} FROM {catalog}'
 
-        if spatial == 'All-Sky':
+        spatial = spatial.lower()
+
+        if spatial == 'all-sky' or spatial == 'allsky':
             where = ''
-        elif spatial == 'Polygon':
+        elif spatial == 'polygon':
             try:
                 coordinates_list = [parse_coordinates(coord).icrs for coord in polygon]
             except TypeError:
@@ -229,12 +231,12 @@ class IrsaClass(BaseVOQuery):
             coords_icrs = parse_coordinates(coordinates).icrs
             ra, dec = coords_icrs.ra.deg, coords_icrs.dec.deg
 
-            if spatial == 'Cone':
+            if spatial == 'cone':
                 if isinstance(radius, str):
                     radius = Angle(radius)
                 where = (" WHERE CONTAINS(POINT('ICRS',ra,dec),"
                          f"CIRCLE('ICRS',{ra},{dec},{radius.to(u.deg).value}))=1")
-            elif spatial == 'Box':
+            elif spatial == 'box':
                 if isinstance(width, str):
                     width = Angle(width)
                 where = (" WHERE CONTAINS(POINT('ICRS',ra,dec),"

--- a/astroquery/ipac/irsa/tests/test_irsa.py
+++ b/astroquery/ipac/irsa/tests/test_irsa.py
@@ -48,7 +48,7 @@ poly2 = [(10.1 * u.deg, 10.1 * u.deg), (10.0 * u.deg, 10.1 * u.deg),
 def test_query_region_polygon(polygon):
     query1 = Irsa.query_region(catalog="fp_psc", spatial="Polygon", polygon=polygon,
                                get_query_payload=True)
-    query2 = Irsa.query_region("m31", catalog="fp_psc", spatial="Polygon", polygon=polygon,
+    query2 = Irsa.query_region("m31", catalog="fp_psc", spatial="polygon", polygon=polygon,
                                get_query_payload=True)
 
     assert query1 == query2
@@ -58,12 +58,12 @@ def test_query_region_polygon(polygon):
 
 def test_query_allsky():
     query1 = Irsa.query_region(catalog="fp_psc", spatial="All-Sky", get_query_payload=True)
-    query2 = Irsa.query_region("m31", catalog="fp_psc", spatial="All-Sky", get_query_payload=True)
+    query2 = Irsa.query_region("m31", catalog="fp_psc", spatial="allsky", get_query_payload=True)
 
     assert query1 == query2 == "SELECT * FROM fp_psc"
 
 
-@pytest.mark.parametrize('spatial', ['cone', 'box', 'polygon', 'all-Sky', 'All-sky', 'invalid'])
+@pytest.mark.parametrize('spatial', ['random_nonsense', 'invalid'])
 def test_spatial_invalid(spatial):
     with pytest.raises(ValueError):
         Irsa.query_region(OBJ_LIST[0], catalog='invalid_spatial', spatial=spatial)


### PR DESCRIPTION
To fix #3222 

Note, the same keyword in heasarc has been recently added as case insensitive.