### PR TITLE
MAINT: dropping python 3.9 support

### DIFF
--- a/.github/workflows/ci_devtests.yml
+++ b/.github/workflows/ci_devtests.yml
@@ -38,7 +38,7 @@ jobs:
 
           - name: Python 3.13
             os: ubuntu-latest
-            python: '3.13-dev'
+            python: '3.13'
             toxenv: py313-test
             toxargs: -v
 

--- a/.github/workflows/ci_tests.yml
+++ b/.github/workflows/ci_tests.yml
@@ -38,13 +38,13 @@ jobs:
 
           - name: oldest version for all dependencies
             os: ubuntu-latest
-            python: "3.9"
-            toxenv: py39-test-oldestdeps-alldeps
+            python: "3.10"
+            toxenv: py310-test-oldestdeps-alldeps
             toxargs: -v
 
           - name: OSX, py310, all optional dependencies
             os: macos-latest
-            python: "3.10"
+            python: "3.12"
             toxenv: py310-test-alldeps
             toxargs: -v
 
@@ -79,18 +79,3 @@ jobs:
       uses: codecov/codecov-action@671740ac38dd9b0130fbe1cec585b89eea48d3de  # v5.5.2
       with:
         file: ./coverage.xml
-
-  egg_info:
-    name: egg_info with Python 3.9
-    runs-on: ubuntu-latest
-    steps:
-    - name: Checkout code
-      uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8  # v6.0.1
-      with:
-        fetch-depth: 0
-    - name: Set up Python
-      uses: actions/setup-python@83679a892e2d95755f2dac6acb0bfd1e9ac5d548  # v6.1.0
-      with:
-        python-version: "3.9"
-    - name: Run egg_info
-      run: python setup.py egg_info

--- a/.github/workflows/ci_tests.yml
+++ b/.github/workflows/ci_tests.yml
@@ -42,10 +42,10 @@ jobs:
             toxenv: py310-test-oldestdeps-alldeps
             toxargs: -v
 
-          - name: OSX, py310, all optional dependencies
+          - name: OSX, py312, all optional dependencies
             os: macos-latest
             python: "3.12"
-            toxenv: py310-test-alldeps
+            toxenv: py312-test-alldeps
             toxargs: -v
 
           - name: Windows, py311, mandatory dependencies only

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -96,6 +96,11 @@ xmatch
 Infrastructure, Utility and Other Changes and Additions
 -------------------------------------------------------
 
