### PR TITLE
URL Length check for locate_data

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -47,6 +47,7 @@ heasarc
 - Add support for astropy.table.Row in Heasarc.download_data and Heasarc.locate_data. [#3270]
 - Heasarc.locate_data returns empty rows with an error in the error_message column if there are
   no data associated with that row rather than filtering it out. [#3275]
+- Heasarc.locate_data changed to use POST request instead of GET to accomodate large requests. [#3356]
 
 imcce
 ^^^^^

--- a/astroquery/heasarc/core.py
+++ b/astroquery/heasarc/core.py
@@ -6,11 +6,10 @@ import requests
 import tarfile
 import warnings
 import numpy as np
-from astropy.table import Table, Row, vstack
+from astropy.table import Table, Row
 from astropy import coordinates
 from astropy import units as u
 from astropy.utils.decorators import deprecated, deprecated_renamed_argument
-from pathlib import Path
 
 import pyvo
 
@@ -522,13 +521,13 @@ class HeasarcClass(BaseVOQuery, BaseQuery):
             baseurl=dlink_url,
             id=query_result['__row'],
             session=self._session
-            )
+        )
 
         dl_result = pyvo.dal.DALResults(
             query.execute_votable(post=True),
             url=query.queryurl,
             session=query._session
-            ).to_table()
+        ).to_table()
 
         # include rows that have directory links (i.e. data) and those
         # that report errors (usually means there are no data products)

--- a/astroquery/heasarc/core.py
+++ b/astroquery/heasarc/core.py
@@ -6,10 +6,11 @@ import requests
 import tarfile
 import warnings
 import numpy as np
-from astropy.table import Table, Row
+from astropy.table import Table, Row, vstack
 from astropy import coordinates
 from astropy import units as u
 from astropy.utils.decorators import deprecated, deprecated_renamed_argument
+from pathlib import Path
 
 import pyvo
 
@@ -517,13 +518,35 @@ class HeasarcClass(BaseVOQuery, BaseQuery):
 
         # datalink url
         dlink_url = f'{self.VO_URL}/datalink/{catalog_name}'
+        def query_func(query_chunk):
+                return pyvo.dal.adhoc.DatalinkQuery(
+                    baseurl=dlink_url,
+                    id=query_chunk['__row'],
+                    session=self._session
+                )
 
-        query = pyvo.dal.adhoc.DatalinkQuery(
-            baseurl=dlink_url,
-            id=query_result['__row'],
-            session=self._session
-        )
-        dl_result = query.execute().to_table()
+        # Standard URL limit of ~2000 characters for GET
+        # With query formula https://[urlbase]?ID=###, could get 100 16 digit IDs 
+        URI_MAX = 100
+        if len(query_result) > URI_MAX:
+            # execute a set amount at a time
+            chunks = len(query_result) % URI_MAX
+            for chunk in range(chunks):
+                query_chunk = query_result[URI_MAX*chunk: URI_MAX*chunk+URI_MAX]
+                query = query_func(query_chunk)
+                dl_result_chunk = query.execute().to_table()
+                if chunk == 0:
+                    dl_result = dl_result_chunk
+                else:
+                    dl_result = vstack([dl_result, dl_result_chunk])
+            query_chunk = query_result[URI_MAX*chunk+URI_MAX:]
+            query = query_func(query_chunk)
+            dl_result_chunk = query.execute().to_table()
+            dl_result = vstack([dl_result, dl_result_chunk])
+        else:
+            query = query_func(query_result)
+            dl_result = query.execute().to_table()
+
         # include rows that have directory links (i.e. data) and those
         # that report errors (usually means there are no data products)
         dl_result = dl_result[np.ma.mask_or(


### PR DESCRIPTION
Fixes #3276.

Considering a standard URL character limit of ~2000 for GET requests, this PR checks the number of targets being queried. Assuming a maximum ID length of 16 (based on the heuristic of not having seen IDs approaching this length personally...), the query could support ~100 IDs at a time before running into the character limit for the URL. This PR splits a query into multiple chunks to avoid this limit and combines the result into a single table.

This PR is created as a draft as the assumptions I've made could merit further discussion, and I'm also unsure if this is the desired behavior rather than simply failing when running into a query that is too long.