### PR TITLE
CI: Prevent cron job workflow runs on forks

### DIFF
--- a/.github/workflows/ci_crontests.yml
+++ b/.github/workflows/ci_crontests.yml
@@ -4,7 +4,7 @@ on:
   push:
     # Run this job on release tags, but not on pushes to the main branch
     tags:
-    - '*'
+      - '*'
   schedule:
     # run every Friday at 22:00 UTC
     - cron: '0 22 * * 5'
@@ -17,7 +17,8 @@ jobs:
   tests:
     name: ${{ matrix.name }}
     runs-on: ${{ matrix.os }}
-    if: github.repository == 'astropy/astroquery'
+    # To enable this cron job on forks, comment out the following line
+    if: github.repository == 'astropy/astroquery' || github.event_name != 'schedule'
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/ci_devtests.yml
+++ b/.github/workflows/ci_devtests.yml
@@ -26,6 +26,8 @@ jobs:
   tests:
     name: ${{ matrix.name }}
     runs-on: ${{ matrix.os }}
+    # To enable this cron job on forks, comment out the following line
+    if: github.repository == 'astropy/astroquery' || github.event_name != 'schedule'
     strategy:
       fail-fast: true
       matrix:

--- a/.github/workflows/ci_tests.yml
+++ b/.github/workflows/ci_tests.yml
@@ -26,6 +26,8 @@ jobs:
   tests:
     name: ${{ matrix.name }}
     runs-on: ${{ matrix.os }}
+    # To enable this cron job on forks, comment out the following line
+    if: github.repository == 'astropy/astroquery' || github.event_name != 'schedule'
     strategy:
       fail-fast: false
       matrix:
@@ -83,6 +85,8 @@ jobs:
   egg_info:
     name: egg_info with Python 3.9
     runs-on: ubuntu-latest
+    # To enable this cron job on forks, comment out the following line
+    if: github.repository == 'astropy/astroquery' || github.event_name != 'schedule'
     steps:
     - name: Checkout code
       uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8  # v5.0.0

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -20,6 +20,7 @@ jobs:
     name: Analyze
     runs-on: ubuntu-latest
 
+    if: github.repository == 'astropy/astroquery'
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
This PR implements conditions to CI actions to prevent scheduled cron job actions from running on forks to resolve  #3457 

### Changes

- Added explicit fork-protection to all scheduled CI workflows using the pattern already in use across the open source python ecosystem:
  ```yaml
  if: github.repository == 'astropy/astroquery' || github.event_name != 'schedule'
  
This allows normal push, pull_request, tag, and manual triggers to continue working on forks (still useful for testing PRs), while completely skipping scheduled runs on any fork. I also left a comment in the workflows for anyone that wants to enable the workflows on their forks.

I applied this to the following workflows:

- [x] `.github/workflows/ci_crontests.yml`

- [x] `.github/workflows/ci_devtest.yml`

- [x] `.github/workflows/ci_tests.yml` (both the tests and egg_info jobs)


- [ ] `.github/workflows/ci-online-crontests.yml` left it alone as it already uses `github.repository == 'astropy/astroquery'` condition.

Also, I know that this was not covered in the issue ticket, but I also applied a condition to the codeql workflow since I looked at my fork and it was running on a schedule there too.

I restricted to the upstream repository only using the stricter condition `if: github.repository == 'astropy/astroquery'` since the results from forks are ignored by GitHub anyway, so its kinda just a waste.

<img width="1529" height="484" alt="Screenshot from 2025-11-28 00-31-09" src="https://github.com/user-attachments/assets/bf595287-fce2-4d3d-b1ff-217eecbe1e0e" />


I'm not sure if this requires a changelog entry. I tried looking at some closed infra/CI PRs and many were marked with a "no-changelog-needed" tag, so I won't include one for now, but can add one if its needed.

Also can make similar changes to https://github.com/astropy/pyvo/issues/705 if that would be helpful @bsipocz.


Hope this is a helpful ! :smile: 