### PR TITLE
Change the location of the FIRST cutout server

### DIFF
--- a/astroquery/image_cutouts/first/__init__.py
+++ b/astroquery/image_cutouts/first/__init__.py
@@ -17,7 +17,7 @@ class Conf(_config.ConfigNamespace):
     Configuration parameters for `astroquery.image_cutouts.first`.
     """
     server = _config.ConfigItem(
-        ['https://third.ucllnl.org/cgi-bin/firstcutout'],
+        ['https://sundog.stsci.edu/cgi-bin/firstcutout'],
         'Name of the FIRST server.')
     timeout = _config.ConfigItem(
         60,


### PR DESCRIPTION
The old third.ucllnl.org server is no longer supported and has practically stopped working.  This configuration change gives the new URL for the server: sundog.stsci.edu.

Note this change does not happen often -- the URL has been the same since 1997 before this change!