### PR TITLE
Get cloud missions dynamically and fix cloud download workflow

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -20,6 +20,7 @@ python:
       path: .
       extra_requirements:
         - docs
+        - all
 
 # Don't build any extra formats
 formats: []

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -83,6 +83,9 @@ mast
 
 - Added full support for the International Ultraviolet Explorer (IUE) mission in ``MastMissions``. [#3517]
 
+- Added a new ``Observations.get_cloud_missions()`` method for querying cloud-supported MAST missions, alongside 
+  improvements to cloud download handling. [#3488]
+
 jplspec
 ^^^^^^^
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -83,7 +83,7 @@ mast
 
 - Added full support for the International Ultraviolet Explorer (IUE) mission in ``MastMissions``. [#3517]
 
-- Added a new ``Observations.get_cloud_missions()`` method for querying cloud-supported MAST missions, alongside 
+- Added a new ``Observations.list_cloud_datasets()`` method for querying cloud-supported MAST datasets, alongside 
   improvements to cloud download handling. [#3488]
 
 jplspec

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -31,6 +31,13 @@ vizier
 
 - Methods ``get_catalog``, ``get_catalog_async`` and ``query_*`` now always return UCD1+ instead of UCD1. [#3458]
 
+mast
+^^^^
+- ``utils.mast_relative_path`` is now deprecated in favor of ``utils.get_cloud_paths``. [#3488]
+- When cloud access is enabled, ``Observations.download_file`` and ``Observations.download_products`` 
+  now check all requested products against cloud storage. As a result, setting ``cloud_only=True`` will skip 
+  any products that are not available in the cloud, rather than falling back to on-prem downloads.
+
 Service fixes and enhancements
 ------------------------------
 

--- a/astroquery/mast/cloud.py
+++ b/astroquery/mast/cloud.py
@@ -148,7 +148,7 @@ class CloudAccess:  # pragma:no-cover
 
         # Making sure we got at least 1 URI from the query above.
         if not uri_list or uri_list[0] is None:
-            warnings.warn('Unable to locate file {}.'.format(data_product[0]), NoResultsWarning)
+            return
         else:
             # Output from ``get_cloud_uri_list`` is always a list even when it's only 1 URI
             return uri_list[0]
@@ -200,7 +200,7 @@ class CloudAccess:  # pragma:no-cover
                     if e.response['Error']['Code'] != "404":
                         raise
                     if verbose:
-                        warnings.warn("Unable to locate file {}.".format(path), NoResultsWarning)
+                        warnings.warn(f"Failed to retrieve cloud path for {path}", NoResultsWarning)
                     uri_list.append(None)
 
         return uri_list
@@ -222,9 +222,6 @@ class CloudAccess:  # pragma:no-cover
             Default is True. Whether to show download progress in the console.
         """
         # TODO: Function that checks if a particular product, by dataURI, can be found in the cloud
-        if not data_product or not isinstance(data_product, str):
-            raise ValueError("A valid data product URI must be provided.")
-
         # Normalize to an S3 key (no bucket)
         if data_product.strip().startswith("s3://"):
             s3_key = data_product.replace(f's3://{self.pubdata_bucket}/', '', 1)

--- a/astroquery/mast/cloud.py
+++ b/astroquery/mast/cloud.py
@@ -14,7 +14,7 @@ from astroquery import log
 from astropy.utils.console import ProgressBarOrSpinner
 from astropy.utils.exceptions import AstropyDeprecationWarning
 
-from ..exceptions import NoResultsWarning
+from ..exceptions import RemoteServiceError, NoResultsWarning
 
 from . import utils
 
@@ -223,14 +223,14 @@ class CloudAccess:  # pragma:no-cover
         """
         # TODO: Function that checks if a particular product, by dataURI, can be found in the cloud
         # Normalize to an S3 key (no bucket)
-        if data_product.strip().startswith("s3://"):
+        if data_product.strip().startswith('s3://'):
             s3_key = data_product.replace(f's3://{self.pubdata_bucket}/', '', 1)
         else:
             s3_key = self.get_cloud_uri_list([data_product], include_bucket=False, verbose=False)[0]
 
         # If s3_key is None, the product was not found in the cloud
         if s3_key is None:
-            raise ValueError(f"Data product {data_product} not found in S3 cloud storage.")
+            raise RemoteServiceError(f'The product {data_product} was not found in the cloud.')
 
         # Query S3 for expected file size
         head = self.s3_client.head_object(Bucket=self.pubdata_bucket, Key=s3_key)

--- a/astroquery/mast/cloud.py
+++ b/astroquery/mast/cloud.py
@@ -13,6 +13,7 @@ import threading
 from astroquery import log
 from astropy.utils.console import ProgressBarOrSpinner
 from astropy.utils.exceptions import AstropyDeprecationWarning
+from botocore.exceptions import ClientError, BotoCoreError
 
 from ..exceptions import RemoteServiceError, NoResultsWarning
 
@@ -101,7 +102,7 @@ class CloudAccess:  # pragma:no-cover
 
             return datasets
 
-        except Exception as e:
+        except (ClientError, BotoCoreError) as e:
             log.error('Failed to retrieve supported datasets from S3 bucket %s: %s', self.pubdata_bucket, e)
             return []
 

--- a/astroquery/mast/cloud.py
+++ b/astroquery/mast/cloud.py
@@ -86,10 +86,10 @@ class CloudAccess:  # pragma:no-cover
                 prefix = prefix_info['Prefix'].rstrip('/')
 
                 if prefix == 'mast':
-                    # 'mast/' contains missions underneath
+                    # 'mast/' contains sub-prefixes for different high-level science products
                     mast_response = self.s3_client.list_objects_v2(
                         Bucket=self.pubdata_bucket,
-                        Prefix='mast/',
+                        Prefix='mast/hlsp/',
                         Delimiter='/',
                     )
                     missions.extend(
@@ -230,7 +230,6 @@ class CloudAccess:  # pragma:no-cover
             s3_key = data_product.replace(f's3://{self.pubdata_bucket}/', '', 1)
         else:
             s3_key = self.get_cloud_uri_list([data_product], include_bucket=False, verbose=False)[0]
-            print(self.get_cloud_uri(data_product, include_bucket=False))
 
         # If s3_key is None, the product was not found in the cloud
         if s3_key is None:

--- a/astroquery/mast/cloud.py
+++ b/astroquery/mast/cloud.py
@@ -58,23 +58,23 @@ class CloudAccess:  # pragma:no-cover
         self.pubdata_bucket = "stpubdata"
         self.s3_client = self.boto3.client('s3', config=self.config)
 
-        # Cached list of missions available in the cloud
-        self._supported_missions = self._fetch_supported_missions()
+        # Cached list of datasets available in the cloud
+        self._supported_datasets = self._fetch_supported_datasets()
 
         if verbose:
             log.info("Using the S3 STScI public dataset")
 
-    def _fetch_supported_missions(self):
+    def _fetch_supported_datasets(self):
         """
-        Returns the list of missions that have data available in the cloud.
+        Returns the list of datasets that have data available in the cloud.
 
         Returns
         -------
         response : list
-              List of supported missions.
+              List of supported datasets.
         """
         try:
-            missions = []
+            datasets = []
 
             # Top-level prefixes in the bucket
             response = self.s3_client.list_objects_v2(
@@ -92,35 +92,35 @@ class CloudAccess:  # pragma:no-cover
                         Prefix='mast/hlsp/',
                         Delimiter='/',
                     )
-                    missions.extend(
+                    datasets.extend(
                         cp['Prefix'].rstrip('/')
                         for cp in mast_response.get('CommonPrefixes', [])
                     )
                 else:
-                    missions.append(prefix)
+                    datasets.append(prefix)
 
-            return missions
+            return datasets
 
         except Exception as e:
-            log.error('Failed to retrieve supported missions from S3 bucket %s: %s', self.pubdata_bucket, e)
+            log.error('Failed to retrieve supported datasets from S3 bucket %s: %s', self.pubdata_bucket, e)
             return []
 
-    def get_supported_missions(self):
+    def get_supported_datasets(self):
         """
-        Returns the list of missions that have data available in the cloud.
+        Returns the list of datasets that have data available in the cloud.
 
         Returns
         -------
         response : list
-              List of supported missions.
+              List of supported datasets.
         """
-        return list(self._supported_missions)
+        return list(self._supported_datasets)
 
     def get_cloud_uri(self, data_product, include_bucket=True, full_url=False):
         """
         For a given data product, returns the associated cloud URI.
-        If the product is from a mission that does not support cloud access an
-        exception is raised. If the mission is supported but the product
+        If the product is from a dataset that does not support cloud access an
+        exception is raised. If the dataset is supported but the product
         cannot be found in the cloud, the returned path is None.
 
         Parameters

--- a/astroquery/mast/cloud.py
+++ b/astroquery/mast/cloud.py
@@ -52,33 +52,69 @@ class CloudAccess:  # pragma:no-cover
         import boto3
         import botocore
 
-        self.supported_missions = ["mast:hst/product", "mast:tess/product", "mast:kepler", "mast:galex", "mast:ps1",
-                                   "mast:jwst/product"]
-
         self.boto3 = boto3
         self.botocore = botocore
         self.config = botocore.client.Config(signature_version=botocore.UNSIGNED)
-
         self.pubdata_bucket = "stpubdata"
+        self.s3_client = self.boto3.client('s3', config=self.config)
+
+        # Cached list of missions available in the cloud
+        self._supported_missions = self._fetch_supported_missions()
 
         if verbose:
             log.info("Using the S3 STScI public dataset")
 
-    def is_supported(self, data_product):
+    def _fetch_supported_missions(self):
         """
-        Given a data product, determines if it is in a mission available in the cloud.
-
-        Parameters
-        ----------
-        data_product : `~astropy.table.Row`
-            Product to be validated.
+        Returns the list of missions that have data available in the cloud.
 
         Returns
         -------
-        response : bool
-              Is the product from a supported mission.
+        response : list
+              List of supported missions.
         """
-        return any(data_product['dataURI'].lower().startswith(mission) for mission in self.supported_missions)
+        try:
+            missions = []
+
+            # Top-level prefixes in the bucket
+            response = self.s3_client.list_objects_v2(
+                Bucket=self.pubdata_bucket,
+                Delimiter='/'  # Use a delimiter to treat the S3 structure like folders
+            )
+
+            for prefix_info in response.get('CommonPrefixes', []):
+                prefix = prefix_info['Prefix'].rstrip('/')
+
+                if prefix == 'mast':
+                    # 'mast/' contains missions underneath
+                    mast_response = self.s3_client.list_objects_v2(
+                        Bucket=self.pubdata_bucket,
+                        Prefix='mast/',
+                        Delimiter='/',
+                    )
+                    missions.extend(
+                        cp['Prefix'].rstrip('/')
+                        for cp in mast_response.get('CommonPrefixes', [])
+                    )
+                else:
+                    missions.append(prefix)
+
+            return missions
+
+        except Exception as e:
+            log.error('Failed to retrieve supported missions from S3 bucket %s: %s', self.pubdata_bucket, e)
+            return []
+
+    def get_supported_missions(self):
+        """
+        Returns the list of missions that have data available in the cloud.
+
+        Returns
+        -------
+        response : list
+              List of supported missions.
+        """
+        return list(self._supported_missions)
 
     def get_cloud_uri(self, data_product, include_bucket=True, full_url=False):
         """
@@ -112,7 +148,7 @@ class CloudAccess:  # pragma:no-cover
 
         # Making sure we got at least 1 URI from the query above.
         if not uri_list or uri_list[0] is None:
-            warnings.warn("Unable to locate file {}.".format(data_product), NoResultsWarning)
+            warnings.warn('Unable to locate file {}.'.format(data_product[0]), NoResultsWarning)
         else:
             # Output from ``get_cloud_uri_list`` is always a list even when it's only 1 URI
             return uri_list[0]
@@ -141,11 +177,8 @@ class CloudAccess:  # pragma:no-cover
             List of URIs generated from the data products, list way contain entries that are None
             if data_products includes products not found in the cloud.
         """
-        s3_client = self.boto3.client('s3', config=self.config)
         data_uris = data_products if isinstance(data_products, list) else data_products['dataURI']
-        paths = utils.mast_relative_path(data_uris, verbose=verbose)
-        if isinstance(paths, str):  # Handle the case where only one product was requested
-            paths = [paths]
+        paths = utils.get_cloud_paths(data_uris, verbose=verbose)
 
         uri_list = []
         for path in paths:
@@ -154,7 +187,7 @@ class CloudAccess:  # pragma:no-cover
             else:
                 try:
                     # Use `head_object` to verify that the product is available on S3 (not all products are)
-                    s3_client.head_object(Bucket=self.pubdata_bucket, Key=path)
+                    self.s3_client.head_object(Bucket=self.pubdata_bucket, Key=path)
                     if include_bucket:
                         s3_path = "s3://{}/{}".format(self.pubdata_bucket, path)
                         uri_list.append(s3_path)
@@ -172,71 +205,77 @@ class CloudAccess:  # pragma:no-cover
 
         return uri_list
 
-    def download_file(self, data_product, local_path, cache=True, verbose=True):
+    def download_file_from_cloud(self, data_product, local_path, cache=True, verbose=True):
         """
-        Takes a data product in the form of an  `~astropy.table.Row` and downloads it from the cloud into
-        the given directory.
+        Download a data product from MAST cloud storage (S3) to a local file.
 
         Parameters
         ----------
-        data_product :  `~astropy.table.Row`
-            Product to download.
+        data_product :  str
+            MAST product URI (e.g. ``mast:JWST/product.fits``) or S3 URI (e.g. ``s3://<bucket>/path/to/product.fits``).
         local_path : str
-            The local filename to which toe downloaded file will be saved.
-        cache : bool
-            Default is True. If file is found on disc it will not be downloaded again.
+            Local filename where the downloaded file will be saved.
+        cache : bool, optional
+            Default is True. If True, and the file already exists locally with the expected size,
+            the download is skipped.
         verbose : bool, optional
             Default is True. Whether to show download progress in the console.
         """
+        # TODO: Function that checks if a particular product, by dataURI, can be found in the cloud
+        if not data_product or not isinstance(data_product, str):
+            raise ValueError("A valid data product URI must be provided.")
 
-        s3 = self.boto3.resource('s3', config=self.config)
-        s3_client = self.boto3.client('s3', config=self.config)
-        bkt = s3.Bucket(self.pubdata_bucket)
-        with warnings.catch_warnings():
-            warnings.simplefilter("ignore")
-            bucket_path = self.get_cloud_uri(data_product, False)
-        if not bucket_path:
-            raise Exception("Unable to locate file {}.".format(data_product['dataURI']))
-
-        # Ask the webserver (in this case S3) what the expected content length is and use that.
-        info_lookup = s3_client.head_object(Bucket=self.pubdata_bucket, Key=bucket_path)
-        length = info_lookup["ContentLength"]
-
-        if cache and os.path.exists(local_path):
-            if length is not None:
-                statinfo = os.stat(local_path)
-                if statinfo.st_size != length:
-                    log.warning("Found cached file {0} with size {1} that is "
-                                "different from expected size {2}"
-                                .format(local_path,
-                                        statinfo.st_size,
-                                        length))
-                else:
-                    log.info("Found cached file {0} with expected size {1}."
-                             .format(local_path, statinfo.st_size))
-                    return
-
-        if verbose:
-            with ProgressBarOrSpinner(length, ('Downloading URL s3://{0}/{1} to {2} ...'.format(
-                    self.pubdata_bucket, bucket_path, local_path))) as pb:
-
-                # Bytes read tracks how much data has been received so far
-                # This variable will be updated in multiple threads below
-                global bytes_read
-                bytes_read = 0
-
-                progress_lock = threading.Lock()
-
-                def progress_callback(numbytes):
-                    # Boto3 calls this from multiple threads pulling the data from S3
-                    global bytes_read
-
-                    # This callback can be called in multiple threads
-                    # Access to updating the console needs to be locked
-                    with progress_lock:
-                        bytes_read += numbytes
-                        pb.update(bytes_read)
-
-                bkt.download_file(bucket_path, local_path, Callback=progress_callback)
+        # Normalize to an S3 key (no bucket)
+        if data_product.strip().startswith("s3://"):
+            s3_key = data_product.replace(f's3://{self.pubdata_bucket}/', '', 1)
         else:
-            bkt.download_file(bucket_path, local_path)
+            s3_key = self.get_cloud_uri_list([data_product], include_bucket=False, verbose=False)[0]
+            print(self.get_cloud_uri(data_product, include_bucket=False))
+
+        # If s3_key is None, the product was not found in the cloud
+        if s3_key is None:
+            raise ValueError(f"Data product {data_product} not found in S3 cloud storage.")
+
+        # Query S3 for expected file size
+        head = self.s3_client.head_object(Bucket=self.pubdata_bucket, Key=s3_key)
+        expected_size = head.get('ContentLength')
+
+        # Cache check
+        if cache and os.path.exists(local_path) and expected_size is not None:
+            local_size = os.path.getsize(local_path)
+            if local_size == expected_size:
+                log.info("Using cached file {0} with expected size {1}."
+                         .format(local_path, local_size))
+                return
+            else:
+                log.warning("Found cached file {0} with size {1} that is "
+                            "different from expected size {2}"
+                            .format(local_path,
+                                    local_size,
+                                    expected_size))
+
+        # Proceed with download
+        bucket = self.boto3.resource('s3', config=self.config).Bucket(self.pubdata_bucket)
+        if not verbose:
+            bucket.download_file(s3_key, local_path)
+            return
+
+        # Progress-aware download
+        bytes_read = 0
+        progress_lock = threading.Lock()
+
+        def progress_callback(numbytes):
+            # Boto3 calls this from multiple threads pulling the data from S3
+            nonlocal bytes_read
+
+            # This callback can be called in multiple threads
+            # Access to updating the console needs to be locked
+            with progress_lock:
+                bytes_read += numbytes
+                pb.update(bytes_read)
+
+        with ProgressBarOrSpinner(
+            expected_size,
+            f'Downloading s3://{self.pubdata_bucket}/{s3_key} to {local_path} ...'
+        ) as pb:
+            bucket.download_file(s3_key, local_path, Callback=progress_callback)

--- a/astroquery/mast/observations.py
+++ b/astroquery/mast/observations.py
@@ -655,6 +655,9 @@ class ObservationsClass(MastQueryWithLogin):
         url : str
             The full url download path
         """
+        if not uri or not isinstance(uri, str):
+            raise InvalidQueryError("A valid data product URI must be provided.")
+
         base_url = base_url or self._portal_api_connection.MAST_DOWNLOAD_URL
         data_url = f"{base_url}?uri={uri}"
         escaped_url = f"{base_url}?uri={quote(uri, safe=':/')}"

--- a/astroquery/mast/tests/test_mast.py
+++ b/astroquery/mast/tests/test_mast.py
@@ -1112,12 +1112,12 @@ def test_observations_download_file_cloud(mock_is_file, mock_client, mock_resour
 
     # Skip file if cloud_only is True but file is not in cloud
     nonexistent_uri = 'mast:HST/product/does_not_exist.fits'
-    with pytest.warns(NoResultsWarning, match=f'Could not download {nonexistent_uri} from cloud'):
+    with pytest.warns(NoResultsWarning, match=f'The product {nonexistent_uri} was not found in the cloud'):
         result = Observations.download_file(nonexistent_uri, cloud_only=True)
         assert result == ('SKIPPED', None, None)
 
     # Use on-prem download if cloud_only is False and file is not in cloud
-    with pytest.warns(InputWarning, match=f'Could not download {nonexistent_uri} from cloud'):
+    with pytest.warns(InputWarning, match=f'The product {nonexistent_uri} was not found in the cloud'):
         result = Observations.download_file(nonexistent_uri, cloud_only=False)
         assert result == ('COMPLETE', None, None)
 
@@ -1844,7 +1844,7 @@ def test_download_file_from_cloud_not_found(mock_client, mock_resource, patch_po
     # Force get_cloud_uri_list to return [None]
     cloud.get_cloud_uri_list = lambda *a, **k: [None]
 
-    with pytest.raises(ValueError, match="not found in S3 cloud storage"):
+    with pytest.raises(RemoteServiceError, match='was not found in the cloud'):
         cloud.download_file_from_cloud(
             "mast:HST/product/missing.fits",
             "local.fits",

--- a/astroquery/mast/tests/test_mast.py
+++ b/astroquery/mast/tests/test_mast.py
@@ -1001,15 +1001,15 @@ def test_observations_download_products(patch_post, tmpdir):
     # Warn if no products to download
     with pytest.warns(NoResultsWarning, match='No products to download'):
         result = Observations.download_products('2003738726',
-                                                     download_dir=str(tmpdir),
-                                                     productType=["INVALID_TYPE"])
+                                                download_dir=str(tmpdir),
+                                                productType=["INVALID_TYPE"])
         assert result is None
 
     # Warn if curl_flag and flags are both set
     with pytest.warns(InputWarning, match='flat=True has no effect on curl downloads.'):
         result = Observations.download_products('2003738726',
-                                                     curl_flag=True,
-                                                     flat=True)
+                                                curl_flag=True,
+                                                flat=True)
         assert isinstance(result, Table)
 
 
@@ -1028,7 +1028,7 @@ def test_observations_download_products_cloud(mock_is_file, mock_client, mock_re
     Observations.enable_cloud_dataset()
 
     result = Observations.download_products(obsid,
-                                                 dataURI=data_uri)
+                                            dataURI=data_uri)
     assert isinstance(result, Table)
     assert result[0]['Status'] == 'COMPLETE'
 
@@ -1037,29 +1037,28 @@ def test_observations_download_products_cloud(mock_is_file, mock_client, mock_re
     # Check that info message is logged
     with pytest.warns(InputWarning, match='Falling back to MAST download'):
         result = Observations.download_products(obsid,
-                                                     dataURI=data_uri)
+                                                dataURI=data_uri)
     assert result[0]['Status'] == 'COMPLETE'
 
     # Cloud download failure, do not fallback to on-prem
     with pytest.warns(NoResultsWarning, match='Skipping download.'):
         result = Observations.download_products(obsid,
-                                                     dataURI=data_uri,
-                                                     cloud_only=True)
+                                                dataURI=data_uri,
+                                                cloud_only=True)
     assert result[0]['Status'] == 'SKIPPED'
 
     # Products not found in cloud, skip download
     monkeypatch.setattr(Observations, 'get_cloud_uris', lambda *a, **k: {})
     with pytest.warns(NoResultsWarning, match='was not found in the cloud. Skipping download.'):
         result = Observations.download_products(obsid,
-                                                     dataURI=data_uri,
-                                                     cloud_only=True)
+                                                dataURI=data_uri,
+                                                cloud_only=True)
     assert result[0]['Status'] == 'SKIPPED'
     assert result[0]['Message'] == 'Product not found in cloud'
 
     # Products not found in cloud, fall back
     with pytest.warns(InputWarning, match='was not found in the cloud. Falling back to MAST download'):
-        result = Observations.download_products(obsid,
-                                                     dataURI=data_uri)
+        result = Observations.download_products(obsid, dataURI=data_uri)
     assert result[0]['Status'] == 'COMPLETE'
 
     Observations.disable_cloud_dataset()
@@ -1067,8 +1066,8 @@ def test_observations_download_products_cloud(mock_is_file, mock_client, mock_re
     # Cloud access not enabled, warn if cloud_only is True
     with pytest.warns(InputWarning, match='cloud data access is not enabled'):
         result = Observations.download_products('2003738726',
-                                                     dataURI='mast:HST/product/u9o40504m_c3m.fits',
-                                                     cloud_only=True)
+                                                dataURI='mast:HST/product/u9o40504m_c3m.fits',
+                                                cloud_only=True)
     assert result[0]['Status'] == 'COMPLETE'
 
 

--- a/astroquery/mast/tests/test_mast.py
+++ b/astroquery/mast/tests/test_mast.py
@@ -51,7 +51,7 @@ DATA_FILES = {'Mast.Caom.Cone': 'caom.json',
               'Mast.HscMatches.Db.v3': 'matchid.json',
               'Mast.HscMatches.Db.v2': 'matchid.json',
               'Mast.HscSpectra.Db.All': 'spectra.json',
-              'mast_relative_path': 'mast_relative_path.json',
+              'get_cloud_paths': 'mast_relative_path.json',
               'panstarrs': 'panstarrs.json',
               'panstarrs_columns': 'panstarrs_columns.json',
               'tess_cutout': 'astrocut_107.27_-70.0_5x5.zip',
@@ -144,7 +144,7 @@ def request_mockreturn(url, params={}):
     elif 'panstarrs' in url:
         filename = data_path(DATA_FILES['panstarrs_columns'])
     elif 'path_lookup' in url:
-        filename = data_path(DATA_FILES['mast_relative_path'])
+        filename = data_path(DATA_FILES['get_cloud_paths'])
     with open(filename, 'rb') as infile:
         content = infile.read()
     return MockResponse(content)

--- a/astroquery/mast/tests/test_mast_remote.py
+++ b/astroquery/mast/tests/test_mast_remote.py
@@ -820,7 +820,8 @@ class TestMast:
         check_result(result, local_path_file)
 
     @pytest.mark.parametrize("in_uri", [
-        'mast:HLA/url/cgi-bin/getdata.cgi?download=1&filename=hst_05206_01_wfpc2_f375n_wf_daophot_trm.cat',
+        'mast:GALEX/url/data/GR6/pipe/01-vsn/03329-MISDR1_18916_0459/d/01-main/0001-img/07-try/'
+        'MISDR1_18916_0459-fd-flagstar.fits.gz',
         'mast:HST/product/u24r0102t_c3m.fits'
     ])
     def test_observations_download_file_cloud(self, tmp_path, in_uri):

--- a/astroquery/mast/tests/test_mast_remote.py
+++ b/astroquery/mast/tests/test_mast_remote.py
@@ -783,6 +783,45 @@ class TestMast:
         with caplog.at_level("INFO", logger="astroquery"):
             assert "products were duplicates" in caplog.text
 
+    def test_observations_download_products_cloud(self, tmp_path, msa_product_table):
+        pytest.importorskip('boto3')
+
+        Observations.enable_cloud_dataset()
+
+        # Adding a product that's not in the cloud to test mixed downloads
+        in_uri = "mast:IUE/url/pub/vospectra/iue2/swp18830mxlo_vo.fits"
+        new_row = {col: msa_product_table[col][0] for col in msa_product_table.colnames}
+        new_row["dataURI"] = in_uri
+        new_row["productFilename"] = Path(in_uri).name
+        msa_product_table = msa_product_table.copy()
+        msa_product_table.add_row(new_row)
+
+        with pytest.warns(NoResultsWarning, match='Skipping download'):
+            result = Observations.download_products(msa_product_table,
+                                                    download_dir=tmp_path,
+                                                    cloud_only=True)
+        assert isinstance(result, Table)
+        assert len(result) == 2
+        # First product should be downloaded from cloud, second should be skipped
+        assert result['Status'][0] == 'COMPLETE'
+        assert result['Status'][1] == 'SKIPPED'
+        assert Path(result['Local Path'][0]).exists()
+        assert not Path(result['Local Path'][1]).exists()
+        Path.unlink(result['Local Path'][0])  # clean up file
+
+        # Should fall back and download if cloud_only is False
+        with pytest.warns(InputWarning, match='Falling back to MAST download.'):
+            result = Observations.download_products(msa_product_table,
+                                                    download_dir=tmp_path)
+        assert isinstance(result, Table)
+        assert len(result) == 2
+        assert result['Status'][0] == 'COMPLETE'
+        assert result['Status'][1] == 'COMPLETE'
+        assert Path(result['Local Path'][0]).exists()
+        assert Path(result['Local Path'][1]).exists()
+
+        Observations.disable_cloud_dataset()
+
     def test_observations_download_file(self, tmp_path):
 
         def check_result(result, path):
@@ -834,6 +873,29 @@ class TestMast:
         assert result == ('COMPLETE', None, None)
         assert Path(tmp_path, filename).exists()
 
+        Observations.disable_cloud_dataset()
+
+    def test_observations_download_file_cloud_not_found(self, tmp_path):
+        pytest.importorskip("boto3")
+        in_uri = 'mast:IUE/url/pub/vospectra/iue2/swp18830mxlo_vo.fits'
+
+        Observations.enable_cloud_dataset()
+
+        # Warn and fallback
+        with pytest.warns(InputWarning, match='Falling back to MAST download.'):
+            result = Observations.download_file(uri=in_uri, local_path=tmp_path)
+            assert result == ('COMPLETE', None, None)
+            assert Path(tmp_path, Path(in_uri).name).exists()
+            Path.unlink(Path(tmp_path, Path(in_uri).name))  # clean up file
+
+        # Skip if cloud_only is set
+        with pytest.warns(NoResultsWarning, match='Skipping download'):
+            result = Observations.download_file(uri=in_uri, cloud_only=True, local_path=tmp_path)
+            assert result == ('SKIPPED', None, None)
+            assert not Path(tmp_path, Path(in_uri).name).exists()
+
+        Observations.disable_cloud_dataset()
+
     def test_observations_download_file_escaped(self, tmp_path):
         # test that `download_file` correctly escapes a URI
         in_uri = 'mast:HLA/url/cgi-bin/fitscut.cgi?' \
@@ -864,6 +926,16 @@ class TestMast:
         assert result == ("COMPLETE", None, None)
         assert Path(tmp_path, filename).exists()
 
+    def test_observations_get_cloud_missions(self):
+        pytest.importorskip('boto3')
+        Observations.enable_cloud_dataset()
+        missions = Observations.get_cloud_missions()
+        assert isinstance(missions, list)
+        assert len(missions) > 0
+        for m in ['hst', 'jwst', 'panstarrs', 'galex', 'tess']:
+            assert m in missions
+        Observations.disable_cloud_dataset()
+
     @pytest.mark.parametrize("test_data_uri, expected_cloud_uri", [
         ("mast:HST/product/u24r0102t_c1f.fits",
          "s3://stpubdata/hst/public/u24r/u24r0102t/u24r0102t_c1f.fits"),
@@ -889,6 +961,8 @@ class TestMast:
         uri = Observations.get_cloud_uri(test_data_uri)
         assert uri == expected_cloud_uri, f'Cloud URI does not match expected. ({uri} != {expected_cloud_uri})'
 
+        Observations.disable_cloud_dataset()
+
     @pytest.mark.parametrize("test_obs_id", ["25568122", "31411", "107604081"])
     def test_observations_get_cloud_uris(self, test_obs_id):
         pytest.importorskip("boto3")
@@ -912,6 +986,8 @@ class TestMast:
         with pytest.warns(NoResultsWarning):
             Observations.get_cloud_uris(products,
                                         extension='png')
+
+        Observations.disable_cloud_dataset()
 
     def test_observations_get_cloud_uris_list_input(self):
         pytest.importorskip("boto3")
@@ -945,6 +1021,8 @@ class TestMast:
         with pytest.warns(NoResultsWarning, match='Failed to retrieve MAST relative path'):
             Observations.get_cloud_uris(['mast:HST/product/does_not_exist.fits'])
 
+        Observations.disable_cloud_dataset()
+
     def test_observations_get_cloud_uris_query(self):
         pytest.importorskip("boto3")
 
@@ -970,6 +1048,8 @@ class TestMast:
         with pytest.warns(NoResultsWarning):
             Observations.get_cloud_uris(target_name=234295611)
 
+        Observations.disable_cloud_dataset()
+
     def test_observations_get_cloud_uris_no_duplicates(self, msa_product_table):
         pytest.importorskip("boto3")
 
@@ -984,6 +1064,8 @@ class TestMast:
         # Check that only one URI is returned
         uris = Observations.get_cloud_uris(products)
         assert len(uris) == 1
+
+        Observations.disable_cloud_dataset()
 
     ######################
     # CatalogClass tests #

--- a/astroquery/mast/tests/test_mast_remote.py
+++ b/astroquery/mast/tests/test_mast_remote.py
@@ -926,10 +926,10 @@ class TestMast:
         assert result == ("COMPLETE", None, None)
         assert Path(tmp_path, filename).exists()
 
-    def test_observations_get_cloud_missions(self):
+    def test_observations_list_cloud_missions(self):
         pytest.importorskip('boto3')
         Observations.enable_cloud_dataset()
-        missions = Observations.get_cloud_missions()
+        missions = Observations.list_cloud_datasets()
         assert isinstance(missions, list)
         assert len(missions) > 0
         for m in ['hst', 'jwst', 'panstarrs', 'galex', 'tess']:

--- a/astroquery/mast/tests/test_mast_remote.py
+++ b/astroquery/mast/tests/test_mast_remote.py
@@ -1018,7 +1018,7 @@ class TestMast:
                                         extension='png')
 
         # check for warning if one of the URIs is not found
-        with pytest.warns(NoResultsWarning, match='Failed to retrieve MAST relative path'):
+        with pytest.warns(NoResultsWarning, match='Failed to retrieve cloud path'):
             Observations.get_cloud_uris(['mast:HST/product/does_not_exist.fits'])
 
         Observations.disable_cloud_dataset()

--- a/astroquery/mast/utils.py
+++ b/astroquery/mast/utils.py
@@ -399,9 +399,9 @@ def get_cloud_paths(mast_uri, *, verbose=True):
     """
     uri_list = [mast_uri] if isinstance(mast_uri, str) else list(mast_uri)
 
-    # Split the list into chunks of 50 URIs; this is necessary
+    # Split the list into chunks of 40 URIs; this is necessary
     # to avoid "414 Client Error: Request-URI Too Large".
-    uri_list_chunks = list(split_list_into_chunks(uri_list, chunk_size=50))
+    uri_list_chunks = list(split_list_into_chunks(uri_list, chunk_size=40))
 
     cloud_paths = []
     for chunk in uri_list_chunks:

--- a/astroquery/mast/utils.py
+++ b/astroquery/mast/utils.py
@@ -14,6 +14,7 @@ import requests
 import platform
 from astropy.coordinates import SkyCoord
 from astropy.table import Table
+from astropy.utils import deprecated
 from astropy.utils.console import ProgressBarOrSpinner
 from astropy import units as u
 
@@ -370,6 +371,16 @@ def split_list_into_chunks(input_list, chunk_size):
         yield input_list[idx:idx + chunk_size]
 
 
+@deprecated(since='v0.4.12',
+            message=('This function is deprecated.'),
+            alternative='astroquery.mast.utils.get_cloud_paths')
+def mast_relative_path(mast_uri, *, verbose=True):
+    """
+    Deprecated function. Use `astroquery.mast.utils.get_cloud_paths` instead.
+    """
+    return get_cloud_paths(mast_uri, verbose=verbose)
+
+
 def get_cloud_paths(mast_uri, *, verbose=True):
     """
     Given one or more MAST dataURI(s), return a list of associated cloud path(s).
@@ -405,7 +416,7 @@ def get_cloud_paths(mast_uri, *, verbose=True):
             path = json_response.get(uri)["path"]
             if path is None:
                 if verbose:
-                    warnings.warn(f"Failed to retrieve MAST relative path for {uri}. Skipping...", NoResultsWarning)
+                    warnings.warn(f"Failed to retrieve cloud path for {uri}. Skipping...", NoResultsWarning)
             else:
                 path = path.lstrip("/")
             cloud_paths.append(path)

--- a/docs/mast/mast_obsquery.rst
+++ b/docs/mast/mast_obsquery.rst
@@ -509,6 +509,15 @@ cloud storage becomes the **preferred source** for data access when available.
    >>> Observations.enable_cloud_dataset(provider='AWS')
    INFO: Using the S3 STScI public dataset [astroquery.mast.cloud]
 
+To get a list of cloud-hosted MAST datasets, use the `~astroquery.mast.ObservationsClass.list_cloud_datasets` method. You 
+should see both mission names (e.g., "hst", "kepler") and High-Level Science Product (`HLSP <https://mast.stsci.edu/hlsp/#/>`__) 
+collections (e.g., "mast/hlsp/jades").
+
+.. doctest-remote-data::
+
+   >>> print(Observations.list_cloud_datasets())  # doctest: +IGNORE_OUTPUT
+   ['gaia', 'galex', 'hst', 'jwst', 'k2', 'kepler', 'mast/hlsp/jades', 'mast/hlsp/maestro', 'mast/hlsp/mast', 'mast/hlsp/qlp', 'mast/hlsp/tess-spoc', 'mast/hlsp/tglc', 'panstarrs', 'roman', 'tess']
+
 To revert to traditional, on-premise MAST data access, use the
 `~astroquery.mast.ObservationsClass.disable_cloud_dataset` method.
 


### PR DESCRIPTION
This PR improves support for downloading MAST data products from public cloud storage (AWS S3) and clarifies cloud-related behavior for the `Observations` class. The changes introduce a more robust cloud download workflow with clearer fallback logic, improved error handling, and expanded test coverage for cloud and mixed cloud/on-prem download scenarios.

**Key Changes**

- Added discovery of cloud-supported datasets
  - Introduces a new internal method to query the public MAST S3 bucket and determine which datasets are available in the cloud.
  - Exposed via `Observations.list_cloud_datsets()` to allow users to inspect cloud availability.
- Refactored cloud download logic
  - Renamed and clarified cloud-specific download functionality (`download_file_from_cloud`) to separate cloud and on-prem paths.
  - Improved handling of `cloud_only`, fallback behavior, and warnings when products are missing from the cloud.
  - Ensures cloud URIs are resolved in batches rather than one-by-one.
- Improved cloud URI resolution
  - Updated path lookup logic to explicitly request cloud paths from MAST.
  - Unified cloud path handling across `get_cloud_uri`, `get_cloud_uris`, and download code paths.
- Expanded test coverage

**Backwards Compatibility**

- Cloud access remains opt-in via `enable_cloud_dataset()`.
- On-prem downloads remain the default fallback unless `cloud_only=True` is specified.
- This PR does change the download workflow in that if the cloud dataset is enabled, Astroquery will attempt to locate every requested product on the cloud. Previously, Astroquery would only attempt this if the product's mission was in a hard-coded list in `cloud.py`. This will prevent us from having to update Astroquery every time new data is made available on the cloud.
  - As a result of this change, when `cloud_only=True`, products that are not found on the cloud will not be downloaded. Previously, products of a mission not in the hard-coded list would go directly to on-prem and still be downloaded. In this case, I think that not downloading actually makes more sense in the context of the parameter.
- Deprecates `mast_relative_path` in favor of `get_cloud_paths`, which is more accurate and descriptive. This is a utility function, so I don't think many people will be using it anyway.
