### PR TITLE
MAINT: raise more errors earlier

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -32,6 +32,10 @@ query.py
   Some corner cases where downloads were not properly continued have been
   fixed. [#3232]
 
+utils
+^^^^^
+
+- Raising cleaner errors earlier when server returns with error. [#3284]
 
 
 0.4.10 (2025-03-18)

--- a/astroquery/utils/process_asyncs.py
+++ b/astroquery/utils/process_asyncs.py
@@ -26,6 +26,7 @@ def async_to_sync(cls):
             response = getattr(self, async_method_name)(*args, **kwargs)
             if kwargs.get('get_query_payload') or kwargs.get('field_help'):
                 return response
+            response.raise_for_status()
             result = self._parse_result(response, verbose=verbose)
             self.table = result
             return result

--- a/astroquery/utils/process_asyncs.py
+++ b/astroquery/utils/process_asyncs.py
@@ -4,6 +4,8 @@ Process all "async" methods into direct methods.
 """
 import textwrap
 import functools
+from requests import Response
+
 from .class_or_instance import class_or_instance
 from .docstr_chompers import remove_sections
 
@@ -26,7 +28,10 @@ def async_to_sync(cls):
             response = getattr(self, async_method_name)(*args, **kwargs)
             if kwargs.get('get_query_payload') or kwargs.get('field_help'):
                 return response
-            response.raise_for_status()
+            # mast is doing something weird by stacking the responses into a list while also using async_to_sync
+            # so we have to check for that here until it's refactored
+            if isinstance(response, Response):
+                response.raise_for_status()
             result = self._parse_result(response, verbose=verbose)
             self.table = result
             return result


### PR DESCRIPTION
So we don't end with red herring errors like when we try to parse an error response into a votable. E.g. I got a ``KeyError: 'RA(h)'`` while working on a fix for https://github.com/astropy/astroquery/issues/3282 all the while the actual problem was a super clear 404

```
HTTPError: 404 Client Error: Not Found for url: https://ssp.imcce.fr/webservices/skybot/skybotconesearch_query.php?-ra=0.0&-dec=0.0&-rd=0.3&-ep=2458291.893831018&-loc=G37&-filter=0.1&-objFilter=111&-refsys=EQJ2000&-output=all&-mime=text
```

