### PR TITLE
EUCLID: update methods cone_search and  cross_match_basic so that the parameters `table_name` and `ra_column_name` and `dec_column_name` can be set independently

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -16,6 +16,9 @@ esa.euclid
   from the server. Specifically, passing ``'METADATA'`` to this argument will retrieve the extra fields
   ``datalabs_path``, ``file_name`` and ``hdu_index``. [#3438]
 
+- Methods ``cone_search`` and ``cross_match_basic`` now define the  parameters ``table_name`` and ``ra_column_name`` and
+  ``dec_column_name`` independently [#3496]
+
 vizier
 ^^^^^^
 - Methods ``get_catalog``, ``get_catalog_async`` and ``query_*`` now always return UCD1+ instead of UCD1. [#3458]


### PR DESCRIPTION
Dear Astroquery team,

we would like to update the methods cone_search and  cross_match_basic so that the parameters `table_name` and `ra_column_name` and `dec_column_name` can be set independently. For example if the parameters `ra_column_name` and `dec_column_name` are not explicitely defined, the resulting query contains None values

```

job = Euclid.cone_search(coordinate=coords, radius=radius, table_name="catalogue.mer_cutouts", async_job=True, verbose = True)

Launched query: '
                SELECT
                  TOP 50
                  *,
                  DISTANCE(
                    POINT('ICRS', None, None),
                    POINT('ICRS', 267.78000034036035, 65.53000542571156)
                  ) AS dist
                FROM
                  catalogue.mer_cutouts
                WHERE
                  1 = CONTAINS(
                    POINT('ICRS', None, None),
                    CIRCLE('ICRS', 267.78000034036035, 65.53000542571156, 0.01)
                  )
                ORDER BY
                  dist ASC
                '

```

A similar result is obtained for the method cross_match_basic .

cc @esdc-esac-esa-int 
jira: EUCLIDPCR-2082