### PR TITLE
Add example of how to get non-public (proprietary) data

### DIFF
--- a/astroquery/alma/core.py
+++ b/astroquery/alma/core.py
@@ -594,6 +594,11 @@ class AlmaClass(QueryWithLogin):
         if science is not None:
             payload['science_observation'] = science
         if public is not None:
+            if 'public_data' in kwargs:
+                warnings.warn("Both public and public_data are set. "
+                              "The ``public`` kwarg takes precedence. "
+                              "If you want ``public_data`` to be respected, "
+                              "set ``public=None``.")
             payload['public_data'] = public
 
         query = _gen_sql(payload)

--- a/docs/alma/alma.rst
+++ b/docs/alma/alma.rst
@@ -182,7 +182,7 @@ Querying For Proprietary Data
 -----------------------------
 
 To query for proprietary data (non-public data), you need to first authenticate using the ``login`` method,
-and then set ``public_data=False`` in your query:
+and then set ``public=False`` in your query:
 
 .. doctest-skip::
 
@@ -191,11 +191,11 @@ and then set ``public_data=False`` in your query:
     >>> # First login to access proprietary data
     >>> alma.login("username")  # Will prompt for password
     >>> # Now query including proprietary data
-    >>> proprietary_data = alma.query(payload=dict(project_code='2017.1.01355.L', public_data=False))
+    >>> proprietary_data = alma.query(payload=dict(project_code='2017.1.01355.L', public=False))
     >>> # Or restrict to only proprietary data
-    >>> only_proprietary = alma.query_region('W51', radius=25*u.arcmin, public_data=False)
+    >>> only_proprietary = alma.query_region('W51', radius=25*u.arcmin, public=False)
 
-When you set ``public_data=False``, the query will include only proprietary data by adding a condition equivalent to ``data_rights='Proprietary'`` in the underlying SQL query.
+When you set ``public=False``, the query will include only proprietary data by adding a condition equivalent to ``data_rights='Proprietary'`` in the underlying SQL query.
 
 The ``query_sia`` method offers another way to query ALMA using the IVOA SIA
 subset of keywords returning results in 'ObsCore' format.  For example,

--- a/docs/alma/alma.rst
+++ b/docs/alma/alma.rst
@@ -181,8 +181,8 @@ or if you wanted all projects by a given PI:
 Querying For Proprietary Data
 -----------------------------
 
-To query for proprietary data (non-public data), you need to first authenticate using the ``login`` method,
-and then set ``public=False`` in your query:
+To query for proprietary (non-public) data, set ``public=False`` or ``public=None``.
+If you want to download the products, you need to first authenticate using the ``login`` method.
 
 .. doctest-skip::
 
@@ -190,12 +190,14 @@ and then set ``public=False`` in your query:
     >>> alma = Alma()
     >>> # First login to access proprietary data
     >>> alma.login("username")  # Will prompt for password
-    >>> # Now query including proprietary data
-    >>> proprietary_data = alma.query(payload=dict(project_code='2017.1.01355.L', public=False))
-    >>> # Or restrict to only proprietary data
+    >>> # include both public and proprietary data using public=None
+    >>> proprietary_data = alma.query(payload=dict(project_code='2017.1.01355.L', public=None))
+    >>> # restrict to only proprietary data with public=False
     >>> only_proprietary = alma.query_region('W51', radius=25*u.arcmin, public=False)
 
-When you set ``public=False``, the query will include only proprietary data by adding a condition equivalent to ``data_rights='Proprietary'`` in the underlying SQL query.
+Setting ``public=False`` will include only proprietary data, while
+``public=None`` will include both public and proprietary data.
+
 
 The ``query_sia`` method offers another way to query ALMA using the IVOA SIA
 subset of keywords returning results in 'ObsCore' format.  For example,

--- a/docs/alma/alma.rst
+++ b/docs/alma/alma.rst
@@ -178,6 +178,25 @@ or if you wanted all projects by a given PI:
 
     >>> Alma.query(payload=dict(pi_name='Ginsburg, Adam'))
 
+Querying For Proprietary Data
+-----------------------------
+
+To query for proprietary data (non-public data), you need to first authenticate using the ``login`` method,
+and then set ``public_data=False`` in your query:
+
+.. doctest-skip::
+
+    >>> from astroquery.alma import Alma
+    >>> alma = Alma()
+    >>> # First login to access proprietary data
+    >>> alma.login("username")  # Will prompt for password
+    >>> # Now query including proprietary data
+    >>> proprietary_data = alma.query(payload=dict(project_code='2017.1.01355.L', public_data=False))
+    >>> # Or restrict to only proprietary data
+    >>> only_proprietary = alma.query_region('W51', radius=25*u.arcmin, public_data=False)
+
+When you set ``public_data=False``, the query will include only proprietary data by adding a condition equivalent to ``data_rights='Proprietary'`` in the underlying SQL query.
+
 The ``query_sia`` method offers another way to query ALMA using the IVOA SIA
 subset of keywords returning results in 'ObsCore' format.  For example,
 to query for all images that have ``'XX'`` polarization (note that this query is too large


### PR DESCRIPTION
cc @andamian 

@low-sky noted that there was no documentation explaining how to get proprietary data.

This example shows technically how to do it, but it won't actually do anything useful.  

```
In [20]: len(Alma.query_region('W51', radius=25*u.arcmin, public_data=True))
Out[20]: 376

In [26]: len(Alma.query_region('W51', radius=25*u.arcmin, public_data=False))
Out[26]: 376
```

by contrast, in other regions, it does work
```
In [24]: len(Alma.query_region(SkyCoord(0.253*u.deg, 0.016*u.deg, frame='galactic'), radius=1*u.arcmin, public=True))
Out[24]: 244

In [25]: len(Alma.query_region(SkyCoord(0.253*u.deg, 0.016*u.deg, frame='galactic'), radius=1*u.arcmin, public=False))
Out[25]: 78
```

so @andamian any idea what's going on here?  Why is it region-dependent?
