### PR TITLE
Bugfix: ALMA enhanced tables don't need qtable

### DIFF
--- a/astroquery/alma/core.py
+++ b/astroquery/alma/core.py
@@ -220,7 +220,7 @@ def get_enhanced_table(result):
             "Please refer to https://astropy-regions.readthedocs.io/en/latest/installation.html for how to install it.")
         raise
 
-    def _parse_stcs_string(input):
+    def s_region_parser(input):
         csys = 'icrs'
 
         def _get_region(tokens):
@@ -293,19 +293,10 @@ def get_enhanced_table(result):
             return result
         else:
             return _get_region(s_region.split())
-    prep_table = result.to_qtable()
-    s_region_parser = None
-    for field in result.resultstable.fields:
-        if ('s_region' == field.ID) and \
-                ('obscore:Char.SpatialAxis.Coverage.Support.Area' == field.utype):
-            if 'adql:REGION' == field.xtype:
-                s_region_parser = _parse_stcs_string
-            # this is where to add other xtype parsers such as shape
-            break
-    if (s_region_parser):
-        for row in prep_table:
-            row['s_region'] = s_region_parser(row['s_region'])
-    return prep_table
+
+    for row in result:
+        row['s_region'] = s_region_parser(row['s_region'])
+    return result
 
 
 class AlmaAuth(BaseVOQuery, BaseQuery):


### PR DESCRIPTION
This example results in an error:
```python
from astroquery.alma import Alma
from astroquery import alma
from astropy.coordinates import SkyCoord
import astropy.units as u

query_results = Alma.query_region(SkyCoord.from_name('NGC 6334'), radius=0.2*u.deg)

etbl = alma.get_enhanced_table(query_results)
```

error:
```
---------------------------------------------------------------------------
AttributeError                            Traceback (most recent call last)
Cell In[1], line 8
      4 import astropy.units as u
      6 query_results = Alma.query_region(SkyCoord.from_name('NGC 6334'), radius=0.2*u.deg)
----> 8 etbl = alma.get_enhanced_table(query_results)

File [/red/adamginsburg/repos/astroquery/astroquery/alma/core.py:296](http://localhost:23456/red/adamginsburg/repos/astroquery/astroquery/alma/core.py#line=295), in get_enhanced_table(result)
    294     else:
    295         return _get_region(s_region.split())
--> 296 prep_table = result.to_qtable()
    297 s_region_parser = None
    298 for field in result.resultstable.fields:

AttributeError: 'Table' object has no attribute 'to_qtable'
```

This PR fixes the problem by skipping the `to_qtable` conversion. 

However, the test is failing:
```
FAILED astroquery/alma/tests/test_alma.py::test_enhanced_table - TypeError: 'Record' object does not support item assignment
```
so I've not clearly solved the problem.

@andamian can you chime in?