### PR TITLE
More powerful column selection in `MastMissions`

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -68,8 +68,8 @@ mast
 
 - Improved robustness of PanSTARRS column metadata parsing. This prevents metadata-related query errors. [#3485]
 
-- The ``select_cols`` parameter in ``MastMissions`` query functions now accepts a comma-delimited string of column names,
-  or the special values 'all' or '*' to return all available columns. [#3492]
+- The ``select_cols`` parameter in ``MastMissions`` query functions now accepts an iterable of column names, a comma-delimited 
+  string of column names, or the special values 'all' or '*' to return all available columns. [#3492]
 
 jplspec
 ^^^^^^^

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -68,6 +68,9 @@ mast
 
 - Improved robustness of PanSTARRS column metadata parsing. This prevents metadata-related query errors. [#3485]
 
+- The ``select_cols`` parameter in ``MastMissions`` query functions now accepts a comma-delimited string of column names,
+  or the special values 'all' or '*' to return all available columns. [#3492]
+
 jplspec
 ^^^^^^^
 

--- a/astroquery/mast/services.py
+++ b/astroquery/mast/services.py
@@ -109,7 +109,7 @@ def _json_to_table(json_obj, data_key='data'):
                 data_table.add_column(
                     MaskedColumn(coerced, name=col_name, mask=ignore_mask)
                 )
-            except Exception:
+            except (ValueError, TypeError):
                 # Fallback to coercing values one by one
                 out = np.empty(len(col_data), dtype=col_type)
                 fail_mask = np.zeros(len(col_data), dtype=bool)
@@ -120,7 +120,7 @@ def _json_to_table(json_obj, data_key='data'):
 
                     try:
                         out[i] = col_type(val)
-                    except Exception:
+                    except (ValueError, TypeError, OverflowError):
                         # Could not coerce value, mask it
                         fail_mask[i] = True
 

--- a/astroquery/mast/tests/test_mast.py
+++ b/astroquery/mast/tests/test_mast.py
@@ -20,8 +20,8 @@ from requests import HTTPError, Response
 from astropy.utils.exceptions import AstropyDeprecationWarning
 from astroquery.mast.services import _json_to_table
 from astroquery.utils.mocks import MockResponse
-from astroquery.exceptions import (InvalidQueryError, InputWarning, MaxResultsWarning, NoResultsWarning,
-                                   RemoteServiceError, ResolverError)
+from astroquery.exceptions import (BlankResponseWarning, InvalidQueryError, InputWarning, MaxResultsWarning,
+                                   NoResultsWarning, RemoteServiceError, ResolverError)
 
 from astroquery import mast
 
@@ -300,6 +300,42 @@ def test_missions_query_criteria(patch_post):
             sci_aec='S',
             limit=1
         )
+
+
+def test_missions_parse_select_cols(patch_post):
+    # Default columns
+    cols = mast.MastMissions._parse_select_cols(None)  # Default columns for HST
+    assert cols is None
+
+    # All columns
+    all_cols = mast.MastMissions._parse_select_cols('all')
+    assert all_cols == mast.MastMissions.get_column_list()['name'].value.tolist()
+
+    # Comma-separated string
+    string_cols = mast.MastMissions._parse_select_cols('sci_pep_id, sci_instrume')
+    for col in ['sci_pep_id', 'sci_instrume', 'sci_data_set_name']:
+        assert col in string_cols
+
+    # List of columns
+    list_cols = mast.MastMissions._parse_select_cols(['sci_pep_id', 'sci_instrume'])
+    for col in ['sci_pep_id', 'sci_instrume', 'sci_data_set_name']:
+        assert col in list_cols
+
+    # Error if invalid type
+    with pytest.raises(InvalidQueryError, match="`select_cols` must be a list of column names"):
+        mast.MastMissions._parse_select_cols(123)
+
+    # Warning for invalid column names
+    with pytest.warns(InputWarning, match="Column 'invalid_column' not found."):
+        valid_cols = mast.MastMissions._parse_select_cols(['sci_pep_id', 'invalid_column'])
+    assert 'sci_pep_id' in valid_cols
+    assert 'invalid_column' not in valid_cols
+
+    # Workaround for Ullyses mission default columns
+    ullyses_mission = mast.MastMissions(mission='ullyses')
+    ullyses_cols = ullyses_mission._parse_select_cols(None)
+    for col in mast.MastMissions._default_ullyses_cols:
+        assert col in ullyses_cols
 
 
 def test_missions_get_product_list_async(patch_post):
@@ -1485,3 +1521,25 @@ def test_parse_input_location(patch_post):
     with pytest.warns(InputWarning, match="Resolver is only used when resolving object names"):
         loc = mast.utils.parse_input_location(coordinates=coord, resolver="SIMBAD")
         assert isinstance(loc, SkyCoord)
+
+
+def test_json_to_table_fallback_type_coercion(patch_post):
+    json_obj = {'info': [{'name': 'test_int', 'type': 'int'}],
+                'data': [['1'], ['2'], ['not_an_int'], ['3'], [-999]]}
+
+    with pytest.warns(BlankResponseWarning):
+        table = _json_to_table(json_obj)
+
+    # Column exists
+    assert 'test_int' in table.colnames
+    col = table['test_int']
+    assert col.dtype == np.int64
+
+    # Good values survived
+    assert col[0] == 1
+    assert col[1] == 2
+    assert col[3] == 3
+
+    # Bad + ignored values are masked
+    assert col.mask[2]  # 'not_an_int'
+    assert col.mask[4]  # ignore_value

--- a/astroquery/mast/tests/test_mast.py
+++ b/astroquery/mast/tests/test_mast.py
@@ -321,9 +321,23 @@ def test_missions_parse_select_cols(patch_post):
     for col in ['sci_pep_id', 'sci_instrume', 'sci_data_set_name']:
         assert col in list_cols
 
+    # Tuple of columns
+    tuple_cols = mast.MastMissions._parse_select_cols(('sci_pep_id', 'sci_instrume'))
+    for col in ['sci_pep_id', 'sci_instrume', 'sci_data_set_name']:
+        assert col in tuple_cols
+
+    # Generator of columns
+    gen_cols = mast.MastMissions._parse_select_cols(col for col in ['sci_pep_id', 'sci_instrume'])
+    for col in ['sci_pep_id', 'sci_instrume', 'sci_data_set_name']:
+        assert col in gen_cols
+
     # Error if invalid type
-    with pytest.raises(InvalidQueryError, match="`select_cols` must be a list of column names"):
+    with pytest.raises(InvalidQueryError, match="`select_cols` must be an iterable of column names"):
         mast.MastMissions._parse_select_cols(123)
+
+    # Error if an individual column is not a string
+    with pytest.raises(InvalidQueryError, match="`select_cols` must contain only strings"):
+        mast.MastMissions._parse_select_cols(['sci_pep_id', 123])
 
     # Warning for invalid column names
     with pytest.warns(InputWarning, match="Column 'invalid_column' not found."):

--- a/astroquery/mast/tests/test_mast_remote.py
+++ b/astroquery/mast/tests/test_mast_remote.py
@@ -153,9 +153,10 @@ class TestMast:
         result = MastMissions.query_criteria(objectname='NGC6121',
                                              radius=0.1,
                                              sci_start_time='<2012',
-                                             sci_actual_duration='0..200'
-                                             )
+                                             sci_actual_duration='0..200',
+                                             select_cols='*')
         assert len(result) == 3
+        assert result.colnames == MastMissions.get_column_list()['name'].value.tolist()
         assert (result['ang_sep'].data.data.astype('float') < 0.1).all()
         assert (result['sci_start_time'] < '2012').all()
         assert ((result['sci_actual_duration'] >= 0) & (result['sci_actual_duration'] <= 200)).all()

--- a/docs/mast/mast_missions.rst
+++ b/docs/mast/mast_missions.rst
@@ -70,7 +70,9 @@ Keyword arguments can also be used to refine results further. The following para
 - ``sort_desc``: A boolean or list of booleans (one for each field specified in ``sort_by``),
   describing if each field should be sorted in descending order (``True``) or ascending order (``False``).
 
-- ``select_cols``: A list of columns to be returned in the response.
+- ``select_cols``: Columns to include in the result table. If not specified, a default set of columns
+  is returned. This parameter may be given as a list of column names, a comma-separated string, or the special
+  values ``'all'`` or ``'*'`` to return all available columns.
 
 
 Mission Positional Queries

--- a/docs/mast/mast_missions.rst
+++ b/docs/mast/mast_missions.rst
@@ -71,7 +71,7 @@ Keyword arguments can also be used to refine results further. The following para
   describing if each field should be sorted in descending order (``True``) or ascending order (``False``).
 
 - ``select_cols``: Columns to include in the result table. If not specified, a default set of columns
-  is returned. This parameter may be given as a list of column names, a comma-separated string, or the special
+  is returned. This parameter may be given as an iterable of column names, a comma-separated string, or the special
   values ``'all'`` or ``'*'`` to return all available columns.
 
 


### PR DESCRIPTION
Make the `select_cols` parameter in `MastMissions` queries more powerful:

- Specify a comma-separated string of columns in addition to a list of columns.
- Specify all available columns with `*` or `all`
- Now validates columns and warns (with suggestions) if a passed column does not exist.

I have also made the `_json_to_table` function more robust so that columns that have values of an unexpected type don't raise an error. Instead, a warning is logged and those particular values are masked.