### PR TITLE
Add batching to MastMissions.get_product_list

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -75,6 +75,9 @@ mast
 
 - Corrected parameter checking in ``MastMissions`` to ensure case-sensitive comparisons. [#3260]
 
+- Add batching to ``MastMissions.get_product_list`` to avoid server errors and allow for a larger number of input datasets. [#3230]
+
+
 simbad
 ^^^^^^
 

--- a/astroquery/mast/missions.py
+++ b/astroquery/mast/missions.py
@@ -392,12 +392,18 @@ class MastMissionsClass(MastQueryWithLogin):
             dataset_chunks = list(utils.split_list_into_chunks(datasets, max_batch))
 
             results = []  # list to store responses from each batch
-            with ProgressBarOrSpinner(len(dataset_chunks), f'Fetching products for {num_datasets} unique datasets '
+            with ProgressBarOrSpinner(num_datasets, f'Fetching products for {num_datasets} unique datasets '
                                       f'in {len(dataset_chunks)} batches ...') as pb:
-                for i, chunk in enumerate(dataset_chunks):
-                    pb.update(i)
+                datasets_fetched = 0
+                pb.update(0)
+                for chunk in dataset_chunks:
+                    # Send request for each chunk and add response to list
                     params = {'dataset_ids': chunk}
                     results.append(self._service_api_connection.missions_request_async(self.service, params))
+
+                    # Update progress bar with the number of datasets that have had products fetched
+                    datasets_fetched += len(chunk)
+                    pb.update(datasets_fetched)
             return results
         else:
             # Single batch request

--- a/astroquery/mast/tests/test_mast.py
+++ b/astroquery/mast/tests/test_mast.py
@@ -344,6 +344,11 @@ def test_missions_get_product_list(patch_post):
     result = mast.MastMissions.get_product_list(datasets[0])
     assert isinstance(result, Table)
 
+    # Batching
+    dataset_list = [f'{i}' for i in range(1001)]
+    result = mast.MastMissions.get_product_list(dataset_list)
+    assert isinstance(result, Table)
+
 
 def test_missions_get_unique_product_list(patch_post, caplog):
     unique_products = mast.MastMissions.get_unique_product_list('Z14Z0104T')

--- a/astroquery/mast/utils.py
+++ b/astroquery/mast/utils.py
@@ -159,6 +159,26 @@ def parse_input_location(coordinates=None, objectname=None):
     return obj_coord
 
 
+def split_list_into_chunks(input_list, chunk_size):
+    """
+    Splits a list into chunks of a specified size.
+
+    Parameters
+    ----------
+    input_list : list
+        List to be split into chunks.
+    chunk_size : int
+        Size of each chunk.
+
+    Yields
+    ------
+    chunk : list
+        A chunk of the input list.
+    """
+    for idx in range(0, len(input_list), chunk_size):
+        yield input_list[idx:idx + chunk_size]
+
+
 def mast_relative_path(mast_uri):
     """
     Given one or more MAST dataURI(s), return the associated relative path(s).
@@ -180,7 +200,7 @@ def mast_relative_path(mast_uri):
 
     # Split the list into chunks of 50 URIs; this is necessary
     # to avoid "414 Client Error: Request-URI Too Large".
-    uri_list_chunks = list(_split_list_into_chunks(uri_list, chunk_size=50))
+    uri_list_chunks = list(split_list_into_chunks(uri_list, chunk_size=50))
 
     result = []
     for chunk in uri_list_chunks:
@@ -212,12 +232,6 @@ def mast_relative_path(mast_uri):
         return result[0]
     # Else, return a list of paths
     return result
-
-
-def _split_list_into_chunks(input_list, chunk_size):
-    """Helper function for `mast_relative_path`."""
-    for idx in range(0, len(input_list), chunk_size):
-        yield input_list[idx:idx + chunk_size]
 
 
 def remove_duplicate_products(data_products, uri_key):


### PR DESCRIPTION
Add batching to ``MastMissions.get_product_list`` to avoid server errors and allow for a larger number of input datasets.

Also added some tests to check for this case, although they don't return any results to avoid performance-intensive queries.