### PR TITLE
Added `get_query_payload` kwarg to skyview

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -51,6 +51,13 @@ SIMBAD
   mode. It provides slower to start, but more robust queries for which the timeout can
   be increased (with the ``timeout`` property or with the configuration file) [#3305]
 
+skyview
+^^^^^^^
+
+
+- Added ``get_query_payload`` kwarg to ``Skyview.get_images()`` and ``Skyview.get_images_list()``
+  to return the query payload [#3318]
+
 utils.tap
 ^^^^^^^^^
 

--- a/astroquery/skyview/core.py
+++ b/astroquery/skyview/core.py
@@ -79,8 +79,10 @@ class SkyViewClass(BaseQuery):
         url = urlparse.urljoin(self.URL, form.get('action'))
         return url, payload
 
-    def _submit_form(self, input=None, cache=True):
+    def _submit_form(self, input=None, cache=True, get_query_payload=False):
         url, payload = self._generate_payload(input=input)
+        if get_query_payload:
+            return payload
         response = self._request('GET', url, params=payload, cache=cache)
         response.raise_for_status()
         return response
@@ -88,7 +90,7 @@ class SkyViewClass(BaseQuery):
     def get_images(self, position, survey, *, coordinates=None, projection=None,
                    pixels=None, scaling=None, sampler=None, resolver=None,
                    deedger=None, radius=None, height=None, width=None, cache=True,
-                   show_progress=True):
+                   show_progress=True, get_query_payload=False):
         """
         Query the SkyView service, download the FITS file that will be
         found and return a generator over the local paths to the
@@ -197,7 +199,10 @@ class SkyViewClass(BaseQuery):
                                                  projection=projection, pixels=pixels, scaling=scaling,
                                                  sampler=sampler, resolver=resolver, deedger=deedger,
                                                  radius=radius, height=height, width=width,
-                                                 cache=cache, show_progress=show_progress)
+                                                 cache=cache, show_progress=show_progress,
+                                                 get_query_payload=get_query_payload)
+        if get_query_payload:
+            return readable_objects
         return [obj.get_fits() for obj in readable_objects]
 
     @prepend_docstr_nosections(get_images.__doc__)
@@ -205,7 +210,7 @@ class SkyViewClass(BaseQuery):
                          projection=None, pixels=None, scaling=None,
                          sampler=None, resolver=None, deedger=None,
                          radius=None, height=None, width=None,
-                         cache=True, show_progress=True):
+                         cache=True, show_progress=True, get_query_payload=False):
         """
         Returns
         -------
@@ -214,16 +219,19 @@ class SkyViewClass(BaseQuery):
         image_urls = self.get_image_list(position, survey, coordinates=coordinates,
                                          projection=projection, pixels=pixels, scaling=scaling, sampler=sampler,
                                          resolver=resolver, deedger=deedger, radius=radius,
-                                         height=height, width=width, cache=cache)
-        return [commons.FileContainer(url, encoding='binary',
-                                      show_progress=show_progress)
+                                         height=height, width=width, cache=cache,
+                                         get_query_payload=get_query_payload)
+        if get_query_payload:
+            return image_urls
+        return [commons.FileContainer(url, encoding='binary', show_progress=show_progress)
                 for url in image_urls]
 
     @prepend_docstr_nosections(get_images.__doc__, sections=['Returns', 'Examples'])
     def get_image_list(self, position, survey, *, coordinates=None,
                        projection=None, pixels=None, scaling=None,
                        sampler=None, resolver=None, deedger=None,
-                       radius=None, width=None, height=None, cache=True):
+                       radius=None, width=None, height=None, cache=True,
+                       get_query_payload=False):
         """
         Returns
         -------
@@ -263,7 +271,9 @@ class SkyViewClass(BaseQuery):
             'imscale': size_deg,
             'size': size_deg,
             'pixels': pixels}
-        response = self._submit_form(input, cache=cache)
+        response = self._submit_form(input, cache=cache, get_query_payload=get_query_payload)
+        if get_query_payload:
+            return response
         urls = self._parse_response(response)
         return urls
 

--- a/astroquery/skyview/tests/test_skyview.py
+++ b/astroquery/skyview/tests/test_skyview.py
@@ -76,6 +76,18 @@ def test_get_image_list_local(patch_get, patch_fromname):
         assert url.startswith('../../tempspace/fits/')
 
 
+def test_get_image_list_payload(patch_get, patch_fromname):
+    surveys = ['Fermi 5', 'HRI', 'NVSS']
+    payload = SkyView.get_image_list(position='Eta Carinae',
+                                     survey=surveys,
+                                     get_query_payload=True)
+    assert len(payload) == 14
+    assert payload["Position"] == '161.265 -59.6844'
+    assert len(payload["survey"]) == 3
+    for survey in surveys:
+        assert survey in payload["survey"]
+
+
 def test_survey_validation(patch_get):
     with pytest.raises(ValueError) as ex:
         SkyView.get_image_list(position='doesnt matter',


### PR DESCRIPTION
Hi yall!

This is a small PR, but I added in the `get_query_payload` kwarg to SkyView.

Long story short, I was trying to do some debugging and noticed the kwarg wasn't there and found #2040.

I looked through and didn't see testing for other services/catalogs/archives that used `get_query_payload` so I didn't add any but I can if you would like. With the changes I made I used the kwarg in the examples to debug and it helped me out.

```
>>> from astroquery.skyview import SkyView
>>> SkyView.get_images(position='crab', survey=['Fermi 5', 'HRI', 'DSS'], get_query_payload=True)
{'coordinates': 'J2000', 'projection': 'Tan', 'pixels': '300', 'float': 'on', 'scaling': 'Log Sqrt Linear HistEq LogLog', 'resolver': 'SIMBAD-NED', 'Sampler': '_skip_', 'Deedger': '_skip_', 'lut': 'colortables/b-w-linear.bin', 'grid': '_skip_', 'gridlabels': '1', 'CatalogIDs': 'on', 'survey': ['Fermi 5', 'HRI', 'DSS'], 'Position': '83.6324 22.0174'}
>>> 
>>> SkyView.get_image_list(position='Eta Carinae', survey='Fermi 5', get_query_payload=True)
{'coordinates': 'J2000', 'projection': 'Tan', 'pixels': '300', 'float': 'on', 'scaling': 'Log Sqrt Linear HistEq LogLog', 'resolver': 'SIMBAD-NED', 'Sampler': '_skip_', 'Deedger': '_skip_', 'lut': 'colortables/b-w-linear.bin', 'grid': '_skip_', 'gridlabels': '1', 'CatalogIDs': 'on', 'survey': 'Fermi 5', 'Position': '161.265 -59.6844'}
```

There's a couple of places where `if get_query_payload:` seems kinda redundant, but I ended up needing them to get this working. Let me know if you want me to find a workaround to clean this up a bit.
