### PR TITLE
MAINT: cleaning pytest cache on first run 

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -23,7 +23,7 @@ description = run tests
 setenv =
     PYTEST_ARGS = ''
     # We have two pytest runs for the online tests, need to suppress the failing status for the first one to be able to run the second.
-    online: PYTEST_ARGS = --remote-data=any -m "not bigdata" --suppress-tests-failed-exit-code
+    online: PYTEST_ARGS = --remote-data=any -m "not bigdata" --suppress-tests-failed-exit-code --cache-clear
     online: PYTEST_ARGS_2 =  --remote-data=any -m "not bigdata" -vv --last-failed --last-failed-no-failures none --suppress-no-test-exit-code
     online: SINGLE_RUN = False
     devdeps: PIP_EXTRA_INDEX_URL =  https://pypi.anaconda.org/scientific-python-nightly-wheels/simple https://pypi.anaconda.org/astropy/simple https://pypi.anaconda.org/liberfa/simple


### PR DESCRIPTION
to make tox envs locally reusable

resolves #3416 