### PR TITLE
GAIA: new datalink retrieve types for DR4

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -14,6 +14,8 @@ gaia
 
 - Deprecated ``band`` from ``load_data`` as it has no effect on upstream
   response any more. [#3278]
+- New datalink retrieve types EPOCH_PHOTOMETRY_CROWDED_FIELD, EPOCH_ASTROMETRY_BRIGHT, XP_MEAN_SPECTRUM_GRAVLENS,
+  EPOCH_FLAGS_NSS, EPOCH_PARAMETERS_RVS_SINGLE, EPOCH_PARAMETERS_RVS_DOUBLE, EPOCH_FLAGS_VARI. [#3371]
 
 Service fixes and enhancements
 ------------------------------

--- a/astroquery/gaia/__init__.py
+++ b/astroquery/gaia/__init__.py
@@ -38,6 +38,7 @@ class Conf(_config.ConfigNamespace):
                                       'RVS_EPOCH_SPECTRUM',
                                       'RVS_TRANSIT',
                                       'EPOCH_ASTROMETRY_CROWDED_FIELD',
+                                      'EPOCH_PHOTOMETRY_CROWDED_FIELD'
                                       'EPOCH_IMAGE',
                                       'EPOCH_PHOTOMETRY_CCD',
                                       'XP_EPOCH_SPECTRUM_SSO',
@@ -45,7 +46,12 @@ class Conf(_config.ConfigNamespace):
                                       'XP_MEAN_SPECTRUM',
                                       'XP_EPOCH_SPECTRUM',
                                       'CROWDED_FIELD_IMAGE',
-                                      'EPOCH_ASTROMETRY_BRIGHT']
+                                      'EPOCH_ASTROMETRY_BRIGHT',
+                                      'XP_MEAN_SPECTRUM_GRAVLENS',
+                                      'EPOCH_FLAGS_NSS',
+                                      'EPOCH_PARAMETERS_RVS_SINGLE',
+                                      'EPOCH_PARAMETERS_RVS_DOUBLE',
+                                      'EPOCH_FLAGS_VARI']
 
     VALID_LINKING_PARAMETERS = {'SOURCE_ID', 'TRANSIT_ID', 'IMAGE_ID'}
 


### PR DESCRIPTION
Dear astroquery team,

we would like to include the following new datalink retrieve types for the next Gaia Data Release 4 (DR4):

1. 'EPOCH_PHOTOMETRY_CROWDED_FIELD'
2. 'EPOCH_ASTROMETRY_BRIGHT',
3. 'XP_MEAN_SPECTRUM_GRAVLENS',
4. 'EPOCH_FLAGS_NSS',
5. 'EPOCH_PARAMETERS_RVS_SINGLE',
6. 'EPOCH_PARAMETERS_RVS_DOUBLE',
7. 'EPOCH_FLAGS_VARI'

It is important to note that this change is backward compatible because the Datalink products associated with these retrieve types are new.

cc @esdc-esac-esa-int 
jira: GAIASWRQ-39