### PR TITLE
Remove unused DATADIR from test_query.py

### DIFF
--- a/astroquery/tests/test_query.py
+++ b/astroquery/tests/test_query.py
@@ -2,16 +2,11 @@
 import pytest
 import requests
 import logging
-from pathlib import Path
 from requests.models import Response
 from requests.structures import CaseInsensitiveDict
 from astroquery.query import BaseQuery, BaseVOQuery
 from astroquery.utils.mocks import MockResponse
 from itertools import product
-
-# Test data directory
-DATA_DIR = Path(__file__).parent / 'data'
-DATA_DIR.mkdir(exist_ok=True)
 
 # Test data files
 TEST_FILE_CONTENT = b'This is a test file with some content.'


### PR DESCRIPTION
This directory is not used in **astroquery.tests** anymore. It cannot be created when the package is installed, causing an error when trying to run pytest on it.

After removing **DATADIR**, the tests pass on the installed package, if one copies `conftest.py` to the working directory (otherwise it complains about a missing **tmp_cwd** fixture).