### PR TITLE
Preliminary support for Roman in `MastMissions` class

### DIFF
--- a/astroquery/mast/__init__.py
+++ b/astroquery/mast/__init__.py
@@ -15,7 +15,7 @@ class Conf(_config.ConfigNamespace):
     """
 
     server = _config.ConfigItem(
-        'https://masttest.stsci.edu',
+        'https://mast.stsci.edu',
         'Name of the MAST server.')
     ssoserver = _config.ConfigItem(
         'https://ssoportal.stsci.edu',

--- a/astroquery/mast/__init__.py
+++ b/astroquery/mast/__init__.py
@@ -15,7 +15,7 @@ class Conf(_config.ConfigNamespace):
     """
 
     server = _config.ConfigItem(
-        'https://mast.stsci.edu',
+        'https://masttest.stsci.edu',
         'Name of the MAST server.')
     ssoserver = _config.ConfigItem(
         'https://ssoportal.stsci.edu',

--- a/astroquery/mast/missions.py
+++ b/astroquery/mast/missions.py
@@ -111,10 +111,16 @@ class MastMissionsClass(MastQueryWithLogin):
             if isinstance(response, list):  # multiple async responses from batching
                 combined_products = []
                 for resp in response:
-                    combined_products.extend(resp.json().get('products', []))
+                    if self.mission == 'roman':
+                        combined_products.extend(resp.json().get('products', [])[0])
+                    else:
+                        combined_products.extend(resp.json().get('products', []))
                 return Table(combined_products)
 
-            results = Table(response.json()['products'])  # single async response
+            if self.mission == 'roman':
+                results = Table(response.json()['products'][0])  # single async response
+            else:
+                results = Table(response.json()['products'])
 
         return results
 

--- a/astroquery/mast/missions.py
+++ b/astroquery/mast/missions.py
@@ -54,6 +54,7 @@ class MastMissionsClass(MastQueryWithLogin):
         self.dataset_kwds = {  # column keywords corresponding to dataset ID
             'hst': 'sci_data_set_name',
             'jwst': 'fileSetName',
+            'roman': 'fileSetName',
             'classy': 'Target',
             'ullyses': 'observation_id'
         }
@@ -536,7 +537,7 @@ class MastMissionsClass(MastQueryWithLogin):
         """
 
         # Construct the full data URL based on mission
-        if self.mission in ['hst', 'jwst']:
+        if self.mission in ['hst', 'jwst', 'roman']:
             # HST and JWST have a dedicated endpoint for retrieving products
             base_url = self._service_api_connection.MISSIONS_DOWNLOAD_URL + self.mission + '/api/v0.1/retrieve_product'
             keyword = 'product_name'

--- a/astroquery/mast/missions.py
+++ b/astroquery/mast/missions.py
@@ -81,6 +81,37 @@ class MastMissionsClass(MastQueryWithLogin):
         self._mission = value.lower()  # case-insensitive
         self._service_api_connection.set_service_params(self.service_dict, f'search/{self.mission}')
 
+    def _extract_products(self, response):
+        """
+        Extract products from the response of a `~requests.Response` object.
+
+        Parameters
+        ----------
+        response : `~requests.Response`
+            The response object containing the products data.
+
+        Returns
+        -------
+        list
+            A list of products extracted from the response.
+        """
+        def normalize_products(products):
+            """
+            Normalize the products list to ensure it is flat and not nested.
+            """
+            if products and isinstance(products[0], list):
+                return products[0]
+            return products
+
+        if isinstance(response, list):  # multiple async responses from batching
+            combined = []
+            for resp in response:
+                products = normalize_products(resp.json().get('products', []))
+                combined.extend(products)
+            return combined
+        else:  # single response
+            return normalize_products(response.json().get('products', []))
+
     def _parse_result(self, response, *, verbose=False):  # Used by the async_to_sync decorator functionality
         """
         Parse the results of a `~requests.Response` objects and return an `~astropy.table.Table` of results.
@@ -106,23 +137,11 @@ class MastMissionsClass(MastQueryWithLogin):
             if len(results) >= self.limit:
                 warnings.warn("Maximum results returned, may not include all sources within radius.",
                               MaxResultsWarning)
+            return results
+
         elif self.service == self._list_products:
-            # Results from post_list_products endpoint need to be handled differently
-            if isinstance(response, list):  # multiple async responses from batching
-                combined_products = []
-                for resp in response:
-                    if self.mission == 'roman':
-                        combined_products.extend(resp.json().get('products', [])[0])
-                    else:
-                        combined_products.extend(resp.json().get('products', []))
-                return Table(combined_products)
-
-            if self.mission == 'roman':
-                results = Table(response.json()['products'][0])  # single async response
-            else:
-                results = Table(response.json()['products'])
-
-        return results
+            products = self._extract_products(response)
+            return Table(products)
 
     def _validate_criteria(self, **criteria):
         """
@@ -544,7 +563,7 @@ class MastMissionsClass(MastQueryWithLogin):
 
         # Construct the full data URL based on mission
         if self.mission in ['hst', 'jwst', 'roman']:
-            # HST and JWST have a dedicated endpoint for retrieving products
+            # HST, JWST, and RST have a dedicated endpoint for retrieving products
             base_url = self._service_api_connection.MISSIONS_DOWNLOAD_URL + self.mission + '/api/v0.1/retrieve_product'
             keyword = 'product_name'
         else:

--- a/astroquery/mast/tests/test_mast_remote.py
+++ b/astroquery/mast/tests/test_mast_remote.py
@@ -365,11 +365,17 @@ class TestMast:
     @pytest.mark.parametrize("mission, query_params", [
         ('jwst', {'fileSetName': 'jw01189001001_02101_00001'}),
         ('classy', {'Target': 'J0021+0052'}),
-        ('ullyses', {'host_galaxy_name': 'WLM', 'select_cols': ['observation_id']})
+        ('ullyses', {'host_galaxy_name': 'WLM', 'select_cols': ['observation_id']}),
+        ('roman', {'program': 3}),
     ])
     def test_missions_workflow(self, tmp_path, mission, query_params):
         # Test workflow with other missions
         m = MastMissions(mission=mission)
+
+        # Roman requires extra setup to point towards the test server
+        if mission == 'roman':
+            m._service_api_connection.SERVICE_URL = 'https://masttest.stsci.edu'
+            m._service_api_connection.REQUEST_URL = 'https://masttest.stsci.edu/search/roman/api/v0.1/'
 
         # Criteria query
         datasets = m.query_criteria(**query_params)


### PR DESCRIPTION
Small changes to `MastMissions` so that we can support queries on Roman data. The Roman endpoints return responses that are slightly different from HST/JWST, so we need to add in some extra handling. 

I also added a test case that queries our test server for test Roman data. Because we are pre-launch and this is all test data, no documentation updates are needed at this time.