### PR TITLE
[SIMBAD] Fix upstream changes

### DIFF
--- a/astroquery/simbad/tests/test_simbad_remote.py
+++ b/astroquery/simbad/tests/test_simbad_remote.py
@@ -116,11 +116,8 @@ class TestSimbad:
         simbad_instance = Simbad()
         simbad_instance.add_votable_fields("flux")
         response = simbad_instance.query_object('algol', criteria="filter='V'")
-        # this is bugged, it should be "flux.qual", see https://github.com/gmantele/vollt/issues/154
-        # when the issue upstream in vollt (the TAP software used in SIMBAD) is fixed we can rewrite this test
-        assert "qual" in response.colnames
-        # replace "filter" by "flux.filter" when upstream bug is fixed
-        assert response["filter"][0] == "V"
+        assert "flux.qual" in response.colnames
+        assert response["flux.filter"][0] == "V"
 
     def test_query_object(self):
         self.simbad.ROW_LIMIT = 5

--- a/docs/simbad/query_tap.rst
+++ b/docs/simbad/query_tap.rst
@@ -142,8 +142,9 @@ some tables, add their name. To get the columns of the tables ``ref`` and ``bibl
     table_name column_name   datatype  ...  unit          ucd
       object      object      object   ... object        object
     ---------- ----------- ----------- ... ------ --------------------
-        biblio      biblio        TEXT ...        meta.record;meta.bib
+        biblio      biblio     VARCHAR ...        meta.record;meta.bib
         biblio      oidref      BIGINT ...         meta.record;meta.id
+           ref      "year"    SMALLINT ...          meta.note;meta.bib
            ref    abstract UNICODECHAR ...                 meta.record
            ref     bibcode        CHAR ...            meta.bib.bibcode
            ref         doi     VARCHAR ...          meta.code;meta.bib
@@ -154,7 +155,6 @@ some tables, add their name. To get the columns of the tables ``ref`` and ``bibl
            ref        page     INTEGER ...               meta.bib.page
            ref       title UNICODECHAR ...                  meta.title
            ref      volume     INTEGER ...             meta.bib.volume
-           ref        year    SMALLINT ...          meta.note;meta.bib
 
 `~astroquery.simbad.SimbadClass.list_columns` can also be called with a keyword argument.
 This returns columns from any table for witch the given keyword is either in the table name,

