### PR TITLE
GAIA: update the authentication implementation to read the cookies sent by the new ESAC tap mechanism

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -27,6 +27,12 @@ heasarc
   no data associated with that row rather than filtering it out. [#3275]
 
 
+utils.tap
+^^^^^^^^^
+
+- Get the cookie associated to the keys JSESSIONID or SESSION due to the tap library release at ESAC. [#3289]
+
+
 Infrastructure, Utility and Other Changes and Additions
 -------------------------------------------------------
 

--- a/astroquery/utils/tap/conn/tapconn.py
+++ b/astroquery/utils/tap/conn/tapconn.py
@@ -17,14 +17,14 @@ Created on 30 jun. 2016
 
 import http.client as httplib
 import mimetypes
-import platform
-import time
 import os
-from astroquery.utils.tap.xmlparser import utils
-from astroquery.utils.tap import taputils
-from astroquery import version
-
+import platform
 import requests
+import time
+
+from astroquery import version
+from astroquery.utils.tap import taputils
+from astroquery.utils.tap.xmlparser import utils
 
 __all__ = ['TapConn']
 
@@ -485,6 +485,22 @@ class TapConn:
         """
         return taputils.taputil_find_header(headers, key)
 
+    def find_all_headers(self, headers, key):
+        """Searches for the specified keyword
+
+        Parameters
+        ----------
+        headers : HTTP(s) headers object, mandatory
+            HTTP(s) response headers
+        key : str, mandatory
+            header key to be searched for
+
+        Returns
+        -------
+        A list of requested header values or an emtpy list if no header is found
+        """
+        return taputils.taputil_find_all_headers(headers, key)
+
     def dump_to_file(self, output, response):
         """Writes the connection response into the specified output
 
@@ -585,7 +601,7 @@ class TapConn:
         if content_disposition is not None:
             p = content_disposition.find('filename="')
             if p >= 0:
-                filename = os.path.basename(content_disposition[p+10:len(content_disposition)-1])
+                filename = os.path.basename(content_disposition[p + 10:len(content_disposition) - 1])
                 content_encoding = self.find_header(headers, 'Content-Encoding')
 
                 if content_encoding is not None:
@@ -722,7 +738,7 @@ class TapConn:
 
     def __str__(self):
         return f"\tHost: {self.__connHost}\n\tUse HTTPS: {self.__isHttps}" \
-            f"\n\tPort: {self.__connPort}\n\tSSL Port: {self.__connPortSsl}"
+               f"\n\tPort: {self.__connPort}\n\tSSL Port: {self.__connPortSsl}"
 
 
 class ConnectionHandler:

--- a/astroquery/utils/tap/conn/tests/DummyConnHandler.py
+++ b/astroquery/utils/tap/conn/tests/DummyConnHandler.py
@@ -138,6 +138,9 @@ class DummyConnHandler:
     def find_header(self, headers, key):
         return taputils.taputil_find_header(headers, key)
 
+    def find_all_headers(self, headers, key):
+        return taputils.taputil_find_all_headers(headers, key)
+
     def execute_table_edit(self, data,
                            content_type="application/x-www-form-urlencoded",
                            verbose=False):

--- a/astroquery/utils/tap/conn/tests/test_conn.py
+++ b/astroquery/utils/tap/conn/tests/test_conn.py
@@ -126,8 +126,8 @@ def test_find_header():
                ('Set-Cookie', 'JSESSIONID=E677B51BA5C4837347D1E17D4E36647E; Path=/data-server; Secure; HttpOnly'),
                ('X-Content-Type-Options', 'nosniff'), ('X-XSS-Protection', '0'),
                ('Cache-Control', 'no-cache, no-store, max-age=0, must-revalidate'), ('Pragma', 'no-cache'),
-               ('Expires', '0'), ('X-Frame-Options', 'SAMEORIGIN'), ('Set-Cookie',
-                                                                     'SESSION=ZjQ3MjIzMDAtNjNiYy00Mjk3LTk5YzctNjczMGY5NWMxOGU3; Path=/data-server; Secure; HttpOnly; SameSite=Lax'),
+               ('Expires', '0'), ('X-Frame-Options', 'SAMEORIGIN'),
+               ('Set-Cookie', 'SESSION=ZjQ3MjIzMDAt; Path=/data-server; Secure; HttpOnly; SameSite=Lax'),
                ('Transfer-Encoding', 'chunked'), ('Content-Type', 'text/plain; charset=UTF-8')]
     key = 'Set-Cookie'
     result = tap.find_header(headers, key)

--- a/astroquery/utils/tap/conn/tests/test_conn.py
+++ b/astroquery/utils/tap/conn/tests/test_conn.py
@@ -115,3 +115,40 @@ def test_login():
     assert r.get_method() == 'POST'
     assert r.get_context() == context
     assert r.get_body() == data
+
+
+def test_find_header():
+    host = "testHost"
+    tap = TapConn(ishttps=False, host=host)
+
+    headers = [('Date', 'Sat, 12 Apr 2025 05:10:47 GMT'),
+               ('Server', 'Apache/2.4.6 (Red Hat Enterprise Linux) OpenSSL/1.0.2k-fips mod_jk/1.2.43'),
+               ('Set-Cookie', 'JSESSIONID=E677B51BA5C4837347D1E17D4E36647E; Path=/data-server; Secure; HttpOnly'),
+               ('X-Content-Type-Options', 'nosniff'), ('X-XSS-Protection', '0'),
+               ('Cache-Control', 'no-cache, no-store, max-age=0, must-revalidate'), ('Pragma', 'no-cache'),
+               ('Expires', '0'), ('X-Frame-Options', 'SAMEORIGIN'), ('Set-Cookie',
+                                                                     'SESSION=ZjQ3MjIzMDAtNjNiYy00Mjk3LTk5YzctNjczMGY5NWMxOGU3; Path=/data-server; Secure; HttpOnly; SameSite=Lax'),
+               ('Transfer-Encoding', 'chunked'), ('Content-Type', 'text/plain; charset=UTF-8')]
+    key = 'Set-Cookie'
+    result = tap.find_header(headers, key)
+
+    assert (result == "JSESSIONID=E677B51BA5C4837347D1E17D4E36647E; Path=/data-server; Secure; HttpOnly")
+
+
+def test_find_all_headers():
+    host = "testHost"
+    tap = TapConn(ishttps=False, host=host)
+
+    headers = [('Date', 'Sat, 12 Apr 2025 05:10:47 GMT'),
+               ('Server', 'Apache/2.4.6 (Red Hat Enterprise Linux) OpenSSL/1.0.2k-fips mod_jk/1.2.43'),
+               ('Set-Cookie', 'JSESSIONID=E677B51BA5C4837347D1E17D4E36647E; Path=/data-server; Secure; HttpOnly'),
+               ('X-Content-Type-Options', 'nosniff'), ('X-XSS-Protection', '0'),
+               ('Cache-Control', 'no-cache, no-store, max-age=0, must-revalidate'), ('Pragma', 'no-cache'),
+               ('Expires', '0'), ('X-Frame-Options', 'SAMEORIGIN'),
+               ('Set-Cookie', 'SESSION=ZjQ3MjIzMDAtNjNiYy00Mj; Path=/data-server; Secure; HttpOnly; SameSite=Lax'),
+               ('Transfer-Encoding', 'chunked'), ('Content-Type', 'text/plain; charset=UTF-8')]
+    key = 'Set-Cookie'
+    result = tap.find_all_headers(headers, key)
+
+    assert (result[0] == "JSESSIONID=E677B51BA5C4837347D1E17D4E36647E; Path=/data-server; Secure; HttpOnly")
+    assert (result[1] == "SESSION=ZjQ3MjIzMDAtNjNiYy00Mj; Path=/data-server; Secure; HttpOnly; SameSite=Lax")

--- a/astroquery/utils/tap/conn/tests/test_conn.py
+++ b/astroquery/utils/tap/conn/tests/test_conn.py
@@ -152,3 +152,22 @@ def test_find_all_headers():
 
     assert (result[0] == "JSESSIONID=E677B51BA5C4837347D1E17D4E36647E; Path=/data-server; Secure; HttpOnly")
     assert (result[1] == "SESSION=ZjQ3MjIzMDAtNjNiYy00Mj; Path=/data-server; Secure; HttpOnly; SameSite=Lax")
+
+
+def test_get_file_from_header():
+    host = "testHost"
+    tap = TapConn(ishttps=False, host=host)
+
+    headers = [('Date', 'Sat, 12 Apr 2025 05:10:47 GMT'),
+               ('Server', 'Apache/2.4.6 (Red Hat Enterprise Linux) OpenSSL/1.0.2k-fips mod_jk/1.2.43'),
+               ('Set-Cookie', 'JSESSIONID=E677B51BA5C4837347D1E17D4E36647E; Path=/data-server; Secure; HttpOnly'),
+               ('X-Content-Type-Options', 'nosniff'), ('X-XSS-Protection', '0'),
+               ('Cache-Control', 'no-cache, no-store, max-age=0, must-revalidate'), ('Pragma', 'no-cache'),
+               ('Expires', '0'), ('X-Frame-Options', 'SAMEORIGIN'),
+               ('Set-Cookie', 'SESSION=ZjQ3MjIzMDAtNjNiYy00Mj; Path=/data-server; Secure; HttpOnly; SameSite=Lax'),
+               ('Transfer-Encoding', 'chunked'), ('Content-Type', 'text/plain; charset=UTF-8'),
+               ('Content-Disposition', 'filename="my_file.vot.gz"'), ('Content-Encoding', "gzip")]
+
+    result = tap.get_file_from_header(headers)
+
+    assert (result == "my_file.vot.gz")

--- a/astroquery/utils/tap/core.py
+++ b/astroquery/utils/tap/core.py
@@ -15,11 +15,10 @@ Modified on 1 jun. 2021 by mhsarmiento
 """
 import getpass
 import os
-import tempfile
-from urllib.parse import urlencode
-
 import requests
+import tempfile
 from astropy.table.table import Table
+from urllib.parse import urlencode
 
 from astroquery import log
 from astroquery.utils.tap import taputils
@@ -661,16 +660,23 @@ class Tap:
         return location[pos:]
 
     def __findCookieInHeader(self, headers, *, verbose=False):
-        cookies = self.__connHandler.find_header(headers, 'Set-Cookie')
+        cookies = self.__connHandler.find_all_headers(headers, 'Set-Cookie')
         if verbose:
             print(cookies)
-        if cookies is None:
+        if not cookies:
             return None
         else:
-            items = cookies.split(';')
-            for i in items:
-                if i.startswith("JSESSIONID="):
-                    return i
+            for cook in cookies:
+                items = cook.split(';')
+                for item in items:
+                    if item.startswith("SESSION="):
+                        return item
+
+            for cook in cookies:
+                items = cook.split(';')
+                for item in items:
+                    if item.startswith("JSESSIONID="):
+                        return item
         return None
 
     def __parseUrl(self, url, *, verbose=False):

--- a/astroquery/utils/tap/taputils.py
+++ b/astroquery/utils/tap/taputils.py
@@ -49,6 +49,28 @@ def taputil_find_header(headers, key):
     return None
 
 
+def taputil_find_all_headers(headers, key):
+    """Searches for the specified keyword
+
+    Parameters
+    ----------
+    headers : HTTP(s) headers object, mandatory
+        HTTP(s) response headers
+    key : str, mandatory
+        header key to be searched for
+
+    Returns
+    -------
+    A list of requested header values or an empty list if not header is found
+    """
+
+    result = list()
+    for entry in headers:
+        if key.lower() == entry[0].lower():
+            result.append(entry[1])
+    return result
+
+
 def taputil_create_sorted_dict_key(dictionaryObject):
     """Searches for the specified keyword
 

--- a/docs/gaia/gaia.rst
+++ b/docs/gaia/gaia.rst
@@ -867,6 +867,7 @@ The following example shows how to retrieve the DataLink products associated wit
   ...                           data_release=data_release, retrieval_type=retrieval_type, data_structure=data_structure)
 
 The DataLink products are stored inside a Python Dictionary. Each of its elements (keys) contains a one-element list that can be extracted as follows:
+
 .. code-block:: python
 
   >>> dl_keys  = [inp for inp in datalink.keys()]


### PR DESCRIPTION
Dear astroquery team,

the ESAC team has released a new tap library (v10.1.0) that implements a new authentication mechanism: the cookies are associated to the key SESSION, while in previous versions of the library the JSESSIONID is used instead.

We have updated the implementation in astroquery/utils/tap/core.py, so the new key SESSION is read if it is present in the header. Note that this implementation is backward compatible.

cc @esdc-esac-esa-int 
jira: GAIAPCR-1341