### PR TITLE
EUCLID: delete Xmatch documentation [ci skip]

### DIFF
--- a/docs/esa/euclid/euclid.rst
+++ b/docs/esa/euclid/euclid.rst
@@ -63,9 +63,6 @@ ESA EUCLID TAP+ server provides two access modes: public and authenticated:
 
   * ADQL queries and results are saved in a user private area.
 
-  * Cross-match operations: a catalog cross-match operation can be executed.
-    Cross-match operations results are saved in a user private area.
-
   * Persistence of uploaded tables: a user can upload a table in a private space.
     These tables can be used in queries as well as in cross-matches operations.
 
@@ -109,8 +106,8 @@ observations), the next campaign shall be run in March-April 2025.
 opened on the 6th of November 2024, with a first pass on the three Euclid deep fields (EDFN, EDFS and EDFF) as well as
 observations on the Lynds Dark Nebula LDN1641.
 
-4. The PDR (Public Data Release) environment of the Euclid science archive holds the public data. Euclid Q1 data will be publicly released on March 19,
-2025. The main component of the Q1 data shall contain Level 2 data of a single visit (at the depth of the Euclid Wide
+4. The PDR (Public Data Release) environment of the Euclid science archive holds the public data. Euclid Q1 data was publicly released on March 19,
+2025. The main component of the Q1 data contains Level 2 data of a single visit (at the depth of the Euclid Wide
 Survey) over the Euclid Deep Fields (EDFs): 20 deg\ :sup:`2` of the EDF North, 10 deg\ :sup:`2` of EDF Fornax, and
 23 deg\ :sup:`2` of the EDF South. The deep fields will be visited multiple times during the mission.
 
@@ -1031,60 +1028,14 @@ We can type the following:
   Table 'user_joe.table' updated.
 
 
-2.8. Cross match
-^^^^^^^^^^^^^^^^
-
-It is possible to run a geometric cross-match between the ra/dec coordinates of two tables
-using the crossmatch function provided by the archive. In order to do so, the user must be
-logged in. This is required because the cross match operation will generate a join table
-in the user private area. That table contains the identifiers of both tables and the separation,
-in degrees, between ra/dec coordinates of each source in the first table and its associated
-source in the second table. Later, the table can be used to obtain the actual data from both tables.
-
-In order to perform a cross match, both tables must have defined RA and Dec columns
-(ra/dec column flags must be set: see previous section to know how to assign those flags).
-
-The following example uploads a table and then, the table is used in a cross match:
-
-.. Skipping authentication requiring examples
-.. doctest-skip::
-
-  >>> from astroquery.esa.euclid import Euclid
-  >>> Euclid.login()
-  >>> table = file or astropy.table
-  >>> Euclid.upload_table(upload_resource=table, table_name='my_sources')
-  >>> # the table will be uploaded into the user private space into the database
-  >>> # the table can be referenced as <database user schema>.<table_name>
-  >>> full_qualified_table_name = 'user_<your_login_name>.my_sources'
-  >>> xmatch_table_name = 'xmatch_table'
-  >>> Euclid.cross_match(full_qualified_table_name_a=full_qualified_table_name,
-  ...                  full_qualified_table_name_b='Eucliddr3.Euclid_source',
-  ...                  results_table_name=xmatch_table_name, radius=1.0)
-
-
-Once you have your cross match finished, you can obtain the results:
-
-.. Skipping authentication requiring examples
-.. doctest-skip::
-
-  >>> from astroquery.esa.euclid import Euclid
-  >>> xmatch_table = 'user_<your_login_name>.' + xmatch_table_name
-  >>> query = (f"SELECT c.separation*3600 AS separation_arcsec, a.*, b.* FROM Eucliddr3.Euclid_source AS a, "
-  ...          f"{full_qualified_table_name} AS b, {xmatch_table} AS c WHERE c.Euclid_source_source_id = a.source_id AND "
-  ...          f"c.my_sources_my_sources_oid = b.my_sources_oid")
-  >>> job = Euclid.launch_job(query=query)
-  >>> results = job.get_results()
-
-Cross-matching catalogues is one of the most popular operations executed in the Euclid archive.
-
-2.9. Tables sharing
+2.8. Tables sharing
 ^^^^^^^^^^^^^^^^^^^
 
 It is possible to share tables with other users. You have to create a group, populate that
 group with users, and share your table to that group. Then, any user belonging to that group
 will be able to access your shared table in a query.
 
-2.9.1. Creating a group
+2.8.1. Creating a group
 ^^^^^^^^^^^^^^^^^^^^^^^
 
 .. Skipping authentication requiring examples
@@ -1094,7 +1045,7 @@ will be able to access your shared table in a query.
   >>> Euclid.login()
   >>> Euclid.share_group_create(group_name="my_group", description="description")
 
-2.9.2. Removing a group
+2.8.2. Removing a group
 ^^^^^^^^^^^^^^^^^^^^^^^
 
 .. Skipping authentication requiring examples
@@ -1104,7 +1055,7 @@ will be able to access your shared table in a query.
   >>> Euclid.login()
   >>> Euclid.share_group_delete(group_name="my_group")
 
-2.9.3. Listing groups
+2.8.3. Listing groups
 ^^^^^^^^^^^^^^^^^^^^^
 
 .. Skipping authentication requiring examples
@@ -1116,7 +1067,7 @@ will be able to access your shared table in a query.
   >>> for group in groups:
   ...     print(group.title)
 
-2.9.4. Adding users to a group
+2.8.4. Adding users to a group
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 .. Skipping authentication requiring examples
@@ -1126,7 +1077,7 @@ will be able to access your shared table in a query.
   >>> Euclid.login()
   >>> Euclid.share_group_add_user(group_name="my_group",user_id="<user_login_name")
 
-2.9.5. Removing users from a group
+2.8.5. Removing users from a group
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 .. Skipping authentication requiring examples
@@ -1136,7 +1087,7 @@ will be able to access your shared table in a query.
   >>> Euclid.login()
   >>> Euclid.share_group_delete_user(group_name="my_group",user_id="<user_login_name>")
 
-2.9.6. Sharing a table to a group
+2.8.6. Sharing a table to a group
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 .. Skipping authentication requiring examples
@@ -1148,7 +1099,7 @@ will be able to access your shared table in a query.
   ...                  table_name="user_<user_login_name>.my_table",
   ...                  description="description")
 
-2.9.7. Stop sharing a table
+2.8.7. Stop sharing a table
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 .. Skipping authentication requiring examples


### PR DESCRIPTION
In https://github.com/astropy/astroquery/issues/3279, it was pointed out that the Euclid documentation stated that there was a function called cross_match, but this functionality is not available.

Although this will be implemented in a near future, we would rather to update the Euclid documentation and remove the section devoted to the cross match.

@esdc-esac-esa-int 

Jira: EUCLIDMNGT-1355