### PR TITLE
FIX: incorrect parameter for JPL Horizons, changed 'BODY EQUATOR' -> 'BODY'

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -36,6 +36,11 @@ gaia
 - New method cross_match_basic that simplifies the positional x-match method [#3320]
 - new DR4 datalink retrieve type MEAN_SPECTRUM_RVS [#3342]
 
+jplhorizons
+^^^^^^^^^^^
+
+- Fixed incorrect ``refplane`` parameter value: the API did not accept ``BODY EQUATOR`` but required ``BODY``. [#3370]
+
 linelists.cdms
 ^^^^^^^^^^^^^^
 

--- a/astroquery/jplhorizons/core.py
+++ b/astroquery/jplhorizons/core.py
@@ -906,7 +906,7 @@ class HorizonsClass(BaseQuery):
             ('OBJ_DATA', 'YES'),
             ('REF_SYSTEM', refsystem),
             ('REF_PLANE', {'ecliptic': 'ECLIPTIC', 'earth': 'FRAME',
-                           'body': "'BODY EQUATOR'"}[refplane]),
+                           'body': 'BODY'}[refplane]),
             ('TP_TYPE', {'absolute': 'ABSOLUTE',
                          'relative': 'RELATIVE'}[tp_type])])
 
@@ -1149,7 +1149,7 @@ class HorizonsClass(BaseQuery):
             ('REF_PLANE', {'ecliptic': 'ECLIPTIC',
                            'earth': 'FRAME',
                            'frame': 'FRAME',
-                           'body': "'BODY EQUATOR'"}[refplane]),
+                           'body': 'BODY'}[refplane]),
             ('REF_SYSTEM', 'ICRF'),
             ('TP_TYPE', 'ABSOLUTE'),
             ('VEC_LABELS', 'YES'),


### PR DESCRIPTION
When querying the results of a JPL Horizons query via `elements(refplane='body')` the API returns this error:
```
ValueError: Query failed without known error message; received the following response:
API VERSION: 1.2
API SOURCE: NASA/JPL Horizons API


 INPUT ERROR in VLADD  in following line:
 REF_PLANE=BODY EQUATOR
                ^  Too many constants
BATVAR: problem loading execution-control setting:
LINE=REF_PLANE=BODY EQUATOR
WLDINI: error loading execution-control file.
```

By changing the line in `core.py` from `BODY EQUATOR` to `BODY`, that API call works again.