### PR TITLE
docs: add a clear message uppon ban

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -62,6 +62,8 @@ xmatch
 - the API is more flexible: you can now ommit the ``vizier:`` before the catalog name
   when crossmatching with a vizier table [#3194]
 
+- add a help message when people are banned instead of returning error code 403 [#3225]
+
 Infrastructure, Utility and Other Changes and Additions
 -------------------------------------------------------
 

--- a/astroquery/xmatch/core.py
+++ b/astroquery/xmatch/core.py
@@ -115,7 +115,7 @@ class XMatchClass(BaseQuery):
         if response.status_code == 403:
             raise HTTPError("Your IP address has been banned from the XMatch server. "
                             "This means that you sent too many cross-matching jobs in "
-                            "parallel to the service blocking other astronomers. Please"
+                            "parallel to the service, blocking other astronomers. Please"
                             " contact the CDS team at cds-question[at]unistra.fr to "
                             "find a solution.")
 

--- a/astroquery/xmatch/core.py
+++ b/astroquery/xmatch/core.py
@@ -111,6 +111,14 @@ class XMatchClass(BaseQuery):
 
         response = self._request(method='POST', url=self.URL, data=payload,
                                  timeout=self.TIMEOUT, cache=cache, **kwargs)
+
+        if response.status_code == 403:
+            raise HTTPError("Your IP address has been banned from the XMatch server. "
+                            "This means that you sent too many cross-matching jobs in "
+                            "parallel to the service blocking other astronomers. Please"
+                            " contact the CDS team at cds-question[at]unistra.fr to "
+                            "find a solution.")
+
         try:
             response.raise_for_status()
         except HTTPError as err:

--- a/docs/xmatch/xmatch.rst
+++ b/docs/xmatch/xmatch.rst
@@ -84,7 +84,7 @@ Troubleshooting
 
 If you are getting a 403 Forbidden error, then your IP address has been banned from
 XMatch's server. This means that you sent too many cross-matching jobs in parallel to 
-the service blocking other astronomers. Please contact the CDS team at
+the service, blocking other astronomers. Please contact the CDS team at
 cds-question[at]unistra.fr to find a solution.
 
 Out of date results

--- a/docs/xmatch/xmatch.rst
+++ b/docs/xmatch/xmatch.rst
@@ -79,6 +79,17 @@ in the resulting table for demonstration purposes.  Finally, ``colRa1`` and
 Troubleshooting
 ===============
 
+403 Forbidden
+-------------
+
+If you are getting a 403 Forbidden error, then your IP address has been banned from
+XMatch's server. This means that you sent too many cross-matching jobs in parallel to 
+the service blocking other astronomers. Please contact the CDS team at
+cds-question[at]unistra.fr to find a solution.
+
+Out of date results
+-------------------
+
 If you are repeatedly getting failed queries, or bad/out-of-date results, try clearing your cache:
 
 .. code-block:: python


### PR DESCRIPTION
Hi astroquery's devs :slightly_smiling_face: 

An abusive XMatch user with astroquery's user agent was banned from our servers today. This made me realize that there are no warnings nor explanations in the documentation about DDoS attacks in this module.

Our support email is also added to the error message and to the documentation so that we can un-ban the astronomers after helping improving their workflows.

The section in the documentation can be removed when there will be a new release, as people won't see the 403: Forbidden error anymore.