### PR TITLE
EUCLID: the parameter output_file is not properly used in the method get_spectrum 

### DIFF
--- a/astroquery/esa/euclid/core.py
+++ b/astroquery/esa/euclid/core.py
@@ -1231,7 +1231,7 @@ class EuclidClass(TapPlus):
         output_file_full_path, output_dir = self.__set_dirs(output_file=output_file, observation_id=fits_file)
 
         if os.listdir(output_dir):
-            raise Exception(f'The directory is not empty: {output_dir}')
+            raise IOError(f'The directory is not empty: {output_dir}')
 
         try:
             self.__eucliddata.load_data(params_dict=params_dict, output_file=output_file_full_path, verbose=verbose)

--- a/astroquery/esa/euclid/core.py
+++ b/astroquery/esa/euclid/core.py
@@ -42,20 +42,19 @@ class EuclidClass(TapPlus):
     __VALID_DATALINK_RETRIEVAL_TYPES = conf.VALID_DATALINK_RETRIEVAL_TYPES
 
     def __init__(self, *, environment='PDR', tap_plus_conn_handler=None, datalink_handler=None, cutout_handler=None,
-                 euclid_tap_server=None, euclid_data_server=None, euclid_cutout_server=None, verbose=False,
-                 show_server_messages=True):
+                 verbose=False, show_server_messages=True):
         """Constructor for EuclidClass.
 
         Parameters
         ----------
         environment : str, mandatory if no tap, data or cutout hosts is specified, default 'PDR'
             The Euclid Science Archive environment: 'PDR', 'IDR', 'OTF' and 'REG'
-        euclid_tap_server : str, optional, default None
-            TAP URL
-        euclid_data_server : str, optional, default None
-            data URL
-        euclid_cutout_server : str, optional, default None
-            cutout URL
+        tap_plus_conn_handler : tap connection handler object, optional, default None
+            HTTP(s) connection hander (creator). If no handler is provided, a new one is created.
+        datalink_handler : dataliink connection handler object, optional, default None
+            HTTP(s) connection hander (creator). If no handler is provided, a new one is created.
+        cutout_handler : cutout connection handler object, optional, default None
+            HTTP(s) connection hander (creator). If no handler is provided, a new one is created.
         verbose : bool, optional, default 'True'
             flag to display information about the process
         show_server_messages : bool, optional, default 'True'

--- a/astroquery/esa/euclid/core.py
+++ b/astroquery/esa/euclid/core.py
@@ -1231,8 +1231,7 @@ class EuclidClass(TapPlus):
         output_file_full_path, output_dir = self.__set_dirs(output_file=output_file, observation_id=fits_file)
 
         if os.listdir(output_dir):
-            log.error(f'The directory is not empty: {output_dir}')
-            return
+            raise Exception(f'The directory is not empty: {output_dir}')
 
         try:
             self.__eucliddata.load_data(params_dict=params_dict, output_file=output_file_full_path, verbose=verbose)

--- a/astroquery/esa/euclid/core.py
+++ b/astroquery/esa/euclid/core.py
@@ -1170,7 +1170,7 @@ class EuclidClass(TapPlus):
         -----------
         Downloads a spectrum with datalink.
 
-        The spectrum associated to the source_id is downloaded as a compressed fits file, and the files it contains
+        The spectrum associated with the source_id is downloaded as a compressed fits file, and the files it contains
         are returned in a list. The compressed fits file is saved in the local path given by output_file. If this
         parameter is not set, the result is saved in the file "<working
         directory>/temp_<%Y%m%d_%H%M%S>/<source_id>.fits.zip". In any case, the content of the zip file is
@@ -1195,7 +1195,7 @@ class EuclidClass(TapPlus):
         -------
         A list of files: the files contained in the downloaded compressed fits file. The format of the file is
         SPECTRA_<colour>-<schema> <source_id>.fits', where <colour> is BGS or RGS, and <schema> and <source_id> are
-        taking from the input parameters.
+        taken from the input parameters.
 
         """
 


### PR DESCRIPTION
Hi Astroquery team,

we want to fix the method get_spectrum  in the Euclid module, so that the parameter output_file is properly used. We check that the output directory, defined by the the parameter output_file, is empty before it is used. Otherwise, the number of the returned files by this method could be incorrect. Also we have added the missing .zip extension when is necessary.

cc @esdc-esac-esa-int 

jira: EUCLIDPCR-1914