### PR TITLE
BUGFIX: prevent gaia from querying server at import time

### DIFF
--- a/astroquery/esa/euclid/core.py
+++ b/astroquery/esa/euclid/core.py
@@ -787,7 +787,6 @@ class EuclidClass(TapPlus):
                     except IndexError:
                         print("Archive down for maintenance")
 
-
     @staticmethod
     def __set_dirs(output_file, observation_id):
         if output_file is None:

--- a/astroquery/esa/euclid/core.py
+++ b/astroquery/esa/euclid/core.py
@@ -776,7 +776,6 @@ class EuclidClass(TapPlus):
         sub_context = self.EUCLID_MESSAGES
         conn_handler = self._TapPlus__getconnhandler()
         response = conn_handler.execute_tapget(sub_context, verbose=verbose)
-        response.raise_for_status()
         if response.status == 200:
             if isinstance(response, Iterable):
                 for line in response:
@@ -787,6 +786,8 @@ class EuclidClass(TapPlus):
                         print(e)
                     except IndexError:
                         print("Archive down for maintenance")
+        else:
+            raise HTTPError(f"Failed to retrieve status messages. HTTP status code: {response.status}")
 
     @staticmethod
     def __set_dirs(output_file, observation_id):

--- a/astroquery/esa/euclid/core.py
+++ b/astroquery/esa/euclid/core.py
@@ -776,6 +776,7 @@ class EuclidClass(TapPlus):
         sub_context = self.EUCLID_MESSAGES
         conn_handler = self._TapPlus__getconnhandler()
         response = conn_handler.execute_tapget(sub_context, verbose=verbose)
+        response.raise_for_status()
         if response.status == 200:
             if isinstance(response, Iterable):
                 for line in response:

--- a/astroquery/esa/euclid/core.py
+++ b/astroquery/esa/euclid/core.py
@@ -773,23 +773,20 @@ class EuclidClass(TapPlus):
             flag to display information about the process
 
         """
-        try:
-            sub_context = self.EUCLID_MESSAGES
-            conn_handler = self._TapPlus__getconnhandler()
-            response = conn_handler.execute_tapget(sub_context, verbose=verbose)
-            if response.status == 200:
-                if isinstance(response, Iterable):
-                    for line in response:
+        sub_context = self.EUCLID_MESSAGES
+        conn_handler = self._TapPlus__getconnhandler()
+        response = conn_handler.execute_tapget(sub_context, verbose=verbose)
+        if response.status == 200:
+            if isinstance(response, Iterable):
+                for line in response:
 
-                        try:
-                            print(line.decode("utf-8").split('=', 1)[1])
-                        except ValueError as e:
-                            print(e)
-                        except IndexError:
-                            print("Archive down for maintenance")
+                    try:
+                        print(line.decode("utf-8").split('=', 1)[1])
+                    except ValueError as e:
+                        print(e)
+                    except IndexError:
+                        print("Archive down for maintenance")
 
-        except OSError:
-            print("Status messages could not be retrieved")
 
     @staticmethod
     def __set_dirs(output_file, observation_id):
@@ -1857,4 +1854,4 @@ class EuclidClass(TapPlus):
         return job.get_results()
 
 
-Euclid = EuclidClass()
+Euclid = EuclidClass(show_server_messages=False)

--- a/astroquery/esa/euclid/tests/test_euclid_remote.py
+++ b/astroquery/esa/euclid/tests/test_euclid_remote.py
@@ -77,3 +77,10 @@ def test_get_tables():
 
     table = euclid.load_table("catalogue.mer_catalogue")
     assert len(table.columns) == 471
+
+
+@pytest.mark.remote_data
+def test_get_status_messages():
+    euclid = EuclidClass(show_server_messages=True)
+    # redundant, but added to be extra-explicit
+    euclid.get_status_messages()

--- a/astroquery/esa/euclid/tests/test_euclidtap.py
+++ b/astroquery/esa/euclid/tests/test_euclidtap.py
@@ -173,25 +173,25 @@ def column_attrs():
 
 
 def test_load_environments():
-    tap = EuclidClass(environment='PDR')
+    tap = EuclidClass(environment='PDR', show_server_messages=False)
 
     assert tap is not None
 
-    tap = EuclidClass(environment='IDR')
+    tap = EuclidClass(environment='IDR', show_server_messages=False)
 
     assert tap is not None
 
-    tap = EuclidClass(environment='OTF')
+    tap = EuclidClass(environment='OTF', show_server_messages=False)
 
     assert tap is not None
 
-    tap = EuclidClass(environment='REG')
+    tap = EuclidClass(environment='REG', show_server_messages=False)
 
     assert tap is not None
 
     environment = 'WRONG'
     try:
-        tap = EuclidClass(environment='WRONG')
+        tap = EuclidClass(environment='WRONG', show_server_messages=False)
     except Exception as e:
         assert str(e).startswith(f"Invalid environment {environment}. Valid values: {list(conf.ENVIRONMENTS.keys())}")
 
@@ -776,7 +776,7 @@ def test_get_product_list_by_tile_index():
 
 
 def test_get_product_list_errors():
-    tap = EuclidClass()
+    tap = EuclidClass(show_server_messages=False)
 
     with pytest.raises(ValueError, match="Missing required argument: 'product_type'"):
         tap.get_product_list(observation_id='13', product_type=None)

--- a/astroquery/esa/hubble/core.py
+++ b/astroquery/esa/hubble/core.py
@@ -857,7 +857,7 @@ class ESAHubbleClass(EsaTap):
         """
 
         subContext = conf.EHST_MESSAGES
