### PR TITLE
ENH: use Table instead of QTable

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -18,7 +18,7 @@ esa.euclid
 ipac.irsa
 ^^^^^^^^^
 
-- ``query_sia`` now returns the results as an astropy QTable. [#3252]
+- ``query_sia`` now returns the results as an astropy Table. [#3252, #3263]
 
 mast
 ^^^^

--- a/astroquery/ipac/irsa/core.py
+++ b/astroquery/ipac/irsa/core.py
@@ -102,7 +102,7 @@ class IrsaClass(BaseVOQuery):
 
         Returns
         -------
-        Results in `~astropy.table.QTable` format.
+        Results in `~astropy.table.Table` format.
 
         """
         results = self.sia.search(
@@ -126,7 +126,7 @@ class IrsaClass(BaseVOQuery):
             maxrec=maxrec,
             **kwargs)
 
-        return results.to_qtable()
+        return results.to_table()
 
     query_sia.__doc__ = query_sia.__doc__.replace('_SIA2_PARAMETERS', SIA2_PARAMETERS_DESC)
 
@@ -153,7 +153,7 @@ class IrsaClass(BaseVOQuery):
 
         Returns
         -------
-        Results in `~astropy.table.QTable` format.
+        Results in `~astropy.table.Table` format.
         """
 
         if radius is None:
@@ -163,7 +163,7 @@ class IrsaClass(BaseVOQuery):
 
         results = self.ssa.search(pos=pos, diameter=diameter, band=band, time=time,
                                   format='all', collection=collection)
-        return results.to_qtable()
+        return results.to_table()
 
     def list_collections(self, servicetype=None):
         """

--- a/docs/ipac/irsa/irsa.rst
+++ b/docs/ipac/irsa/irsa.rst
@@ -121,8 +121,8 @@ and width parameter of the box search must also be specified.
     >>> table = Irsa.query_region(coordinates=coord, spatial='Box',
     ...                           catalog='fp_psc', width=2 * u.arcmin)
     >>> print(table)
-        ra       dec    err_maj err_min err_ang   designation    ... ext_key scan_key coadd_key coadd        htm20       
-       deg       deg     arcsec  arcsec   deg                    ...                                                     
+        ra       dec    err_maj err_min err_ang   designation    ... ext_key scan_key coadd_key coadd        htm20
+       deg       deg     arcsec  arcsec   deg                    ...
     --------- --------- ------- ------- ------- ---------------- ... ------- -------- --------- ----- -------------------
     10.692216 41.260162    0.10    0.09      87 00424613+4115365 ...      --    69157   1590591    33 4805203678124326400
     10.700059 41.263481    0.31    0.30     155 00424801+4115485 ...      --    69157   1590591    33 4805203678125364736
@@ -229,8 +229,8 @@ the query is send in asynchronous mode.
     >>> from astroquery.ipac.irsa import Irsa
     >>> table = Irsa.query_region("HIP 12", catalog="allwise_p3as_psd", spatial="Cone", async_job=True)
     >>> print(table)
-        designation         ra        dec     sigra  ...         y                   z           spt_ind      htm20    
-                           deg        deg     arcsec ...                                                               
+        designation         ra        dec     sigra  ...         y                   z           spt_ind      htm20
+                           deg        deg     arcsec ...
     ------------------- --------- ----------- ------ ... ------------------ ------------------- --------- -------------
     J000009.78-355736.9 0.0407905 -35.9602605 0.0454 ... 0.0005762523295116 -0.5872239888098030 100102010 8873706189183
 
@@ -271,7 +271,7 @@ Simple image access queries
 
 `~astroquery.ipac.irsa.IrsaClass.query_sia` provides a way to access IRSA's Simple
 Image Access VO service. In the following example we are looking for Spitzer
-Enhanced Imaging products in the centre of the COSMOS field as a `~astropy.table.QTable`.
+Enhanced Imaging products in the centre of the COSMOS field as a `~astropy.table.Table`.
 
 .. doctest-remote-data::
 
@@ -356,7 +356,7 @@ Simple spectral access queries
 
 `~astroquery.ipac.irsa.IrsaClass.query_ssa` provides a way to access IRSA's Simple
 Spectral Access VO service. In the following example we are looking for Spitzer
-Enhanced Imaging products in the centre of the COSMOS field as a `~astropy.table.QTable`.
+Enhanced Imaging products in the centre of the COSMOS field as a `~astropy.table.Table`.
 
 .. doctest-remote-data::
 


### PR DESCRIPTION
otherwise, I run into some warnings for the s_region SIA column. Not yet sure if it's a server-side issue or an issue with the standard, but for now we'll just have Tables instead.

Follow-up for #3252 