### PR TITLE
MAINT: deprecating legacy print_catalogs()

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -20,6 +20,8 @@ ipac.irsa
 
 - ``query_sia`` now returns the results as an astropy Table. [#3252, #3263]
 
+- Deprecate ``print_catalogs`` in favour of ``list_catalogs``. [#3266]
+
 mast
 ^^^^
 

--- a/astroquery/ipac/irsa/core.py
+++ b/astroquery/ipac/irsa/core.py
@@ -10,7 +10,7 @@ Module to query the IRSA archive.
 import warnings
 from astropy.coordinates import SkyCoord, Angle
 from astropy import units as u
-from astropy.utils.decorators import deprecated_renamed_argument
+from astropy.utils.decorators import deprecated, deprecated_renamed_argument
 
 from pyvo.dal import TAPService, SIA2Service, SSAService
 from pyvo.dal.sia2 import SIA2_PARAMETERS_DESC
@@ -314,7 +314,7 @@ class IrsaClass(BaseVOQuery):
         else:
             return {tap_table['table_name']: tap_table['description'] for tap_table in tap_tables}
 
-    # TODO, deprecate this as legacy
+    @deprecated(since="0.4.10", alternative="list_catalogs")
     def print_catalogs(self):
         catalogs = self.list_catalogs()
 


### PR DESCRIPTION
Not sure why this wasn't done at the time of previous refactorings, anyway it's done now.