### PR TITLE
GAIA: new simplified cross match method

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -23,6 +23,12 @@ alma
 
 - Bug fix in ``footprint_to_reg`` that did not allow regions to be plotted. [#3285]
 
+
+gaia
+^^^^
+
+- New method cross_match_stream that simplifies the positional x-match method [#3320]
+
 linelists.cdms
 ^^^^^^^^^^^^^^
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -27,7 +27,7 @@ alma
 gaia
 ^^^^
 
-- New method cross_match_stream that simplifies the positional x-match method [#3320]
+- New method cross_match_basic that simplifies the positional x-match method [#3320]
 
 linelists.cdms
 ^^^^^^^^^^^^^^

--- a/astroquery/esa/euclid/tests/test_euclidtap.py
+++ b/astroquery/esa/euclid/tests/test_euclidtap.py
@@ -266,7 +266,7 @@ def test_load_table():
     responseLaunchJob = DummyResponse(200)
     responseLaunchJob.set_data(method='GET', context=None, body=TABLE_DATA, headers=None)
 
-    table = 'my_table'
+    table = 'schema.my_table'
     conn_handler.set_response(f"tables?tables={table}", responseLaunchJob)
     tap = EuclidClass(tap_plus_conn_handler=conn_handler, datalink_handler=tap_plus, show_server_messages=False)
 

--- a/astroquery/gaia/core.py
+++ b/astroquery/gaia/core.py
@@ -4,14 +4,9 @@
 Gaia TAP plus
 =============
 
-@author: Juan Carlos Segovia
-@contact: juan.carlos.segovia@sciops.esa.int
-
 European Space Astronomy Centre (ESAC)
 European Space Agency (ESA)
 
-Created on 30 jun. 2016
-Modified on 18 Ene. 2022 by mhsarmiento
 """
 import datetime
 import json
@@ -919,12 +914,12 @@ class GaiaClass(TapPlus):
         self.__check_columns_exist(table_metadata_a, table_a_full_qualified_name, table_a_column_ra, table_a_column_dec)
 
         self.__update_ra_dec_columns(table_a_full_qualified_name, table_a_column_ra, table_a_column_dec,
-                                     table_metadata_a)
+                                     table_metadata_a, verbose)
 
         self.__check_columns_exist(table_metadata_b, table_b_full_qualified_name, table_b_column_ra, table_b_column_dec)
 
         self.__update_ra_dec_columns(table_b_full_qualified_name, table_b_column_ra, table_b_column_dec,
-                                     table_metadata_b)
+                                     table_metadata_b, verbose)
 
         query = (
             f"SELECT a.*, b.*, DISTANCE(a.{table_a_column_ra}, a.{table_a_column_dec}, b.{table_b_column_ra}, "
@@ -943,20 +938,21 @@ class GaiaClass(TapPlus):
                                      upload_resource=None,
                                      upload_table_name=None)
 
-    def __update_ra_dec_columns(self, full_qualified_table_name, column_ra, column_dec, table_metadata):
+    def __update_ra_dec_columns(self, full_qualified_table_name, column_ra, column_dec, table_metadata, verbose):
         """
         Update table metadata for the ‘ra’ and the ‘dec’ columns in the input table
         """
         if full_qualified_table_name.startswith("user_"):
-            list_of_changes_a = list()
+            list_of_changes = list()
             for column in table_metadata.columns:
-                if column.name == column_ra and column.flags != 1:
-                    list_of_changes_a.append([column_ra, "flags", "Ra"])
-                if column.name == column_dec and column.flags != 2:
-                    list_of_changes_a.append([column_dec, "flags", "Dec"])
+                if column.name == column_ra and column.flags != '1':
+                    list_of_changes.append([column_ra, "flags", "Ra"])
+                if column.name == column_dec and column.flags != '2':
+                    list_of_changes.append([column_dec, "flags", "Dec"])
 
-            if not list_of_changes_a:
-                self.update_user_table(table_name=full_qualified_table_name, list_of_changes=list_of_changes_a)
+            if list_of_changes:
+                TapPlus.update_user_table(self, table_name=full_qualified_table_name, list_of_changes=list_of_changes,
+                                          verbose=verbose)
 
     def __check_columns_exist(self, table_metadata_a, full_qualified_table_name, column_ra, column_dec):
         """

--- a/astroquery/gaia/core.py
+++ b/astroquery/gaia/core.py
@@ -848,10 +848,10 @@ class GaiaClass(TapPlus):
 
         return self.is_valid_user(user_id=user_id, verbose=verbose)
 
-    def cross_match_stream(self, *, table_a_full_qualified_name, table_a_column_ra, table_a_column_dec,
-                           table_b_full_qualified_name=MAIN_GAIA_TABLE, table_b_column_ra=MAIN_GAIA_TABLE_RA,
-                           table_b_column_dec=MAIN_GAIA_TABLE_DEC, results_name=None,
-                           radius=1.0, background=False, verbose=False):
+    def cross_match_basic(self, *, table_a_full_qualified_name, table_a_column_ra, table_a_column_dec,
+                          table_b_full_qualified_name=MAIN_GAIA_TABLE, table_b_column_ra=MAIN_GAIA_TABLE_RA,
+                          table_b_column_dec=MAIN_GAIA_TABLE_DEC, results_name=None,
+                          radius=1.0, background=False, verbose=False):
         """Performs a positional cross-match between the specified tables.
 
         This methods simples the execution of the method `cross_match` since it carries out the following steps in one
@@ -861,8 +861,10 @@ class GaiaClass(TapPlus):
             #. launches a positional cross-match as an asynchronous query;
             #. returns all the columns from both tables plus the angular distance (deg) for the cross-matched sources.
 
-        The result is a join table with the identifies of both tables and the distance. To speed up the cross-match,
-        pass the biggest table to the ``table_b_full_qualified_name`` parameter.
+        The result is a join table with the identifies of both tables and the distance (degrees), that is returned
+        without metadata units. If desired, units can be added using the Units package of Astropy as follows:
+        results[‘separation’].unit = u.degree. To speed up the cross-match, pass the biggest table to the
+        ``table_b_full_qualified_name`` parameter.
         TAP+ only
 
         Parameters

--- a/astroquery/gaia/core.py
+++ b/astroquery/gaia/core.py
@@ -1026,6 +1026,9 @@ class GaiaClass(TapPlus):
 
         table_b = taputils.get_table_name(full_qualified_table_name_b)
 
+        if taputils.get_schema_name(results_table_name) is not None:
+            raise ValueError("Please, do not specify schema for 'results_table_name'")
+
         query = f"SELECT crossmatch_positional('{schema_a}','{table_a}','{schema_b}','{table_b}',{radius}, " \
                 f"'{results_table_name}') FROM dual;"
 

--- a/astroquery/gaia/core.py
+++ b/astroquery/gaia/core.py
@@ -854,12 +854,12 @@ class GaiaClass(TapPlus):
                           radius=1.0, background=False, verbose=False):
         """Performs a positional cross-match between the specified tables.
 
-        This methods simples the execution of the method `cross_match` since it carries out the following steps in one
+        This method simples the execution of the method `cross_match` since it carries out the following steps in one
         step:
 
-            #. updates the user table metadata to flag the positional RA/Dec columns;
-            #. launches a positional cross-match as an asynchronous query;
-            #. returns all the columns from both tables plus the angular distance (deg) for the cross-matched sources.
+            1. updates the user table metadata to flag the positional RA/Dec columns;
+            2. launches a positional cross-match as an asynchronous query;
+            3. returns all the columns from both tables plus the angular distance (deg) for the cross-matched sources.
 
         The result is a join table with the identifies of both tables and the distance (degrees), that is returned
         without metadata units. If desired, units can be added using the Units package of Astropy as follows:

--- a/astroquery/gaia/core.py
+++ b/astroquery/gaia/core.py
@@ -949,8 +949,10 @@ class GaiaClass(TapPlus):
             for column in table_metadata.columns:
                 if column.name == column_ra and column.flags != '1':
                     list_of_changes.append([column_ra, "flags", "Ra"])
+                    list_of_changes.append([column_ra, "indexed", True])
                 if column.name == column_dec and column.flags != '2':
                     list_of_changes.append([column_dec, "flags", "Dec"])
+                    list_of_changes.append([column_dec, "indexed", True])
 
             if list_of_changes:
                 TapPlus.update_user_table(self, table_name=full_qualified_table_name, list_of_changes=list_of_changes,

--- a/astroquery/gaia/core.py
+++ b/astroquery/gaia/core.py
@@ -853,15 +853,143 @@ class GaiaClass(TapPlus):
 
         return self.is_valid_user(user_id=user_id, verbose=verbose)
 
+    def cross_match_stream(self, *, table_a_full_qualified_name, table_a_column_ra, table_a_column_dec,
+                           table_b_full_qualified_name=MAIN_GAIA_TABLE, table_b_column_ra=MAIN_GAIA_TABLE_RA,
+                           table_b_column_dec=MAIN_GAIA_TABLE_DEC, results_name=None,
+                           radius=1.0, background=False, verbose=False):
+        """Performs a positional cross-match between the specified tables.
+
+        The result is a join table with the identifies of both tables and the distance. To speed up the cross-match,
+        pass the biggest table to the `full_qualified_table_name_b` parameter.
+        TAP+ only
+
+        Parameters
+        ----------
+        table_a_full_qualified_name : str, mandatory
+            a full qualified table name (i.e. schema name and table name)
+        table_a_column_ra : str, mandatory
+            the ‘ra’ column in the table full_qualified_table_name_a
+        table_a_column_dec :  str, mandatory
+            the ‘dec’ column in the table full_qualified_table_name_a
+        table_b_full_qualified_name : str, optional, default MAIN_GAIA_TABLE
+            a full qualified table name (i.e. schema name and table name)
+        table_b_column_ra : str, optional, default MAIN_GAIA_TABLE_RA
+            the ‘ra’ column in the table full_qualified_table_name_b
+        table_b_column_dec :  str, default MAIN_GAIA_TABLE_DEC
+            the ‘dec’ column in the table full_qualified_table_name_b
+        results_name : str, optional, default None
+            custom name defined by the user for the job that is going to be created
+        radius : float (arc. seconds), optional, default 1.0
+            radius  (valid range: 0.1-10.0)
+        background : bool, optional, default 'False'
+            when the job is executed in asynchronous mode, this flag specifies
+            whether the execution will wait until results are available
+        verbose : bool, optional, default 'False'
+            flag to display information about the process
+
+        Returns
+        -------
+        A Job object
+        """
+
+        if radius < 0.1 or radius > 10.0:
+            raise ValueError(f"Invalid radius value. Found {radius}, valid range is: 0.1 to 10.0")
+
+        schema_a = self.__get_schema_name(table_a_full_qualified_name)
+        if not schema_a:
+            raise ValueError(f"Schema name is empty in full qualified table: '{table_a_full_qualified_name}'")
+
+        table_b_full_qualified_name = table_b_full_qualified_name or self.MAIN_GAIA_TABLE or conf.MAIN_GAIA_TABLE
+
+        schema_b = self.__get_schema_name(table_b_full_qualified_name)
+        if not schema_b:
+            raise ValueError(f"Schema name is empty in full qualified table: '{table_b_full_qualified_name}'")
+
+        table_metadata_a = self.__get_table_metadata(table_a_full_qualified_name, verbose)
+
+        table_metadata_b = self.__get_table_metadata(table_b_full_qualified_name, verbose)
+
+        self.__check_columns_exist(table_metadata_a, table_a_full_qualified_name, table_a_column_ra, table_a_column_dec)
+
+        self.__update_ra_dec_columns(table_a_full_qualified_name, table_a_column_ra, table_a_column_dec,
+                                     table_metadata_a)
+
+        self.__check_columns_exist(table_metadata_b, table_b_full_qualified_name, table_b_column_ra, table_b_column_dec)
+
+        self.__update_ra_dec_columns(table_b_full_qualified_name, table_b_column_ra, table_b_column_dec,
+                                     table_metadata_b)
+
+        query = (
+            f"SELECT a.*, b.*, DISTANCE(a.{table_a_column_ra}, a.{table_a_column_dec}, b.{table_b_column_ra}, "
+            f"b.{table_b_column_dec}) AS ang_sep_arcsec "
+            f"FROM {table_a_full_qualified_name} AS a JOIN {table_b_full_qualified_name} AS b "
+            f"ON DISTANCE(a.{table_a_column_ra}, a.{table_a_column_dec}, b.{table_b_column_ra}, b.{table_b_column_dec})"
+            f" < {radius} / 3600.")
+
+        return self.launch_job_async(query=query,
+                                     name=results_name,
+                                     output_file=None,
+                                     output_format="votable_gzip",
+                                     verbose=verbose,
+                                     dump_to_file=False,
+                                     background=background,
+                                     upload_resource=None,
+                                     upload_table_name=None)
+
+    def __update_ra_dec_columns(self, full_qualified_table_name, column_ra, column_dec, table_metadata):
+        """
+        Update table metadata for the ‘ra’ and the ‘dec’ columns in the input table
+        """
+        if full_qualified_table_name.startswith("user_"):
+            list_of_changes_a = list()
+            for column in table_metadata.columns:
+                if column.name == column_ra and column.flags != 1:
+                    list_of_changes_a.append([column_ra, "flags", "Ra"])
+                if column.name == column_dec and column.flags != 2:
+                    list_of_changes_a.append([column_dec, "flags", "Dec"])
+
+            if not list_of_changes_a:
+                Gaia.update_user_table(table_name=full_qualified_table_name, list_of_changes=list_of_changes_a)
+
+    def __check_columns_exist(self, table_metadata_a, full_qualified_table_name, column_ra, column_dec):
+        """
+        Check whether the ‘ra’ and the ‘dec’ columns exists the input table
+        """
+        column_names = [column.name for column in table_metadata_a.columns]
+        if column_ra not in column_names or column_dec not in column_names:
+            raise ValueError(
+                f"Please, columns {column_ra} or {column_dec}  not available in the table '"
+                f"{full_qualified_table_name}'")
+
+    def __get_table_metadata(self, full_qualified_table_name, verbose):
+        """
+        Get the table metadata for the input table
+        """
+        try:
+            table_metadata = self.load_table(table=full_qualified_table_name, verbose=verbose)
+        except Exception:
+            raise ValueError(f"Not found table '{full_qualified_table_name}' in the archive")
+        return table_metadata
+
+    def __get_schema_name(self, full_qualified_table_name):
+        """
+        Get the schema name from the full qualified table
+        """
+        schema = taputils.get_schema_name(full_qualified_table_name)
+        if schema is None:
+            raise ValueError(f"Not found schema name in full qualified table: '{full_qualified_table_name}'")
+        return schema
+
     def cross_match(self, *, full_qualified_table_name_a,
                     full_qualified_table_name_b,
                     results_table_name,
                     radius=1.0,
                     background=False,
                     verbose=False):
-        """Performs a cross-match between the specified tables
-        The result is a join table (stored in the user storage area)
-        with the identifies of both tables and the distance.
+        """Performs a positional cross-match between the specified tables.
+
+        The result is a join table (stored in the user storage area) with the identifies of both tables and the
+        distance.
         TAP+ only
 
         Parameters
@@ -887,21 +1015,15 @@ class GaiaClass(TapPlus):
         if radius < 0.1 or radius > 10.0:
             raise ValueError(f"Invalid radius value. Found {radius}, valid range is: 0.1 to 10.0")
 
-        schemaA = taputils.get_schema_name(full_qualified_table_name_a)
-        if schemaA is None:
-            raise ValueError(f"Not found schema name in full qualified table A: '{full_qualified_table_name_a}'")
-        tableA = taputils.get_table_name(full_qualified_table_name_a)
-        schemaB = taputils.get_schema_name(full_qualified_table_name_b)
+        schema_a = self.__get_schema_name(full_qualified_table_name_a)
 
-        if schemaB is None:
-            raise ValueError(f"Not found schema name in full qualified table B: '{full_qualified_table_name_b}'")
+        table_a = taputils.get_table_name(full_qualified_table_name_a)
 
-        tableB = taputils.get_table_name(full_qualified_table_name_b)
+        schema_b = self.__get_schema_name(full_qualified_table_name_b)
 
-        if taputils.get_schema_name(results_table_name) is not None:
-            raise ValueError("Please, do not specify schema for 'results_table_name'")
+        table_b = taputils.get_table_name(full_qualified_table_name_b)
 
-        query = f"SELECT crossmatch_positional('{schemaA}','{tableA}','{schemaB}','{tableB}',{radius}, " \
+        query = f"SELECT crossmatch_positional('{schema_a}','{table_a}','{schema_b}','{table_b}',{radius}, " \
                 f"'{results_table_name}') FROM dual;"
 
         name = str(results_table_name)
@@ -916,10 +1038,8 @@ class GaiaClass(TapPlus):
                                      upload_resource=None,
                                      upload_table_name=None)
 
-    def launch_job(self, query, *, name=None, output_file=None,
-                   output_format="votable_gzip", verbose=False,
-                   dump_to_file=False, upload_resource=None,
-                   upload_table_name=None):
+    def launch_job(self, query, *, name=None, output_file=None, output_format="votable_gzip", verbose=False,
+                   dump_to_file=False, upload_resource=None, upload_table_name=None):
         """Launches a synchronous job
 
         Parameters

--- a/astroquery/gaia/core.py
+++ b/astroquery/gaia/core.py
@@ -859,8 +859,15 @@ class GaiaClass(TapPlus):
                            radius=1.0, background=False, verbose=False):
         """Performs a positional cross-match between the specified tables.
 
+        This methods simples the execution of the method `cross_match` since it carries out the following steps in one
+        step:
+
+            #. updates the user table metadata to flag the positional RA/Dec columns;
+            #. launches a positional cross-match as an asynchronous query;
+            #. returns all the columns from both tables plus the angular distance (deg) for the cross-matched sources.
+
         The result is a join table with the identifies of both tables and the distance. To speed up the cross-match,
-        pass the biggest table to the `full_qualified_table_name_b` parameter.
+        pass the biggest table to the ``table_b_full_qualified_name`` parameter.
         TAP+ only
 
         Parameters
@@ -868,15 +875,15 @@ class GaiaClass(TapPlus):
         table_a_full_qualified_name : str, mandatory
             a full qualified table name (i.e. schema name and table name)
         table_a_column_ra : str, mandatory
-            the ‘ra’ column in the table full_qualified_table_name_a
+            the ‘ra’ column in the table table_a_full_qualified_name
         table_a_column_dec :  str, mandatory
-            the ‘dec’ column in the table full_qualified_table_name_a
+            the ‘dec’ column in the table table_a_full_qualified_name
         table_b_full_qualified_name : str, optional, default MAIN_GAIA_TABLE
             a full qualified table name (i.e. schema name and table name)
         table_b_column_ra : str, optional, default MAIN_GAIA_TABLE_RA
-            the ‘ra’ column in the table full_qualified_table_name_b
+            the ‘ra’ column in the table table_b_full_qualified_name
         table_b_column_dec :  str, default MAIN_GAIA_TABLE_DEC
-            the ‘dec’ column in the table full_qualified_table_name_b
+            the ‘dec’ column in the table table_b_full_qualified_name
         results_name : str, optional, default None
             custom name defined by the user for the job that is going to be created
         radius : float (arc. seconds), optional, default 1.0
@@ -949,7 +956,7 @@ class GaiaClass(TapPlus):
                     list_of_changes_a.append([column_dec, "flags", "Dec"])
 
             if not list_of_changes_a:
-                Gaia.update_user_table(table_name=full_qualified_table_name, list_of_changes=list_of_changes_a)
+                self.update_user_table(table_name=full_qualified_table_name, list_of_changes=list_of_changes_a)
 
     def __check_columns_exist(self, table_metadata_a, full_qualified_table_name, column_ra, column_dec):
         """

--- a/astroquery/gaia/core.py
+++ b/astroquery/gaia/core.py
@@ -922,8 +922,8 @@ class GaiaClass(TapPlus):
                                      table_metadata_b, verbose)
 
         query = (
-            f"SELECT a.*, b.*, DISTANCE(a.{table_a_column_ra}, a.{table_a_column_dec}, b.{table_b_column_ra}, "
-            f"b.{table_b_column_dec}) AS ang_sep_arcsec "
+            f"SELECT a.*, DISTANCE(a.{table_a_column_ra}, a.{table_a_column_dec}, b.{table_b_column_ra}, "
+            f"b.{table_b_column_dec}) AS separation, b.* "
             f"FROM {table_a_full_qualified_name} AS a JOIN {table_b_full_qualified_name} AS b "
             f"ON DISTANCE(a.{table_a_column_ra}, a.{table_a_column_dec}, b.{table_b_column_ra}, b.{table_b_column_dec})"
             f" < {radius} / 3600.")
@@ -961,7 +961,7 @@ class GaiaClass(TapPlus):
         column_names = [column.name for column in table_metadata_a.columns]
         if column_ra not in column_names or column_dec not in column_names:
             raise ValueError(
-                f"Please, columns {column_ra} or {column_dec}  not available in the table '"
+                f"Please check: columns {column_ra} or {column_dec} not available in the table '"
                 f"{full_qualified_table_name}'")
 
     def __get_table_metadata(self, full_qualified_table_name, verbose):

--- a/astroquery/gaia/tests/test_gaiatap.py
+++ b/astroquery/gaia/tests/test_gaiatap.py
@@ -1468,13 +1468,13 @@ def test_cross_match_stream_wrong_column(monkeypatch, background, mock_querier_a
     monkeypatch.setattr(Tap, "load_table", load_table_monkeypatched)
     monkeypatch.setattr(TapPlus, "update_user_table", update_user_table)
 
-    error_message = "Please, columns Wrong_ra or dec  not available in the table 'user_hola.tableA'"
+    error_message = "Please check: columns Wrong_ra or dec not available in the table 'user_hola.tableA'"
     with pytest.raises(ValueError, match=error_message):
         mock_querier_async.cross_match_stream(table_a_full_qualified_name="user_hola.tableA",
                                               table_a_column_ra="Wrong_ra", table_a_column_dec="dec",
                                               background=background)
 
-    error_message = "Please, columns ra or Wrong_dec  not available in the table 'user_hola.tableA'"
+    error_message = "Please check: columns ra or Wrong_dec not available in the table 'user_hola.tableA'"
     with pytest.raises(ValueError, match=error_message):
         mock_querier_async.cross_match_stream(table_a_full_qualified_name="user_hola.tableA",
                                               table_a_column_ra="ra", table_a_column_dec="Wrong_dec",

--- a/astroquery/gaia/tests/test_gaiatap.py
+++ b/astroquery/gaia/tests/test_gaiatap.py
@@ -447,7 +447,7 @@ def cross_match_kwargs():
 
 
 @pytest.fixture
-def cross_match_stream_kwargs():
+def cross_match_basic_kwargs():
     return {"table_a_full_qualified_name": "schemaA.tableA",
             "table_a_column_ra": "ra",
             "table_a_column_dec": "dec",
@@ -457,7 +457,7 @@ def cross_match_stream_kwargs():
 
 
 @pytest.fixture
-def cross_match_stream_2_kwargs():
+def cross_match_basic_2_kwargs():
     return {"table_a_full_qualified_name": "user_hola.tableA",
             "table_a_column_ra": "ra",
             "table_a_column_dec": "dec",
@@ -1390,7 +1390,7 @@ def make_table_metadata(table_name):
 
 
 @pytest.mark.parametrize("background", [False, True])
-def test_cross_match_stream(monkeypatch, background, cross_match_stream_kwargs, mock_querier_async):
+def test_cross_match_basic(monkeypatch, background, cross_match_basic_kwargs, mock_querier_async):
     def load_table_monkeypatched(self, table, verbose):
         tap_table_a = make_table_metadata("schemaA.tableA")
         tap_table_b = make_table_metadata("schemaB.tableB")
@@ -1400,14 +1400,14 @@ def test_cross_match_stream(monkeypatch, background, cross_match_stream_kwargs, 
 
     monkeypatch.setattr(Tap, "load_table", load_table_monkeypatched)
 
-    job = mock_querier_async.cross_match_stream(**cross_match_stream_kwargs, background=background)
+    job = mock_querier_async.cross_match_basic(**cross_match_basic_kwargs, background=background)
     assert job.async_ is True
     assert job.get_phase() == "EXECUTING" if background else "COMPLETED"
     assert job.failed is False
 
 
 @pytest.mark.parametrize("background", [False, True])
-def test_cross_match_stream_2(monkeypatch, background, cross_match_stream_2_kwargs, mock_querier_async):
+def test_cross_match_basic_2(monkeypatch, background, cross_match_basic_2_kwargs, mock_querier_async):
     def load_table_monkeypatched(self, table, verbose):
         tap_table_a = make_table_metadata("user_hola.tableA")
         tap_table_b = make_table_metadata("user_hola.tableB")
@@ -1421,14 +1421,14 @@ def test_cross_match_stream_2(monkeypatch, background, cross_match_stream_2_kwar
     monkeypatch.setattr(Tap, "load_table", load_table_monkeypatched)
     monkeypatch.setattr(TapPlus, "update_user_table", update_user_table)
 
-    job = mock_querier_async.cross_match_stream(**cross_match_stream_2_kwargs, background=background)
+    job = mock_querier_async.cross_match_basic(**cross_match_basic_2_kwargs, background=background)
     assert job.async_ is True
     assert job.get_phase() == "EXECUTING" if background else "COMPLETED"
     assert job.failed is False
 
 
 @pytest.mark.parametrize("background", [False, True])
-def test_cross_match_stream_3(monkeypatch, background, mock_querier_async):
+def test_cross_match_basic_3(monkeypatch, background, mock_querier_async):
     mock_querier_async.MAIN_GAIA_TABLE = None
 
     def load_table_monkeypatched_2(self, table, verbose):
@@ -1444,15 +1444,15 @@ def test_cross_match_stream_3(monkeypatch, background, mock_querier_async):
     monkeypatch.setattr(Tap, "load_table", load_table_monkeypatched_2)
     monkeypatch.setattr(TapPlus, "update_user_table", update_user_table)
 
-    job = mock_querier_async.cross_match_stream(table_a_full_qualified_name="user_hola.tableA", table_a_column_ra="ra",
-                                                table_a_column_dec="dec", background=background)
+    job = mock_querier_async.cross_match_basic(table_a_full_qualified_name="user_hola.tableA", table_a_column_ra="ra",
+                                               table_a_column_dec="dec", background=background)
     assert job.async_ is True
     assert job.get_phase() == "EXECUTING" if background else "COMPLETED"
     assert job.failed is False
 
 
 @pytest.mark.parametrize("background", [False, True])
-def test_cross_match_stream_wrong_column(monkeypatch, background, mock_querier_async):
+def test_cross_match_basic_wrong_column(monkeypatch, background, mock_querier_async):
     mock_querier_async.MAIN_GAIA_TABLE = None
 
     def load_table_monkeypatched(self, table, verbose):
@@ -1470,18 +1470,18 @@ def test_cross_match_stream_wrong_column(monkeypatch, background, mock_querier_a
 
     error_message = "Please check: columns Wrong_ra or dec not available in the table 'user_hola.tableA'"
     with pytest.raises(ValueError, match=error_message):
-        mock_querier_async.cross_match_stream(table_a_full_qualified_name="user_hola.tableA",
-                                              table_a_column_ra="Wrong_ra", table_a_column_dec="dec",
-                                              background=background)
+        mock_querier_async.cross_match_basic(table_a_full_qualified_name="user_hola.tableA",
+                                             table_a_column_ra="Wrong_ra", table_a_column_dec="dec",
+                                             background=background)
 
     error_message = "Please check: columns ra or Wrong_dec not available in the table 'user_hola.tableA'"
     with pytest.raises(ValueError, match=error_message):
-        mock_querier_async.cross_match_stream(table_a_full_qualified_name="user_hola.tableA",
-                                              table_a_column_ra="ra", table_a_column_dec="Wrong_dec",
-                                              background=background)
+        mock_querier_async.cross_match_basic(table_a_full_qualified_name="user_hola.tableA",
+                                             table_a_column_ra="ra", table_a_column_dec="Wrong_dec",
+                                             background=background)
 
 
-def test_cross_match_stream_exceptions(monkeypatch):
+def test_cross_match_basic_exceptions(monkeypatch):
     def load_table_monkeypatched(self, table, verbose):
         raise ValueError(f"Not found schema name in full qualified table: '{table}'")
 
@@ -1493,41 +1493,41 @@ def test_cross_match_stream_exceptions(monkeypatch):
 
     error_message = "Not found table 'user_hola.tableA' in the archive"
     with pytest.raises(ValueError, match=error_message):
-        GAIA_QUERIER.cross_match_stream(table_a_full_qualified_name="user_hola.tableA", table_a_column_ra="ra",
-                                        table_a_column_dec="dec", background=True)
+        GAIA_QUERIER.cross_match_basic(table_a_full_qualified_name="user_hola.tableA", table_a_column_ra="ra",
+                                       table_a_column_dec="dec", background=True)
 
     # Check invalid input values
     error_message = "Not found schema name in full qualified table: 'hola'"
     with pytest.raises(ValueError, match=error_message):
-        GAIA_QUERIER.cross_match_stream(table_a_full_qualified_name="hola", table_a_column_ra="ra",
-                                        table_a_column_dec="dec")
+        GAIA_QUERIER.cross_match_basic(table_a_full_qualified_name="hola", table_a_column_ra="ra",
+                                       table_a_column_dec="dec")
 
     error_message = "Schema name is empty in full qualified table: '.table_name'"
     with pytest.raises(ValueError, match=error_message):
-        GAIA_QUERIER.cross_match_stream(table_a_full_qualified_name=".table_name", table_a_column_ra="ra",
-                                        table_a_column_dec="dec")
+        GAIA_QUERIER.cross_match_basic(table_a_full_qualified_name=".table_name", table_a_column_ra="ra",
+                                       table_a_column_dec="dec")
 
     error_message = "Not found schema name in full qualified table: 'hola'"
     with pytest.raises(ValueError, match=error_message):
-        GAIA_QUERIER.cross_match_stream(table_a_full_qualified_name="schema.table_name", table_a_column_ra="ra",
-                                        table_a_column_dec="dec", table_b_full_qualified_name="hola")
+        GAIA_QUERIER.cross_match_basic(table_a_full_qualified_name="schema.table_name", table_a_column_ra="ra",
+                                       table_a_column_dec="dec", table_b_full_qualified_name="hola")
 
     error_message = "Schema name is empty in full qualified table: '.table_name'"
     with pytest.raises(ValueError, match=error_message):
-        GAIA_QUERIER.cross_match_stream(table_a_full_qualified_name="schema.table_name", table_a_column_ra="ra",
-                                        table_a_column_dec="dec", table_b_full_qualified_name=".table_name")
+        GAIA_QUERIER.cross_match_basic(table_a_full_qualified_name="schema.table_name", table_a_column_ra="ra",
+                                       table_a_column_dec="dec", table_b_full_qualified_name=".table_name")
 
     error_message = "Invalid radius value. Found 50.0, valid range is: 0.1 to 10.0"
     with pytest.raises(ValueError, match=error_message):
-        GAIA_QUERIER.cross_match_stream(table_a_full_qualified_name="schema.table_name", table_a_column_ra="ra",
-                                        table_a_column_dec="dec", table_b_full_qualified_name="schema.table_name",
-                                        radius=50.0)
+        GAIA_QUERIER.cross_match_basic(table_a_full_qualified_name="schema.table_name", table_a_column_ra="ra",
+                                       table_a_column_dec="dec", table_b_full_qualified_name="schema.table_name",
+                                       radius=50.0)
 
     error_message = "Invalid radius value. Found 0.01, valid range is: 0.1 to 10.0"
     with pytest.raises(ValueError, match=error_message):
-        GAIA_QUERIER.cross_match_stream(table_a_full_qualified_name="schema.table_name", table_a_column_ra="ra",
-                                        table_a_column_dec="dec", table_b_full_qualified_name="schema.table_name",
-                                        radius=0.01)
+        GAIA_QUERIER.cross_match_basic(table_a_full_qualified_name="schema.table_name", table_a_column_ra="ra",
+                                       table_a_column_dec="dec", table_b_full_qualified_name="schema.table_name",
+                                       radius=0.01)
 
 
 @patch.object(TapPlus, 'login')

--- a/astroquery/gaia/tests/test_gaiatap.py
+++ b/astroquery/gaia/tests/test_gaiatap.py
@@ -854,10 +854,8 @@ def test_datalink_querier_load_data_vot_exception(mock_datalink_querier, overwri
                                             overwrite_output_file=overwrite_output_file,
                                             verbose=False)
 
-        assert str(
-            excinfo.value) == (
-                   f"{file_final} file already exists. Please use overwrite_output_file='True' to overwrite output "
-                   f"file.")
+        messg = f"{file_final} file already exists. Please use overwrite_output_file='True' to overwrite output file."
+        assert str(excinfo.value) == messg
 
     else:
         mock_datalink_querier.load_data(ids=[5937083312263887616], data_release='Gaia DR3',

--- a/astroquery/utils/tap/core.py
+++ b/astroquery/utils/tap/core.py
@@ -181,18 +181,30 @@ class Tap:
         """
         if table is None:
             raise ValueError("Table name is required")
+
+        schema = taputils.get_schema_name(table)
+        if schema is None:
+            raise ValueError(f"Not found schema name in full qualified table: '{table}'")
+
         if verbose:
             print(f"Retrieving table '{table}'")
+
         response = self.__connHandler.execute_tapget(f"tables?tables={table}", verbose=verbose)
+
         if verbose:
             print(response.status, response.reason)
+
         self.__connHandler.check_launch_response_status(response, verbose, 200)
+
         if verbose:
             print(f"Parsing table '{table}'...")
+
         tsp = TableSaxParser()
         tsp.parseData(response)
+
         if verbose:
             print("Done.")
+
         return tsp.get_table()
 
     def __load_tables(self, *, only_names=False, include_shared_tables=False, verbose=False):

--- a/astroquery/utils/tap/model/taptable.py
+++ b/astroquery/utils/tap/model/taptable.py
@@ -34,7 +34,7 @@ class TapTableMeta:
 
         Returns
         -------
-        The the qualified TAP table name (schema+table)
+        The qualified TAP table name (schema+table)
         """
         if '.' in self.name:
             return self.name

--- a/astroquery/utils/tap/tests/test_tap.py
+++ b/astroquery/utils/tap/tests/test_tap.py
@@ -9,7 +9,6 @@ European Space Agency (ESA)
 """
 import gzip
 import os
-
 from pathlib import Path
 from unittest.mock import patch
 from urllib.parse import quote_plus, urlencode
@@ -19,7 +18,6 @@ import pytest
 from astropy.io.registry import IORegistryError
 from astropy.table import Table
 from astropy.utils.data import get_pkg_data_filename
-
 from requests import HTTPError
 
 from astroquery.utils.tap import taputils
@@ -118,7 +116,8 @@ def test_load_table():
     tap = TapPlus(url="http://test:1111/tap", connhandler=conn_handler)
 
     # No arguments
-    with pytest.raises(Exception):
+    error_message = ".*load_table\\(\\) missing 1 required positional argument: 'table'$"
+    with pytest.raises(TypeError, match=error_message):
         tap.load_table()
 
     responseLoadTable = DummyResponse(500)
@@ -129,11 +128,12 @@ def test_load_table():
     tableRequest = f"tables?tables={fullQualifiedTableName}"
     conn_handler.set_response(tableRequest, responseLoadTable)
 
-    with pytest.raises(Exception):
+    error_message = "^Error 500"
+    with pytest.raises(Exception, match=error_message):
         tap.load_table(fullQualifiedTableName)
 
     responseLoadTable.set_status_code(200)
-    table = tap.load_table(fullQualifiedTableName)
+    table = tap.load_table(fullQualifiedTableName, verbose=True)
     assert table is not None
     assert table.description == 'Table1 desc'
     columns = table.columns
@@ -142,6 +142,19 @@ def test_load_table():
     __check_column(col, 'Table1 Column1 desc', '', 'VARCHAR', 'indexed')
     col = __find_column('table1_col2', columns)
     __check_column(col, 'Table1 Column2 desc', '', 'INTEGER', None)
+
+
+def test_load_table_exceptions():
+    conn_handler = DummyConnHandler()
+    tap = TapPlus(url="http://test:1111/tap", connhandler=conn_handler)
+
+    error_message = "Table name is required"
+    with pytest.raises(ValueError, match=error_message):
+        tap.load_table(None)
+
+    error_message = "Not found schema name in full qualified table: 'only_table_name'"
+    with pytest.raises(ValueError, match=error_message):
+        tap.load_table("only_table_name")
 
 
 def test_launch_sync_job():

--- a/astroquery/utils/tap/tests/test_tap.py
+++ b/astroquery/utils/tap/tests/test_tap.py
@@ -778,7 +778,7 @@ def test_get_current_column_values_for_update():
 
 
 def test_update_user_table():
-    tableName = 'table'
+    tableName = 'schema.table'
     conn_handler = DummyConnHandler()
     tap = TapPlus(url="http://test:1111/tap", connhandler=conn_handler)
     dummyResponse = DummyResponse(200)

--- a/docs/gaia/gaia.rst
+++ b/docs/gaia/gaia.rst
@@ -747,9 +747,11 @@ source in the second table.
 
 The cross-match requires 3 steps:
 
-# Update the user table metadata to flag the positional RA/Dec columns using the dedicated method `update_user_table`,
-since both tables must have defined RA and Dec columns. See previous section to know how to assign those flags;
-# Launch the built-in cross-match method `cross_match`, the makes a table in the user's private area;
+# Update the user table metadata to flag the positional RA/Dec columns using the dedicated method
+`~astroquery.utils.tap.core.TapPlus.update_user_table`, since both tables must have defined RA and Dec columns. See
+previous section to know how to assign those flags;
+# Launch the built-in cross-match method `~astroquery.gaia.GaiaClass.cross_match`, the makes a table in the user's
+private area;
 # Later, this table can be used to obtain the actual data from both tables, launching an ADQL query using the
 "launch_job" or "launch_job_async" method.
 
@@ -784,8 +786,8 @@ The previous 3-step cross-match can be executed in one step by the following met
 
   >>> from astroquery.gaia import Gaia
   >>> Gaia.login()
-  >>> job = Gaia.cross_match_stream(full_qualified_table_name_a=full_qualified_table_name, table_a_column_ra='raj2000',
-                       table_a_column_dec='dej2000', full_qualified_table_name_b='gaiadr3.gaia_source',
+  >>> job = Gaia.cross_match_stream(table_a_full_qualified_name=full_qualified_table_name, table_a_column_ra='raj2000',
+                       table_a_column_dec='dej2000', table_b_full_qualified_name='gaiadr3.gaia_source',
                        table_b_column_ra='ra', table_b_column_dec='dec, radius=1.0, background=True):
   >>> print(job)
   Jobid: 1611860482314O

--- a/docs/gaia/gaia.rst
+++ b/docs/gaia/gaia.rst
@@ -787,7 +787,7 @@ The previous 3-step cross-match can be executed in one step by the following met
 
   >>> from astroquery.gaia import Gaia
   >>> Gaia.login()
-  >>> job = Gaia.cross_match_stream(table_a_full_qualified_name=full_qualified_table_name, table_a_column_ra='raj2000',
+  >>> job = Gaia.cross_match_basic(table_a_full_qualified_name=full_qualified_table_name, table_a_column_ra='raj2000',
                        table_a_column_dec='dej2000', table_b_full_qualified_name='gaiadr3.gaia_source',
                        table_b_column_ra='ra', table_b_column_dec='dec, radius=1.0, background=True):
   >>> print(job)

--- a/docs/gaia/gaia.rst
+++ b/docs/gaia/gaia.rst
@@ -738,21 +738,22 @@ We can type the following::
 2.6. Cross match
 ^^^^^^^^^^^^^^^^
 
-It is possible to run a geometric cross-match between the RA/Dec coordinates of two tables
-using the crossmatch function provided by the archive. In order to do so the user must be
-logged in. This is required because the cross match operation will generate a join table
-in the user private area. That table contains the identifiers of both tables and the separation,
-in degrees, between RA/Dec coordinates of each source in the first table and its associated
-source in the second table.
+It is possible to run a geometric cross-match between the RA/Dec coordinates of two tables using the crossmatch function
+provided by the archive. To do so, the user must be logged in. This is necessary as the cross-match process will create
+a join table within the user's private space. That table includes the identifiers from both tables and the angular
+separation, in degrees, between the RA/Dec coordinates of each source in the first table and its corresponding source
+in the second table.
 
 The cross-match requires 3 steps:
 
-# Update the user table metadata to flag the positional RA/Dec columns using the dedicated method
-`~astroquery.utils.tap.core.TapPlus.update_user_table`, since both tables must have defined RA and Dec columns. See
-previous section to know how to assign those flags;
-# Launch the built-in cross-match method `~astroquery.gaia.GaiaClass.cross_match`, the makes a table in the user's
+1. Update the user table metadata to flag the positional RA/Dec columns using the dedicated method
+`~astroquery.utils.tap.core.TapPlus.update_user_table`, as both tables must have defined RA and Dec columns. See
+previous section to learn how to assign those flags;
+
+2. Launch the built-in cross-match method `~astroquery.gaia.GaiaClass.cross_match`, which creates a table in the user's
 private area;
-# Later, this table can be used to obtain the actual data from both tables, launching an ADQL query using the
+
+3. Subsequently, this table can be employed to retrieve the data from both tables, launching an ADQL query with the
 "launch_job" or "launch_job_async" method.
 
 The following example uploads a table and then, the table is used in a cross match::
@@ -771,7 +772,7 @@ The following example uploads a table and then, the table is used in a cross mat
 
 The cross-match launches an asynchronous query that saves the results at the user's private area, so it depends on the
 user files quota. This table only contains 3 columns: first table column id, second table column id and the angular
-separation (ded) between each source. Once you have your cross match finished, you can access to this table::
+separation (degrees) between each source. Once you have your cross match finished, you can access to this table::
 
   >>> xmatch_table = 'user_<your_login_name>.' + xmatch_table_name
   >>> query = (f"SELECT c.separation*3600 AS separation_arcsec, a.*, b.* FROM gaiadr3.gaia_source AS a, "
@@ -796,10 +797,10 @@ The previous 3-step cross-match can be executed in one step by the following met
   Output file: 1611860482314O-result.vot.gz
   Results: None
 
-This method updates all the user table metadata to flag the positional RA/Dec columns, launches the positional
-cross-match as an asynchronous query. The returned job provides information for all the columns in both input tables
-plus the angular distance (deg) between each cross-matched source. Unlike the previous 3-step method, the output table
-contains all the columns from each table, so that size of the cross-match output could be pretty large.
+This method updates the user table metadata to flag the positional RA/Dec columns and launches the positional
+cross-match as an asynchronous query. Unlike the previous 3-step cross-match method, the returned job provides direct
+access to the output of the cross-match information: for each matched source, all the columns from the input tables plus
+the angular distance (degrees). Therefore, the size of the output can be quite large.
 
 
 2.7. Tables sharing

--- a/docs/gaia/gaia.rst
+++ b/docs/gaia/gaia.rst
@@ -82,7 +82,7 @@ This query searches for all the objects contained in an arbitrary rectangular pr
 WARNING: This method implements the ADQL BOX function that is deprecated in the latest version of the standard
 (ADQL 2.1,  see: https://ivoa.net/documents/ADQL/20231107/PR-ADQL-2.1-20231107.html#tth_sEc4.2.9).
 
-It is possible to choose which data release to query, by default the Gaia DR3 catalogue is used. For example::
+It is possible to choose which data release to query, by default the Gaia DR3 catalogue is used. For example
 
 .. doctest-remote-data::
 
@@ -796,12 +796,21 @@ The previous 3-step cross-match can be executed in one step by the following met
   Owner: None
   Output file: 1611860482314O-result.vot.gz
   Results: None
+  >>> result = job.get_results()
 
 This method updates the user table metadata to flag the positional RA/Dec columns and launches the positional
 cross-match as an asynchronous query. Unlike the previous 3-step cross-match method, the returned job provides direct
 access to the output of the cross-match information: for each matched source, all the columns from the input tables plus
 the angular distance (degrees). Therefore, the size of the output can be quite large.
 
+By default, this method targets the main catalogue of the Gaia DR3 ("gaiadr3.gaia_source") using a cone search radius
+of 1.0 arcseconds. Therefore, the above example can also be simplified as follows::
+
+  >>> from astroquery.gaia import Gaia
+  >>> Gaia.login()
+  >>> job = Gaia.cross_match_basic(table_a_full_qualified_name=full_qualified_table_name, table_a_column_ra='raj2000',
+                                   table_a_column_dec='dej2000')
+  >>> result = job.get_results()
 
 2.7. Tables sharing
 ^^^^^^^^^^^^^^^^^^^


### PR DESCRIPTION
Dear astroquery team,

The current implementation of the astroquery.gaia built-in cross-match tool relies in a sub-optimal intermediate ADQL query. Furthermore (and after uploading a table to the user space), it requires a 3-step approach involving different functionalities (each of them requiring multiple "user clicks"):

1. Update the user table metadata to flag the positional (ra & dec) fields using a dedicated method ("update_user_table" - see Sect 2.5 in the [astroquery.gaia documentation](https://astroquery.readthedocs.io/en/latest/gaia/gaia.html))
2. Launch the built-in cross-match method ("cross_match" - see Sect 2.6 in the [astroquery.gaia documentation](https://astroquery.readthedocs.io/en/latest/gaia/gaia.html))
3. Launch a sub-optimal and complicated ADQL query using the "launch_job" or "launch_job_async" method (see Sect 2.6 in the [astroquery.gaia documentation](https://astroquery.readthedocs.io/en/latest/gaia/gaia.html)).

 
We propose to streamline this procedure to improve the user experience and hopefully promote the usage of this functionality by updating the current implementation.

The proposed mechanism:

1. allows to obtain a basic cross-match using a single step (versus three steps currently).
2. allows to perform cross-matches between: user_table X user_table, user_table X GACS_table, and GACS_table X GACS_table (as in the current implementation).


We have developed the new method cross_match_basic as well as new tests. This change is backward compatible with the present implementation of the cross-match method.


cc @esdc-esac-esa-int 

jira: GAIASWRQ-25