### PR TITLE
MAINT: deprecate ``band`` from ``Gaia.load_data()``

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -9,7 +9,11 @@ New Tools and Services
 API changes
 -----------
 
+gaia
+^^^^
 
+- Deprecated ``band`` from ``load_data`` as it has no effect on upstream
+  response any more. [#3278]
 
 Service fixes and enhancements
 ------------------------------

--- a/astroquery/gaia/core.py
+++ b/astroquery/gaia/core.py
@@ -168,7 +168,7 @@ class GaiaClass(TapPlus):
         except HTTPError:
             log.error("Error logging out data server")
 
-    @deprecated_renamed_argument("output_file", None, since="0.4.8")
+    @deprecated_renamed_argument(("output_file", "band"), (None, None), since=("0.4.8", "0.4.11"))
     def load_data(self, ids, *, data_release=None, data_structure='INDIVIDUAL', retrieval_type="ALL",
                   linking_parameter='SOURCE_ID', valid_data=False, band=None, avoid_datatype_check=False,
                   format="votable", dump_to_file=False, overwrite_output_file=False, verbose=False,
@@ -212,10 +212,6 @@ class GaiaClass(TapPlus):
             In order to retrieve only valid data (data rows where flux is not null and/or the
             rejected_by_photometry flag is set to False) this request parameter should be included
             with valid_data=True.
-        band : str, optional, default None, valid values: G, BP, RP
-            By default, the epoch photometry service returns all the
-            available photometry bands for the requested source.
-            This parameter allows to filter the output lightcurve by its band.
         avoid_datatype_check: boolean, optional, default False.
             By default, this value will be set to False. If it is set to 'true'
             the Datalink items tags will not be checked.
@@ -281,11 +277,6 @@ class GaiaClass(TapPlus):
         elif valid_data:
             params_dict['VALID_DATA'] = "true"
 
-        if band is not None:
-            if band != 'G' and band != 'BP' and band != 'RP':
-                raise ValueError(f"Invalid band value '{band}' (Valid values: 'G', 'BP' and 'RP)")
-            else:
-                params_dict['BAND'] = band
         if isinstance(ids, str):
             ids_arg = ids
         else:

--- a/astroquery/gaia/tests/test_gaiatap.py
+++ b/astroquery/gaia/tests/test_gaiatap.py
@@ -821,7 +821,7 @@ def test_datalink_querier_load_data_vot_exception(mock_datalink_querier, overwri
             mock_datalink_querier.load_data(ids=[5937083312263887616], data_release='Gaia DR3',
                                             data_structure='INDIVIDUAL',
                                             retrieval_type="ALL",
-                                            linking_parameter='SOURCE_ID', valid_data=False, band=None,
+                                            linking_parameter='SOURCE_ID', valid_data=False,
                                             avoid_datatype_check=False,
                                             format="votable", dump_to_file=True,
                                             overwrite_output_file=overwrite_output_file,
@@ -835,7 +835,7 @@ def test_datalink_querier_load_data_vot_exception(mock_datalink_querier, overwri
         mock_datalink_querier.load_data(ids=[5937083312263887616], data_release='Gaia DR3',
                                         data_structure='INDIVIDUAL',
                                         retrieval_type="ALL",
-                                        linking_parameter='SOURCE_ID', valid_data=False, band=None,
+                                        linking_parameter='SOURCE_ID', valid_data=False,
                                         avoid_datatype_check=False,
                                         format="votable", dump_to_file=True,
                                         overwrite_output_file=overwrite_output_file,
@@ -850,7 +850,7 @@ def test_datalink_querier_load_data_vot(mock_datalink_querier):
     result_dict = mock_datalink_querier.load_data(ids=[5937083312263887616], data_release='Gaia DR3',
                                                   data_structure='INDIVIDUAL',
                                                   retrieval_type="ALL",
-                                                  linking_parameter='SOURCE_ID', valid_data=False, band=None,
+                                                  linking_parameter='SOURCE_ID', valid_data=False,
                                                   avoid_datatype_check=False,
                                                   format="votable", dump_to_file=True, overwrite_output_file=True,
                                                   verbose=False)
@@ -888,7 +888,7 @@ def test_datalink_querier_load_data_ecsv(mock_datalink_querier_ecsv):
     result_dict = mock_datalink_querier_ecsv.load_data(ids=[5937083312263887616], data_release='Gaia DR3',
                                                        data_structure='INDIVIDUAL',
                                                        retrieval_type="ALL",
-                                                       linking_parameter='SOURCE_ID', valid_data=False, band=None,
+                                                       linking_parameter='SOURCE_ID', valid_data=False,
                                                        avoid_datatype_check=False,
                                                        format="ecsv", dump_to_file=True, overwrite_output_file=True,
                                                        verbose=False)
@@ -926,7 +926,7 @@ def test_datalink_querier_load_data_csv(mock_datalink_querier_csv):
     result_dict = mock_datalink_querier_csv.load_data(ids=[5937083312263887616], data_release='Gaia DR3',
                                                       data_structure='INDIVIDUAL',
                                                       retrieval_type="ALL",
-                                                      linking_parameter='SOURCE_ID', valid_data=False, band=None,
+                                                      linking_parameter='SOURCE_ID', valid_data=False,
                                                       avoid_datatype_check=False,
                                                       format="csv", dump_to_file=True, overwrite_output_file=True,
                                                       verbose=False)
@@ -965,7 +965,7 @@ def test_datalink_querier_load_data_fits(mock_datalink_querier_fits):
     result_dict = mock_datalink_querier_fits.load_data(ids=[5937083312263887616], data_release='Gaia DR3',
                                                        data_structure='INDIVIDUAL',
                                                        retrieval_type="ALL",
-                                                       linking_parameter='SOURCE_ID', valid_data=False, band=None,
+                                                       linking_parameter='SOURCE_ID', valid_data=False,
                                                        avoid_datatype_check=False,
                                                        format="fits", dump_to_file=True, overwrite_output_file=True,
                                                        verbose=False)


### PR DESCRIPTION
It has no effect on upstream query any more, thus we should remove it (but with a deprecation, so it doesn't break user code straight away).

Closes #3248 