### PR TITLE
MAINT: bumping minimum required pytest version and fixes coverage job

### DIFF
--- a/astroquery/casda/tests/test_casda.py
+++ b/astroquery/casda/tests/test_casda.py
@@ -11,10 +11,8 @@ from astropy.coordinates import SkyCoord
 import astropy.units as u
 from astropy.table import Table, Column
 from astropy.io.votable import parse
-from astropy.io.votable.exceptions import W03, W06, W50
+from astropy.io.votable.exceptions import W03, W50
 from astroquery import log
-from astroquery.utils.commons import ASTROPY_LT_5_3
-from contextlib import nullcontext
 
 import numpy as np
 
@@ -274,10 +272,8 @@ def test_query_region_async_box(patch_get):
 
 
 def test_filter_out_unreleased():
-    # The ``W06: Invalid UCD 'meta.ref.url;meta.curation'`` warning is only raised with older astropy
-    with pytest.warns(W06) if ASTROPY_LT_5_3 else nullcontext():
-        with pytest.warns(W03):
-            all_records = parse(data_path('partial_unreleased.xml'), verify='warn').get_first_table().to_table()
+    with pytest.warns(W03):
+        all_records = parse(data_path('partial_unreleased.xml'), verify='warn').get_first_table().to_table()
     assert all_records[0]['obs_release_date'] == '2017-08-02T03:51:19.728Z'
     assert all_records[1]['obs_release_date'] == '2218-01-02T16:51:00.728Z'
     assert all_records[2]['obs_release_date'] == ''

--- a/setup.cfg
+++ b/setup.cfg
@@ -89,6 +89,9 @@ filterwarnings =
     ignore: The 'strip_cdata' option of HTMLParser:DeprecationWarning
 # Triggered in mast, likely boto related
     ignore:datetime.datetime.utcnow\(\) is deprecated:DeprecationWarning
+# CoverageWarnings triggered by one of the other plugins(?). Either case, explicitely
+# ignore it here to have passing test for pytest 8.4.
+    ignore:Module astroquery was previously imported, but not measured:coverage.exceptions.CoverageWarning
 
 markers =
     bigdata: marks tests that are expected to trigger a large download (deselect with '-m "not bigdata"')

--- a/setup.cfg
+++ b/setup.cfg
@@ -35,7 +35,7 @@ upload-dir = docs/_build/html
 show-response = 1
 
 [tool:pytest]
-minversion = 6.0
+minversion = 7.4
 norecursedirs = build docs/_build astroquery/irsa astroquery/nasa_exoplanet_archive astroquery/ned astroquery/ibe astroquery/irsa_dust astroquery/cds astroquery/sha astroquery/dace
 testpaths = astroquery docs
 doctest_plus = enabled

--- a/tox.ini
+++ b/tox.ini
@@ -53,7 +53,7 @@ deps =
     oldestdeps: keyring==15.0
     oldestdeps: pytest==7.4
     oldestdeps: beautifulsoup4==4.9
-    oldestdeps-alldeps: mocpy==0.9
+    oldestdeps-alldeps: mocpy==0.12
     oldestdeps-alldeps: regions==0.5
 
     online: pytest-custom_exit_code

--- a/tox.ini
+++ b/tox.ini
@@ -51,7 +51,7 @@ deps =
     oldestdeps: pytest-doctestplus==0.13
     oldestdeps: requests==2.25
     oldestdeps: keyring==15.0
-    oldestdeps: pytest==6.0
+    oldestdeps: pytest==7.4
     oldestdeps: beautifulsoup4==4.9
     oldestdeps-alldeps: mocpy==0.9
     oldestdeps-alldeps: regions==0.5


### PR DESCRIPTION
This should fix the CI failure for the oldestdeps job (a newer version was picked up there, and there is really no point in forcing the plugins to have older versions for the sake of keeping the 6.0 in place.

I couldn't reproduce the devdeps failure locally, but will iterate on it in this PR.