### PR TITLE
MAINT: adding workaround for astropy type hints 

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -197,7 +197,9 @@ if eval(setup_cfg.get('edit_on_github')):
     edit_on_github_doc_root = "docs"
 
 nitpicky = True
-nitpick_ignore = [('py:class', 'astroquery.mast.core.MastQueryWithLogin')]
+nitpick_ignore = [('py:class', 'astroquery.mast.core.MastQueryWithLogin'),
+                  # astropy interited type annotations
+                  ('py:class', 'ConfigItem')]
 
 
 # -- Linkcheck builder options ----------------------------------------------


### PR DESCRIPTION
so sphinx doesn't choke on them here

closes #3326 

This can be merged once RTD is passing build