### PR TITLE
MAINT: fixing VSA and WFAU links

### DIFF
--- a/astroquery/vsa/__init__.py
+++ b/astroquery/vsa/__init__.py
@@ -21,7 +21,7 @@ class Conf(_config.ConfigNamespace):
     Configuration parameters for `astroquery.vsa`.
     """
     server = _config.ConfigItem(
-        ['http://horus.roe.ac.uk:8080/vdfs/'],
+        ['http://vsa.roe.ac.uk:8080/vdfs/'],
         'Name of the VSA mirror to use')
 
     timeout = _config.ConfigItem(

--- a/astroquery/wfau/core.py
+++ b/astroquery/wfau/core.py
@@ -470,7 +470,7 @@ class BaseWFAUClass(QueryWithLogin):
             data columns.
         attributes : list, optional.
             Attributes to select from the table.  See, e.g.,
-            http://horus.roe.ac.uk/vsa/crossID_notes.html
+            http://wsa.roe.ac.uk/crossID_notes.html
         constraints : str, optional
             SQL constraints to the search. Default is empty (no constrains
             applied).
@@ -534,7 +534,7 @@ class BaseWFAUClass(QueryWithLogin):
             Defaults to `False`.
         attributes : list, optional.
             Attributes to select from the table.  See, e.g.,
-            http://horus.roe.ac.uk/vsa/crossID_notes.html
+            http://wsa.roe.ac.uk/crossID_notes.html
         constraints : str, optional
             SQL constraints to the search. Default is empty (no constrains
             applied).
@@ -753,7 +753,7 @@ class BaseWFAUClass(QueryWithLogin):
             automatically
         attributes : str
             Additional attributes to select from the table.  See, e.g.,
-            http://horus.roe.ac.uk/vsa/crossID_notes.html
+            http://wsa.roe.ac.uk/crossID_notes.html
         system : 'J2000' or 'Galactic'
             The system in which to perform the query. Can affect the output
             data columns.

--- a/docs/vsa/vsa.rst
+++ b/docs/vsa/vsa.rst
@@ -6,7 +6,7 @@
 VSA Queries (`astroquery.vsa`)
 ******************************
 
-The Vista Science Archive (VSA; http://horus.roe.ac.uk/vsa/index.html) shares a
+The Vista Science Archive (VSA; http://vsa.roe.ac.uk/) shares a
 common interface with the :doc:`../ukidss/ukidss` archive.  Both are hosted
 by the Wide Field Astronomy Unit (WFAU; www.roe.ac.uk/ifa/wfau;
 :doc:`../wfau/wfau`).  Please see the UKIDSS documentation pages for


### PR DESCRIPTION
This is to resolve #3392 

Note that #3033 has already fixed the functionality (tests were at least passing prior to this PR, etc.), but we still had the old links peppered through.
(it's all a bit of a mess though, we both have a config system but also a hard wired base url at init time)