### PR TITLE
MAINT: addig ignoring for py39 warning triggered in boto

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -95,6 +95,8 @@ filterwarnings =
 # CoverageWarnings triggered by one of the other plugins(?). Either case, explicitely
 # ignore it here to have passing test for pytest 8.4.
     ignore:Module astroquery was previously imported, but not measured:coverage.exceptions.CoverageWarning
+# Python 3.9 warning for the newest boto releases
+  ignore:Boto3 will no longer support Python 3.9:boto3.exceptions.PythonDeprecationWarning
 
 markers =
     bigdata: marks tests that are expected to trigger a large download (deselect with '-m "not bigdata"')


### PR DESCRIPTION
This is to fix the issue we started seeing nowish, though it's very possible that py3.9 support will eventually be removed in the next release, too.