### PR TITLE
MAINT: only rerun failed tests even if everything passes

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -24,7 +24,7 @@ setenv =
     PYTEST_ARGS = ''
     # We have two pytest runs for the online tests, need to suppress the failing status for the first one to be able to run the second.
     online: PYTEST_ARGS = --remote-data=any -m "not bigdata" --suppress-tests-failed-exit-code
-    online: PYTEST_ARGS_2 =  --remote-data=any -vv --last-failed -m "not bigdata"
+    online: PYTEST_ARGS_2 =  --remote-data=any -m "not bigdata" -vv --last-failed --last-failed-no-failures none --suppress-no-test-exit-code
     online: SINGLE_RUN = False
     devdeps: PIP_EXTRA_INDEX_URL =  https://pypi.anaconda.org/scientific-python-nightly-wheels/simple https://pypi.anaconda.org/astropy/simple https://pypi.anaconda.org/liberfa/simple
     # astropy doesn't yet have a 3.13 compatible release


### PR DESCRIPTION
This was a bug for the cases when all tests are passing and `--last-failed` was used as its default is to rerun everything again.

(It never was really an issue in CI as we always have some failing tests, but it made testing with only one or a few modules problematic)