### PR TITLE
EUCLID: Override TAP method get_datalinks

### DIFF
--- a/astroquery/esa/euclid/core.py
+++ b/astroquery/esa/euclid/core.py
@@ -1225,5 +1225,26 @@ class EuclidClass(TapPlus):
 
         return files
 
+    def get_datalinks(self, ids, *, linking_parameter='SOURCE_ID', verbose=False):
+        """Gets datalinks associated to the provided identifiers
+        TAP+ only
+
+        Parameters
+        ----------
+        ids : str, int, str list or int list, mandatory
+            list of identifiers
+        linking_parameter : str, optional, default SOURCE_ID, valid values: SOURCE_ID
+            By default, all the identifiers are considered as source_id
+        verbose : bool, optional, default 'False'
+            flag to display information about the process
+
+        Returns
+        -------
+        A table object
+
+        """
+
+        return self.__eucliddata.get_datalinks(ids=ids, linking_parameter=linking_parameter, verbose=verbose)
+
 
 Euclid = EuclidClass()

--- a/astroquery/esa/euclid/core.py
+++ b/astroquery/esa/euclid/core.py
@@ -1231,7 +1231,7 @@ class EuclidClass(TapPlus):
 
         Parameters
         ----------
-        ids : str, int, str list or int list, mandatory
+        ids : str, int, list of str or list of int, mandatory
             list of identifiers
         linking_parameter : str, optional, default SOURCE_ID, valid values: SOURCE_ID
             By default, all the identifiers are considered as source_id

--- a/astroquery/esa/euclid/tests/test_euclidtap.py
+++ b/astroquery/esa/euclid/tests/test_euclidtap.py
@@ -1091,6 +1091,20 @@ def test_logout(mock_logout):
     assert (mock_logout.call_count == 4)
 
 
+def test_get_datalinks(monkeypatch):
+    def get_datalinks_monkeypatched(self, ids, linking_parameter, verbose):
+        return Table()
+
+    # `GaiaClass` is a subclass of `TapPlus`, but it does not inherit
+    # `get_datalinks()`, it replaces it with a call to the `get_datalinks()`
+    # of its `__gaiadata`.
+    monkeypatch.setattr(TapPlus, "get_datalinks", get_datalinks_monkeypatched)
+    euclid = EuclidClass(show_server_messages=False)
+
+    result = euclid.get_datalinks(ids=[12345678], verbose=True)
+    assert isinstance(result, Table)
+
+
 def test_load_async_job(mock_querier_async):
     jobid = '1479386030738O'
     name = None

--- a/docs/esa/euclid/euclid.rst
+++ b/docs/esa/euclid/euclid.rst
@@ -1177,17 +1177,16 @@ To find out the resources associated with a given source:
 .. doctest-skip::
 
   >>> from astroquery.esa.euclid import Euclid
->>> Euclid.login()
+  >>> Euclid.login()
   >>> ids=["2707008224650763513"]
   >>> datalink = Euclid.get_datalinks(ids=ids)
-  >>> datatlink
-  <Table length=2>
+  >>> print(datalink)
              ID            linking_parameter                                          access_url                                         service_def error_message semantics     description     content_type content_length
                                                                                                                                                                                                                    byte
-           object                object                                                 object                                              object       object      object         object          object        int64
   ------------------------ ----------------- ------------------------------------------------------------------------------------------- ----------- ------------- --------- ------------------- ------------ --------------
   sedm 2707008224650763513         SOURCE_ID https://eas.esac.esa.int/sas-dd/data?ID=sedm+2707008224650763513&RETRIEVAL_TYPE=SPECTRA_RGS                               #this  Spectra Red Source                          --
   sedm 2707008224650763513         SOURCE_ID https://eas.esac.esa.int/sas-dd/data?ID=sedm+2707008224650763513&RETRIEVAL_TYPE=SPECTRA_BGS                               #this Spectra Blue Source                          --
+
 
 
 

--- a/docs/esa/euclid/euclid.rst
+++ b/docs/esa/euclid/euclid.rst
@@ -1177,8 +1177,18 @@ To find out the resources associated with a given source:
 .. doctest-skip::
 
   >>> from astroquery.esa.euclid import Euclid
-  >>> ids=["sedm -522481450274091664"]
+>>> Euclid.login()
+  >>> ids=["2707008224650763513"]
   >>> datalink = Euclid.get_datalinks(ids=ids)
+  >>> datatlink
+  <Table length=2>
+             ID            linking_parameter                                          access_url                                         service_def error_message semantics     description     content_type content_length
+                                                                                                                                                                                                                   byte
+           object                object                                                 object                                              object       object      object         object          object        int64
+  ------------------------ ----------------- ------------------------------------------------------------------------------------------- ----------- ------------- --------- ------------------- ------------ --------------
+  sedm 2707008224650763513         SOURCE_ID https://eas.esac.esa.int/sas-dd/data?ID=sedm+2707008224650763513&RETRIEVAL_TYPE=SPECTRA_RGS                               #this  Spectra Red Source                          --
+  sedm 2707008224650763513         SOURCE_ID https://eas.esac.esa.int/sas-dd/data?ID=sedm+2707008224650763513&RETRIEVAL_TYPE=SPECTRA_BGS                               #this Spectra Blue Source                          --
+
 
 
 The query below retrieves a random sample of Euclid sources having spectra.


### PR DESCRIPTION
Hi Astroquery team,

we need to overload the method TAP get_datalinks, so that the correct TapPlus class associated to the sas-data service is used.


cc @esdc-esac-esa-int 

jira: EUCLIDPCR-1914