### PR TITLE
Make criteria in MastMissions queries case-sensitive

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -61,6 +61,8 @@ mast
 
 - Bugfix where ``Observations.get_cloud_uri`` and ``Observations.get_cloud_uris`` fail if the MAST relative path is not found. [#3193]
 
+- Corrected parameter checking in ``MastMissions`` to ensure case-sensitive comparisons. [#3260]
+
 simbad
 ^^^^^^
 

--- a/astroquery/mast/missions.py
+++ b/astroquery/mast/missions.py
@@ -132,7 +132,7 @@ class MastMissionsClass(MastQueryWithLogin):
         # Check each criteria argument for validity
         valid_cols = list(self.columns[self.mission]['name']) + self._search_option_fields
         for kwd in criteria.keys():
-            col = next((name for name in valid_cols if name.lower() == kwd.lower()), None)
+            col = next((name for name in valid_cols if name == kwd), None)
             if not col:
                 closest_match = difflib.get_close_matches(kwd, valid_cols, n=1)
                 error_msg = (
@@ -499,7 +499,7 @@ class MastMissionsClass(MastQueryWithLogin):
 
         try:
             # Attempt file download
-            self._download_file(escaped_url, local_path, cache=cache, continuation=False, verbose=verbose)
+            self._download_file(escaped_url, local_path, cache=cache, verbose=verbose)
 
             # Check if file exists
             if not local_path.is_file() and status != 'SKIPPED':

--- a/astroquery/mast/tests/test_mast_remote.py
+++ b/astroquery/mast/tests/test_mast_remote.py
@@ -154,6 +154,11 @@ class TestMast:
             MastMissions.query_criteria(search_position='30 30')
         assert 'search_pos' in str(err_with_alt.value)
 
+        # Should be case sensitive
+        with pytest.raises(InvalidQueryError) as err_case:
+            MastMissions.query_criteria(Search_Pos='30 30')
+        assert 'search_pos' in str(err_case.value)
+
     def test_missions_get_product_list_async(self):
         datasets = MastMissions.query_object("M4", radius=0.1)
 
@@ -315,7 +320,7 @@ class TestMast:
 
     @pytest.mark.parametrize("mission, query_params", [
         ('jwst', {'fileSetName': 'jw01189001001_02101_00001'}),
-        ('classy', {'target': 'J0021+0052'}),
+        ('classy', {'Target': 'J0021+0052'}),
         ('ullyses', {'host_galaxy_name': 'WLM', 'select_cols': ['observation_id']})
     ])
     def test_missions_workflow(self, tmp_path, mission, query_params):


### PR DESCRIPTION
When I added parameter checking to `MastMissions`, I incorrectly assumed that criteria were case-insensitive in the underlying API. This PR performs a case-sensitive comparison to check that parameters match available criteria exactly. 