### PR TITLE
GAIA: the method load_data must parse ecsv files

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -34,6 +34,7 @@ gaia
 ^^^^
 
 - New datalink DR4 retrieval type RESIDUAL_IMAGE. [#3489]
+- The method ``load_data`` parses ecsv files [#3500].
 
 esa.hubble
 ^^^^^^^^^^

--- a/astroquery/gaia/core.py
+++ b/astroquery/gaia/core.py
@@ -194,9 +194,9 @@ class GaiaClass(TapPlus):
             'EPOCH_PHOTOMETRY_CROWDED_FIELD', 'EPOCH_IMAGE', 'EPOCH_PHOTOMETRY_CCD', 'EPOCH_SPECTRUM_XP_SSO',
             'EPOCH_SPECTRUM_XP_CROWDING', 'MEAN_SPECTRUM_XP', 'EPOCH_SPECTRUM_XP', 'CROWDED_FIELD_IMAGE',
             'EPOCH_ASTROMETRY_BRIGHT', 'MEAN_SPECTRUM_XP_GRAVLENS', 'EPOCH_FLAGS_NSS', 'EPOCH_PARAMETERS_RVS_SINGLE',
-            'EPOCH_PARAMETERS_RVS_DOUBLE', 'EPOCH_FLAGS_VARI']. Note that for 'CROWDED_FIELD_IMAGE', only the format
-            'fits' can be used, and its image, in the principal header, will not be available in the returned
-            dictionary. Set 'output_file' to retrieve all data: image + tables. Note that for 'RESIDUAL_IMAGE',
+            'EPOCH_PARAMETERS_RVS_DOUBLE', 'EPOCH_FLAGS_VARI', 'RESIDUAL_IMAGE']. Note that for 'CROWDED_FIELD_IMAGE',
+            only the format 'fits' can be used, and its image, in the principal header, will not be available in the
+            returned dictionary. Set 'output_file' to retrieve all data: image + tables. Note that for 'RESIDUAL_IMAGE',
             only the format 'fits' can be used. Since the fits files only contain images, the returned table will be
             empty. Therefore, set 'output_file' to save the files to get access to their content.
         linking_parameter : str, optional, default SOURCE_ID, valid values: SOURCE_ID, TRANSIT_ID, IMAGE_ID
@@ -357,6 +357,12 @@ class GaiaClass(TapPlus):
             elif key.endswith('.csv'):
                 tables = []
                 table = Table.read(value, format='ascii.csv', fast_reader=False)
+                tables.append(table)
+                files[key] = tables
+
+            elif key.endswith('.ecsv'):
+                tables = []
+                table = Table.read(value, format='ascii.ecsv', fast_reader=False)
                 tables.append(table)
                 files[key] = tables
 

