### PR TITLE
[SIMBAD] add async_job option in all queries

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -44,6 +44,13 @@ imcce
 - Changing RuntimeError to NoResultsWarning when an empty result is
   returned. [#3307]
 
+SIMBAD
+^^^^^^
+
+- add ``async_job`` option in all query methods. This executes the query in asynchronous
+  mode. It provides slower to start, but more robust queries for which the timeout can
+  be increased (with the ``timeout`` property or with the configuration file) [#3305]
+
 utils.tap
 ^^^^^^^^^
 

--- a/astroquery/simbad/__init__.py
+++ b/astroquery/simbad/__init__.py
@@ -22,8 +22,11 @@ class Conf(_config.ConfigNamespace):
         'Name of the SIMBAD mirror to use.')
 
     timeout = _config.ConfigItem(
-        60,
-        'Time limit for connecting to Simbad server.')
+        1080,
+        # this is the default value in SIMBAD's main mirror
+        # https://simbad.cds.unistra.fr/simbad/sim-tap/capabilities
+        "Time limit for the execution of asynchronous queries, "
+        "in seconds.")
 
     row_limit = _config.ConfigItem(
         # defaults to the maximum limit

--- a/astroquery/simbad/core.py
+++ b/astroquery/simbad/core.py
@@ -242,18 +242,18 @@ class SimbadClass(BaseVOQuery):
         >>> options = Simbad.list_votable_fields() # doctest: +REMOTE_DATA
         >>> # to print only the available bundles of columns
         >>> options[options["type"] == "bundle of basic columns"][["name", "description"]] # doctest: +REMOTE_DATA
-        <Table length=9>
-             name                           description
-            object                             object
-        ------------- -------------------------------------------------------
-          coordinates                     all fields related with coordinates
-                  dim             major and minor axis, angle and inclination
-           dimensions                 all fields related to object dimensions
-            morphtype            all fields related to the morphological type
-             parallax                        all fields related to parallaxes
-        propermotions              all fields related with the proper motions
-                   sp               all fields related with the spectral type
-             velocity    all fields related with radial velocity and redshift
+        <Table length=8>
+             name                         description
+            object                           object
+        ------------- ----------------------------------------------------
+          coordinates                  all fields related with coordinates
+                  dim          major and minor axis, angle and inclination
+           dimensions              all fields related to object dimensions
+            morphtype         all fields related to the morphological type
+             parallax                     all fields related to parallaxes
+        propermotions           all fields related with the proper motions
+                   sp            all fields related with the spectral type
+             velocity all fields related with radial velocity and redshift
         """
         # get the tables with a simple link to basic
         query_tables = """SELECT DISTINCT table_name AS name, tables.description
@@ -1276,37 +1276,37 @@ class SimbadClass(BaseVOQuery):
         >>> from astroquery.simbad import Simbad
         >>> Simbad.list_columns("ids", "ident") # doctest: +REMOTE_DATA
         <Table length=4>
-        table_name column_name datatype ...  unit    ucd
-          object      object    object  ... object  object
-        ---------- ----------- -------- ... ------ -------
-             ident          id  VARCHAR ...        meta.id
-             ident      oidref   BIGINT ...
-               ids         ids  VARCHAR ...        meta.id
-               ids      oidref   BIGINT ...
+        table_name column_name datatype ...  unit      ucd
+          object      object    object  ... object    object
+        ---------- ----------- -------- ... ------ -----------
+             ident          id  VARCHAR ...            meta.id
+             ident      oidref   BIGINT ...        meta.record
+               ids         ids  VARCHAR ...            meta.id
+               ids      oidref   BIGINT ...        meta.record
 
 
         >>> from astroquery.simbad import Simbad
         >>> Simbad.list_columns(keyword="filter") # doctest: +REMOTE_DATA
         <Table length=5>
-         table_name column_name   datatype  ...  unit           ucd
-           object      object      object   ... object         object
-        ----------- ----------- ----------- ... ------ ----------------------
-             filter description UNICODECHAR ...        meta.note;instr.filter
-             filter  filtername     VARCHAR ...                  instr.filter
-             filter        unit     VARCHAR ...                     meta.unit
-               flux      filter     VARCHAR ...                  instr.filter
-        mesDiameter      filter        CHAR ...                  instr.filter
+         table_name column_name   datatype  ...  unit              ucd
+           object      object      object   ... object            object
+        ----------- ----------- ----------- ... ------ ---------------------------
+             filter description UNICODECHAR ...             meta.note;instr.filter
+             filter  filtername     VARCHAR ...        instr.bandpass;instr.filter
+             filter        unit     VARCHAR ...                          meta.unit
+               flux      filter     VARCHAR ...        instr.bandpass;instr.filter
+        mesDiameter      filter        CHAR ...        instr.bandpass;instr.filter
 
         >>> from astroquery.simbad import Simbad
         >>> Simbad.list_columns("basic", keyword="object") # doctest: +REMOTE_DATA
         <Table length=4>
-        table_name column_name datatype ...  unit          ucd
-          object      object    object  ... object        object
-        ---------- ----------- -------- ... ------ -------------------
-             basic     main_id  VARCHAR ...          meta.id;meta.main
-             basic   otype_txt  VARCHAR ...                  src.class
-             basic         oid   BIGINT ...        meta.record;meta.id
-             basic       otype  VARCHAR ...                  src.class
+        table_name column_name datatype ...  unit         ucd
+          object      object    object  ... object       object
+        ---------- ----------- -------- ... ------ -----------------
+             basic     main_id  VARCHAR ...        meta.id;meta.main
+             basic   otype_txt  VARCHAR ...                src.class
+             basic         oid   BIGINT ...              meta.record
+             basic       otype  VARCHAR ...                src.class
         """
         query = ("SELECT table_name, column_name, datatype, description, unit, ucd"
                  " FROM TAP_SCHEMA.columns"

--- a/astroquery/simbad/core.py
+++ b/astroquery/simbad/core.py
@@ -687,9 +687,6 @@ class SimbadClass(BaseVOQuery):
             better for very long queries, as it prevents transient failures to abort the
             query execution.
             Defaults to `False`.
-        cache : Deprecated since 0.4.8. The cache is now automatically emptied at the
-            end of the python session. It can also be emptied manually with
-            `~astroquery.simbad.SimbadClass.clear_cache` but cannot be deactivated.
 
         Returns
         -------
@@ -773,9 +770,6 @@ class SimbadClass(BaseVOQuery):
             better for very long queries, as it prevents transient failures to abort the
             query execution.
             Defaults to `False`.
-        cache : Deprecated since 0.4.8. The cache is now automatically emptied at the
-            end of the python session. It can also be emptied manually with
-            `~astroquery.simbad.SimbadClass.clear_cache` but cannot be deactivated.
 
         Returns
         -------
@@ -894,9 +888,6 @@ class SimbadClass(BaseVOQuery):
             better for very long queries, as it prevents transient failures to abort the
             query execution.
             Defaults to `False`.
-        cache : Deprecated since 0.4.8. The cache is now automatically emptied at the
-            end of the python session. It can also be emptied manually with
-            `~astroquery.simbad.SimbadClass.clear_cache` but cannot be deactivated.
 
         Returns
         -------
@@ -1097,9 +1088,6 @@ class SimbadClass(BaseVOQuery):
             better for very long queries, as it prevents transient failures to abort the
             query execution.
             Defaults to `False`.
-        cache : Deprecated since 0.4.8. The cache is now automatically emptied at the
-            end of the python session. It can also be emptied manually with
-            `~astroquery.simbad.SimbadClass.clear_cache` but cannot be deactivated.
 
         Returns
         -------
@@ -1170,9 +1158,6 @@ class SimbadClass(BaseVOQuery):
             better for very long queries, as it prevents transient failures to abort the
             query execution.
             Defaults to `False`.
-        cache : Deprecated since 0.4.8. The cache is now automatically emptied at the
-            end of the python session. It can also be emptied manually with
-            `~astroquery.simbad.SimbadClass.clear_cache` but cannot be deactivated.
 
         Returns
         -------

--- a/astroquery/simbad/tests/test_simbad.py
+++ b/astroquery/simbad/tests/test_simbad.py
@@ -563,14 +563,16 @@ def test_query_tap_errors():
 @pytest.mark.usefixtures("_mock_simbad_class")
 def test_query_tap_cache_call(monkeypatch):
     msg = "called_cached_query_tap"
-    monkeypatch.setattr(simbad.core, "_cached_query_tap", lambda tap, query, maxrec: msg)
+    monkeypatch.setattr(simbad.core, "_cached_query_tap",
+                        lambda tap, query, maxrec, async_job: msg)
     assert simbad.Simbad.query_tap("select top 1 * from basic") == msg
 
 
 @pytest.mark.usefixtures("_mock_simbad_class")
 def test_empty_response_warns(monkeypatch):
     # return something of length zero
-    monkeypatch.setattr(simbad.core.Simbad, "query_tap", lambda _, get_query_payload, maxrec: [])
+    monkeypatch.setattr(simbad.core.Simbad, "query_tap",
+                        lambda _, get_query_payload, maxrec, async_job: [])
     msg = ("The request executed correctly, but there was no data corresponding to these"
            " criteria in SIMBAD")
     with pytest.warns(NoResultsWarning, match=msg):

--- a/astroquery/simbad/tests/test_simbad_remote.py
+++ b/astroquery/simbad/tests/test_simbad_remote.py
@@ -168,6 +168,12 @@ class TestSimbad:
         Simbad.clear_cache()
         assert _cached_query_tap.cache_info().currsize == 0
 
+    def test_async_query(self):
+        adql = "select top 1 main_id from basic"
+        sync_job = Simbad.query_tap(adql)
+        async_job = Simbad.query_tap(adql, async_job=True)
+        assert sync_job["main_id"] == async_job["main_id"]
+
     def test_empty_response_warns(self):
         with pytest.warns(NoResultsWarning, match="The request executed correctly, but *"):
             # a catalog that does not exists should return an empty response

--- a/docs/simbad/query_tap.rst
+++ b/docs/simbad/query_tap.rst
@@ -139,22 +139,22 @@ some tables, add their name. To get the columns of the tables ``ref`` and ``bibl
     >>> from astroquery.simbad import Simbad
     >>> Simbad.list_columns("ref", "biblio")
     <Table length=13>
-    table_name column_name   datatype  ...  unit          ucd
-      object      object      object   ... object        object
-    ---------- ----------- ----------- ... ------ --------------------
-        biblio      biblio     VARCHAR ...        meta.record;meta.bib
-        biblio      oidref      BIGINT ...         meta.record;meta.id
-           ref      "year"    SMALLINT ...          meta.note;meta.bib
-           ref    abstract UNICODECHAR ...                 meta.record
-           ref     bibcode        CHAR ...            meta.bib.bibcode
-           ref         doi     VARCHAR ...          meta.code;meta.bib
-           ref     journal     VARCHAR ...            meta.bib.journal
-           ref   last_page     INTEGER ...               meta.bib.page
-           ref    nbobject     INTEGER ...                 meta.number
-           ref      oidbib      BIGINT ...        meta.record;meta.bib
-           ref        page     INTEGER ...               meta.bib.page
-           ref       title UNICODECHAR ...                  meta.title
-           ref      volume     INTEGER ...             meta.bib.volume
+    table_name column_name   datatype  ...  unit         ucd       
+      object      object      object   ... object       object     
+    ---------- ----------- ----------- ... ------ -----------------
+        biblio      biblio     VARCHAR ...         meta.bib.bibcode
+        biblio      oidref      BIGINT ...              meta.record
+           ref      "year"    SMALLINT ...           time.publiYear
+           ref    abstract UNICODECHAR ...              meta.record
+           ref     bibcode        CHAR ...         meta.bib.bibcode
+           ref         doi     VARCHAR ...             meta.ref.doi
+           ref     journal     VARCHAR ...         meta.bib.journal
+           ref   last_page     INTEGER ...            meta.bib.page
+           ref    nbobject     INTEGER ...        meta.id;arith.sum
+           ref      oidbib      BIGINT ...              meta.record
+           ref        page     INTEGER ...            meta.bib.page
+           ref       title UNICODECHAR ...               meta.title
+           ref      volume     INTEGER ...          meta.bib.volume
 
 `~astroquery.simbad.SimbadClass.list_columns` can also be called with a keyword argument.
 This returns columns from any table for witch the given keyword is either in the table name,

--- a/docs/simbad/simbad.rst
+++ b/docs/simbad/simbad.rst
@@ -829,6 +829,30 @@ Query TAP
 Troubleshooting
 ===============
 
+Longer queries
+--------------
+
+It can be useful to execute longer queries in asynchronous mode by setting the
+``async_job`` argument to ``True``. This may take longer to start, depending on the
+current number of other people using the asynchronous SIMBAD queue, but it is more
+robust against transient errors. Asynchronous queries will take the ``timeout`` property
+in account:
+
+.. doctest-remote-data::
+
+    >>> from astroquery.simbad import Simbad
+    >>> simbad = Simbad(timeout=2000) # in seconds
+    >>> simbad.query_tap("select otype, description from otypedef where otype = 'N*'",
+    ...                  async_job=True)
+    <Table length=1>
+    otype  description
+    object    object
+    ------ ------------
+        N* Neutron Star
+
+Clearing the cache
+------------------
+
 If you are repeatedly getting failed queries, or bad/out-of-date results, try clearing
 your cache:
 


### PR DESCRIPTION
This should fix #3205 

It adds the possibility to launch SIMBAD queries in asynchronous mode. This mode allows to take `timeout` in account (this translates into `executionDuration` in the VOSI async standard).