--- a/docs/simbad/simbad-er.gv
+++ b/docs/simbad/simbad-er.gv
@@ -2,7 +2,7 @@ graph "Simbad Relational Database" {
 	node [color=lightgray penwidth=6 shape=box style=filled]
 	graph [esep="+0" mode=major overlap=false sep=0 splines=polyline]
 	edge [color=lightgray labelOverlay="100%" penwidth=7]
-	"Measurement tables" [label="{mesHerschel | mesXmm | mesVelocities | mesVar | mesRot | mesPM | mesPLX | mesIUE | mesISO | mesFe_h | mesDiameter | mesDistance | mesSpT }" fontsize=16 shape=record]
+	"Measurement tables" [label="{mesHerschel | mesXmm | mesVelocities | mesVar | mesRot | mesPM | mesPLX | mesIUE | mesISO | mesFe_h | mesDiameter | mesDistance | mesSpT | mesOtype }" fontsize=16 shape=record]
 	basic -- "Measurement tables" [color="#9EADC8" tooltip="oid:oidref"]
 	allfluxes [fontsize=16 tooltip="all flux/magnitudes U,B,V,I,J,H,K,u_,g_,r_,i_,z_"]
 	alltypes [fontsize=16 tooltip="all object types concatenated with pipe"]

--- a/docs/simbad/simbad_evolution.rst
+++ b/docs/simbad/simbad_evolution.rst
@@ -91,10 +91,10 @@ See a more elaborated example:
     >>> simbad.add_votable_fields("otype", "alltypes")
     >>> result = simbad.query_catalog("M", criteria=CriteriaTranslator.parse(old_criteria))
     >>> result.sort("catalog_id")
-    >>> result[["main_id", "catalog_id", "otype", "otypes"]]
+    >>> result[["main_id", "catalog_id", "otype", "alltypes.otypes"]]
     <Table length=11>
-     main_id  catalog_id otype                   otypes
-      object    object   object                  object
+     main_id  catalog_id otype              alltypes.otypes             
+      object    object   object                  object                 
     --------- ---------- ------ ----------------------------------------
         M   1      M   1    SNR                 HII|IR|Psr|Rad|SNR|X|gam
         M  24      M  24    As*                              As*|Cl*|GNe
@@ -249,26 +249,23 @@ A query for fluxes would then look like:
 However, this quick access does not allow to retrieve the flux error or the bibcode of the
 article from which the information is extracted. To do so, prefer the ``flux`` votable field:
 
-.. this will fail when upstream bug https://github.com/gmantele/vollt/issues/154 is fixed.
-.. "filter" should be replaced by "flux.filter" and "bibcode" by "flux.bibcode".
-
 .. doctest-remote-data::
 
     >>> from astroquery.simbad import Simbad
     >>> simbad = Simbad()
     >>> simbad.add_votable_fields("flux")
     >>> result = simbad.query_object("BD-16  5701")
-    >>> result[["main_id", "flux", "flux_err", "filter", "bibcode"]]
+    >>> result[["main_id", "flux", "flux_err", "flux.filter", "flux.bibcode"]]
     <Table length=6>
-      main_id      flux   flux_err filter       bibcode      
-       object    float32  float32  object        object      
-    ----------- --------- -------- ------ -------------------
-    BD-16  5701 10.322191 0.002762      G 2020yCat.1350....0G
-    BD-16  5701      10.6     0.06      V 2000A&A...355L..27H
-    BD-16  5701     9.205    0.023      J 2003yCat.2246....0C
-    BD-16  5701     8.879    0.042      H 2003yCat.2246....0C
-    BD-16  5701     8.777     0.02      K 2003yCat.2246....0C
-    BD-16  5701     11.15     0.07      B 2000A&A...355L..27H
+      main_id      flux   flux_err flux.filter     flux.bibcode   
+       object    float32  float32     object          object      
+    ----------- --------- -------- ----------- -------------------
+    BD-16  5701 10.322191 0.002762           G 2020yCat.1350....0G
+    BD-16  5701      10.6     0.06           V 2000A&A...355L..27H
+    BD-16  5701     9.205    0.023           J 2003yCat.2246....0C
+    BD-16  5701     8.879    0.042           H 2003yCat.2246....0C
+    BD-16  5701     8.777     0.02           K 2003yCat.2246....0C
+    BD-16  5701     11.15     0.07           B 2000A&A...355L..27H
 
 This gives more details than the quick view. Each line corresponds to a unique filter.
 The ``bibcode`` column corresponds to the article in which the flux information was found.
@@ -280,14 +277,12 @@ We could also add a criteria to restrict the filters in the output:
     >>> simbad = Simbad()
     >>> simbad.add_votable_fields("flux")
     >>> result = simbad.query_object("BD-16  5701", criteria="filter IN ('U', 'B', 'G')")
-    >>> result[["main_id", "flux", "flux_err", "filter", "bibcode"]]
+    >>> result[["main_id", "flux", "flux_err", "flux.filter", "flux.bibcode"]]
     <Table length=2>
-      main_id      flux   flux_err filter       bibcode
-       object    float32  float32  object        object
-    ----------- --------- -------- ------ -------------------
-    BD-16  5701     11.15     0.07      B 2000A&A...355L..27H
-    BD-16  5701 10.322191 0.002762      G 2020yCat.1350....0G
+      main_id      flux   flux_err flux.filter     flux.bibcode   
+       object    float32  float32     object          object      
+    ----------- --------- -------- ----------- -------------------
+    BD-16  5701     11.15     0.07           B 2000A&A...355L..27H
+    BD-16  5701 10.322191 0.002762           G 2020yCat.1350....0G
 
 There was no match for ``U``, but the information is there for ``B`` and ``G``.
-
-.. replace ``bibcode`` by ``flux.bibcode`` here when https://github.com/gmantele/vollt/issues/154 is fixed.


### PR DESCRIPTION
SIMBAD upgraded VOLLT today. This includes the fix from https://github.com/gmantele/vollt/commit/407753f875c899840d53f5e0a8acf659efc56dc6 that was expected to break some of the examples (see the comments that are now removed)

The new version also makes SIMBAD's columns names respect the ADQL reserved keywords, this appears in the table `biblio` where the column `year` is now protected by quotation marks.

PS: I'm not sure about weather this needs a changelog entry or not? The changes are not from astroquery and only appear in the docs