### PR TITLE
TST: Move full conftest.py back to package level

### DIFF
--- a/astroquery/conftest.py
+++ b/astroquery/conftest.py
@@ -1,7 +1,18 @@
-# Duplicate pytest header config here for tox.
+# Licensed under a 3-clause BSD style license - see LICENSE.rst
 
+import os
+from pathlib import Path
+
+from astropy.utils import minversion
+import numpy as np
+import pytest
 from pytest_astropy_header.display import (PYTEST_HEADER_MODULES,
                                            TESTED_VERSIONS)
+
+
+# Keep this until we require numpy to be >=2.0
+if minversion(np, "2.0.0.dev0+git20230726"):
+    np.set_printoptions(legacy="1.25")
 
 
 def pytest_configure(config):
@@ -28,3 +39,24 @@ def pytest_configure(config):
 
     TESTED_VERSIONS['astroquery'] = version.version
     TESTED_VERSIONS['astropy_helpers'] = version.astropy_helpers_version
+
+
+def pytest_addoption(parser):
+    parser.addoption(
+        '--alma-site',
+        action='store',
+        default='almascience.eso.org',
+        help='ALMA site (almascience.nrao.edu, almascience.eso.org or '
+             'almascience.nao.ac.jp for example)'
+    )
+
+
+@pytest.fixture(scope='function')
+def tmp_cwd(tmp_path):
+    """Perform test in a pristine temporary working directory."""
+    old_dir = Path.cwd()
+    os.chdir(tmp_path)
+    try:
+        yield tmp_path
+    finally:
+        os.chdir(old_dir)

--- a/astroquery/conftest.py
+++ b/astroquery/conftest.py
@@ -25,9 +25,9 @@ def pytest_configure(config):
     PYTEST_HEADER_MODULES['astropy-healpix'] = 'astropy_healpix'
     PYTEST_HEADER_MODULES['vamdclib'] = 'vamdclib'
 
-    del PYTEST_HEADER_MODULES['h5py']
-    del PYTEST_HEADER_MODULES['Scipy']
-    del PYTEST_HEADER_MODULES['Pandas']
+    PYTEST_HEADER_MODULES.pop('h5py', None)
+    PYTEST_HEADER_MODULES.pop('Scipy', None)
+    PYTEST_HEADER_MODULES.pop('Pandas', None)
 
     # keyring doesn't provide __version__ any more
     # PYTEST_HEADER_MODULES['keyring'] = 'keyring'

--- a/conftest.py
+++ b/conftest.py
@@ -14,9 +14,9 @@ def pytest_configure(config):
     PYTEST_HEADER_MODULES['astropy-healpix'] = 'astropy_healpix'
     PYTEST_HEADER_MODULES['vamdclib'] = 'vamdclib'
 
-    del PYTEST_HEADER_MODULES['h5py']
-    del PYTEST_HEADER_MODULES['Scipy']
-    del PYTEST_HEADER_MODULES['Pandas']
+    PYTEST_HEADER_MODULES.pop('h5py', None)
+    PYTEST_HEADER_MODULES.pop('Scipy', None)
+    PYTEST_HEADER_MODULES.pop('Pandas', None)
 
     # keyring doesn't provide __version__ any more
     # PYTEST_HEADER_MODULES['keyring'] = 'keyring'


### PR DESCRIPTION
Move full conftest.py back to package level because otherwise pytest cannot find it if run on installed code but we still need root level for tox pytest header. This is a follow-up of #3215

Example failing log without this patch: https://github.com/astropy/astropy-integration-testing/actions/runs/13929757409/job/39007964709

With this patch: https://github.com/astropy/astropy-integration-testing/pull/27 produces https://github.com/astropy/astropy-integration-testing/actions/runs/13954373539/job/39061703535?pr=27

See also https://github.com/astropy/ccdproc/pull/884