### PR TITLE
Fix bug in MAST doc tests

### DIFF
--- a/docs/mast/mast_obsquery.rst
+++ b/docs/mast/mast_obsquery.rst
@@ -566,6 +566,7 @@ Once the URIs are obtained, they can be used directly in cloud-based workflows o
 use the `~astropy.io.fits.open` function with the S3 URI and appropriate ``fsspec`` keyword arguments.
 
 .. doctest-remote-data::
+.. doctest-requires:: fsspec,s3fs
 
    >>> from astropy.io import fits
    ...

--- a/setup.cfg
+++ b/setup.cfg
@@ -162,6 +162,7 @@ test=
    pytest-rerunfailures
    fsspec[http]
    moto[s3]
+   s3fs
 docs=
    sphinx
    # https://github.com/astropy/astroquery/issues/3102


### PR DESCRIPTION
Fixes #3508 by:
- Adding `s3fs` to test dependencies.
- Skipping the particular test if `fsspec` and `s3fs` are not installed.