-        connHandler = self._tap._TapPlus__getconnhandler()
+        connHandler = self.tap._TapPlus__getconnhandler()
         response = connHandler.execute_tapget(subContext, verbose=False)
         if response.status == 200:
             for line in response:

--- a/astroquery/esa/hubble/core.py
+++ b/astroquery/esa/hubble/core.py
@@ -856,13 +856,12 @@ class ESAHubbleClass(EsaTap):
         the status of eHST TAP
         """
 
-        subContext = conf.EHST_MESSAGES
-        connHandler = self.tap._TapPlus__getconnhandler()
-        response = connHandler.execute_tapget(subContext, verbose=False)
-        if response.status == 200:
-            for line in response:
-                string_message = line.decode("utf-8")
-                print(string_message[string_message.index('=') + 1:])
+        esautils.execute_servlet_request(
+            url=conf.EHST_TAP_SERVER + "/" + conf.EHST_MESSAGES,
+            tap=self.tap,
+            query_params={},
+            parser_method=self.parse_messages_response
+        )
 
     def parse_messages_response(self, response):
         string_messages = []

--- a/astroquery/esa/hubble/core.py
+++ b/astroquery/esa/hubble/core.py
@@ -856,15 +856,13 @@ class ESAHubbleClass(EsaTap):
         the status of eHST TAP
         """
 
-        try:
-            esautils.execute_servlet_request(
-                url=conf.EHST_TAP_SERVER + "/" + conf.EHST_MESSAGES,
-                tap=self.tap,
-                query_params={},
-                parser_method=self.parse_messages_response
-            )
-        except OSError:
-            print("Status messages could not be retrieved")
+        subContext = conf.EHST_MESSAGES
+        connHandler = self._tap._TapPlus__getconnhandler()
+        response = connHandler.execute_tapget(subContext, verbose=False)
+        if response.status == 200:
+            for line in response:
+                string_message = line.decode("utf-8")
+                print(string_message[string_message.index('=') + 1:])
 
     def parse_messages_response(self, response):
         string_messages = []
@@ -1014,5 +1012,8 @@ class ESAHubbleClass(EsaTap):
         return f"{datalabs_path}hub_{path_parsed}/{filename}"
 
 
+<<<<<<< HEAD
 # Need to be False in order to avoid reaching out to the remote server at import time
+=======
+>>>>>>> d99705881... remove try/except clauses in more show messages, and set show_messages to false by default at import time
 ESAHubble = ESAHubbleClass(show_messages=False)

--- a/astroquery/esa/hubble/core.py
+++ b/astroquery/esa/hubble/core.py
@@ -1012,8 +1012,5 @@ class ESAHubbleClass(EsaTap):
         return f"{datalabs_path}hub_{path_parsed}/{filename}"
 
 
-<<<<<<< HEAD
 # Need to be False in order to avoid reaching out to the remote server at import time
-=======
->>>>>>> d99705881... remove try/except clauses in more show messages, and set show_messages to false by default at import time
 ESAHubble = ESAHubbleClass(show_messages=False)

--- a/astroquery/esa/hubble/tests/test_esa_hubble_remote.py
+++ b/astroquery/esa/hubble/tests/test_esa_hubble_remote.py
@@ -144,3 +144,10 @@ class TestEsaHubbleRemoteData:
         assert len(recwarn) == 1
         assert "ib4x04ivq_flt.fits" in str(recwarn[0].message)
         assert result == '/data/hub_hstdata_i/i/b4x/04/ib4x04ivq_flt.fits.gz'
