### PR TITLE
GAIA:  Revert change in the name of the datalink RVS type, in the PR #3207

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -34,7 +34,7 @@ Service fixes and enhancements
 gaia
 ^^^^
 
-- Update DR4 retrieval_type names and include the new one EPOCH_ASTROMETRY_BRIGHT [#3207]
+- Update DR4 retrieval_type names and include the new one EPOCH_ASTROMETRY_BRIGHT [#3207, #3238]
 
 ipac.irsa
 ^^^^^^^^^

--- a/astroquery/gaia/__init__.py
+++ b/astroquery/gaia/__init__.py
@@ -28,7 +28,7 @@ class Conf(_config.ConfigNamespace):
     VALID_DATALINK_RETRIEVAL_TYPES = ['EPOCH_PHOTOMETRY',
                                       'XP_CONTINUOUS',
                                       'XP_SAMPLED',
-                                      'RVS_MEAN_SPECTRUM',
+                                      'RVS',
                                       'MCMC_GSPPHOT',
                                       'MCMC_MSC',
                                       'EPOCH_ASTROMETRY',


### PR DESCRIPTION
In  PR #3207 we changed the name of the datalink retrieve type RVS by RVS_MEAN_SPECTRUM.  We would like to revert this change. The rests of the changes done in the PR #3207 were right.

cc @esdc-esac-esa-int 

jira:GAIAMNGT-1828)