### PR TITLE
ENH: returning (Q)Table for Alma.query_sia

### DIFF
--- a/astroquery/alma/core.py
+++ b/astroquery/alma/core.py
@@ -642,7 +642,7 @@ class AlmaClass(QueryWithLogin):
                   instrument=None, data_type=None,
                   calib_level=None, target_name=None,
                   res_format=None, maxrec=None,
-                  **kwargs):
+                  enhanced_results=False, **kwargs):
         """
         Use standard SIA2 attributes to query the ALMA SIA service.
 
@@ -655,7 +655,7 @@ class AlmaClass(QueryWithLogin):
         Results in `~astropy.table.QTable` format.
 
         """
-        results = self.sia.search(
+        result = self.sia.search(
             pos=pos,
             band=band,
             time=time,
@@ -676,7 +676,13 @@ class AlmaClass(QueryWithLogin):
             maxrec=maxrec,
             **kwargs)
 
-        return results.to_qtable()
+        if result is not None:
+            if enhanced_results:
+                result = get_enhanced_table(result)
+            else:
+                result = result.to_table()
+
+        return result
 
     query_sia.__doc__ = query_sia.__doc__.replace('_SIA2_PARAMETERS', SIA2_PARAMETERS_DESC)
 

--- a/astroquery/alma/core.py
+++ b/astroquery/alma/core.py
@@ -652,10 +652,10 @@ class AlmaClass(QueryWithLogin):
 
         Returns
         -------
-        Results in `~pyvo.dal.sia2.SIA2Results` format.
-        result.to_qtable in `~astropy.table.QTable` format
+        Results in `~astropy.table.QTable` format.
+
         """
-        return self.sia.search(
+        results = self.sia.search(
             pos=pos,
             band=band,
             time=time,
@@ -675,6 +675,8 @@ class AlmaClass(QueryWithLogin):
             res_format=res_format,
             maxrec=maxrec,
             **kwargs)
+
+        return results.to_qtable()
 
     query_sia.__doc__ = query_sia.__doc__.replace('_SIA2_PARAMETERS', SIA2_PARAMETERS_DESC)
 

--- a/astroquery/alma/tests/test_alma.py
+++ b/astroquery/alma/tests/test_alma.py
@@ -465,7 +465,7 @@ def test_sia():
     empty_result = Table.read(os.path.join(DATA_DIR, 'alma-empty.txt'),
                               format='ascii')
     mock_result = Mock()
-    mock_result.to_qtable.return_value = empty_result
+    mock_result.to_table.return_value = empty_result
     sia_mock.search.return_value = mock_result
     alma = Alma()
     alma._get_dataarchive_url = Mock()

--- a/astroquery/alma/tests/test_alma.py
+++ b/astroquery/alma/tests/test_alma.py
@@ -464,7 +464,9 @@ def test_sia():
     sia_mock = Mock()
     empty_result = Table.read(os.path.join(DATA_DIR, 'alma-empty.txt'),
                               format='ascii')
-    sia_mock.search.return_value = Mock(table=empty_result)
+    mock_result = Mock()
+    mock_result.to_qtable.return_value = empty_result
+    sia_mock.search.return_value = mock_result
     alma = Alma()
     alma._get_dataarchive_url = Mock()
     alma._sia = sia_mock
@@ -477,7 +479,7 @@ def test_sia():
                             target_name='J0423-013',
                             publisher_did='ADS/JAO.ALMA#2013.1.00546.S',
                             exptime=25)
-    assert len(result.table) == 0
+    assert len(result) == 0
     assert_called_with(sia_mock.search, calib_level=[0, 1],
                        band=(300, 400), data_type='cube',
                        pos='CIRCLE 1 2 1',


### PR DESCRIPTION
This has been pulled out from #3252. Also, based on the discussion, I added the `enhanced_results` kwarg, but again, this is an API change for whomever is using `query_sia` as they don't get a `SIA2Results` but a Table/QTable instead.