+
+
+@pytest.mark.remote_data
+def test_get_status_messages():
+    esa_hubble = ESAHubble(show_messages=True)
+    # redundant, but added to be extra-explicit
+    esa_hubble.get_status_messages()

--- a/astroquery/esa/hubble/tests/test_esa_hubble_remote.py
+++ b/astroquery/esa/hubble/tests/test_esa_hubble_remote.py
@@ -18,6 +18,7 @@ import pytest
 from astroquery.esa.hubble import ESAHubble
 from astropy import coordinates
 
+# don't show messages during test: it creates a remote call
 esa_hubble = ESAHubble(show_messages=False)
 
 

--- a/astroquery/esa/jwst/core.py
+++ b/astroquery/esa/jwst/core.py
@@ -697,6 +697,7 @@ class JwstClass(BaseQuery):
         subContext = conf.JWST_MESSAGES
         connHandler = self.__jwsttap._TapPlus__getconnhandler()
         response = connHandler.execute_tapget(subContext, verbose=False)
+        response.raise_for_status()
         if response.status == 200:
             for line in response:
                 string_message = line.decode("utf-8")

--- a/astroquery/esa/jwst/core.py
+++ b/astroquery/esa/jwst/core.py
@@ -694,16 +694,13 @@ class JwstClass(BaseQuery):
         the status of JWST TAP
         """
 
-        try:
-            subContext = conf.JWST_MESSAGES
-            connHandler = self.__jwsttap._TapPlus__getconnhandler()
-            response = connHandler.execute_tapget(subContext, verbose=False)
-            if response.status == 200:
-                for line in response:
-                    string_message = line.decode("utf-8")
-                    print(string_message[string_message.index('=') + 1:])
-        except OSError:
-            print("Status messages could not be retrieved")
+        subContext = conf.JWST_MESSAGES
+        connHandler = self.__jwsttap._TapPlus__getconnhandler()
+        response = connHandler.execute_tapget(subContext, verbose=False)
+        if response.status == 200:
+            for line in response:
+                string_message = line.decode("utf-8")
+                print(string_message[string_message.index('=') + 1:])
 
     def get_product_list(self, *, observation_id=None,
                          cal_level="ALL",
@@ -1275,4 +1272,4 @@ class JwstClass(BaseQuery):
             return str
 
 
-Jwst = JwstClass()
+Jwst = JwstClass(show_messages=False)

--- a/astroquery/esa/jwst/core.py
+++ b/astroquery/esa/jwst/core.py
@@ -17,6 +17,7 @@ import tarfile as esatar
 import zipfile
 from datetime import datetime, timezone
 from urllib.parse import urlencode
+from requests.exceptions import HTTPError
 
 import astroquery.esa.utils.utils as esautils
 
@@ -697,11 +698,12 @@ class JwstClass(BaseQuery):
         subContext = conf.JWST_MESSAGES
         connHandler = self.__jwsttap._TapPlus__getconnhandler()
         response = connHandler.execute_tapget(subContext, verbose=False)
-        response.raise_for_status()
         if response.status == 200:
             for line in response:
                 string_message = line.decode("utf-8")
                 print(string_message[string_message.index('=') + 1:])
+        else:
+            raise HTTPError(f"Failed to retrieve status messages. HTTP status code: {response.status}")
 
     def get_product_list(self, *, observation_id=None,
                          cal_level="ALL",

--- a/astroquery/esa/jwst/tests/test_jwstdata.py
+++ b/astroquery/esa/jwst/tests/test_jwstdata.py
@@ -66,3 +66,10 @@ def test_login_error():
     with pytest.raises(HTTPError) as err:
         jwst.login(user="dummy", password="dummy")
     assert "Unauthorized" in err.value.args[0]
+
+
+@pytest.mark.remote_data
+def test_get_status_messages():
+    jwst = JwstClass(show_messages=True)
+    # redundant, but added to be extra-explicit
+    jwst.get_status_messages()

--- a/astroquery/gaia/core.py
+++ b/astroquery/gaia/core.py
@@ -1205,6 +1205,7 @@ class GaiaClass(TapPlus):
         sub_context = self.GAIA_MESSAGES
         conn_handler = self._TapPlus__getconnhandler()
         response = conn_handler.execute_tapget(sub_context, verbose=False)
+        response.raise_for_status()
         if response.status == 200:
             if isinstance(response, Iterable):
                 for line in response:

--- a/astroquery/gaia/core.py
+++ b/astroquery/gaia/core.py
@@ -1205,7 +1205,6 @@ class GaiaClass(TapPlus):
         sub_context = self.GAIA_MESSAGES
         conn_handler = self._TapPlus__getconnhandler()
         response = conn_handler.execute_tapget(sub_context, verbose=False)
-        response.raise_for_status()
         if response.status == 200:
             if isinstance(response, Iterable):
                 for line in response:
@@ -1216,6 +1215,8 @@ class GaiaClass(TapPlus):
                         print(e)
                     except IndexError:
                         print("Archive down for maintenance")
+        else:
+            raise HTTPError(f"Failed to retrieve status messages. HTTP status code: {response.status}")
 
 
 Gaia = GaiaClass(show_server_messages=False)

--- a/astroquery/gaia/core.py
+++ b/astroquery/gaia/core.py
@@ -56,7 +56,7 @@ class GaiaClass(TapPlus):
                  gaia_data_server='https://gea.esac.esa.int/',
                  tap_server_context="tap-server",
                  data_server_context="data-server",
-                 verbose=False, show_server_messages=True):
+                 verbose=False, show_server_messages=False):
         super(GaiaClass, self).__init__(url=gaia_tap_server,
                                         server_context=tap_server_context,
                                         tap_context="tap",
@@ -1202,23 +1202,19 @@ class GaiaClass(TapPlus):
         """Retrieve the messages to inform users about
         the status of Gaia TAP
         """
-        try:
-            sub_context = self.GAIA_MESSAGES
-            conn_handler = self._TapPlus__getconnhandler()
-            response = conn_handler.execute_tapget(sub_context, verbose=False)
-            if response.status == 200:
-                if isinstance(response, Iterable):
-                    for line in response:
+        sub_context = self.GAIA_MESSAGES
+        conn_handler = self._TapPlus__getconnhandler()
+        response = conn_handler.execute_tapget(sub_context, verbose=False)
+        if response.status == 200:
+            if isinstance(response, Iterable):
+                for line in response:
 
-                        try:
-                            print(line.decode("utf-8").split('=', 1)[1])
-                        except ValueError as e:
-                            print(e)
-                        except IndexError:
-                            print("Archive down for maintenance")
-
-        except OSError:
-            print("Status messages could not be retrieved")
+                    try:
+                        print(line.decode("utf-8").split('=', 1)[1])
+                    except ValueError as e:
+                        print(e)
+                    except IndexError:
+                        print("Archive down for maintenance")
 
 
 Gaia = GaiaClass()

--- a/astroquery/gaia/core.py
+++ b/astroquery/gaia/core.py
@@ -56,7 +56,7 @@ class GaiaClass(TapPlus):
                  gaia_data_server='https://gea.esac.esa.int/',
                  tap_server_context="tap-server",
                  data_server_context="data-server",
-                 verbose=False, show_server_messages=False):
+                 verbose=False, show_server_messages=True):
         super(GaiaClass, self).__init__(url=gaia_tap_server,
                                         server_context=tap_server_context,
                                         tap_context="tap",
@@ -1217,4 +1217,4 @@ class GaiaClass(TapPlus):
                         print("Archive down for maintenance")
 
 
-Gaia = GaiaClass()
+Gaia = GaiaClass(show_server_messages=False)

--- a/astroquery/gaia/tests/test_gaia_remote.py
+++ b/astroquery/gaia/tests/test_gaia_remote.py
@@ -67,3 +67,10 @@ def test_search_async_jobs():
     jobfilter.limit = 10
     jobs = gaia.search_async_jobs(jobfilter=jobfilter, verbose=True)
     assert len(jobs) == 10
+
+
+@pytest.mark.remote_data
+def test_get_status_messages():
+    gaia = GaiaClass(show_server_messages=True)
+    # redundant, but added to be extra-explicit
+    gaia.get_status_messages()

--- a/astroquery/tests/test_imports.py
+++ b/astroquery/tests/test_imports.py
@@ -2,10 +2,8 @@
 import sys
 import importlib
 import pytest
-import socket
 from unittest.mock import patch
 from pytest_remotedata.disable_internet import no_internet
-from pytest_remotedata.disable_internet import INTERNET_OFF
 
 # List of all astroquery modules to test
 ASTROQUERY_MODULES = [
@@ -62,6 +60,7 @@ ASTROQUERY_MODULES = [
     'astroquery.xmatch',
 ]
 
+
 class SocketTracker:
     def __init__(self):
         self.socket_attempts = []
@@ -96,6 +95,7 @@ def test_no_http_calls_during_import(module_name):
 
         assert not tracker.socket_attempts, (
             f"Module {module_name} attempted to create {len(tracker.socket_attempts)} "
-            f"socket(s) during import:\n" +
-            "\n".join(f"  - {args} {kwargs}" for args, kwargs in tracker.socket_attempts)
+            "socket(s) during import:\n" + (
+                "\n".join(f"  - {args} {kwargs}" for args, kwargs in tracker.socket_attempts)
+            )
         )

--- a/astroquery/tests/test_imports.py
+++ b/astroquery/tests/test_imports.py
@@ -1,0 +1,101 @@
+# Licensed under a 3-clause BSD style license - see LICENSE.rst
+import sys
+import importlib
+import pytest
+import socket
+from unittest.mock import patch
+from pytest_remotedata.disable_internet import no_internet
+from pytest_remotedata.disable_internet import INTERNET_OFF
+
+# List of all astroquery modules to test
+ASTROQUERY_MODULES = [
+    'astroquery.alma',
+    'astroquery.astrometry_net',
+    'astroquery.besancon',
+    'astroquery.cadc',
+    'astroquery.cosmosim',
+    'astroquery.esa',
+    'astroquery.esasky',
+    'astroquery.eso',
+    'astroquery.exoplanet_orbit_database',
+    'astroquery.fermi',
+    'astroquery.gaia',
+    'astroquery.gama',
+    'astroquery.gemini',
+    'astroquery.heasarc',
+    'astroquery.hitran',
+    'astroquery.ipac.irsa.ibe',
+    'astroquery.hips2fits',
+    'astroquery.image_cutouts',
+    'astroquery.imcce',
+    'astroquery.ipac',
+    'astroquery.ipac.irsa',
+    'astroquery.ipac.irsa.irsa_dust',
+    'astroquery.ipac.ned',
+    'astroquery.ipac.nexsci.nasa_exoplanet_archive',
+    'astroquery.jplhorizons',
+    'astroquery.jplsbdb',
+    'astroquery.jplspec',
+    'astroquery.linelists',
+    'astroquery.magpis',
+    'astroquery.mast',
+    'astroquery.mocserver',
+    'astroquery.mpc',
+    'astroquery.nasa_ads',
+    'astroquery.nist',
+    'astroquery.nvas',
+    'astroquery.oac',
+    'astroquery.ogle',
+    'astroquery.open_exoplanet_catalogue',
+    'astroquery.sdss',
+    'astroquery.simbad',
+    'astroquery.skyview',
+    'astroquery.solarsystem',
+    'astroquery.splatalogue',
+    'astroquery.svo_fps',
+    'astroquery.utils',
+    'astroquery.vamdc',
+    'astroquery.vo_conesearch',
+    'astroquery.vizier',
+    'astroquery.vsa',
+    'astroquery.wfau',
+    'astroquery.xmatch',
+]
+
+class SocketTracker:
+    def __init__(self):
+        self.socket_attempts = []
+
+    def __call__(self, *args, **kwargs):
+        # Record the attempt
+        self.socket_attempts.append((args, kwargs))
+        # Raise a clear error to indicate socket creation
+        raise RuntimeError("Socket creation attempted during import")
+
+
+@pytest.mark.parametrize("module_name", ASTROQUERY_MODULES)
+def test_no_http_calls_during_import(module_name):
+    """
+    Test that importing astroquery modules does not make any remote calls.
+
+    This is a regression test for 3343, and the error that raises is not
+    properly caught by the framework below, but that's an unrelated issue.
+
+    This is the error shown if Gaia(show_server_messages=True) is called:
+    ```
+    E       TypeError: isinstance() arg 2 must be a type, a tuple of types, or a union
+    ```
+    """
+    with no_internet():
+        if module_name in sys.modules:
+            del sys.modules[module_name]
+
+        tracker = SocketTracker()
+        with patch('socket.socket', tracker):
+            importlib.import_module(module_name)
+
+        assert not tracker.socket_attempts, (
+            f"Module {module_name} attempted to create {len(tracker.socket_attempts)} "
+            f"socket(s) during import:\n" +
+            "\n".join(f"  - {args} {kwargs}" for args, kwargs in tracker.socket_attempts)
+        )


### PR DESCRIPTION
see #3343.

I believe we had some discussion about this point in another issue as well, but I want to reaffirm that we have a hard rule that no remote queries should be performed at import time for exactly the reasons highlighted in the linked issue.