+- Versions of Python <3.10 are no longer supported. [#3504]
+
+- Versions of numpy <1.22 are no longer supported. [#3504]
+
+
 utils.tap
 ^^^^^^^^^
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -95,11 +95,11 @@ building the documentation, in editable mode:
 Requirements
 ------------
 
-Astroquery works with Python 3.9 or later.
+Astroquery works with Python 3.10 or later.
 
 The following packages are required for astroquery installation & use:
 
-* `numpy <https://numpy.org>`_ >= 1.20
+* `numpy <https://numpy.org>`_ >= 1.22
 * `astropy <https://www.astropy.org>`__ (>=5.0)
 * `pyVO`_ (>=1.5)
 * `requests <https://requests.readthedocs.io/en/latest/>`_
@@ -116,9 +116,9 @@ and for running the tests:
 The following packages are optional dependencies and are required for the
 full functionality of the `~astroquery.mocserver`, `~astroquery.alma`, and `~astroquery.xmatch` modules:
 
-* `astropy-healpix <https://astropy-healpix.readthedocs.io/en/latest/>`_
-* `regions <https://astropy-regions.readthedocs.io/en/latest/>`_
-* `mocpy <https://cds-astro.github.io/mocpy/>`_ >= 0.9
+* `astropy-healpix <https://astropy-healpix.readthedocs.io/en/latest/>`_ >= 0.7
+* `regions <https://astropy-regions.readthedocs.io/en/latest/>`_ >= 0.5
+* `mocpy <https://cds-astro.github.io/mocpy/>`_ >= 0.12
 
 For the `~astroquery.vamdc` module:
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -129,6 +129,7 @@ The following packages are optional dependencies and are required for the
 full functionality of the `~astroquery.mast` and `~astroquery.heasarc` modules:
 
 * `boto3 <https://boto3.amazonaws.com/v1/documentation/api/latest/index.html>`_
+* ``botocore``
 
 Using astroquery
 ----------------

--- a/setup.cfg
+++ b/setup.cfg
@@ -143,12 +143,12 @@ omit =
 python_requires = >=3.10
 
 install_requires=
-   numpy>=1.20
+   numpy>=1.22
    astropy>=5.0
-   requests>=2.19
-   beautifulsoup4>=4.8
+   requests>=2.26
+   beautifulsoup4>=4.10
    html5lib>=0.999
-   keyring>=15.0
+   keyring>=23.0
    pyvo>=1.5
 
 [options.extras_require]

--- a/setup.cfg
+++ b/setup.cfg
@@ -97,8 +97,6 @@ filterwarnings =
 # CoverageWarnings triggered by one of the other plugins(?). Either case, explicitely
 # ignore it here to have passing test for pytest 8.4.
     ignore:Module astroquery was previously imported, but not measured:coverage.exceptions.CoverageWarning
-# Python 3.9 warning for the newest boto releases
-  ignore:Boto3 will no longer support Python 3.9:boto3.exceptions.PythonDeprecationWarning
 
 markers =
     bigdata: marks tests that are expected to trigger a large download (deselect with '-m "not bigdata"')
@@ -142,7 +140,7 @@ omit =
 
 [options]
 
-python_requires = >=3.9
+python_requires = >=3.10
 
 install_requires=
    numpy>=1.20

--- a/setup.cfg
+++ b/setup.cfg
@@ -174,4 +174,5 @@ all=
    mocpy>=0.12
    astropy-healpix
    boto3
+   botocore
    regions>=0.5

--- a/tox.ini
+++ b/tox.ini
@@ -37,9 +37,6 @@ deps =
     devdeps: pyerfa>=0.0.dev0
     devdeps: git+https://github.com/astropy/pyvo.git#egg=pyvo
 
-    # astropy doesn't yet have a 3.13 compatible release
-    py313: astropy>0.0dev0
-
 # mpl while not a dependency, it's required for the tests, and would pull up a newer numpy version if not pinned.
 # And pillow should be pinned as well, otherwise a too new version is pulled that is not compatible with old np.
 

--- a/tox.ini
+++ b/tox.ini
@@ -52,6 +52,7 @@ deps =
     oldestdeps: beautifulsoup4==4.10
     oldestdeps-alldeps: mocpy==0.12
     oldestdeps-alldeps: regions==0.5
+    oldestdeps-alldeps: astropy-healpix==0.7
 
     online: pytest-custom_exit_code
 

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 envlist =
-    py{39,310,311,312,313}-test{,-alldeps,-oldestdeps,-devdeps,-predeps}{,-online}{,-cov}
+    py{310,311,312,313}-test{,-alldeps,-oldestdeps,-devdeps,-predeps}{,-online}{,-cov}
     codestyle
     linkcheck
     build_docs

--- a/tox.ini
+++ b/tox.ini
@@ -44,15 +44,15 @@ deps =
 # And pillow should be pinned as well, otherwise a too new version is pulled that is not compatible with old np.
 
     oldestdeps: astropy==5.0.0
-    oldestdeps: numpy==1.20
-    oldestdeps: matplotlib==3.4.*
+    oldestdeps: numpy==1.22
+    oldestdeps: matplotlib==3.5.0
     oldestdeps: pillow==10.0.0
     oldestdeps: pyvo==1.5
-    oldestdeps: pytest-doctestplus==0.13
-    oldestdeps: requests==2.25
-    oldestdeps: keyring==15.0
+    oldestdeps: pytest-doctestplus==1.4
+    oldestdeps: requests==2.26
+    oldestdeps: keyring==23.0
     oldestdeps: pytest==7.4
-    oldestdeps: beautifulsoup4==4.9
+    oldestdeps: beautifulsoup4==4.10
     oldestdeps-alldeps: mocpy==0.12
     oldestdeps-alldeps: regions==0.5
 


### PR DESCRIPTION
It had EOL already, so time to drop it. I have also updated some other minimal dependencies to drop versions that didn't have python 3.10 support yet.

I was also double checking the diff with pyupgrade but it was full of cruft mostly around f-strings, so I decided not to add that much noise in here.