### PR TITLE
Fix issue3296: prevent writing when running tests in CDMS

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -19,6 +19,11 @@ alma
 
 - Bug fix in ``footprint_to_reg`` that did not allow regions to be plotted. [#3285]
 
+linelists.cdms
+^^^^^^^^^^^^^^
+
+- Add a keyword to control writing of new species cache files.  This is needed to prevent tests from overwriting those files. [#3300]
+
 heasarc
 ^^^^^^^
 

--- a/astroquery/linelists/cdms/core.py
+++ b/astroquery/linelists/cdms/core.py
@@ -294,7 +294,8 @@ class CDMSClass(BaseQuery):
 
     def get_species_table(self, *, catfile='partfunc.cat', use_cached=True,
                           catfile_url=conf.catfile_url,
-                          catfile2='catdir.cat', catfile_url2=conf.catfile_url2):
+                          catfile2='catdir.cat', catfile_url2=conf.catfile_url2,
+                          write=True):
         """
         A directory of the catalog is found in a file called 'catdir.cat.'
 
@@ -304,6 +305,13 @@ class CDMSClass(BaseQuery):
         ----------
         catfile : str, name of file, default 'catdir.cat'
             The catalog file, installed locally along with the package
+        use_cached : bool, optional
+            If True, use the cached file if it exists.  If False, download the
+            file from the CDMS server and save it to the cache (if ``write`` is set).
+        write : bool, optional
+            If True, and if ``use_cached`` is set, write the file to the cache.  Use this
+            option if you need to update the index from CDMS; this should be set to False
+            for testing.
 
         Returns
         -------
@@ -332,8 +340,9 @@ class CDMSClass(BaseQuery):
         else:
             result = retrieve_catfile(catfile_url)
             result2 = retrieve_catfile2(catfile_url2)
-            result.write(data_path(catfile), format='ascii.fixed_width', delimiter='|', overwrite=True)
-            result2.write(data_path(catfile2), format='ascii.fixed_width', delimiter='|', overwrite=True)
+            if write:
+                result.write(data_path(catfile), format='ascii.fixed_width', delimiter='|', overwrite=True)
+                result2.write(data_path(catfile2), format='ascii.fixed_width', delimiter='|', overwrite=True)
 
         merged = table.join(result, result2, keys=['tag'])
         if not all(merged['#lines'] == merged['# lines']):

--- a/astroquery/linelists/cdms/core.py
+++ b/astroquery/linelists/cdms/core.py
@@ -13,7 +13,6 @@ from astroquery.utils import async_to_sync
 from astroquery.linelists.cdms import conf
 from astroquery.exceptions import InvalidQueryError, EmptyResponseError
 
-import warnings
 import re
 import string
 
@@ -296,7 +295,7 @@ class CDMSClass(BaseQuery):
     def get_species_table(self, *, catfile='partfunc.cat', use_cached=True,
                           catfile_url=conf.catfile_url,
                           catfile2='catdir.cat', catfile_url2=conf.catfile_url2,
-                          write_new_species_cache=True):
+                          write_new_species_cache=False):
         """
         A directory of the catalog is found in a file called 'catdir.cat.'
 
@@ -308,12 +307,13 @@ class CDMSClass(BaseQuery):
             The catalog file, installed locally along with the package
         use_cached : bool, optional
             If True, use the cached file if it exists.  If False, download the
-            file from the CDMS server and save it to the cache (if ``write`` is set).
+            file from the CDMS server and save it to the cache if
+            ``write_new_species_cache`` is set.
         write_new_species_cache : bool, optional
-            If True, and if ``use_cached`` is False, write the species data
-            table files to the CDMS data directory.  Use this option if you need
-            to update the index from CDMS; this should be set to False for
-            testing.
+            *Overrides ``use_cached=True``*.
+            If True, write the species data table files to the CDMS data
+            directory.  Use this option if you need to update the index from
+            CDMS; this should be set to False for testing.
 
         Returns
         -------
@@ -326,9 +326,7 @@ class CDMSClass(BaseQuery):
 
         """
 
-        if use_cached:
-            if write_new_species_cache:
-                warnings.warn("use_cached and write_new_species_cache are both set to True; write_new_species_cache will be ignored.  If you meant to update the cache, set use_cached to False.")
+        if use_cached and not write_new_species_cache:
             try:
                 result = ascii.read(data_path(catfile), format='fixed_width', delimiter='|')
                 result2 = ascii.read(data_path(catfile2), format='fixed_width', delimiter='|')

--- a/astroquery/linelists/cdms/core.py
+++ b/astroquery/linelists/cdms/core.py
@@ -13,6 +13,7 @@ from astroquery.utils import async_to_sync
 from astroquery.linelists.cdms import conf
 from astroquery.exceptions import InvalidQueryError, EmptyResponseError
 
+import warnings
 import re
 import string
 
@@ -295,7 +296,7 @@ class CDMSClass(BaseQuery):
     def get_species_table(self, *, catfile='partfunc.cat', use_cached=True,
                           catfile_url=conf.catfile_url,
                           catfile2='catdir.cat', catfile_url2=conf.catfile_url2,
-                          write=True):
+                          write_new_species_cache=True):
         """
         A directory of the catalog is found in a file called 'catdir.cat.'
 
@@ -308,10 +309,11 @@ class CDMSClass(BaseQuery):
         use_cached : bool, optional
             If True, use the cached file if it exists.  If False, download the
             file from the CDMS server and save it to the cache (if ``write`` is set).
-        write : bool, optional
-            If True, and if ``use_cached`` is set, write the file to the cache.  Use this
-            option if you need to update the index from CDMS; this should be set to False
-            for testing.
+        write_new_species_cache : bool, optional
+            If True, and if ``use_cached`` is False, write the species data
+            table files to the CDMS data directory.  Use this option if you need
+            to update the index from CDMS; this should be set to False for
+            testing.
 
         Returns
         -------
@@ -325,6 +327,8 @@ class CDMSClass(BaseQuery):
         """
 
         if use_cached:
+            if write_new_species_cache:
+                warnings.warn("use_cached and write_new_species_cache are both set to True; write_new_species_cache will be ignored.  If you meant to update the cache, set use_cached to False.")
             try:
                 result = ascii.read(data_path(catfile), format='fixed_width', delimiter='|')
                 result2 = ascii.read(data_path(catfile2), format='fixed_width', delimiter='|')
@@ -340,7 +344,7 @@ class CDMSClass(BaseQuery):
         else:
             result = retrieve_catfile(catfile_url)
             result2 = retrieve_catfile2(catfile_url2)
-            if write:
+            if write_new_species_cache:
                 result.write(data_path(catfile), format='ascii.fixed_width', delimiter='|', overwrite=True)
                 result2.write(data_path(catfile2), format='ascii.fixed_width', delimiter='|', overwrite=True)
 

--- a/astroquery/linelists/cdms/tests/test_cdms_remote.py
+++ b/astroquery/linelists/cdms/tests/test_cdms_remote.py
@@ -127,7 +127,7 @@ def test_regression_allcats():
     """
     Expensive test - try all the molecules
     """
-    species_table = CDMS.get_species_table()
+    species_table = CDMS.get_species_table(write=False)
     for row in species_table:
         tag = f"{row['tag']:06d}"
         result = CDMS.get_molecule(tag)

--- a/astroquery/linelists/cdms/tests/test_cdms_remote.py
+++ b/astroquery/linelists/cdms/tests/test_cdms_remote.py
@@ -113,7 +113,7 @@ def test_complex_molecule_remote():
 
 @pytest.mark.remote_data
 def test_retrieve_species_table():
-    species_table = CDMS.get_species_table(use_cached=False, write=False)
+    species_table = CDMS.get_species_table(use_cached=False, write_new_species_cache=False)
     # as of 2025/01/16
     assert len(species_table) >= 1293
     assert 'int' in species_table['tag'].dtype.name
@@ -127,7 +127,7 @@ def test_regression_allcats():
     """
     Expensive test - try all the molecules
     """
-    species_table = CDMS.get_species_table(write=False)
+    species_table = CDMS.get_species_table(write_new_species_cache=False)
     for row in species_table:
         tag = f"{row['tag']:06d}"
         result = CDMS.get_molecule(tag)

--- a/astroquery/linelists/cdms/tests/test_cdms_remote.py
+++ b/astroquery/linelists/cdms/tests/test_cdms_remote.py
@@ -113,7 +113,7 @@ def test_complex_molecule_remote():
 
 @pytest.mark.remote_data
 def test_retrieve_species_table():
-    species_table = CDMS.get_species_table(use_cached=False)
+    species_table = CDMS.get_species_table(use_cached=False, write=False)
     # as of 2025/01/16
     assert len(species_table) >= 1293
     assert 'int' in species_table['tag'].dtype.name


### PR DESCRIPTION
Simple fix for #3296.  We _do_ want the remote tests grabbing stuff from the remote server, but you're right, we don't want it modifying data files in the repository.