### PR TITLE
Enhancements for mast.Observations.get_cloud_uris()

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -72,6 +72,9 @@ mast
 - Added ``return_uri_map`` parameter to ``Observations.get_cloud_uris`` to return a mapping of the input data product URIs 
   to the returned cloud URIs. [#3314]
 
+- Added ``verbose`` parameter to ``Observations.get_cloud_uris`` to control whether warnings are logged when a product cannot 
+  be found in the cloud. [#3314]
+
 
 Infrastructure, Utility and Other Changes and Additions
 -------------------------------------------------------

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -67,6 +67,11 @@ mast
 - Added ``resolve_all`` parameter to ``MastClass.resolve_object`` to resolve object names and return
   coordinates for all available resolvers. [#3292]
 
+- Fix bug in ``utils.remove_duplicate_products`` that does not retain the order of the products in an input table. [#3314]
+
+- Added ``return_uri_map`` parameter to ``Observations.get_cloud_uris`` to return a mapping of the input data product URIs 
+  to the returned cloud URIs. [#3314]
+
 
 Infrastructure, Utility and Other Changes and Additions
 -------------------------------------------------------

--- a/astroquery/mast/observations.py
+++ b/astroquery/mast/observations.py
@@ -874,7 +874,8 @@ class ObservationsClass(MastQueryWithLogin):
         return manifest
 
     def get_cloud_uris(self, data_products=None, *, include_bucket=True, full_url=False, pagesize=None, page=None,
-                       mrp_only=False, extension=None, filter_products={}, return_uri_map=False, **criteria):
+                       mrp_only=False, extension=None, filter_products={}, return_uri_map=False, verbose=True,
+                       **criteria):
         """
         Given an `~astropy.table.Table` of data products or query criteria and filter parameters,
         returns the associated cloud data URIs.
@@ -912,6 +913,8 @@ class ObservationsClass(MastQueryWithLogin):
             Default False. If set to True, returns a dictionary mapping the original data product
             URIs to their corresponding cloud URIs. This is useful for tracking which products were
             successfully converted to cloud URIs.
+        verbose : bool, optional
+            Default True. Whether to issue warnings if a product cannot be found in the cloud.
         **criteria
             Criteria to apply. At least one non-positional criteria must be supplied.
             Valid criteria are coordinates, objectname, radius (as in `query_region` and `query_object`),
@@ -972,7 +975,10 @@ class ObservationsClass(MastQueryWithLogin):
         data_uris = utils.remove_duplicate_products(data_uris, 'dataURI')
 
         # Get cloud URIS
-        cloud_uris = self._cloud_connection.get_cloud_uri_list(data_uris, include_bucket, full_url)
+        cloud_uris = self._cloud_connection.get_cloud_uri_list(data_uris,
+                                                               include_bucket=include_bucket,
+                                                               full_url=full_url,
+                                                               verbose=verbose)
 
         # If return_uri_map is True, create a mapping of dataURIs to cloud URIs
         if return_uri_map:

--- a/astroquery/mast/observations.py
+++ b/astroquery/mast/observations.py
@@ -979,6 +979,9 @@ class ObservationsClass(MastQueryWithLogin):
             uri_map = dict(zip(data_uris, cloud_uris))
             return uri_map
 
+        # Remove None values from the list
+        cloud_uris = [uri for uri in cloud_uris if uri is not None]
+
         return cloud_uris
 
     def get_cloud_uri(self, data_product, *, include_bucket=True, full_url=False):

--- a/astroquery/mast/tests/test_mast.py
+++ b/astroquery/mast/tests/test_mast.py
@@ -353,7 +353,7 @@ def test_missions_get_product_list(patch_post):
 def test_missions_get_unique_product_list(patch_post, caplog):
     unique_products = mast.MastMissions.get_unique_product_list('Z14Z0104T')
     assert isinstance(unique_products, Table)
-    assert (unique_products == unique(unique_products, keys='filename')).all()
+    assert (len(unique_products) == len(unique(unique_products, keys='filename')))
     # No INFO messages should be logged
     with caplog.at_level('INFO', logger='astroquery'):
         assert caplog.text == ''
@@ -769,6 +769,12 @@ def test_observations_get_cloud_uris(mock_client, patch_post):
     assert isinstance(uris, list)
     assert len(uris) == 1
     assert uris[0] == expected
+
+    # Return a map of URIs
+    uri_map = mast.Observations.get_cloud_uris([mast_uri], return_uri_map=True)
+    assert isinstance(uri_map, dict)
+    assert len(uri_map) == 1
+    assert uri_map[mast_uri] == expected
 
     # Warn if attempting to filter with list input
     with pytest.warns(InputWarning, match='Filtering is not supported'):

--- a/astroquery/mast/tests/test_mast_remote.py
+++ b/astroquery/mast/tests/test_mast_remote.py
@@ -269,7 +269,7 @@ class TestMast:
         # Unique product list should have fewer rows
         assert len(products) > len(unique_products)
         # Rows should be unique based on filename
-        assert (unique_products == unique(unique_products, keys='filename')).all()
+        assert (len(unique_products) == len(unique(unique_products, keys='filename')))
         # Check that INFO messages were logged
         with caplog.at_level('INFO', logger='astroquery'):
             assert 'products were duplicates' in caplog.text
@@ -644,7 +644,7 @@ class TestMast:
         # Unique product list should have fewer rows
         assert len(products) > len(unique_products)
         # Rows should be unique based on dataURI
-        assert (unique_products == unique(unique_products, keys='dataURI')).all()
+        assert (len(unique_products) == len(unique(unique_products, keys='dataURI')))
         # Check that INFO messages were logged
         with caplog.at_level('INFO', logger='astroquery'):
             assert 'products were duplicates' in caplog.text
@@ -877,6 +877,13 @@ class TestMast:
         uris = Observations.get_cloud_uris(uri_list)
         assert len(uris) > 0, f'Products for URI list {uri_list} were not found in the cloud.'
         assert uris == expected
+
+        # return map of dataURI to cloud URI
+        uri_map = Observations.get_cloud_uris(uri_list, return_uri_map=True)
+        assert isinstance(uri_map, dict)
+        assert len(uri_map) == 2
+        for i, uri in enumerate(uri_list):
+            assert uri_map[uri] == expected[i]
 
         # check for warning if filters are provided with list input
         with pytest.warns(InputWarning, match='Filtering is not supported'):

--- a/astroquery/mast/tests/test_mast_remote.py
+++ b/astroquery/mast/tests/test_mast_remote.py
@@ -570,7 +570,7 @@ class TestMast:
         responses = Observations.get_product_list_async(test_obs[2:3])
         assert isinstance(responses, list)
 
-        observations = Observations.query_object("M8", radius=".02 deg")
+        observations = Observations.query_criteria(objectname="M8", obs_collection=["K2", "IUE"])
         responses = Observations.get_product_list_async(observations[0])
         assert isinstance(responses, list)
 
@@ -578,7 +578,7 @@ class TestMast:
         assert isinstance(responses, list)
 
     def test_observations_get_product_list(self):
-        observations = Observations.query_object("M8", radius=".04 deg")
+        observations = Observations.query_criteria(objectname='M8', obs_collection=['K2', 'IUE'])
         test_obs_id = str(observations[0]['obsid'])
         mult_obs_ids = str(observations[0]['obsid']) + ',' + str(observations[1]['obsid'])
 
@@ -598,7 +598,7 @@ class TestMast:
         assert len(result1) == len(result2)
         assert set(filenames1) == set(filenames2)
 
-        obsLoc = np.where(observations["obs_id"] == 'ktwo200071160-c92_lc')
+        obsLoc = np.where(observations['obs_id'] == 'ktwo200071160-c92_lc')
         result = Observations.get_product_list(observations[obsLoc])
         assert isinstance(result, Table)
         assert len(result) == 1

--- a/astroquery/mast/utils.py
+++ b/astroquery/mast/utils.py
@@ -13,7 +13,7 @@ import requests
 import platform
 
 from astropy.coordinates import SkyCoord
-from astropy.table import unique, Table
+from astropy.table import Table
 from astropy import units as u
 
 from .. import log
@@ -273,9 +273,9 @@ def mast_relative_path(mast_uri):
         The associated relative path(s).
     """
     if isinstance(mast_uri, str):
-        uri_list = [("uri", mast_uri)]
-    else:  # mast_uri parameter is a list
-        uri_list = [("uri", uri) for uri in mast_uri]
+        uri_list = [mast_uri]
+    else:
+        uri_list = list(mast_uri)
 
     # Split the list into chunks of 50 URIs; this is necessary
     # to avoid "414 Client Error: Request-URI Too Large".
@@ -284,7 +284,7 @@ def mast_relative_path(mast_uri):
     result = []
     for chunk in uri_list_chunks:
         response = _simple_request("https://mast.stsci.edu/api/v0.1/path_lookup/",
-                                   {"uri": [mast_uri[1] for mast_uri in chunk]})
+                                   {"uri": [mast_uri for mast_uri in chunk]})
 
         json_response = response.json()
 
@@ -292,11 +292,11 @@ def mast_relative_path(mast_uri):
             # Chunk is a list of tuples where the tuple is
             # ("uri", "/path/to/product")
             # so we index for path (index=1)
-            path = json_response.get(uri[1])["path"]
+            path = json_response.get(uri)["path"]
             if path is None:
-                warnings.warn(f"Failed to retrieve MAST relative path for {uri[1]}. Skipping...", NoResultsWarning)
-                continue
-            if 'galex' in path:
+                warnings.warn(f"Failed to retrieve MAST relative path for {uri}. Skipping...", NoResultsWarning)
+                path = None
+            elif 'galex' in path:
                 path = path.lstrip("/mast/")
             elif '/ps1/' in path:
                 path = path.replace("/ps1/", "panstarrs/ps1/public/")
@@ -330,20 +330,16 @@ def remove_duplicate_products(data_products, uri_key):
         Table containing products with unique dataURIs.
     """
     # Get unique products based on input type
+    seen = set()
     if isinstance(data_products, Table):
-        unique_products = unique(data_products, keys=uri_key)
-    else:  # data_products is a list
-        seen = set()
-        unique_products = []
-        for uri in data_products:
-            if uri not in seen:
-                seen.add(uri)
-                unique_products.append(uri)
+        unique_rows = [row for row in data_products if not (row[uri_key] in seen or seen.add(row[uri_key]))]
+        unique_products = type(data_products)(rows=unique_rows)
+    else:  # Assume data_products is a list of URIs
+        unique_products = [uri for uri in data_products if not (uri in seen or seen.add(uri))]
 
-    number = len(data_products)
-    number_unique = len(unique_products)
-    if number_unique < number:
-        log.info(f"{number - number_unique} of {number} products were duplicates. "
-                 f"Only returning {number_unique} unique product(s).")
+    duplicates_removed = len(data_products) - len(unique_products)
+    if duplicates_removed > 0:
+        log.info(f"{duplicates_removed} of {len(data_products)} products were duplicates. "
+                 f"Only returning {len(unique_products)} unique product(s).")
 
     return unique_products

--- a/astroquery/mast/utils.py
+++ b/astroquery/mast/utils.py
@@ -330,11 +330,11 @@ def remove_duplicate_products(data_products, uri_key):
         Table containing products with unique dataURIs.
     """
     # Get unique products based on input type
-    seen = set()
     if isinstance(data_products, Table):
-        unique_rows = [row for row in data_products if not (row[uri_key] in seen or seen.add(row[uri_key]))]
-        unique_products = type(data_products)(rows=unique_rows)
-    else:  # Assume data_products is a list of URIs
+        _, unique_indices = np.unique(data_products[uri_key], return_index=True)
+        unique_products = data_products[np.sort(unique_indices)]
+    else:  # list of URIs
+        seen = set()
         unique_products = [uri for uri in data_products if not (uri in seen or seen.add(uri))]
 
     duplicates_removed = len(data_products) - len(unique_products)

--- a/astroquery/mast/utils.py
+++ b/astroquery/mast/utils.py
@@ -295,7 +295,6 @@ def mast_relative_path(mast_uri):
             path = json_response.get(uri)["path"]
             if path is None:
                 warnings.warn(f"Failed to retrieve MAST relative path for {uri}. Skipping...", NoResultsWarning)
-                path = None
             elif 'galex' in path:
                 path = path.lstrip("/mast/")
             elif '/ps1/' in path:

--- a/astroquery/mast/utils.py
+++ b/astroquery/mast/utils.py
@@ -258,7 +258,7 @@ def split_list_into_chunks(input_list, chunk_size):
         yield input_list[idx:idx + chunk_size]
 
 
-def mast_relative_path(mast_uri):
+def mast_relative_path(mast_uri, *, verbose=True):
     """
     Given one or more MAST dataURI(s), return the associated relative path(s).
 
@@ -266,6 +266,8 @@ def mast_relative_path(mast_uri):
     ----------
     mast_uri : str, list of str
         The MAST uri(s).
+    verbose : bool, optional
+        Default True. Whether to issue warnings if the MAST relative path cannot be found for a product.
 
     Returns
     -------
@@ -294,7 +296,8 @@ def mast_relative_path(mast_uri):
             # so we index for path (index=1)
             path = json_response.get(uri)["path"]
             if path is None:
-                warnings.warn(f"Failed to retrieve MAST relative path for {uri}. Skipping...", NoResultsWarning)
+                if verbose:
+                    warnings.warn(f"Failed to retrieve MAST relative path for {uri}. Skipping...", NoResultsWarning)
             elif 'galex' in path:
                 path = path.lstrip("/mast/")
             elif '/ps1/' in path:

--- a/docs/mast/mast_obsquery.rst
+++ b/docs/mast/mast_obsquery.rst
@@ -223,64 +223,20 @@ The product fields are documented `here <https://mast.stsci.edu/api/v0/_products
 
    >>> from astroquery.mast import Observations
    ...
-   >>> obs_table = Observations.query_object("M8",radius=".02 deg")
+   >>> obs_table = Observations.query_criteria(objectname="M8", obs_collection=["K2", "IUE"])
    >>> data_products_by_obs = Observations.get_product_list(obs_table[0:2])
    >>> print(data_products_by_obs)  # doctest: +IGNORE_OUTPUT
-      obsID    obs_collection dataproduct_type ...   size  parent_obsid
-   ----------- -------------- ---------------- ... ------- ------------
-   19000016510    SPITZER_SHA            image ...  316800  19000016510
-   19000016510    SPITZER_SHA            image ...  316800  19000016510
-   19000016510    SPITZER_SHA            image ...  316800  19000016510
-   19000016510    SPITZER_SHA            image ...  316800  19000016510
-   19000016510    SPITZER_SHA            image ...  316800  19000016510
-   19000016510    SPITZER_SHA            image ...  316800  19000016510
-   19000016510    SPITZER_SHA            image ...  316800  19000016510
-   19000016510    SPITZER_SHA            image ...  316800  19000016510
-   19000016510    SPITZER_SHA            image ...  316800  19000016510
-   19000016510    SPITZER_SHA            image ...  316800  19000016510
-           ...            ...              ... ...     ...          ...
-   19000016510    SPITZER_SHA            image ...   57600  19000016510
-   19000016510    SPITZER_SHA            image ...   57600  19000016510
-   19000016510    SPITZER_SHA            image ...   57600  19000016510
-   19000016510    SPITZER_SHA            image ...   57600  19000016510
-   19000016510    SPITZER_SHA            image ...   57600  19000016510
-   19000016510    SPITZER_SHA            image ...   57600  19000016510
-   19000016510    SPITZER_SHA            image ...   57600  19000016510
-   19000016510    SPITZER_SHA            image ...   57600  19000016510
-   19000016510    SPITZER_SHA            image ...   57600  19000016510
-   19000016510    SPITZER_SHA            image ...   57600  19000016510
-   19000016510    SPITZER_SHA            image ... 8648640  19000016510
-   Length = 1153 rows
-   ...
+   obsID  obs_collection dataproduct_type ... dataRights calib_level filters
+   ------ -------------- ---------------- ... ---------- ----------- -------
+   664784             K2       timeseries ...     PUBLIC           2  KEPLER
+   664785             K2       timeseries ...     PUBLIC           2  KEPLER
    >>> obsids = obs_table[0:2]['obsid']
    >>> data_products_by_id = Observations.get_product_list(obsids)
    >>> print(data_products_by_id)  # doctest: +IGNORE_OUTPUT
-      obsID    obs_collection dataproduct_type ...   size  parent_obsid
-   ----------- -------------- ---------------- ... ------- ------------
-   19000016510    SPITZER_SHA            image ...  316800  19000016510
-   19000016510    SPITZER_SHA            image ...  316800  19000016510
-   19000016510    SPITZER_SHA            image ...  316800  19000016510
-   19000016510    SPITZER_SHA            image ...  316800  19000016510
-   19000016510    SPITZER_SHA            image ...  316800  19000016510
-   19000016510    SPITZER_SHA            image ...  316800  19000016510
-   19000016510    SPITZER_SHA            image ...  316800  19000016510
-   19000016510    SPITZER_SHA            image ...  316800  19000016510
-   19000016510    SPITZER_SHA            image ...  316800  19000016510
-   19000016510    SPITZER_SHA            image ...  316800  19000016510
-           ...            ...              ... ...     ...          ...
-   19000016510    SPITZER_SHA            image ...   57600  19000016510
-   19000016510    SPITZER_SHA            image ...   57600  19000016510
-   19000016510    SPITZER_SHA            image ...   57600  19000016510
-   19000016510    SPITZER_SHA            image ...   57600  19000016510
-   19000016510    SPITZER_SHA            image ...   57600  19000016510
-   19000016510    SPITZER_SHA            image ...   57600  19000016510
-   19000016510    SPITZER_SHA            image ...   57600  19000016510
-   19000016510    SPITZER_SHA            image ...   57600  19000016510
-   19000016510    SPITZER_SHA            image ...   57600  19000016510
-   19000016510    SPITZER_SHA            image ...   57600  19000016510
-   19000016510    SPITZER_SHA            image ... 8648640  19000016510
-   Length = 1153 rows
-   ...
+   obsID  obs_collection dataproduct_type ... dataRights calib_level filters
+   ------ -------------- ---------------- ... ---------- ----------- -------
+   664784             K2       timeseries ...     PUBLIC           2  KEPLER
+   664785             K2       timeseries ...     PUBLIC           2  KEPLER
    >>> print((data_products_by_obs == data_products_by_id).all())
    True
 
@@ -309,18 +265,18 @@ To return only unique data products for an observation, use `~astroquery.mast.Ob
    INFO: 180 of 370 products were duplicates. Only returning 190 unique product(s). [astroquery.mast.utils]
    INFO: To return all products, use `Observations.get_product_list` [astroquery.mast.observations]
    >>> print(unique_products[:10]['dataURI'])
-                                 dataURI                              
-   -------------------------------------------------------------------
-           mast:HST/product/hst_12062_eo_acs_wfc_f606w_jbeveo_drc.fits
-            mast:HST/product/hst_12062_eo_acs_wfc_f606w_jbeveo_drc.jpg
-     mast:HST/product/hst_12062_eo_acs_wfc_f606w_jbeveo_point-cat.ecsv
-   mast:HST/product/hst_12062_eo_acs_wfc_f606w_jbeveo_segment-cat.ecsv
-            mast:HST/product/hst_12062_eo_acs_wfc_f606w_jbeveo_trl.txt
-         mast:HST/product/hst_12062_eo_acs_wfc_f606w_jbeveoes_drc.fits
-          mast:HST/product/hst_12062_eo_acs_wfc_f606w_jbeveoes_drc.jpg
-         mast:HST/product/hst_12062_eo_acs_wfc_f606w_jbeveoes_flc.fits
-        mast:HST/product/hst_12062_eo_acs_wfc_f606w_jbeveoes_hlet.fits
-          mast:HST/product/hst_12062_eo_acs_wfc_f606w_jbeveoes_trl.txt
+                   dataURI                 
+   ----------------------------------------
+   mast:HST/product/jbeveoesq_flt_hlet.fits
+      mast:HST/product/jbeveoesq_spt.fits
+      mast:HST/product/jbeveoesq_trl.fits
+         mast:HST/product/jbeveoesq_log.txt
+         mast:HST/product/jbeveoesq_raw.jpg
+         mast:HST/product/jbeveoesq_flc.jpg
+         mast:HST/product/jbeveoesq_flt.jpg
+      mast:HST/product/jbeveoesq_flc.fits
+      mast:HST/product/jbeveoesq_flt.fits
+      mast:HST/product/jbeveoesq_raw.fits
 
 Filtering
 ---------


### PR DESCRIPTION
- Fix bug in `utils.remove_duplicate_products` that does not retain the order of the products in an input table.
- Added `return_uri_map` parameter to `Observations.get_cloud_uris` to return a mapping of the input data product URIs to the returned cloud URIs.
- Added `verbose` parameter to `Observations.get_cloud_uris` to control whether warnings are logged when a product cannot be found in the cloud.
- Also fixed an issue with some unrelated tests/documentation. The results of the original query changed so that subsequent commands were no longer working as expected (TESS FFI observations were being returned, and we no longer allow users to get product lists for these observations). The updated queries filter out any results from TESS.