### PR TITLE
ENH: adding ``Irsa.list_columns``

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -53,6 +53,9 @@ ipac.irsa
 
 - Making ``'spatial'`` keyword in ``query_region`` case insensitive. [#3224]
 
+- Adding new ``list_columns`` method to list available columns for a given
+  catalog. [#3265]
+
 ipac.nexsci.nasa_exoplanet_archive
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 

--- a/astroquery/ipac/irsa/core.py
+++ b/astroquery/ipac/irsa/core.py
@@ -321,5 +321,27 @@ class IrsaClass(BaseVOQuery):
         for catname in catalogs:
             print("{:30s}  {:s}".format(catname, catalogs[catname]))
 
+    def list_columns(self, catalog, *, full=False):
+        """
+        Return list of columns of a given IRSA catalog.
+
+        Parameters
+        ----------
+        catalog : str
+            The name of the catalog.
+        full : bool
+            If True returns the full schema as a `~astropy.table.Table`.
+            If False returns a dictionary of the column names and their description.
+        """
+
+        query = f"SELECT * from TAP_SCHEMA.columns where table_name='{catalog}'"
+
+        column_table = self.query_tap(query).to_table()
+
+        if full:
+            return column_table
+        else:
+            return {column['column_name']: column['description'] for column in column_table}
+
 
 Irsa = IrsaClass()

--- a/astroquery/ipac/irsa/tests/test_irsa_remote.py
+++ b/astroquery/ipac/irsa/tests/test_irsa_remote.py
@@ -61,6 +61,14 @@ class TestIrsa:
         assert isinstance(result, Table)
         assert len(result) == 7
 
+    def test_list_columns(self):
+        columns = Irsa.list_columns('slphotdr4')
+        assert len(columns) == 203
+        assert isinstance(columns, dict)
+
+        full_columns = Irsa.list_columns('slphotdr4', full=True)
+        assert isinstance(full_columns, Table)
+
     def test_list_catalogs(self):
         catalogs = Irsa.list_catalogs()
         # Number of available catalogs may change over time, test only for significant drop.

--- a/docs/ipac/irsa/irsa.rst
+++ b/docs/ipac/irsa/irsa.rst
@@ -218,6 +218,26 @@ star HIP 12 with just the ra, dec and w1mpro columns would be:
     --------- ----------- ------
     0.0407905 -35.9602605  4.837
 
+
+You can use the `~astroquery.ipac.irsa.IrsaClass.list_columns` method to
+list all available columns for a given catalog. This method behaves
+similarly to what we saw above with ``list_catalogs`` and either returns
+pairs of column names and column descriptions; or a full list of information
+available about the columns in a `~astropy.table.Table`.
+
+.. doctest-remote-data::
+
+    >>> from astroquery.ipac.irsa import Irsa
+    >>> Irsa.list_columns(catalog="allwise_p3as_psd")
+    {'designation': 'WISE source designation',
+     'ra': 'right ascension (J2000)',
+     'dec': 'declination (J2000)',
+     'sigra': 'uncertainty in RA',
+     'sigdec': 'uncertainty in DEC',
+     ...
+     'htm20': 'HTM20 spatial index key'}
+
+
 Async queries
 --------------
 


### PR DESCRIPTION
to list the columns of a given catalog.

I've done it to be similar to list_catalogs, and return a dict of name: description pairs rather than a table with two columns, but I'm happy to change it to return a table instead. (but then we should probably do the same for list_catalogs, too)

The obvious advantage I see for the dict approach is then there is no default ellipsis added, all the columns are listed out on the screen.

This is to close https://github.com/astropy/astroquery/issues/3177

I'm adding docs and tests while waiting for the review.