--- a/astroquery/gaia/tests/test_gaiatap.py
+++ b/astroquery/gaia/tests/test_gaiatap.py
@@ -1081,7 +1081,7 @@ def test_load_data_vot(monkeypatch, tmp_path, tmp_path_factory, patch_datetime_n
     path.unlink()
 
 
-@pytest.mark.filterwarnings("ignore: ")
+@pytest.mark.filterwarnings("ignore:")
 def test_load_data_fits(monkeypatch, tmp_path, tmp_path_factory, patch_datetime_now):
     assert datetime.datetime.now(datetime.timezone.utc) == FAKE_TIME
 
@@ -1090,7 +1090,7 @@ def test_load_data_fits(monkeypatch, tmp_path, tmp_path_factory, patch_datetime_
 
     path = Path(os.getcwd(), output_file)
 
-    with open(DL_PRODUCTS_CSV, 'rb') as file:
+    with open(DL_PRODUCTS_FITS, 'rb') as file:
         zip_bytes = file.read()
 
     path.write_bytes(zip_bytes)

--- a/astroquery/gaia/tests/test_gaiatap.py
+++ b/astroquery/gaia/tests/test_gaiatap.py
@@ -942,11 +942,14 @@ def test_datalink_querier_load_data_ecsv(mock_datalink_querier_ecsv):
 
     assert len(result_dict) == 3
 
-    files = list(result_dict.keys())
-    files.sort()
-    assert files[0] == 'MCMC_MSC-Gaia DR3 5937083312263887616.ecsv'
-    assert files[1] == 'XP_CONTINUOUS-Gaia DR3 5937083312263887616.ecsv'
-    assert files[2] == 'XP_SAMPLED-Gaia DR3 5937083312263887616.ecsv'
+    files = list(sorted(result_dict.items()))
+    assert files[0][0] == 'MCMC_MSC-Gaia DR3 5937083312263887616.ecsv'
+    assert files[1][0] == 'XP_CONTINUOUS-Gaia DR3 5937083312263887616.ecsv'
+    assert files[2][0] == 'XP_SAMPLED-Gaia DR3 5937083312263887616.ecsv'
+
+    assert isinstance(files[0][1][0], Table)
+    assert isinstance(files[1][1][0], Table)
+    assert isinstance(files[2][1][0], Table)
 
     os.remove(os.path.join(os.getcwd(), datalink_output))
 
@@ -980,18 +983,21 @@ def test_datalink_querier_load_data_csv(mock_datalink_querier_csv):
 
     assert len(result_dict) == 3
 
-    files = list(result_dict.keys())
-    files.sort()
-    assert files[0] == 'MCMC_MSC-Gaia DR3 5937083312263887616.csv'
-    assert files[1] == 'XP_CONTINUOUS-Gaia DR3 5937083312263887616.csv'
-    assert files[2] == 'XP_SAMPLED-Gaia DR3 5937083312263887616.csv'
+    files = list(sorted(result_dict.items()))
+    assert files[0][0] == 'MCMC_MSC-Gaia DR3 5937083312263887616.csv'
+    assert files[1][0] == 'XP_CONTINUOUS-Gaia DR3 5937083312263887616.csv'
+    assert files[2][0] == 'XP_SAMPLED-Gaia DR3 5937083312263887616.csv'
+
+    assert isinstance(files[0][1][0], Table)
+    assert isinstance(files[1][1][0], Table)
+    assert isinstance(files[2][1][0], Table)
 
     os.remove(os.path.join(os.getcwd(), datalink_output))
 
     assert not os.path.exists(datalink_output)
 
 
-@pytest.mark.skip(reason="Thes fits files generate an error relatate to the unit 'log(cm.s**-2)")
+@pytest.mark.filterwarnings("ignore:")
 def test_datalink_querier_load_data_fits(mock_datalink_querier_fits):
     result_dict = mock_datalink_querier_fits.load_data(ids=[5937083312263887616], data_release='Gaia DR3',
                                                        data_structure='INDIVIDUAL',
@@ -1019,11 +1025,14 @@ def test_datalink_querier_load_data_fits(mock_datalink_querier_fits):
 
     assert len(result_dict) == 3
 
-    files = list(result_dict.keys())
-    files.sort()
-    assert files[0] == 'MCMC_MSC-Gaia DR3 5937083312263887616.fits'
-    assert files[1] == 'XP_CONTINUOUS-Gaia DR3 5937083312263887616.fits'
-    assert files[2] == 'XP_SAMPLED-Gaia DR3 5937083312263887616.fits'
+    files = list(sorted(result_dict.items()))
+    assert files[0][0] == 'MCMC_MSC-Gaia DR3 5937083312263887616.fits'
+    assert files[1][0] == 'XP_CONTINUOUS-Gaia DR3 5937083312263887616.fits'
+    assert files[2][0] == 'XP_SAMPLED-Gaia DR3 5937083312263887616.fits'
+
+    assert isinstance(files[0][1][0], Table)
+    assert isinstance(files[1][1][0], Table)
+    assert isinstance(files[2][1][0], Table)
 
     os.remove(os.path.join(os.getcwd(), datalink_output))
 
@@ -1072,14 +1081,16 @@ def test_load_data_vot(monkeypatch, tmp_path, tmp_path_factory, patch_datetime_n
     path.unlink()
 
 
-@pytest.mark.skip(reason="Thes fits files generate an error relatate to the unit 'log(cm.s**-2)")
-def test_load_data_fits(monkeypatch, tmp_path, tmp_path_factory):
+@pytest.mark.filterwarnings("ignore: ")
+def test_load_data_fits(monkeypatch, tmp_path, tmp_path_factory, patch_datetime_now):
+    assert datetime.datetime.now(datetime.timezone.utc) == FAKE_TIME
+
     now = datetime.datetime.now(datetime.timezone.utc)
-    output_file = 'datalink_output_' + now.strftime("%Y%m%dT%H%M%S") + '.zip'
+    output_file = 'datalink_output_' + now.strftime("%Y%m%dT%H%M%S.%f") + '.zip'
 
     path = Path(os.getcwd(), output_file)
 
-    with open(DL_PRODUCTS_FITS, 'rb') as file:
+    with open(DL_PRODUCTS_CSV, 'rb') as file:
         zip_bytes = file.read()
 
     path.write_bytes(zip_bytes)
@@ -1092,7 +1103,7 @@ def test_load_data_fits(monkeypatch, tmp_path, tmp_path_factory):
             "RETRIEVAL_TYPE": "epoch_photometry",
             "DATA_STRUCTURE": "INDIVIDUAL",
             "USE_ZIP_ALWAYS": "true"}
-        assert output_file == Path(os.getcwd(), 'datalink_output.zip')
+        assert str(path) == output_file
         assert verbose is True
 
     monkeypatch.setattr(TapPlus, "load_data", load_data_monkeypatched)


### PR DESCRIPTION
Dear Astroquery team,

we would like to update the method load_data in the Gaia module, since we have found that it does not return the expected results (an astropy Table) for the format = 'ecsv'. The following example illustrates this issue


```
from astroquery.gaia import Gaia

user = 'xxxx'
password = 'xxxxx'
Gaia.login(user = user, password = password)


source_ids     = ['6680733225618222592']
retrieval_type = 'EPOCH_PHOTOMETRY' 
data_structure = 'RAW'     
data_release   = 'Gaia DR2'


# The data is retrieved as a csv file
# The returned dictionary contains an astropy Table

datalink = Gaia.load_data(ids=source_ids, 
                          data_release=data_release, 
                          retrieval_type=retrieval_type, 
                          data_structure=data_structure, 
                          verbose=False, 
                          dump_to_file=True,
                          format='csv')

dl_keys = sorted([key for key in datalink.keys()])
print("\nThe Datalink product has been downloaded:")
print('-' * 160)
for dl_key in dl_keys:
    print(f' * {dl_key}')
    print(datalink[dl_key])

INFO: DataLink products will be stored in the /home/jfernandez/datalink_output_20260116T061207.476383.zip file [astroquery.gaia.core]

The Datalink product has been downloaded:
----------------------------------------------------------------------------------------------------------------------------------------------------------------
 * EPOCH_PHOTOMETRY-Gaia DR2 6680733225618222592.csv
[<Table length=132>
     source_id          transit_id    band ... other_flags    solution_id    
       int64              int64       str2 ...    int64          int64       
------------------- ----------------- ---- ... ----------- ------------------
6680733225618222592 17714070537773976    G ...           1 369295549951641967
...




# The data is retrieved as an ecsv file
# The returned dictionary contains a path to the downloaded file

datalink = Gaia.load_data(ids=source_ids, 
                          data_release=data_release, 
                          retrieval_type=retrieval_type, 
                          data_structure=data_structure, 
                          verbose=False, 
                          dump_to_file=True,
                          format='ecsv')

dl_keys = sorted([key for key in datalink.keys()])
print("\nThe Datalink product has been downloaded:")
print('-' * 160)
for dl_key in dl_keys:
    print(f' * {dl_key}')
    print(datalink[dl_key])
    
The Datalink product has been downloaded:
----------------------------------------------------------------------------------------------------------------------------------------------------------------
 * EPOCH_PHOTOMETRY-Gaia DR2 6680733225618222592.ecsv
/home/jfernandez/EPOCH_PHOTOMETRY-Gaia DR2 6680733225618222592.ecsv 
```
 


cc @esdc-esac-esa-int 
Jira: C9GACS-1079