### PR TITLE
Check that a column does not exist before adding to result table

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -130,6 +130,8 @@ mast
 
 - Enhanced ``filter_products`` methods in ``MastMissions`` and ``Observations`` to support filtering with negated values. [#3393]
 
+- Fix bug where duplicate columns from server responses cause an error when converting to an `~astropy.table.Table`. [#3400]
+
 
 Infrastructure, Utility and Other Changes and Additions
 -------------------------------------------------------

--- a/astroquery/mast/discovery_portal.py
+++ b/astroquery/mast/discovery_portal.py
@@ -101,8 +101,9 @@ def _json_to_table(json_obj, col_config=None):
         else:
             col_mask = np.equal(col_data, ignore_value)
 
-        # add the column
-        data_table.add_column(MaskedColumn(col_data.astype(atype), name=col, mask=col_mask))
+        # add the column if it does not exist already
+        if col not in data_table.colnames:
+            data_table.add_column(MaskedColumn(col_data.astype(atype), name=col, mask=col_mask))
 
     return data_table
 

--- a/astroquery/mast/services.py
+++ b/astroquery/mast/services.py
@@ -101,8 +101,9 @@ def _json_to_table(json_obj, data_key='data'):
         else:
             col_mask = np.equal(col_data, ignore_value)
 
-        # add the column
-        data_table.add_column(MaskedColumn(col_data.astype(col_type), name=col_name, mask=col_mask))
+        # add the column if it does not exist already
+        if col_name not in data_table.colnames:
+            data_table.add_column(MaskedColumn(col_data.astype(col_type), name=col_name, mask=col_mask))
 
     return data_table
 


### PR DESCRIPTION
resolves #3399 

This bug is actually due to a duplicated column in the response from our Roman search endpoint in the test environment. Others are making that fix, but I've also added checks here so that duplicated columns are not added to the output table. 