### PR TITLE
ESA: abstract EsaTap using PyVO, HST and ISLA refactored, EMDS module and EinsteinProbe module

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -10,8 +10,25 @@ noirlab
 - Restore access to the `NSF NOIRLab <https://noirlab.edu>`_
   `Astro Data Archive <https://astroarchive.noirlab.edu>`_ [#3359].
 
+esa.emds
+^^^^^^^^
+
+- New module to access the ESA ESDC Multi-Mission Data Services (EMDS). [#3511]
+
+esa.emds.einsteinprobe
+^^^^^^^^^^^^^^^^^^^^^^
+
+- New module to access the ESA Einstein Probe Science Archive. [#3511]
+
+
+
 API changes
 -----------
+
+esa.utils
+^^^^^^^^^^
+
+- Class EsaTap created as abstract class to extend all ESA modules based on PyVO. [#3511]
 
 esa.euclid
 ^^^^^^^^^^

--- a/astroquery/esa/emds/__init__.py
+++ b/astroquery/esa/emds/__init__.py
@@ -27,8 +27,11 @@ class Conf(_config.ConfigNamespace):
     EMDS_TARGET_RESOLVER = _config.ConfigItem(EMDS_DOMAIN + "servlet/target-resolver?TARGET_NAME={}"
                                                             "&RESOLVER_TYPE={}&FORMAT=json",
                                               "EMDS Target Resolver Request")
-    DEFAULT_SCHEMA = _config.ConfigItem("ivoa",
-                                "Default TAP schema for EMDS")
+    DEFAULT_SCHEMAS = _config.ConfigItem("",
+                                         "Default TAP schema(s) used to filter available tables. "
+                                                    "If empty, no schema-based filtering is applied and all tables are returned. "
+                                                    "Use a comma-separated list if multiple schemas are required."
+                                                    "e.g. \"schema1, schema2, schema3\".")
     OBSCORE_TABLE = _config.ConfigItem("ivoa.ObsCore",
                                        "Fully qualified ObsCore table or view name (including schema)")
 

--- a/astroquery/esa/emds/__init__.py
+++ b/astroquery/esa/emds/__init__.py
@@ -30,7 +30,7 @@ class Conf(_config.ConfigNamespace):
     DEFAULT_SCHEMA = _config.ConfigItem("ivoa",
                                 "Default TAP schema for EMDS")
     OBSCORE_TABLE = _config.ConfigItem("ivoa.ObsCore",
-                                       "Fully-qualified ObsCore view/table")
+                                       "Fully qualified ObsCore table or view name (including schema)")
 
     TIMEOUT = 60
 

--- a/astroquery/esa/emds/__init__.py
+++ b/astroquery/esa/emds/__init__.py
@@ -1,0 +1,42 @@
+"""
+=========
+EMDS Init
+=========
+
+European Space Astronomy Centre (ESAC)
+European Space Agency (ESA)
+
+"""
+
+from astropy import config as _config
+
+EMDS_DOMAIN = 'https://emds.esac.esa.int/service/'
+EMDS_TAP_URL = EMDS_DOMAIN + 'tap'
+
+
+class Conf(_config.ConfigNamespace):
+    """
+    Configuration parameters for `astroquery.esa.emds`.
+    """
+    EMDS_TAP_SERVER = _config.ConfigItem(EMDS_TAP_URL, "EMDS TAP Server")
+    EMDS_DATA_SERVER = _config.ConfigItem(EMDS_DOMAIN + 'data?', "EMDS Data Server")
+    EMDS_LOGIN_SERVER = _config.ConfigItem(EMDS_DOMAIN + 'login', "EMDS Login Server")
+    EMDS_LOGOUT_SERVER = _config.ConfigItem(EMDS_DOMAIN + 'logout', "EMDS Logout Server")
+    EMDS_SERVLET = _config.ConfigItem(EMDS_TAP_URL + "/sync/?PHASE=RUN",
+                                      "EMDS Sync Request")
+    EMDS_TARGET_RESOLVER = _config.ConfigItem(EMDS_DOMAIN + "servlet/target-resolver?TARGET_NAME={}"
+                                                            "&RESOLVER_TYPE={}&FORMAT=json",
+                                              "EMDS Target Resolver Request")
+    DEFAULT_SCHEMA = _config.ConfigItem("ivoa",
+                                "Default TAP schema for EMDS")
+    OBSCORE_TABLE = _config.ConfigItem("ivoa.ObsCore",
+                                       "Fully-qualified ObsCore view/table")
+
+    TIMEOUT = 60
+
+
+conf = Conf()
+
+from .core import Emds, EmdsClass
+
+__all__ = ['Emds', 'EmdsClass', 'Conf', 'conf']

--- a/astroquery/esa/emds/__init__.py
+++ b/astroquery/esa/emds/__init__.py
@@ -29,9 +29,9 @@ class Conf(_config.ConfigNamespace):
                                               "EMDS Target Resolver Request")
     DEFAULT_SCHEMAS = _config.ConfigItem("",
                                          "Default TAP schema(s) used to filter available tables. "
-                                                    "If empty, no schema-based filtering is applied and all tables are returned. "
-                                                    "Use a comma-separated list if multiple schemas are required."
-                                                    "e.g. \"schema1, schema2, schema3\".")
+                                         "If empty, no schema-based filtering is applied and all tables are returned. "
+                                         "Use a comma-separated list if multiple schemas are required."
+                                         "e.g. \"schema1, schema2, schema3\".")
     OBSCORE_TABLE = _config.ConfigItem("ivoa.ObsCore",
                                        "Fully qualified ObsCore table or view name (including schema)")
 

--- a/astroquery/esa/emds/core.py
+++ b/astroquery/esa/emds/core.py
@@ -1,0 +1,263 @@
+# Licensed under a 3-clause BSD style license - see LICENSE.rst
+"""
+==========================================
+Multi-Mission Data Services (EMDS)
+==========================================
+
+European Space Astronomy Centre (ESAC)
+European Space Agency (ESA)
+
+"""
+
+from . import conf
+from astroquery.utils import commons
+import astroquery.esa.utils.utils as esautils
+
+__all__ = ['Emds', 'EmdsClass']
+
+class EmdsClass(esautils.EsaTap):
+
+    """
+    EMDS TAP client (multi-mission / multi-schema).
+
+    EMDS provides access to multiple missions through a single TAP service. Mission data are
+    organised under different TAP schemas. This client offers a small convenience layer to work
+    with mission-specific tables while reusing the standard TAP utilities.
+    """
+
+    ESA_ARCHIVE_NAME = "ESA Multi-Mission Data Services (EMDS)"
+    TAP_URL = conf.EMDS_TAP_SERVER
+    LOGIN_URL = conf.EMDS_LOGIN_SERVER
+    LOGOUT_URL = conf.EMDS_LOGOUT_SERVER
+
+    def __init__(self, auth_session=None, tap_url=None):
+        super().__init__(auth_session=auth_session, tap_url=tap_url)
+        # IMPORTANT: ensure every instance has a config namespace.
+        # Subclasses (missions) can overwrite this with their own module conf.
+        self.conf = conf
+
+    def _get_obscore_table(self) -> str:
+        """
+        Return the fully-qualified ObsCore table/view used by this client.
+        Sub-clients override this by providing `conf.OBSCORE_TABLE`.
+        """
+        table = getattr(self.conf, "OBSCORE_TABLE", None)
+        if not (isinstance(table, str) and table.strip()):
+            raise ValueError(
+                "OBSCORE_TABLE is not configured for this client. "
+                "Please set conf.OBSCORE_TABLE to a fully-qualified name like 'schema.table'."
+            )
+        return table
+
+    def _qualify_table_name(self, table_name: str) -> str:
+        """
+        Return a schema-qualified table name when needed.
+
+        If the input table name does not include a schema, the default mission schema
+        is applied when available. Fully-qualified table names are returned unchanged.
+
+        Parameters
+        ----------
+        table_name : str
+            Table name, either fully-qualified ('schema.table') or unqualified ('table').
+        """
+
+        if "." in table_name:
+            return table_name
+
+        default_schema = getattr(self.conf, "DEFAULT_SCHEMA", None)
+        if isinstance(default_schema, str) and default_schema.strip():
+            return f"{default_schema}.{table_name}"
+
+        # Independent missions: do not modify.
+        return table_name
+
+    def get_tables(self, *, only_names=False):
+        """
+        Return the tables available for this mission.
+
+        By default, only tables belonging to the mission-specific schema are returned.
+        Set ``only_names=True`` to return table names instead of table objects.
+
+        """
+        tables = super().get_tables(only_names=only_names)
+
+        schema = getattr(self.conf, "DEFAULT_SCHEMA", None)
+        if not schema:
+            return tables
+
+        schema_prefix = schema.lower() + "."
+
+        if only_names:
+            return [t for t in tables if t.lower().startswith(schema_prefix)]
+        else:
+            return [
+                t for t in tables
+                if getattr(t, "name", "").lower().startswith(schema_prefix)
+            ]
+
+    def get_table(self, table):
+        """
+        Retrieve a table from the TAP service.
+
+        Parameters
+        ----------
+        table : str
+            Table name. It can be fully qualified (``schema.table``) or unqualified
+            (``table``). Unqualified names are automatically prefixed with the default
+            mission schema when available.
+
+        """
+
+        qualified = self._qualify_table_name(table)
+        return super().get_table(qualified)
+
+    def get_metadata(self, table):
+        """
+        Retrieve metadata for a table.
+
+        The table name can be provided with or without a schema. If no schema is given,
+        the default mission schema is applied when available.
+
+        Parameters
+        ----------
+        table : str
+            Table name. It can be fully qualified (``schema.table``) or unqualified
+            (``table``). Unqualified names are automatically prefixed with the default
+            mission schema when available.
+
+        """
+
+        qualified = self._qualify_table_name(table)
+        return super().get_metadata(qualified)
+
+    def query_table(self, table_name, *, columns=None, custom_filters=None, get_metadata=False,
+                    async_job=False, output_file=None, output_format='votable', **filters):
+        """
+        Query a table in the TAP service.
+
+        The table name can be provided with or without a schema. If no schema is given,
+        the default mission schema is applied when available.
+
+        Parameters
+        ----------
+        table_name : str
+            Table name (either 'schema.table' or 'table').
+        columns : str or list of str, optional
+            Columns to retrieve.
+        custom_filters : str, optional
+            Additional ADQL conditions (e.g. cone search predicate).
+        get_metadata : bool, optional
+            If True, return column metadata for the table.
+        async_job : bool, optional
+            Run query asynchronously.
+        output_file : str, optional
+            Output filename.
+        output_format : str, optional
+            Output format (e.g. 'votable').
+        **filters
+            Column-based filters passed to the underlying implementation.
+
+        """
+
+        qualified = self._qualify_table_name(table_name)
+
+        # Ensure the metadata path uses the qualified table name.
+        if get_metadata:
+            return self.get_metadata(qualified)
+
+        return super().query_table(
+            qualified,
+            columns=columns,
+            custom_filters=custom_filters,
+            get_metadata=False,
+            async_job=async_job,
+            output_file=output_file,
+            output_format=output_format,
+            **filters
+        )
+
+    def get_emds_missions(self):
+        """
+        Retrieve the list of missions available in the EMDS ObsCore view.
+
+        This method returns the distinct values of the ``obs_collection`` field
+        from the ``ivoa.ObsCore`` view, where ``obs_collection`` typically
+        identifies the mission or data collection associated with each observation.
+
+        Returns
+        -------
+        astropy.table that contains the distinct mission identifiers present in ObsCore.
+        """
+        query = "SELECT DISTINCT obs_collection FROM ivoa.ObsCore WHERE obs_collection IS NOT NULL"
+        return self.query_tap(query=query)
+
+    def get_observations(self, *, target_name=None, coordinates=None, radius=1.0, columns=None, get_metadata=False,
+                          output_file=None, **filters):
+        """
+        Query the observation catalogue for this mission.
+
+        This method queries the mission-specific observation catalogue configured for
+        this client and returns observation-level metadata as an Astropy table.
+        Queries can be restricted using a cone search (by target name or coordinates)
+        and additional column-based filters.
+
+        Parameters
+        ----------
+        target_name: str, optional
+            Name of the target to be resolved against SIMBAD/NED/VIZIER
+        coordinates: str or SkyCoord, optional
+            coordinates of the center in the cone search
+        radius: float or quantity, optional, default value 1 degree
+            radius in degrees (int, float) or quantity of the cone_search
+        columns : str or list of str, optional, default None
+            Columns from the table to be retrieved. They can be checked using
+            get_metadata=True
+        get_metadata : bool, optional, default False
+            Get the table metadata to verify the columns that can be filtered
+        output_file : str, optional, default None
+            file name where the results are saved.
+            If this parameter is not provided, the jobid is used instead
+        **filters : str, optional, default None
+            Filters to be applied to the search. The column name is the keyword and the value is any
+            value accepted by the column datatype. They will be
+            used to generate the SQL filters for the query. Some examples are described below,
+            where the left side is the parameter defined for this method and the right side the
+            SQL filter generated:
+            obs_collection="EPSA" -> obs_collection = 'EPSA'
+            target_name="AT 2023%" -> target_name ILIKE 'AT 2023%'
+            dataproduct_type=["img", "pha"] -> dataproduct_type = 'img' OR dataproduct_type = 'pha'
+            dataproduct_type=["img", "pha"] -> dataproduct_type IN ('img', 'pha')
+            t_min=(">", 60000) -> t_min > 60000
+            s_ra=(80, 82) -> s_ra >= 80 AND s_ra <= 82
+
+        Returns
+        -------
+        An astropy.table containing the query results, or the metadata table when ``get_metadata=True``
+
+        """
+
+        cone_search_filter = None
+        if radius:
+            radius = esautils.get_degree_radius(radius)
+
+        if target_name and coordinates:
+            raise TypeError("Please use only target or coordinates as "
+                            "parameter.")
+        elif target_name:
+            coordinates = esautils.resolve_target(conf.EMDS_TARGET_RESOLVER,
+                                                  self.tap._session, target_name,
+                                                  'ALL')
+            cone_search_filter = self.create_cone_search_query(coordinates.ra.deg, coordinates.dec.deg,
+                                                               "s_ra", "s_dec", radius)
+        elif coordinates:
+            coord = commons.parse_coordinates(coordinates=coordinates)
+            ra = coord.ra.degree
+            dec = coord.dec.degree
+            cone_search_filter = self.create_cone_search_query(ra, dec, "s_ra", "s_dec", radius)
+
+        obscore_table = self._get_obscore_table()
+        return self.query_table(table_name=obscore_table, columns=columns, custom_filters=cone_search_filter,
+                                get_metadata=get_metadata, async_job=True, output_file=output_file, **filters)
+
+Emds = EmdsClass()

--- a/astroquery/esa/emds/core.py
+++ b/astroquery/esa/emds/core.py
@@ -41,6 +41,7 @@ class EmdsClass(esautils.EsaTap):
         Return the fully-qualified ObsCore table/view used by this client.
         Sub-clients override this by providing `conf.OBSCORE_TABLE`.
         """
+
         table = getattr(self.conf, "OBSCORE_TABLE", None)
         if not (isinstance(table, str) and table.strip()):
             raise ValueError(
@@ -80,6 +81,7 @@ class EmdsClass(esautils.EsaTap):
         Set ``only_names=True`` to return table names instead of table objects.
 
         """
+
         tables = super().get_tables(only_names=only_names)
 
         schema = getattr(self.conf, "DEFAULT_SCHEMA", None)
@@ -189,6 +191,7 @@ class EmdsClass(esautils.EsaTap):
         -------
         astropy.table that contains the distinct mission identifiers present in ObsCore.
         """
+
         query = "SELECT DISTINCT obs_collection FROM ivoa.ObsCore WHERE obs_collection IS NOT NULL"
         return self.query_tap(query=query)
 

--- a/astroquery/esa/emds/core.py
+++ b/astroquery/esa/emds/core.py
@@ -11,6 +11,8 @@ European Space Agency (ESA)
 
 from . import conf
 from astroquery.utils import commons
+from html import unescape
+import os
 import astroquery.esa.utils.utils as esautils
 
 __all__ = ['Emds', 'EmdsClass']
@@ -181,6 +183,109 @@ class EmdsClass(esautils.EsaTap):
         obscore_table = self._get_obscore_table()
         return self.query_table(table_name=obscore_table, columns=columns, custom_filters=cone_search_filter,
                                 get_metadata=get_metadata, async_job=True, output_file=output_file, **filters)
+
+    def get_products(self, *, target_name=None, coordinates=None, radius=1.0, get_metadata=False, **filters):
+
+        """
+        Retrieve data products given a Taget Name, coordinates and/or some filters
+
+        This method queries the mission product catalogue and returns product-level
+        information. It ensures that the ``obs_publisher_did`` and ``access_url`` columns required
+        for downloading products are included in the results.
+
+        Parameters
+        ----------
+        target_name: str, optional
+            Name of the target to be resolved against SIMBAD/NED/VIZIER
+        coordinates: str or SkyCoord, optional
+            coordinates of the center in the cone search
+        radius: float or quantity, optional, default value 1 degree
+            radius in degrees (int, float) or quantity of the cone_search
+        get_metadata : bool, optional, default False
+            Get the table metadata to verify the columns that can be filtered
+        **filters : str, optional, default None
+            Filters to be applied to the search. The column name is the keyword and the value is any
+            value accepted by the column datatype. They will be
+            used to generate the SQL filters for the query. Some examples are described below,
+            where the left side is the parameter defined for this method and the right side the
+            SQL filter generated:
+            obs_collection="EPSA" -> obs_collection = 'EPSA'
+            target_name="AT 2023%" -> target_name ILIKE 'AT 2023%'
+            dataproduct_type=["img", "pha"] -> dataproduct_type = 'img' OR dataproduct_type = 'pha'
+            dataproduct_type=["img", "pha"] -> dataproduct_type IN ('img', 'pha')
+            t_min=(">", 60000) -> t_min > 60000
+            s_ra=(80, 82) -> s_ra >= 80 AND s_ra <= 82
+
+        Returns
+        -------
+        astropy.table.Table
+        """
+        return self.get_observations(target_name=target_name, coordinates=coordinates, radius=radius,
+                                     columns=['obs_id', 'obs_publisher_did', 'access_url'],
+                                     get_metadata=get_metadata, **filters)
+
+    def download_products(self, products, *, path="", cache=False, cache_folder=None,
+                          verbose=False, params=None):
+        """
+        Download all products from a table returned by `get_products()`.
+
+
+        Parameters
+        ----------
+        products : `~astropy.table.Table`
+            Table returned by `get_products()`. The table must contain the
+            ``access_url`` and ``obs_publisher_did`` columns.
+        path : str, optional
+            Local directory where the downloaded files will be stored.
+            If not provided, files are downloaded to the current working directory.
+            Ignored if ``cache=True``.
+        cache : bool, optional
+            If True, store the downloaded files in the Astroquery cache.
+            Default is False.
+        cache_folder : str, optional
+            Subdirectory within the Astroquery cache where files will be stored.
+            Only used if ``cache=True``.
+        verbose : bool, optional
+            If True, print progress messages during download.
+            Default is False.
+        params : dict, optional
+            Additional parameters passed to the HTTP request.
+
+        Returns
+        -------
+        list of str
+            List of local file paths for the downloaded products.
+        """
+        if products is None or len(products) == 0:
+            return []
+
+        if "access_url" not in products.colnames:
+            raise ValueError("Products table must contain an 'access_url' column.")
+
+        if "obs_publisher_did" not in products.colnames:
+            raise ValueError("Products table must contain an 'obs_publisher_did' column.")
+
+        if path and not cache:
+            os.makedirs(path, exist_ok=True)
+
+        downloaded = []
+
+        for row in products:
+            url = unescape(row["access_url"])
+            session = self.tap._session
+
+            file_path = esautils.download_file(
+                url,
+                session,
+                params=params,
+                path=path,
+                cache=cache,
+                cache_folder=cache_folder,
+                verbose=verbose,
+            )
+            downloaded.append(file_path)
+
+        return downloaded
 
 
 Emds = EmdsClass()

--- a/astroquery/esa/emds/core.py
+++ b/astroquery/esa/emds/core.py
@@ -14,11 +14,12 @@ from astroquery.utils import commons
 from html import unescape
 import os
 import astroquery.esa.utils.utils as esautils
+from astroquery.esa.utils import EsaTap, download_file
 
 __all__ = ['Emds', 'EmdsClass']
 
 
-class EmdsClass(esautils.EsaTap):
+class EmdsClass(EsaTap):
 
     """
     EMDS TAP client (multi-mission / multi-schema).
@@ -274,7 +275,7 @@ class EmdsClass(esautils.EsaTap):
             url = unescape(row["access_url"])
             session = self.tap._session
 
-            file_path = esautils.download_file(
+            file_path = download_file(
                 url,
                 session,
                 params=params,

--- a/astroquery/esa/emds/core.py
+++ b/astroquery/esa/emds/core.py
@@ -15,6 +15,7 @@ import astroquery.esa.utils.utils as esautils
 
 __all__ = ['Emds', 'EmdsClass']
 
+
 class EmdsClass(esautils.EsaTap):
 
     """
@@ -114,7 +115,7 @@ class EmdsClass(esautils.EsaTap):
         return self.query_tap(query=query)
 
     def get_observations(self, *, target_name=None, coordinates=None, radius=1.0, columns=None, get_metadata=False,
-                          output_file=None, **filters):
+                         output_file=None, **filters):
         """
         Query the observation catalogue for this mission.
 
@@ -180,5 +181,6 @@ class EmdsClass(esautils.EsaTap):
         obscore_table = self._get_obscore_table()
         return self.query_table(table_name=obscore_table, columns=columns, custom_filters=cone_search_filter,
                                 get_metadata=get_metadata, async_job=True, output_file=output_file, **filters)
+
 
 Emds = EmdsClass()

--- a/astroquery/esa/emds/core.py
+++ b/astroquery/esa/emds/core.py
@@ -13,10 +13,13 @@ from . import conf
 from astroquery.utils import commons
 from html import unescape
 import os
+import warnings
 import astroquery.esa.utils.utils as esautils
 from astroquery.esa.utils import EsaTap, download_file
 
 __all__ = ['Emds', 'EmdsClass']
+
+from ...exceptions import NoResultsWarning
 
 
 class EmdsClass(EsaTap):
@@ -101,7 +104,7 @@ class EmdsClass(EsaTap):
                 if belongs(getattr(t, "name", ""))
             ]
 
-    def get_missions(self):
+    def list_missions(self):
         """
         Retrieve the list of missions available in the EMDS ObsCore view.
 
@@ -258,6 +261,7 @@ class EmdsClass(EsaTap):
             List of local file paths for the downloaded products.
         """
         if products is None or len(products) == 0:
+            warnings.warn('There are no products available', NoResultsWarning)
             return []
 
         if "access_url" not in products.colnames:

--- a/astroquery/esa/emds/core.py
+++ b/astroquery/esa/emds/core.py
@@ -166,7 +166,7 @@ class EmdsClass(EsaTap):
         """
 
         cone_search_filter = None
-        if radius:
+        if radius is not None:
             radius = esautils.get_degree_radius(radius)
 
         if target_name and coordinates:

--- a/astroquery/esa/emds/einsteinprobe/__init__.py
+++ b/astroquery/esa/emds/einsteinprobe/__init__.py
@@ -20,7 +20,7 @@ class Conf(EmdsConf):
     DEFAULT_SCHEMA = _config.ConfigItem("einsteinprobe",
                             "Default TAP schema for Einstein Probe")
     OBSCORE_TABLE = _config.ConfigItem("einsteinprobe.obscore_extended",
-                                       "Fully-qualified ObsCore view/table")
+                                       "Fully-qualified ObsCore table or view name (including schema)")
 
 conf = Conf()
 

--- a/astroquery/esa/emds/einsteinprobe/__init__.py
+++ b/astroquery/esa/emds/einsteinprobe/__init__.py
@@ -11,6 +11,7 @@ European Space Agency (ESA)
 from astropy import config as _config
 from astroquery.esa.emds import Conf as EmdsConf
 
+
 class Conf(EmdsConf):
     """
     Configuration parameters for EinsteinProbe.
@@ -19,10 +20,11 @@ class Conf(EmdsConf):
     """
 
     DEFAULT_SCHEMAS = _config.ConfigItem("einsteinprobe",
-                                          "Default TAP schema(s) for this mission (comma-separated), "
-                                                    "e.g. \"schema1, schema2, schema3\".")
+                                         "Default TAP schema(s) for this mission (comma-separated) "
+                                         "e.g. \"schema1, schema2, schema3\".")
     OBSCORE_TABLE = _config.ConfigItem("einsteinprobe.obscore_extended",
                                        "Fully-qualified ObsCore table or view name (including schema)")
+
 
 conf = Conf()
 

--- a/astroquery/esa/emds/einsteinprobe/__init__.py
+++ b/astroquery/esa/emds/einsteinprobe/__init__.py
@@ -17,8 +17,10 @@ class Conf(EmdsConf):
 
     Inherits all EMDS configuration items and adds/overrides only the EinsteinProbe ones.
     """
-    DEFAULT_SCHEMA = _config.ConfigItem("einsteinprobe",
-                            "Default TAP schema for Einstein Probe")
+
+    DEFAULT_SCHEMAS = _config.ConfigItem("einsteinprobe, lisapathfinder, lisapathfinder_must_extension",
+                                          "Default TAP schema(s) for this mission (comma-separated), "
+                                                    "e.g. \"schema1, schema2, schema3\".")
     OBSCORE_TABLE = _config.ConfigItem("einsteinprobe.obscore_extended",
                                        "Fully-qualified ObsCore table or view name (including schema)")
 

--- a/astroquery/esa/emds/einsteinprobe/__init__.py
+++ b/astroquery/esa/emds/einsteinprobe/__init__.py
@@ -18,7 +18,7 @@ class Conf(EmdsConf):
     Inherits all EMDS configuration items and adds/overrides only the EinsteinProbe ones.
     """
 
-    DEFAULT_SCHEMAS = _config.ConfigItem("einsteinprobe, lisapathfinder, lisapathfinder_must_extension",
+    DEFAULT_SCHEMAS = _config.ConfigItem("einsteinprobe",
                                           "Default TAP schema(s) for this mission (comma-separated), "
                                                     "e.g. \"schema1, schema2, schema3\".")
     OBSCORE_TABLE = _config.ConfigItem("einsteinprobe.obscore_extended",

--- a/astroquery/esa/emds/einsteinprobe/__init__.py
+++ b/astroquery/esa/emds/einsteinprobe/__init__.py
@@ -1,0 +1,29 @@
+"""
+==================
+EinsteinProbe Init
+==================
+
+European Space Astronomy Centre (ESAC)
+European Space Agency (ESA)
+
+"""
+
+from astropy import config as _config
+from astroquery.esa.emds import Conf as EmdsConf
+
+class Conf(EmdsConf):
+    """
+    Configuration parameters for EinsteinProbe.
+
+    Inherits all EMDS configuration items and adds/overrides only the EinsteinProbe ones.
+    """
+    DEFAULT_SCHEMA = _config.ConfigItem("einsteinprobe",
+                            "Default TAP schema for Einstein Probe")
+    OBSCORE_TABLE = _config.ConfigItem("einsteinprobe.obscore_extended",
+                                       "Fully-qualified ObsCore view/table")
+
+conf = Conf()
+
+from .core import EinsteinProbe, EinsteinProbeClass
+
+__all__ = ['EinsteinProbe', 'EinsteinProbeClass']

--- a/astroquery/esa/emds/einsteinprobe/core.py
+++ b/astroquery/esa/emds/einsteinprobe/core.py
@@ -12,8 +12,6 @@ import os
 import astroquery.esa.utils.utils as esautils
 
 from . import conf
-from urllib.parse import quote
-from astroquery.utils import commons
 from ..core import EmdsClass
 
 
@@ -65,6 +63,7 @@ class EinsteinProbeClass(EmdsClass):
         -------
         astropy.table.Table
         """
+
         table = getattr(self.conf, "OBSCORE_TABLE", None)
         if not table:
             raise ValueError("OBSCORE_TABLE is not configured for EinsteinProbe.")
@@ -85,12 +84,14 @@ class EinsteinProbeClass(EmdsClass):
         obs_filter = None
         if obs_id:
             obs_filter = "obs_id = '{0}'".format(obs_id)
+
         # Combine obs_id filter with any custom_filters
         if obs_filter:
             if custom_filters:
                 custom_filters = "({0}) AND ({1})".format(custom_filters, obs_filter)
             else:
                 custom_filters = obs_filter
+
         return self.query_table(
             table_name=table,
             columns=columns,
@@ -129,9 +130,10 @@ class EinsteinProbeClass(EmdsClass):
         str
             Local file path returned by `esautils.download_file`.
         """
-        data_url = getattr(self.conf, "EMDS_DATA_SERVER", None) or getattr(self.conf, "X_DATA_SERVER", None)
+
+        data_url = getattr(self.conf, "EMDS_DATA_SERVER", None)
         if not data_url:
-            raise ValueError("Data server URL is not configured (EMDS_DATA_SERVER / X_DATA_SERVER).")
+            raise ValueError("Data server URL is not configured (EMDS_DATA_SERVER).")
 
         if table is None:
             table = getattr(self.conf, "OBSCORE_TABLE", None)

--- a/astroquery/esa/emds/einsteinprobe/core.py
+++ b/astroquery/esa/emds/einsteinprobe/core.py
@@ -1,0 +1,189 @@
+# Licensed under a 3-clause BSD style license - see LICENSE.rst
+"""
+==========================================
+EinsteinProbe Space Archive (EPSA)
+==========================================
+
+European Space Astronomy Centre (ESAC)
+European Space Agency (ESA)
+
+"""
+import os
+import astroquery.esa.utils.utils as esautils
+
+from . import conf
+from urllib.parse import quote
+from astroquery.utils import commons
+from ..core import EmdsClass
+
+
+__all__ = ['EinsteinProbe', 'EinsteinProbeClass']
+
+
+class EinsteinProbeClass(EmdsClass):
+
+    """
+    Einstein Probe TAP client.
+
+    This module provides access to Einstein Probe data through the EMDS multi-mission
+    TAP and data services. It builds on the generic EMDS client and configures
+    mission-specific defaults, such as the observation catalogue and table schema.
+    """
+
+    ESA_ARCHIVE_NAME = "EinsteinProbe Space Archive (EPSA)"
+
+    def __init__(self, auth_session=None, tap_url=None):
+        super().__init__(auth_session=auth_session, tap_url=tap_url)
+        self.conf = conf
+
+    def get_products(self, obs_id=None, *, columns=None, custom_filters=None,
+                     get_metadata=False, output_file=None, **filters):
+        """
+        Retrieve data products associated with Einstein Probe observations.
+
+        This method queries the mission product catalogue and returns product-level
+        information. It ensures that the ``filename`` and ``filepath`` columns required
+        for downloading products are included in the results.
+
+        Parameters
+        ----------
+        obs_id : str, optional
+            Observation identifier to restrict the query (e.g. a specific observation).
+        columns : str or list of str, optional
+            Columns to retrieve. If provided as a list, `filename` and `filepath`
+            will be appended if missing. If not provided, a minimal useful set is used.
+        custom_filters : str, optional
+            Additional ADQL conditions appended to the WHERE clause.
+        get_metadata : bool, optional
+            If True, return metadata (columns) instead of results.
+        output_file : str, optional
+            If provided, save results to this file.
+        **filters
+            Column-based filters passed through to `query_table`.
+
+        Returns
+        -------
+        astropy.table.Table
+        """
+        table = getattr(self.conf, "OBSCORE_TABLE", None)
+        if not table:
+            raise ValueError("OBSCORE_TABLE is not configured for EinsteinProbe.")
+
+        # Ensure required columns for downloading are present
+        required = ["filename", "filepath"]
+
+        if columns is None:
+            # Minimal set + obs_id for context
+            columns = ["obs_id"] + required
+        elif isinstance(columns, list):
+            for r in required:
+                if r not in columns:
+                    columns.append(r)
+
+        # If columns is a string (e.g. "*"), we leave it as-is.
+        # Build an obs_id filter if provided
+        obs_filter = None
+        if obs_id:
+            obs_filter = "obs_id = '{0}'".format(obs_id)
+        # Combine obs_id filter with any custom_filters
+        if obs_filter:
+            if custom_filters:
+                custom_filters = "({0}) AND ({1})".format(custom_filters, obs_filter)
+            else:
+                custom_filters = obs_filter
+        return self.query_table(
+            table_name=table,
+            columns=columns,
+            custom_filters=custom_filters,
+            get_metadata=get_metadata,
+            async_job=True,
+            output_file=output_file,
+            **filters
+        )
+
+    def download_product(self, filename, *, table=None, output_filename=None, path="", cache=False, verbose=False):
+        """
+        Download a single data product file.
+
+        The product is retrieved from the EMDS data service using its filename and
+        saved locally.
+
+        Parameters
+        ----------
+        filename : str
+            Product filename stored in the mission tables (unique identifier).
+        table : str, optional
+            Table to query for (filepath, filename). If not provided, defaults to
+            `self.conf.OBSCORE_TABLE`.
+        output_filename : str, optional
+            Local filename for the downloaded file. Defaults to `filename`.
+        path : str, optional
+            Local directory where the file will be saved. Default is current working directory.
+        cache : bool, optional
+            Use astroquery cache (if supported by your downloader).
+        verbose : bool, optional
+            Verbose download output.
+
+        Returns
+        -------
+        str
+            Local file path returned by `esautils.download_file`.
+        """
+        data_url = getattr(self.conf, "EMDS_DATA_SERVER", None) or getattr(self.conf, "X_DATA_SERVER", None)
+        if not data_url:
+            raise ValueError("Data server URL is not configured (EMDS_DATA_SERVER / X_DATA_SERVER).")
+
+        if table is None:
+            table = getattr(self.conf, "OBSCORE_TABLE", None)
+        if not table:
+            raise ValueError("OBSCORE_TABLE is not configured for EinsteinProbe.")
+
+        if output_filename is None:
+            output_filename = filename
+
+        if path:
+            os.makedirs(path, exist_ok=True)
+
+        query = self._build_retrieval_query(table=table, filename=filename)
+        params = self._build_data_params(retrieval_type="PRODUCT", query=query)
+
+        session = self.tap._session
+        return esautils.download_file(
+            url=data_url,
+            session=session,
+            params=params,
+            path=path,
+            filename=output_filename,
+            cache=cache,
+            verbose=verbose
+        )
+
+    def _escape_adql_string(self, value: str) -> str:
+        """
+        Escape single quotes for ADQL/SQL string literals.
+        """
+        return value.replace("'", "''")
+
+    def _build_retrieval_query(self, *, table: str, filename: str) -> str:
+        """
+        Build the retrieval QUERY used by the EMDS /data service to locate a product.
+
+        The service expects a query that returns at least (filepath, filename).
+        """
+        safe = self._escape_adql_string(filename)
+        return "SELECT filepath, filename FROM {0} WHERE filename = '{1}'".format(table, safe)
+
+    def _build_data_params(self, *, retrieval_type: str, query: str, size: str = None) -> dict:
+        """
+        Build query parameters for the EMDS /data endpoint.
+        """
+        params = {
+            "retrieval_type": retrieval_type,
+            "QUERY": query,
+        }
+        if size is not None:
+            params["SIZE"] = size
+        return params
+
+
+EinsteinProbe = EinsteinProbeClass()

--- a/astroquery/esa/emds/einsteinprobe/core.py
+++ b/astroquery/esa/emds/einsteinprobe/core.py
@@ -163,7 +163,18 @@ class EinsteinProbeClass(EmdsClass):
     def _escape_adql_string(self, value: str) -> str:
         """
         Escape single quotes for ADQL/SQL string literals.
+
+            Parameters
+            ----------
+            value : str
+                Input string to be escaped for safe use in ADQL/SQL queries.
+
+            Returns
+            -------
+            str
+                Escaped string with single quotes doubled.
         """
+
         return value.replace("'", "''")
 
     def _build_retrieval_query(self, *, table: str, filename: str) -> str:
@@ -171,14 +182,42 @@ class EinsteinProbeClass(EmdsClass):
         Build the retrieval QUERY used by the EMDS /data service to locate a product.
 
         The service expects a query that returns at least (filepath, filename).
+
+        Parameters
+        ----------
+        table : str
+            Name of the table to query.
+        filename : str
+            Name of the file to be retrieved.
+
+        Returns
+        -------
+            str
+                ADQL query string used to retrieve the product location.
         """
+
         safe = self._escape_adql_string(filename)
         return "SELECT filepath, filename FROM {0} WHERE filename = '{1}'".format(table, safe)
 
     def _build_data_params(self, *, retrieval_type: str, query: str, size: str = None) -> dict:
         """
         Build query parameters for the EMDS /data endpoint.
+
+        Parameters
+        ----------
+        retrieval_type : str
+            Type of retrieval to be performed by the EMDS service.
+        query : str
+            ADQL query string used to locate the requested product(s).
+        size : str, optional
+            Maximum size of the response, if supported by the service.
+
+        Returns
+        -------
+        dict
+            Dictionary of query parameters to be sent to the EMDS /data endpoint.
         """
+
         params = {
             "retrieval_type": retrieval_type,
             "QUERY": query,

--- a/astroquery/esa/emds/einsteinprobe/core.py
+++ b/astroquery/esa/emds/einsteinprobe/core.py
@@ -12,13 +12,13 @@ import os
 import astroquery.esa.utils.utils as esautils
 
 from . import conf
-from ..core import EmdsClass
+import astroquery.esa.emds as emds
 
 
 __all__ = ['EinsteinProbe', 'EinsteinProbeClass']
 
 
-class EinsteinProbeClass(EmdsClass):
+class EinsteinProbeClass(emds.EmdsClass):
 
     """
     Einstein Probe TAP client.

--- a/astroquery/esa/emds/einsteinprobe/core.py
+++ b/astroquery/esa/emds/einsteinprobe/core.py
@@ -9,16 +9,15 @@ European Space Agency (ESA)
 
 """
 import os
-import astroquery.esa.utils.utils as esautils
+from astroquery.esa.utils import download_file
 
 from . import conf
-import astroquery.esa.emds as emds
-
+from astroquery.esa.emds import EmdsClass
 
 __all__ = ['EinsteinProbe', 'EinsteinProbeClass']
 
 
-class EinsteinProbeClass(emds.EmdsClass):
+class EinsteinProbeClass(EmdsClass):
 
     """
     Einstein Probe TAP client.
@@ -48,7 +47,7 @@ class EinsteinProbeClass(emds.EmdsClass):
         obs_id : str, optional
             Observation identifier to restrict the query (e.g. a specific observation).
         columns : str or list of str, optional
-            Columns to retrieve. If provided as a list, `filename` and `filepath`
+            Columns to retrieve. If provided as a list, filename and filepath
             will be appended if missing. If not provided, a minimal useful set is used.
         custom_filters : str, optional
             Additional ADQL conditions appended to the WHERE clause.
@@ -57,7 +56,7 @@ class EinsteinProbeClass(emds.EmdsClass):
         output_file : str, optional
             If provided, save results to this file.
         **filters
-            Column-based filters passed through to `query_table`.
+            Column-based filters passed through to query_table method.
 
         Returns
         -------
@@ -115,9 +114,9 @@ class EinsteinProbeClass(emds.EmdsClass):
             Product filename stored in the mission tables (unique identifier).
         table : str, optional
             Table to query for (filepath, filename). If not provided, defaults to
-            `self.conf.OBSCORE_TABLE`.
+            the obscore table for Einstein Probe.
         output_filename : str, optional
-            Local filename for the downloaded file. Defaults to `filename`.
+            Local filename for the downloaded file. Defaults to None.
         path : str, optional
             Local directory where the file will be saved. Default is current working directory.
         cache : bool, optional
@@ -128,7 +127,7 @@ class EinsteinProbeClass(emds.EmdsClass):
         Returns
         -------
         str
-            Local file path returned by `esautils.download_file`.
+            Local file path returned by esautils.download_file.
         """
 
         data_url = getattr(self.conf, "EMDS_DATA_SERVER", None)
@@ -150,7 +149,7 @@ class EinsteinProbeClass(emds.EmdsClass):
         params = self._build_data_params(retrieval_type="PRODUCT", query=query)
 
         session = self.tap._session
-        return esautils.download_file(
+        return download_file(
             url=data_url,
             session=session,
             params=params,

--- a/astroquery/esa/emds/einsteinprobe/core.py
+++ b/astroquery/esa/emds/einsteinprobe/core.py
@@ -164,15 +164,15 @@ class EinsteinProbeClass(EmdsClass):
         """
         Escape single quotes for ADQL/SQL string literals.
 
-            Parameters
-            ----------
-            value : str
-                Input string to be escaped for safe use in ADQL/SQL queries.
+        Parameters
+        ----------
+        value : str
+            Input string to be escaped for safe use in ADQL/SQL queries.
 
-            Returns
-            -------
-            str
-                Escaped string with single quotes doubled.
+        Returns
+        -------
+        str
+            Escaped string with single quotes doubled.
         """
 
         return value.replace("'", "''")
@@ -192,8 +192,8 @@ class EinsteinProbeClass(EmdsClass):
 
         Returns
         -------
-            str
-                ADQL query string used to retrieve the product location.
+        str
+            ADQL query string used to retrieve the product location.
         """
 
         safe = self._escape_adql_string(filename)

--- a/astroquery/esa/emds/einsteinprobe/core.py
+++ b/astroquery/esa/emds/einsteinprobe/core.py
@@ -33,7 +33,7 @@ class EinsteinProbeClass(EmdsClass):
         super().__init__(auth_session=auth_session, tap_url=tap_url)
         self.conf = conf
 
-    def get_products(self, obs_id=None, *, columns=None, custom_filters=None,
+    def get_products(self, *, obs_id=None, columns=None, custom_filters=None,
                      get_metadata=False, output_file=None, **filters):
         """
         Retrieve data products associated with Einstein Probe observations.
@@ -72,22 +72,21 @@ class EinsteinProbeClass(EmdsClass):
 
         if columns is None:
             # Minimal set + obs_id for context
-            columns = ["obs_id"] + required
+            columns = ["obs_id", *required]
         elif isinstance(columns, list):
-            for r in required:
-                if r not in columns:
-                    columns.append(r)
+            existing = set(columns)
+            columns.extend(r for r in required if r not in existing)
 
-        # If columns is a string (e.g. "*"), we leave it as-is.
+# If columns is a string (e.g. "*"), we leave it as-is.
         # Build an obs_id filter if provided
         obs_filter = None
         if obs_id:
-            obs_filter = "obs_id = '{0}'".format(obs_id)
+            obs_filter = f"obs_id = '{obs_id}'"
 
         # Combine obs_id filter with any custom_filters
         if obs_filter:
             if custom_filters:
-                custom_filters = "({0}) AND ({1})".format(custom_filters, obs_filter)
+                custom_filters = f"({custom_filters}) AND ({obs_filter})"
             else:
                 custom_filters = obs_filter
 
@@ -195,8 +194,8 @@ class EinsteinProbeClass(EmdsClass):
             ADQL query string used to retrieve the product location.
         """
 
-        safe = self._escape_adql_string(filename)
-        return "SELECT filepath, filename FROM {0} WHERE filename = '{1}'".format(table, safe)
+        safe_name = self._escape_adql_string(filename)
+        return "SELECT filepath, filename FROM {0} WHERE filename = '{1}'".format(table, safe_name)
 
     def _build_data_params(self, *, retrieval_type: str, query: str, size: str = None) -> dict:
         """

--- a/astroquery/esa/emds/einsteinprobe/core.py
+++ b/astroquery/esa/emds/einsteinprobe/core.py
@@ -33,7 +33,7 @@ class EinsteinProbeClass(EmdsClass):
         super().__init__(auth_session=auth_session, tap_url=tap_url)
         self.conf = conf
 
-    def get_products(self, *, obs_id=None, columns=None, custom_filters=None,
+    def get_products(self, *, observation_id=None, columns=None, custom_filters=None,
                      get_metadata=False, output_file=None, **filters):
         """
         Retrieve data products associated with Einstein Probe observations.
@@ -44,7 +44,7 @@ class EinsteinProbeClass(EmdsClass):
 
         Parameters
         ----------
-        obs_id : str, optional
+        observation_id : str, optional
             Observation identifier to restrict the query (e.g. a specific observation).
         columns : str or list of str, optional
             Columns to retrieve. If provided as a list, filename and filepath
@@ -80,8 +80,8 @@ class EinsteinProbeClass(EmdsClass):
 # If columns is a string (e.g. "*"), we leave it as-is.
         # Build an obs_id filter if provided
         obs_filter = None
-        if obs_id:
-            obs_filter = f"obs_id = '{obs_id}'"
+        if observation_id:
+            obs_filter = f"obs_id = '{observation_id}'"
 
         # Combine obs_id filter with any custom_filters
         if obs_filter:

--- a/astroquery/esa/emds/einsteinprobe/test/test_einsteinprobe_remote.py
+++ b/astroquery/esa/emds/einsteinprobe/test/test_einsteinprobe_remote.py
@@ -32,6 +32,7 @@ def close_files(file_list):
 def create_temp_folder():
     return tempfile.TemporaryDirectory()
 
+
 @pytest.mark.remote_data
 class TestEmdsRemote:
 
@@ -43,7 +44,6 @@ class TestEmdsRemote:
         assert len(names) > 0
         assert all(isinstance(n, str) for n in names)
         assert "einsteinprobe.obscore_extended" in [n.lower() for n in names]
-
 
     def test_get_table(self):
         epsa = EinsteinProbeClass()

--- a/astroquery/esa/emds/einsteinprobe/test/test_einsteinprobe_remote.py
+++ b/astroquery/esa/emds/einsteinprobe/test/test_einsteinprobe_remote.py
@@ -1,0 +1,206 @@
+# Licensed under a 3-clause BSD style license - see LICENSE.rst
+"""
+==========================================
+EinsteinProbe (EPSA) tests
+==========================================
+
+European Space Astronomy Centre (ESAC)
+European Space Agency (ESA)
+
+"""
+import pytest
+import os
+import tempfile
+from pyvo import DALQueryError
+from astroquery.esa.emds.einsteinprobe import EinsteinProbeClass
+
+
+def data_path(filename):
+    data_dir = os.path.join(os.path.dirname(__file__), 'data')
+    return os.path.join(data_dir, filename)
+
+
+def close_file(file):
+    file.close()
+
+
+def close_files(file_list):
+    for file in file_list:
+        close_file(file['fits'])
+
+
+def create_temp_folder():
+    return tempfile.TemporaryDirectory()
+
+@pytest.mark.remote_data
+class TestEmdsRemote:
+
+    def test_get_tables(self):
+        epsa = EinsteinProbeClass()
+        names = epsa.get_tables(only_names=True)
+
+        assert isinstance(names, list)
+        assert len(names) > 0
+        assert all(isinstance(n, str) for n in names)
+        assert "einsteinprobe.obscore_extended" in [n.lower() for n in names]
+
+
+    def test_get_table(self):
+        epsa = EinsteinProbeClass()
+
+        obscore = epsa.get_table('einsteinprobe.obscore_extended')
+        assert obscore is not None
+        assert hasattr(obscore, "columns")
+        assert len(obscore.columns) > 0
+
+        # BaseParam objects expose the column name in `.name`
+        colnames = {c.name for c in obscore.columns}
+        for expected in {"obs_id", "s_ra", "s_dec", "obs_collection"}:
+            assert expected in colnames
+
+    def test_query_tap(self):
+        epsa = EinsteinProbeClass()
+
+        # Query an existing table
+        result = epsa.query_tap("SELECT TOP 10 obs_id, s_ra, s_dec FROM einsteinprobe.obscore_extended")
+        assert result is not None
+        assert len(result) > 0
+        assert {"obs_id", "s_ra", "s_dec"}.issubset(set(result.colnames))
+
+        # Query a table that does not exist
+        with pytest.raises(DALQueryError) as err:
+            epsa.query_tap("SELECT TOP 10 * FROM schema.table")
+        assert "Unknown table" in str(err.value) or "does not exist" in str(err.value)
+
+        # Store the result in a file
+        temp_folder = create_temp_folder()
+        filename = os.path.join(temp_folder.name, "query_tap.votable")
+        epsa.query_tap("SELECT TOP 10 obs_id FROM ivoa.ObsCore", output_file=filename)
+        assert os.path.exists(filename)
+
+        temp_folder.cleanup()
+
+    def test_get_observations_metadata(self):
+        epsa = EinsteinProbeClass()
+        meta = epsa.get_observations(get_metadata=True)
+
+        assert meta is not None
+        assert len(meta) > 0
+
+        expected_cols = {"Column", "Description", "Unit", "Data Type", "UCD", "UType"}
+        assert expected_cols.issubset(set(meta.colnames))
+
+        # Check that some ObsCore columns appear in the metadata
+        available = set(meta["Column"])
+        assert {"s_ra", "s_dec"}.issubset(available)
+
+    def test_get_observations_cone_coordinates(self):
+        epsa = EinsteinProbeClass()
+
+        results = epsa.get_observations(
+            coordinates="81.1238 17.4175",
+            radius=0.1,
+            columns=["obs_id", "s_ra", "s_dec"],
+        )
+
+        assert results is not None
+        assert {"obs_id", "s_ra", "s_dec"}.issubset(set(results.colnames))
+
+    def test_get_observations_cone_target_name(self):
+        epsa = EinsteinProbeClass()
+
+        results = epsa.get_observations(
+            target_name="V1589 Cyg",
+            radius=0.1,
+            columns=["obs_id", "s_ra", "s_dec", "target_name"],
+        )
+
+        assert results is not None
+        assert {"obs_id", "s_ra", "s_dec", "target_name"}.issubset(set(results.colnames))
+
+    def test_get_observations_filters(self):
+        epsa = EinsteinProbeClass()
+
+        # Discover one valid obs_collection value
+        missions = epsa.query_tap(
+            "SELECT DISTINCT TOP 10 obs_collection FROM ivoa.ObsCore WHERE obs_collection IS NOT NULL"
+        )
+        assert len(missions) > 0
+        obs_collection = missions["obs_collection"][0]
+
+        # Discover one valid instrument_name for that collection
+        instruments = epsa.query_tap(
+            "SELECT DISTINCT TOP 10 instrument_name "
+            f"FROM ivoa.ObsCore WHERE obs_collection = '{obs_collection}' AND instrument_name IS NOT NULL"
+        )
+        instrument_name = instruments["instrument_name"][0] if len(instruments) > 0 else None
+
+        # Run the filtered search
+        filters = {"obs_collection": obs_collection}
+        if instrument_name is not None:
+            filters["instrument_name"] = instrument_name
+
+        results = epsa.get_observations(
+            columns=["obs_id", "obs_collection", "instrument_name", "dataproduct_type"],
+            **filters,
+        )
+
+        assert results is not None
+        assert {"obs_id", "obs_collection", "instrument_name", "dataproduct_type"}.issubset(
+            set(results.colnames)
+        )
+
+        # If results exist, validate they match filters
+        if len(results) > 0:
+            assert set(results["obs_collection"]) == {obs_collection}
+            if instrument_name is not None:
+                assert set(results["instrument_name"]) == {instrument_name}
+
+    def test_get_observations_output_file(self):
+        epsa = EinsteinProbeClass()
+
+        temp_folder = create_temp_folder()
+        filename = os.path.join(temp_folder.name, "get_observations.votable")
+
+        results = epsa.get_observations(
+            coordinates="81.1238 17.4175",
+            radius=0.1,
+            columns=["obs_id", "s_ra", "s_dec"],
+            output_file=filename,
+        )
+
+        assert os.path.exists(filename)
+        assert results is not None
+        assert {"obs_id", "s_ra", "s_dec"}.issubset(set(results.colnames))
+
+        temp_folder.cleanup()
+
+    def test_get_products(self):
+        epsa = EinsteinProbeClass()
+
+        table = epsa.get_products()
+
+        assert table is not None
+        assert len(table) > 0
+
+        # Mandatory columns for download
+        assert "filename" in table.colnames
+        assert "filepath" in table.colnames
+
+    def test_download_product(self, tmp_path):
+        epsa = EinsteinProbeClass()
+
+        table = epsa.get_products()
+        assert len(table) > 0
+
+        filename = table["filename"][0]
+
+        local_path = epsa.download_product(
+            filename=filename,
+            path=str(tmp_path),
+            output_filename=filename,
+            verbose=True,
+        )
+
+        assert os.path.exists(local_path)
+        assert os.path.getsize(local_path) > 0

--- a/astroquery/esa/emds/einsteinprobe/test/test_einsteinprobe_tap.py
+++ b/astroquery/esa/emds/einsteinprobe/test/test_einsteinprobe_tap.py
@@ -1,0 +1,352 @@
+# Licensed under a 3-clause BSD style license - see LICENSE.rst
+"""
+==========================================
+EinsteinProbe (EPSA) tests
+==========================================
+
+European Space Astronomy Centre (ESAC)
+European Space Agency (ESA)
+
+"""
+import os
+import shutil
+import tempfile
+import pytest
+from unittest.mock import PropertyMock, patch, Mock
+from astropy.table import Table
+from astroquery.esa.emds.einsteinprobe import EinsteinProbeClass
+from astroquery.esa.emds import conf
+from requests import HTTPError
+from astropy.coordinates import SkyCoord
+
+def data_path(filename):
+    data_dir = os.path.join(os.path.dirname(__file__), 'data')
+    return os.path.join(data_dir, filename)
+
+
+def create_temp_folder():
+    return tempfile.TemporaryDirectory()
+
+
+def copy_to_temporal_path(data_path, temp_folder, filename):
+    temp_data_dir = os.path.join(temp_folder.name, filename)
+    shutil.copy(data_path, temp_data_dir)
+    return temp_data_dir
+
+
+def close_file(file):
+    file.close()
+
+
+def close_files(file_list):
+    for file in file_list:
+        close_file(file['fits'])
+
+
+class TestEmdsTap:
+
+    @patch('astroquery.esa.utils.utils.pyvo.dal.TAPService.capabilities', [])
+    @patch('astroquery.esa.emds.einsteinprobe.core.EinsteinProbeClass.tap')
+    @patch('astroquery.esa.utils.utils.pyvo.dal.AsyncTAPJob')
+    def test_load_job(self, epsa_job_mock, mock_tap):
+        jobid = '101'
+        mock_job = Mock()
+        mock_job.job_id = '101'
+        epsa_job_mock.job_id.return_value = '101'
+        mock_tap.get_job.return_value = mock_job
+        epsa = EinsteinProbeClass()
+
+        job = epsa.get_job(jobid=jobid)
+        assert job.job_id == '101'
+
+    @patch('astroquery.esa.utils.utils.pyvo.dal.TAPService.capabilities', [])
+    @patch('astroquery.esa.emds.einsteinprobe.core.EinsteinProbeClass.tap')
+    def test_get_job_list(self, mock_get_job_list):
+        mock_job = Mock()
+        mock_job.job_id = '101'
+        mock_get_job_list.get_job_list.return_value = [mock_job]
+        epsa = EinsteinProbeClass()
+
+        jobs = epsa.get_job_list()
+        assert len(jobs) == 1
+        mock_get_job_list.get_job_list.assert_called_once()
+
+    @patch('astroquery.esa.utils.utils.pyvo.dal.TAPService.capabilities', [])
+    @patch('astroquery.esa.utils.utils.ESAAuthSession.post')
+    def test_login_success(self, mock_post):
+        mock_response = Mock()
+        mock_response.raise_for_status.return_value = None  # Simulate no HTTP error
+        mock_response.json.return_value = {"status": "success", "token": "mocked_token"}
+
+        # Configure the mock post method to return the mock Response
+        mock_post.return_value = mock_response
+        epsa = EinsteinProbeClass()
+        epsa.login(user='dummyUser', password='dummyPassword')
+
+        mock_post.assert_called_once_with(url=conf.EMDS_LOGIN_SERVER,
+                                          data={"username": "dummyUser", "password": "dummyPassword"},
+                                          headers={'Content-type': 'application/x-www-form-urlencoded',
+                                                   'Accept': 'text/plain'})
+        mock_response.raise_for_status.assert_called_once()
+
+    @patch("astroquery.esa.utils.utils.pyvo.dal.TAPService.capabilities", [])
+    @patch("astroquery.esa.utils.utils.ESAAuthSession.post")
+    def test_login_error(self, mock_post):
+        error_message = "Mocked HTTP error"
+
+        mock_response = Mock()
+        mock_response.raise_for_status.side_effect = HTTPError(error_message)
+        mock_response.json.return_value = {"status": "error"}
+
+        mock_post.return_value = mock_response
+
+        epsa = EinsteinProbeClass()
+        with pytest.raises(HTTPError) as err:
+            epsa.login(user="dummyUser", password="dummyPassword")
+
+        assert error_message in str(err.value)
+        mock_response.raise_for_status.assert_called_once()
+
+    @patch('astroquery.esa.utils.utils.pyvo.dal.TAPService.capabilities', [])
+    @patch('astroquery.esa.utils.utils.ESAAuthSession.post')
+    def test_logout_success(self, mock_post):
+        mock_response = Mock()
+        mock_response.raise_for_status.return_value = None  # Simulate no HTTP error
+        mock_response.json.return_value = {"status": "success", "token": "mocked_token"}
+
+        # Configure the mock post method to return the mock Response
+        mock_post.return_value = mock_response
+        epsa = EinsteinProbeClass()
+        epsa.logout()
+
+        mock_post.assert_called_once_with(url=conf.EMDS_LOGOUT_SERVER,
+                                          headers={'Content-type': 'application/x-www-form-urlencoded',
+                                                   'Accept': 'text/plain'})
+        mock_response.raise_for_status.assert_called_once()
+
+    @patch("astroquery.esa.utils.utils.pyvo.dal.TAPService.capabilities", [])
+    @patch("astroquery.esa.utils.utils.ESAAuthSession.post")
+    def test_logout_error(self, mock_post):
+        error_message = "Mocked HTTP error"
+
+        mock_response = Mock()
+        mock_response.raise_for_status.side_effect = HTTPError(error_message)
+        mock_response.json.return_value = {"status": "error"}
+
+        mock_post.return_value = mock_response
+
+        epsa = EinsteinProbeClass()
+        with pytest.raises(HTTPError) as err:
+            epsa.logout()
+
+        assert error_message in str(err.value)
+        mock_response.raise_for_status.assert_called_once()
+
+    def test_get_tables(self):
+        table_set = PropertyMock()
+        table_set.keys.return_value = ["einsteinprobe.obscore_extended"]
+
+        t1 = Mock()
+        t1.name = "einsteinprobe.obscore_extended"
+        table_set.values.return_value = [t1]
+
+        with patch("astroquery.esa.utils.utils.pyvo.dal.TAPService", autospec=True) as tap_mock:
+            tap_mock.return_value.tables = table_set
+            epsa = EinsteinProbeClass()
+            assert len(epsa.get_tables(only_names=True)) == 1
+            assert len(epsa.get_tables()) == 1
+
+    @patch("astroquery.esa.utils.utils.pyvo.dal.TAPService.capabilities", [])
+    @patch("astropy.table.Table.write")
+    @patch("astroquery.esa.utils.utils.pyvo.dal.TAPService.search")
+    def test_query_tap_sync(self, search_mock, table_write_mock):
+        # Simulate pyvo search() result with a .to_table() method
+        mock_result = Mock()
+        mock_result.to_table.return_value = Table({"a": [1]})
+        search_mock.return_value = mock_result
+
+        epsa = EinsteinProbeClass()
+        epsa.query_tap(query="SELECT 1", output_file="dummy.vot")
+
+        search_mock.assert_called_once_with("SELECT 1")
+        table_write_mock.assert_called()  # called when writing output_file
+
+    @patch("astroquery.esa.utils.utils.pyvo.dal.TAPService.capabilities", [])
+    @patch("astroquery.esa.utils.utils.pyvo.dal.TAPService.run_async")
+    def test_query_tap_async(self, run_async_mock):
+        mock_job = Mock()
+        mock_job.to_table.return_value = Table({"a": [1]})
+        run_async_mock.return_value = mock_job
+
+        epsa = EinsteinProbeClass()
+        epsa.query_tap(query="SELECT 1", async_job=True)
+
+        run_async_mock.assert_called_once()
+
+    @patch("astroquery.esa.utils.utils.pyvo.dal.TAPService.capabilities", [])
+    @patch("astroquery.esa.emds.einsteinprobe.core.EinsteinProbeClass.query_table")
+    def test_get_observations_basic_calls_query_table(self, query_table_mock):
+        epsa = EinsteinProbeClass()
+        epsa.get_observations()
+
+        query_table_mock.assert_called_once_with(
+            table_name="einsteinprobe.obscore_extended",
+            columns=None,
+            custom_filters=None,
+            get_metadata=False,
+            async_job=True,
+            output_file=None,
+        )
+
+    @patch("astroquery.esa.utils.utils.pyvo.dal.TAPService.capabilities", [])
+    @patch("astroquery.esa.emds.einsteinprobe.core.EinsteinProbeClass.query_table")
+    def test_get_observations_with_columns(self, query_table_mock):
+        epsa = EinsteinProbeClass()
+        epsa.get_observations(columns=["obs_id", "s_ra", "s_dec"])
+
+        query_table_mock.assert_called_once_with(
+            table_name="einsteinprobe.obscore_extended",
+            columns=["obs_id", "s_ra", "s_dec"],
+            custom_filters=None,
+            get_metadata=False,
+            async_job=True,
+            output_file=None,
+        )
+
+    def test_get_observations_error_target_and_coordinates(self):
+        epsa = EinsteinProbeClass()
+
+        with pytest.raises(TypeError) as err:
+            epsa.get_observations(target_name="M31", coordinates="12 13")
+
+        assert "Please use only target or coordinates" in str(err.value)
+
+    @patch("astroquery.esa.utils.utils.pyvo.dal.TAPService.capabilities", [])
+    @patch("astroquery.esa.emds.einsteinprobe.core.EinsteinProbeClass.query_table")
+    def test_get_observations_with_filters(self, query_table_mock):
+        epsa = EinsteinProbeClass()
+        epsa.get_observations(
+            columns=["obs_id", "obs_collection", "instrument_name"],
+            obs_collection="EPSA",
+            instrument_name="FXT",
+            dataproduct_type=["img", "pha"],
+            t_min=(">", 60000),
+        )
+
+        query_table_mock.assert_called_once()
+
+        # Check core arguments
+        _, kwargs = query_table_mock.call_args
+        assert kwargs["table_name"] == "einsteinprobe.obscore_extended"
+        assert kwargs["columns"] == ["obs_id", "obs_collection", "instrument_name"]
+        assert kwargs["custom_filters"] is None
+        assert kwargs["get_metadata"] is False
+        assert kwargs["async_job"] is True
+        assert kwargs["output_file"] is None
+
+        # Check that filters are forwarded
+        assert kwargs["obs_collection"] == "EPSA"
+        assert kwargs["instrument_name"] == "FXT"
+        assert kwargs["dataproduct_type"] == ["img", "pha"]
+        assert kwargs["t_min"] == (">", 60000)
+
+    @patch("astroquery.esa.utils.utils.pyvo.dal.TAPService.capabilities", [])
+    @patch("astroquery.esa.emds.einsteinprobe.core.EinsteinProbeClass.query_table")
+    def test_get_observations_get_metadata(self, query_table_mock):
+        epsa = EinsteinProbeClass()
+        epsa.get_observations(get_metadata=True)
+
+        query_table_mock.assert_called_once()
+
+        _, kwargs = query_table_mock.call_args
+        assert kwargs["table_name"] == "einsteinprobe.obscore_extended"
+        assert kwargs["get_metadata"] is True
+        assert kwargs["async_job"] is True
+
+    @patch("astroquery.esa.utils.utils.pyvo.dal.TAPService.capabilities", [])
+    @patch("astroquery.esa.emds.core.commons.parse_coordinates")
+    @patch("astroquery.esa.emds.einsteinprobe.core.EinsteinProbeClass.query_table")
+    def test_get_observations_coordinates_builds_cone_filter(
+        self, query_table_mock, parse_coordinates_mock
+    ):
+        # Force deterministic coordinates
+        parse_coordinates_mock.return_value = SkyCoord(ra=12, dec=13, unit="deg")
+
+        epsa = EinsteinProbeClass()
+        epsa.get_observations(coordinates="12 13", radius=1.0)
+
+        query_table_mock.assert_called_once()
+        _, kwargs = query_table_mock.call_args
+
+        assert kwargs["table_name"] == "einsteinprobe.obscore_extended"
+        assert kwargs["async_job"] is True
+
+        cone = kwargs["custom_filters"]
+        assert cone is not None
+        assert "CONTAINS" in cone
+        assert "CIRCLE" in cone
+        assert "s_ra" in cone
+        assert "s_dec" in cone
+        assert "12.0" in cone
+        assert "13.0" in cone
+
+    @patch("astroquery.esa.utils.utils.pyvo.dal.TAPService.capabilities", [])
+    @patch("astroquery.esa.emds.core.esautils.resolve_target")
+    @patch("astroquery.esa.emds.einsteinprobe.core.EinsteinProbeClass.query_table")
+    def test_get_observations_target_name_builds_cone_filter(
+        self, query_table_mock, resolve_target_mock
+    ):
+        resolve_target_mock.return_value = SkyCoord(ra=12, dec=13, unit="deg")
+
+        epsa = EinsteinProbeClass()
+        epsa.get_observations(target_name="M31", radius=1.0)
+
+        query_table_mock.assert_called_once()
+        _, kwargs = query_table_mock.call_args
+
+        assert kwargs["table_name"] == "einsteinprobe.obscore_extended"
+        assert kwargs["async_job"] is True
+
+        cone = kwargs["custom_filters"]
+        assert cone is not None
+        assert "CONTAINS" in cone
+        assert "CIRCLE" in cone
+        assert "s_ra" in cone
+        assert "s_dec" in cone
+        assert "12.0" in cone
+        assert "13.0" in cone
+
+    def test_get_products_adds_required_columns(self):
+        epsa = EinsteinProbeClass()
+        # epsa.epsaconf.OBSCORE_TABLE = "einsteinprobe.obscore_extended"
+
+        with patch.object(EinsteinProbeClass, "query_table", autospec=True) as qmock:
+            epsa.get_products(
+                obs_id="OBS123",
+                columns=["obs_id", "dataproduct_type"]
+            )
+
+            assert qmock.called
+            _, kwargs = qmock.call_args
+
+            assert kwargs["table_name"] == "einsteinprobe.obscore_extended"
+
+            # Required download columns appended
+            cols = kwargs["columns"]
+            assert "filename" in cols
+            assert "filepath" in cols
+
+            assert "custom_filters" in kwargs
+            assert "OBS123" in (kwargs["custom_filters"] or "")
+
+    def test_get_products_default_columns_include_download_fields(self):
+        epsa = EinsteinProbeClass()
+        # epsa.conf.OBSCORE_TABLE = "einsteinprobe.obscore_extended"
+
+        with patch.object(EinsteinProbeClass, "query_table", autospec=True) as qmock:
+            epsa.get_products(obs_id="OBS123")
+
+            _, kwargs = qmock.call_args
+            cols = kwargs["columns"]
+            assert "filename" in cols
+            assert "filepath" in cols

--- a/astroquery/esa/emds/einsteinprobe/test/test_einsteinprobe_tap.py
+++ b/astroquery/esa/emds/einsteinprobe/test/test_einsteinprobe_tap.py
@@ -19,6 +19,7 @@ from astroquery.esa.emds import conf
 from requests import HTTPError
 from astropy.coordinates import SkyCoord
 
+
 def data_path(filename):
     data_dir = os.path.join(os.path.dirname(__file__), 'data')
     return os.path.join(data_dir, filename)

--- a/astroquery/esa/emds/einsteinprobe/test/test_einsteinprobe_tap.py
+++ b/astroquery/esa/emds/einsteinprobe/test/test_einsteinprobe_tap.py
@@ -319,7 +319,6 @@ class TestEmdsTap:
 
     def test_get_products_adds_required_columns(self):
         epsa = EinsteinProbeClass()
-        # epsa.epsaconf.OBSCORE_TABLE = "einsteinprobe.obscore_extended"
 
         with patch.object(EinsteinProbeClass, "query_table", autospec=True) as qmock:
             epsa.get_products(
@@ -342,7 +341,6 @@ class TestEmdsTap:
 
     def test_get_products_default_columns_include_download_fields(self):
         epsa = EinsteinProbeClass()
-        # epsa.conf.OBSCORE_TABLE = "einsteinprobe.obscore_extended"
 
         with patch.object(EinsteinProbeClass, "query_table", autospec=True) as qmock:
             epsa.get_products(obs_id="OBS123")

--- a/astroquery/esa/emds/einsteinprobe/test/test_einsteinprobe_tap.py
+++ b/astroquery/esa/emds/einsteinprobe/test/test_einsteinprobe_tap.py
@@ -389,4 +389,3 @@ class TestEmdsTap:
         with pytest.raises(ValueError) as err:
             epsa.download_product("dummy_file")
         assert 'OBSCORE_TABLE is not configured for EinsteinProbe.' in err.value.args[0]
-

--- a/astroquery/esa/emds/einsteinprobe/test/test_einsteinprobe_tap.py
+++ b/astroquery/esa/emds/einsteinprobe/test/test_einsteinprobe_tap.py
@@ -389,3 +389,7 @@ class TestEmdsTap:
         with pytest.raises(ValueError) as err:
             epsa.download_product("dummy_file")
         assert 'OBSCORE_TABLE is not configured for EinsteinProbe.' in err.value.args[0]
+
+        # Restart overriden parameters
+        epsa.conf.OBSCORE_TABLE = 'einsteinprobe.obscore_extended'
+        epsa.conf.EMDS_DATA_SERVER = 'data?'

--- a/astroquery/esa/emds/einsteinprobe/test/test_einsteinprobe_tap.py
+++ b/astroquery/esa/emds/einsteinprobe/test/test_einsteinprobe_tap.py
@@ -321,10 +321,8 @@ class TestEmdsTap:
         epsa = EinsteinProbeClass()
 
         with patch.object(EinsteinProbeClass, "query_table", autospec=True) as qmock:
-            epsa.get_products(
-                obs_id="OBS123",
-                columns=["obs_id", "dataproduct_type"]
-            )
+            epsa.get_products(observation_id="OBS123",
+                              columns=["obs_id", "dataproduct_type"])
 
             assert qmock.called
             _, kwargs = qmock.call_args
@@ -343,7 +341,7 @@ class TestEmdsTap:
         epsa = EinsteinProbeClass()
 
         with patch.object(EinsteinProbeClass, "query_table", autospec=True) as qmock:
-            epsa.get_products(obs_id="OBS123")
+            epsa.get_products(observation_id="OBS123")
 
             _, kwargs = qmock.call_args
             cols = kwargs["columns"]
@@ -354,7 +352,7 @@ class TestEmdsTap:
         epsa = EinsteinProbeClass()
 
         with patch.object(EinsteinProbeClass, "query_table", autospec=True) as qmock:
-            epsa.get_products(obs_id="OBS123")
+            epsa.get_products(observation_id="OBS123")
 
             _, kwargs = qmock.call_args
             cols = kwargs["columns"]

--- a/astroquery/esa/emds/tests/test_emds_remote.py
+++ b/astroquery/esa/emds/tests/test_emds_remote.py
@@ -60,9 +60,9 @@ class TestEmdsRemote:
         for expected in {"obs_id", "s_ra", "s_dec", "obs_collection"}:
             assert expected in colnames
 
-    def test_get_emds_missions(self):
+    def test_get_missions(self):
         emds = EmdsClass()
-        missions = emds.get_emds_missions()
+        missions = emds.get_missions()
 
         assert missions is not None
         assert len(missions) > 0

--- a/astroquery/esa/emds/tests/test_emds_remote.py
+++ b/astroquery/esa/emds/tests/test_emds_remote.py
@@ -1,0 +1,196 @@
+# Licensed under a 3-clause BSD style license - see LICENSE.rst
+"""
+==========================================
+Multi-Mission Data Services (EMDS) tests
+==========================================
+
+European Space Astronomy Centre (ESAC)
+European Space Agency (ESA)
+
+"""
+import pytest
+import os
+import tempfile
+
+from pyvo import DALQueryError
+
+from astroquery.esa.emds import EmdsClass
+
+def data_path(filename):
+    data_dir = os.path.join(os.path.dirname(__file__), 'data')
+    return os.path.join(data_dir, filename)
+
+
+def close_file(file):
+    file.close()
+
+
+def close_files(file_list):
+    for file in file_list:
+        close_file(file['fits'])
+
+
+def create_temp_folder():
+    return tempfile.TemporaryDirectory()
+
+
+@pytest.mark.remote_data
+class TestEmdsRemote:
+
+    def test_get_tables(self):
+        emds = EmdsClass()
+        names = emds.get_tables(only_names=True)
+
+        assert isinstance(names, list)
+        assert len(names) > 0
+        assert all(isinstance(n, str) for n in names)
+        assert "ivoa.obscore" in [n.lower() for n in names]
+
+
+    def test_get_table(self):
+        emds = EmdsClass()
+
+        obscore = emds.get_table('ivoa.ObsCore')
+        assert obscore is not None
+        assert hasattr(obscore, "columns")
+        assert len(obscore.columns) > 0
+
+        # BaseParam objects expose the column name in `.name`
+        colnames = {c.name for c in obscore.columns}
+        for expected in {"obs_id", "s_ra", "s_dec", "obs_collection"}:
+            assert expected in colnames
+
+    def test_get_emds_missions(self):
+        emds = EmdsClass()
+        missions = emds.get_emds_missions()
+
+        assert missions is not None
+        assert len(missions) > 0
+        assert "obs_collection" in missions.colnames
+
+        # The query filters out NULL values, so obs_collection should not be null/masked
+        col = missions["obs_collection"]
+        if hasattr(col, "mask"):
+            assert (~col.mask).all()
+        else:
+            assert all(v is not None for v in col)
+
+    def test_query_tap(self):
+        emds = EmdsClass()
+
+        # Query an existing table
+        result = emds.query_tap("SELECT TOP 10 obs_id, s_ra, s_dec FROM ivoa.ObsCore")
+        assert result is not None
+        assert len(result) > 0
+        assert {"obs_id", "s_ra", "s_dec"}.issubset(set(result.colnames))
+
+        # Query a table that does not exist
+        with pytest.raises(DALQueryError) as err:
+            emds.query_tap("SELECT TOP 10 * FROM schema.table")
+        assert "Unknown table" in str(err.value) or "does not exist" in str(err.value)
+
+        # Store the result in a file
+        temp_folder = create_temp_folder()
+        filename = os.path.join(temp_folder.name, "query_tap.votable")
+        emds.query_tap("SELECT TOP 10 obs_id FROM ivoa.ObsCore", output_file=filename)
+        assert os.path.exists(filename)
+
+        temp_folder.cleanup()
+
+    def test_get_observations_metadata(self):
+        emds = EmdsClass()
+        meta = emds.get_observations(get_metadata=True)
+
+        assert meta is not None
+        assert len(meta) > 0
+
+        expected_cols = {"Column", "Description", "Unit", "Data Type", "UCD", "UType"}
+        assert expected_cols.issubset(set(meta.colnames))
+
+        # Check that some ObsCore columns appear in the metadata
+        available = set(meta["Column"])
+        assert {"s_ra", "s_dec"}.issubset(available)
+
+    def test_get_observations_cone_coordinates(self):
+        emds = EmdsClass()
+
+        results = emds.get_observations(
+            coordinates="81.1238 17.4175",
+            radius=0.1,
+            columns=["obs_id", "s_ra", "s_dec"],
+        )
+
+        assert results is not None
+        assert {"obs_id", "s_ra", "s_dec"}.issubset(set(results.colnames))
+
+    def test_get_observations_cone_target_name(self):
+        emds = EmdsClass()
+
+        results = emds.get_observations(
+            target_name="V1589 Cyg",
+            radius=0.1,
+            columns=["obs_id", "s_ra", "s_dec", "target_name"],
+        )
+
+        assert results is not None
+        assert {"obs_id", "s_ra", "s_dec", "target_name"}.issubset(set(results.colnames))
+
+    def test_get_observations_filters(self):
+        emds = EmdsClass()
+
+        # Discover one valid obs_collection value
+        missions = emds.query_tap(
+            "SELECT DISTINCT TOP 10 obs_collection FROM ivoa.ObsCore WHERE obs_collection IS NOT NULL"
+        )
+        assert len(missions) > 0
+        obs_collection = missions["obs_collection"][0]
+
+        # Discover one valid instrument_name for that collection
+        instruments = emds.query_tap(
+            "SELECT DISTINCT TOP 10 instrument_name "
+            f"FROM ivoa.ObsCore WHERE obs_collection = '{obs_collection}' AND instrument_name IS NOT NULL"
+        )
+        instrument_name = instruments["instrument_name"][0] if len(instruments) > 0 else None
+
+        # Run the filtered search
+        filters = {"obs_collection": obs_collection}
+        if instrument_name is not None:
+            filters["instrument_name"] = instrument_name
+
+        results = emds.get_observations(
+            columns=["obs_id", "obs_collection", "instrument_name", "dataproduct_type"],
+            **filters,
+        )
+
+        assert results is not None
+        assert {"obs_id", "obs_collection", "instrument_name", "dataproduct_type"}.issubset(
+            set(results.colnames)
+        )
+
+        # If results exist, validate they match filters
+        if len(results) > 0:
+            assert set(results["obs_collection"]) == {obs_collection}
+            if instrument_name is not None:
+                assert set(results["instrument_name"]) == {instrument_name}
+
+    def test_get_observations_output_file(self):
+        emds = EmdsClass()
+
+        temp_folder = create_temp_folder()
+        filename = os.path.join(temp_folder.name, "get_observations.votable")
+
+        results = emds.get_observations(
+            coordinates="81.1238 17.4175",
+            radius=0.1,
+            columns=["obs_id", "s_ra", "s_dec"],
+            output_file=filename,
+        )
+
+        # File should exist regardless of number of rows
+        assert os.path.exists(filename)
+
+        # The returned table should have the requested columns
+        assert results is not None
+        assert {"obs_id", "s_ra", "s_dec"}.issubset(set(results.colnames))
+
+        temp_folder.cleanup()

--- a/astroquery/esa/emds/tests/test_emds_remote.py
+++ b/astroquery/esa/emds/tests/test_emds_remote.py
@@ -194,3 +194,31 @@ class TestEmdsRemote:
         assert {"obs_id", "s_ra", "s_dec"}.issubset(set(results.colnames))
 
         temp_folder.cleanup()
+
+    def test_get_products(self):
+        emds = EmdsClass()
+
+        table = emds.get_products()
+
+        assert table is not None
+        assert len(table) > 0
+
+        # Mandatory columns for download
+        assert "access_url" in table.colnames
+        assert "obs_publisher_did" in table.colnames
+
+    def test_download_product(self, tmp_path):
+        emds = EmdsClass()
+
+        products = emds.get_products(target_name="RXCJ0120.9-1351")
+        if len(products) == 0:
+            pytest.skip("No products returned for target_name; remote dataset may have changed.")
+
+        products = products[:1]
+        local_path = emds.download_products(products, path=tmp_path)
+        paths = local_path if isinstance(local_path, (list, tuple)) else [local_path]
+
+        assert len(paths) > 0
+        for p in paths:
+            assert os.path.exists(p)
+            assert os.path.getsize(p) > 0

--- a/astroquery/esa/emds/tests/test_emds_remote.py
+++ b/astroquery/esa/emds/tests/test_emds_remote.py
@@ -16,6 +16,7 @@ from pyvo import DALQueryError
 
 from astroquery.esa.emds import EmdsClass
 
+
 def data_path(filename):
     data_dir = os.path.join(os.path.dirname(__file__), 'data')
     return os.path.join(data_dir, filename)
@@ -45,7 +46,6 @@ class TestEmdsRemote:
         assert len(names) > 0
         assert all(isinstance(n, str) for n in names)
         assert "ivoa.obscore" in [n.lower() for n in names]
-
 
     def test_get_table(self):
         emds = EmdsClass()

--- a/astroquery/esa/emds/tests/test_emds_remote.py
+++ b/astroquery/esa/emds/tests/test_emds_remote.py
@@ -60,9 +60,9 @@ class TestEmdsRemote:
         for expected in {"obs_id", "s_ra", "s_dec", "obs_collection"}:
             assert expected in colnames
 
-    def test_get_missions(self):
+    def test_list_missions(self):
         emds = EmdsClass()
-        missions = emds.get_missions()
+        missions = emds.list_missions()
 
         assert missions is not None
         assert len(missions) > 0

--- a/astroquery/esa/emds/tests/test_emds_tap.py
+++ b/astroquery/esa/emds/tests/test_emds_tap.py
@@ -158,9 +158,9 @@ class TestEmdsTap:
 
     @patch("astroquery.esa.utils.utils.pyvo.dal.TAPService.capabilities", [])
     @patch("astroquery.esa.emds.core.EmdsClass.query_tap")
-    def test_get_emds_missions_calls_query_tap(self, query_tap_mock):
+    def test_get_missions_calls_query_tap(self, query_tap_mock):
         emds = EmdsClass()
-        emds.get_emds_missions()
+        emds.get_missions()
 
         query_tap_mock.assert_called_once()
         args, kwargs = query_tap_mock.call_args

--- a/astroquery/esa/emds/tests/test_emds_tap.py
+++ b/astroquery/esa/emds/tests/test_emds_tap.py
@@ -1,0 +1,333 @@
+# Licensed under a 3-clause BSD style license - see LICENSE.rst
+"""
+==========================================
+Multi-Mission Data Services (EMDS) tests
+==========================================
+
+European Space Astronomy Centre (ESAC)
+European Space Agency (ESA)
+
+"""
+import os
+import shutil
+import tempfile
+import pytest
+from unittest.mock import PropertyMock, patch, Mock
+from astropy.table import Table
+from astroquery.esa.emds import EmdsClass
+from astroquery.esa.emds import conf
+from requests import HTTPError
+from astropy.coordinates import SkyCoord
+
+def data_path(filename):
+    data_dir = os.path.join(os.path.dirname(__file__), 'data')
+    return os.path.join(data_dir, filename)
+
+
+def create_temp_folder():
+    return tempfile.TemporaryDirectory()
+
+
+def copy_to_temporal_path(data_path, temp_folder, filename):
+    temp_data_dir = os.path.join(temp_folder.name, filename)
+    shutil.copy(data_path, temp_data_dir)
+    return temp_data_dir
+
+
+def close_file(file):
+    file.close()
+
+
+def close_files(file_list):
+    for file in file_list:
+        close_file(file['fits'])
+
+
+class TestEmdsTap:
+
+    @patch('astroquery.esa.utils.utils.pyvo.dal.TAPService.capabilities', [])
+    @patch('astroquery.esa.emds.core.EmdsClass.tap')
+    @patch('astroquery.esa.utils.utils.pyvo.dal.AsyncTAPJob')
+    def test_load_job(self, emds_job_mock, mock_tap):
+        jobid = '101'
+        mock_job = Mock()
+        mock_job.job_id = '101'
+        emds_job_mock.job_id.return_value = '101'
+        mock_tap.get_job.return_value = mock_job
+        emds =EmdsClass()
+
+        job = emds.get_job(jobid=jobid)
+        assert job.job_id == '101'
+
+    @patch('astroquery.esa.utils.utils.pyvo.dal.TAPService.capabilities', [])
+    @patch('astroquery.esa.emds.core.EmdsClass.tap')
+    def test_get_job_list(self, mock_get_job_list):
+        mock_job = Mock()
+        mock_job.job_id = '101'
+        mock_get_job_list.get_job_list.return_value = [mock_job]
+        emds = EmdsClass()
+
+        jobs = emds.get_job_list()
+        assert len(jobs) == 1
+        mock_get_job_list.get_job_list.assert_called_once()
+
+    @patch('astroquery.esa.utils.utils.pyvo.dal.TAPService.capabilities', [])
+    @patch('astroquery.esa.utils.utils.ESAAuthSession.post')
+    def test_login_success(self, mock_post):
+        mock_response = Mock()
+        mock_response.raise_for_status.return_value = None  # Simulate no HTTP error
+        mock_response.json.return_value = {"status": "success", "token": "mocked_token"}
+
+        # Configure the mock post method to return the mock Response
+        mock_post.return_value = mock_response
+        emds = EmdsClass()
+        emds.login(user='dummyUser', password='dummyPassword')
+
+        mock_post.assert_called_once_with(url=conf.EMDS_LOGIN_SERVER,
+                                          data={"username": "dummyUser", "password": "dummyPassword"},
+                                          headers={'Content-type': 'application/x-www-form-urlencoded',
+                                                   'Accept': 'text/plain'})
+        mock_response.raise_for_status.assert_called_once()
+
+    @patch("astroquery.esa.utils.utils.pyvo.dal.TAPService.capabilities", [])
+    @patch("astroquery.esa.utils.utils.ESAAuthSession.post")
+    def test_login_error(self, mock_post):
+        error_message = "Mocked HTTP error"
+
+        mock_response = Mock()
+        mock_response.raise_for_status.side_effect = HTTPError(error_message)
+        mock_response.json.return_value = {"status": "error"}
+
+        mock_post.return_value = mock_response
+
+        emds = EmdsClass()
+        with pytest.raises(HTTPError) as err:
+            emds.login(user="dummyUser", password="dummyPassword")
+
+        assert error_message in str(err.value)
+        mock_response.raise_for_status.assert_called_once()
+
+    @patch('astroquery.esa.utils.utils.pyvo.dal.TAPService.capabilities', [])
+    @patch('astroquery.esa.utils.utils.ESAAuthSession.post')
+    def test_logout_success(self, mock_post):
+        mock_response = Mock()
+        mock_response.raise_for_status.return_value = None  # Simulate no HTTP error
+        mock_response.json.return_value = {"status": "success", "token": "mocked_token"}
+
+        # Configure the mock post method to return the mock Response
+        mock_post.return_value = mock_response
+        emds = EmdsClass()
+        emds.logout()
+
+        mock_post.assert_called_once_with(url=conf.EMDS_LOGOUT_SERVER,
+                                          headers={'Content-type': 'application/x-www-form-urlencoded',
+                                                   'Accept': 'text/plain'})
+        mock_response.raise_for_status.assert_called_once()
+
+    @patch("astroquery.esa.utils.utils.pyvo.dal.TAPService.capabilities", [])
+    @patch("astroquery.esa.utils.utils.ESAAuthSession.post")
+    def test_logout_error(self, mock_post):
+        error_message = "Mocked HTTP error"
+
+        mock_response = Mock()
+        mock_response.raise_for_status.side_effect = HTTPError(error_message)
+        mock_response.json.return_value = {"status": "error"}
+
+        mock_post.return_value = mock_response
+
+        emds = EmdsClass()
+        with pytest.raises(HTTPError) as err:
+            emds.logout()
+
+        assert error_message in str(err.value)
+        mock_response.raise_for_status.assert_called_once()
+
+    def test_get_tables(self):
+        table_set = PropertyMock()
+        table_set.keys.return_value = ["ivoa.ObsCore"]
+
+        t1 = Mock()
+        t1.name = "ivoa.ObsCore"
+        table_set.values.return_value = [t1]
+
+        with patch("astroquery.esa.utils.utils.pyvo.dal.TAPService", autospec=True) as tap_mock:
+            tap_mock.return_value.tables = table_set
+            emds = EmdsClass()
+            assert len(emds.get_tables(only_names=True)) == 1
+            assert len(emds.get_tables()) == 1
+
+    @patch("astroquery.esa.utils.utils.pyvo.dal.TAPService.capabilities", [])
+    @patch("astroquery.esa.emds.core.EmdsClass.query_tap")
+    def test_get_emds_missions_calls_query_tap(self, query_tap_mock):
+        emds = EmdsClass()
+        emds.get_emds_missions()
+
+        query_tap_mock.assert_called_once()
+        args, kwargs = query_tap_mock.call_args
+        query = kwargs.get("query", args[0] if args else "")
+
+        q = query.lower()
+        assert "select distinct" in q
+        assert "obs_collection" in q
+        assert "from ivoa.obscore" in q
+        assert "is not null" in q
+
+    @patch("astroquery.esa.utils.utils.pyvo.dal.TAPService.capabilities", [])
+    @patch("astropy.table.Table.write")
+    @patch("astroquery.esa.utils.utils.pyvo.dal.TAPService.search")
+    def test_query_tap_sync(self, search_mock, table_write_mock):
+        # Simulate pyvo search() result with a .to_table() method
+        mock_result = Mock()
+        mock_result.to_table.return_value = Table({"a": [1]})
+        search_mock.return_value = mock_result
+
+        emds = EmdsClass()
+        emds.query_tap(query="SELECT 1", output_file="dummy.vot")
+
+        search_mock.assert_called_once_with("SELECT 1")
+        table_write_mock.assert_called()  # called when writing output_file
+
+    @patch("astroquery.esa.utils.utils.pyvo.dal.TAPService.capabilities", [])
+    @patch("astroquery.esa.utils.utils.pyvo.dal.TAPService.run_async")
+    def test_query_tap_async(self, run_async_mock):
+        mock_job = Mock()
+        mock_job.to_table.return_value = Table({"a": [1]})
+        run_async_mock.return_value = mock_job
+
+        emds = EmdsClass()
+        emds.query_tap(query="SELECT 1", async_job=True)
+
+        run_async_mock.assert_called_once()
+
+    @patch("astroquery.esa.utils.utils.pyvo.dal.TAPService.capabilities", [])
+    @patch("astroquery.esa.emds.core.EmdsClass.query_table")
+    def test_get_observations_basic_calls_query_table(self, query_table_mock):
+        emds = EmdsClass()
+        emds.get_observations()
+
+        query_table_mock.assert_called_once_with(
+            table_name="ivoa.ObsCore",
+            columns=None,
+            custom_filters=None,
+            get_metadata=False,
+            async_job=True,
+            output_file=None,
+        )
+
+    @patch("astroquery.esa.utils.utils.pyvo.dal.TAPService.capabilities", [])
+    @patch("astroquery.esa.emds.core.EmdsClass.query_table")
+    def test_get_observations_with_columns(self, query_table_mock):
+        emds = EmdsClass()
+        emds.get_observations(columns=["obs_id", "s_ra", "s_dec"])
+
+        query_table_mock.assert_called_once_with(
+            table_name="ivoa.ObsCore",
+            columns=["obs_id", "s_ra", "s_dec"],
+            custom_filters=None,
+            get_metadata=False,
+            async_job=True,
+            output_file=None,
+        )
+
+    def test_get_observations_error_target_and_coordinates(self):
+        emds = EmdsClass()
+
+        with pytest.raises(TypeError) as err:
+            emds.get_observations(target_name="M31", coordinates="12 13")
+
+        assert "Please use only target or coordinates" in str(err.value)
+
+    @patch("astroquery.esa.utils.utils.pyvo.dal.TAPService.capabilities", [])
+    @patch("astroquery.esa.emds.core.EmdsClass.query_table")
+    def test_get_observations_with_filters(self, query_table_mock):
+        emds = EmdsClass()
+        emds.get_observations(
+            columns=["obs_id", "obs_collection", "instrument_name"],
+            obs_collection="EPSA",
+            instrument_name="FXT",
+            dataproduct_type=["img", "pha"],
+            t_min=(">", 60000),
+        )
+
+        query_table_mock.assert_called_once()
+
+        # Check core arguments
+        _, kwargs = query_table_mock.call_args
+        assert kwargs["table_name"] == "ivoa.ObsCore"
+        assert kwargs["columns"] == ["obs_id", "obs_collection", "instrument_name"]
+        assert kwargs["custom_filters"] is None
+        assert kwargs["get_metadata"] is False
+        assert kwargs["async_job"] is True
+        assert kwargs["output_file"] is None
+
+        # Check that filters are forwarded
+        assert kwargs["obs_collection"] == "EPSA"
+        assert kwargs["instrument_name"] == "FXT"
+        assert kwargs["dataproduct_type"] == ["img", "pha"]
+        assert kwargs["t_min"] == (">", 60000)
+
+    @patch("astroquery.esa.utils.utils.pyvo.dal.TAPService.capabilities", [])
+    @patch("astroquery.esa.emds.core.EmdsClass.query_table")
+    def test_get_observations_get_metadata(self, query_table_mock):
+        emds = EmdsClass()
+        emds.get_observations(get_metadata=True)
+
+        query_table_mock.assert_called_once()
+
+        _, kwargs = query_table_mock.call_args
+        assert kwargs["table_name"] == "ivoa.ObsCore"
+        assert kwargs["get_metadata"] is True
+        assert kwargs["async_job"] is True
+
+    @patch("astroquery.esa.utils.utils.pyvo.dal.TAPService.capabilities", [])
+    @patch("astroquery.esa.emds.core.commons.parse_coordinates")
+    @patch("astroquery.esa.emds.core.EmdsClass.query_table")
+    def test_get_observations_coordinates_builds_cone_filter(
+        self, query_table_mock, parse_coordinates_mock
+    ):
+        # Force deterministic coordinates
+        parse_coordinates_mock.return_value = SkyCoord(ra=12, dec=13, unit="deg")
+
+        emds = EmdsClass()
+        emds.get_observations(coordinates="12 13", radius=1.0)
+
+        query_table_mock.assert_called_once()
+        _, kwargs = query_table_mock.call_args
+
+        assert kwargs["table_name"] == "ivoa.ObsCore"
+        assert kwargs["async_job"] is True
+
+        cone = kwargs["custom_filters"]
+        assert cone is not None
+        assert "CONTAINS" in cone
+        assert "CIRCLE" in cone
+        assert "s_ra" in cone
+        assert "s_dec" in cone
+        assert "12.0" in cone
+        assert "13.0" in cone
+
+    @patch("astroquery.esa.utils.utils.pyvo.dal.TAPService.capabilities", [])
+    @patch("astroquery.esa.emds.core.esautils.resolve_target")
+    @patch("astroquery.esa.emds.core.EmdsClass.query_table")
+    def test_get_observations_target_name_builds_cone_filter(
+        self, query_table_mock, resolve_target_mock
+    ):
+        resolve_target_mock.return_value = SkyCoord(ra=12, dec=13, unit="deg")
+
+        emds = EmdsClass()
+        emds.get_observations(target_name="M31", radius=1.0)
+
+        query_table_mock.assert_called_once()
+        _, kwargs = query_table_mock.call_args
+
+        assert kwargs["table_name"] == "ivoa.ObsCore"
+        assert kwargs["async_job"] is True
+
+        cone = kwargs["custom_filters"]
+        assert cone is not None
+        assert "CONTAINS" in cone
+        assert "CIRCLE" in cone
+        assert "s_ra" in cone
+        assert "s_dec" in cone
+        assert "12.0" in cone
+        assert "13.0" in cone

--- a/astroquery/esa/emds/tests/test_emds_tap.py
+++ b/astroquery/esa/emds/tests/test_emds_tap.py
@@ -332,3 +332,30 @@ class TestEmdsTap:
         assert "s_dec" in cone
         assert "12.0" in cone
         assert "13.0" in cone
+
+    def test_get_products(self):
+        emds = EmdsClass()
+
+        with patch.object(EmdsClass, "query_table", autospec=True) as qmock:
+            emds.get_products(target_name="RXCJ0120.9-1351")
+
+            assert qmock.called
+            _, kwargs = qmock.call_args
+
+            assert kwargs["table_name"] == "ivoa.ObsCore"
+
+            # Required download columns appended
+            cols = kwargs["columns"]
+            assert "access_url" in cols
+            assert "obs_publisher_did" in cols
+
+    def test_get_products_download_fiels(self):
+        emds = EmdsClass()
+
+        with patch.object(EmdsClass, "query_table", autospec=True) as qmock:
+            emds.get_products(target_name="RXCJ0120.9-1351")
+
+            _, kwargs = qmock.call_args
+            cols = kwargs["columns"]
+            assert "access_url" in cols
+            assert "obs_publisher_did" in cols

--- a/astroquery/esa/emds/tests/test_emds_tap.py
+++ b/astroquery/esa/emds/tests/test_emds_tap.py
@@ -333,11 +333,14 @@ class TestEmdsTap:
         assert "12.0" in cone
         assert "13.0" in cone
 
-    def test_get_products(self):
+    @patch('astroquery.esa.utils.utils.resolve_target')
+    @patch('astroquery.esa.utils.utils.pyvo.dal.TAPService.capabilities', [])
+    def test_get_products(self, resolve_target_mock):
+        resolve_target_mock.return_value = SkyCoord(ra=12, dec=13, unit="deg")
         emds = EmdsClass()
 
         with patch.object(EmdsClass, "query_table", autospec=True) as qmock:
-            emds.get_products(target_name="RXCJ0120.9-1351")
+            emds.get_products(target_name="target")
 
             assert qmock.called
             _, kwargs = qmock.call_args
@@ -349,7 +352,10 @@ class TestEmdsTap:
             assert "access_url" in cols
             assert "obs_publisher_did" in cols
 
-    def test_get_products_download_fiels(self):
+    @patch('astroquery.esa.utils.utils.resolve_target')
+    @patch('astroquery.esa.utils.utils.pyvo.dal.TAPService.capabilities', [])
+    def test_get_products_download_files(self, resolve_target_mock):
+        resolve_target_mock.return_value = SkyCoord(ra=12, dec=13, unit="deg")
         emds = EmdsClass()
 
         with patch.object(EmdsClass, "query_table", autospec=True) as qmock:

--- a/astroquery/esa/emds/tests/test_emds_tap.py
+++ b/astroquery/esa/emds/tests/test_emds_tap.py
@@ -19,6 +19,7 @@ from astroquery.esa.emds import conf
 from requests import HTTPError
 from astropy.coordinates import SkyCoord
 
+
 def data_path(filename):
     data_dir = os.path.join(os.path.dirname(__file__), 'data')
     return os.path.join(data_dir, filename)
@@ -54,7 +55,7 @@ class TestEmdsTap:
         mock_job.job_id = '101'
         emds_job_mock.job_id.return_value = '101'
         mock_tap.get_job.return_value = mock_job
-        emds =EmdsClass()
+        emds = EmdsClass()
 
         job = emds.get_job(jobid=jobid)
         assert job.job_id == '101'

--- a/astroquery/esa/emds/tests/test_emds_tap.py
+++ b/astroquery/esa/emds/tests/test_emds_tap.py
@@ -159,9 +159,9 @@ class TestEmdsTap:
 
     @patch("astroquery.esa.utils.utils.pyvo.dal.TAPService.capabilities", [])
     @patch("astroquery.esa.emds.core.EmdsClass.query_tap")
-    def test_get_missions_calls_query_tap(self, query_tap_mock):
+    def test_list_missions_calls_query_tap(self, query_tap_mock):
         emds = EmdsClass()
-        emds.get_missions()
+        emds.list_missions()
 
         query_tap_mock.assert_called_once()
         args, kwargs = query_tap_mock.call_args

--- a/astroquery/esa/hubble/__init__.py
+++ b/astroquery/esa/hubble/__init__.py
@@ -28,6 +28,8 @@ class Conf(_config.ConfigNamespace):
     EHST_TABLES_SERVER = _config.ConfigItem(EHST_COMMON_SERVER + EHST_TAP_COMMON + "/tables", "eHST TAP Common Server")
     EHST_TARGET_ACTION = _config.ConfigItem("servlet/target-resolver?", "eHST Target Resolver")
     EHST_MESSAGES = _config.ConfigItem("notification?action=GetNotifications", "eHST Messages")
+    EHST_LOGIN_SERVER = _config.ConfigItem(EHST_COMMON_SERVER + 'login', "eHST Login Server")
+    EHST_LOGOUT_SERVER = _config.ConfigItem(EHST_COMMON_SERVER + 'logout', "eHST Logout Server")
     TIMEOUT = 60
 
     cache_location = os.path.join(paths.get_cache_dir(), 'astroquery/ehst', )

--- a/astroquery/esa/hubble/core.py
+++ b/astroquery/esa/hubble/core.py
@@ -19,9 +19,7 @@ from astropy.coordinates import SkyCoord
 from astropy.coordinates import Angle
 from numpy.ma import MaskedArray
 
-from astroquery.query import BaseQuery, BaseVOQuery
 import warnings
-import pyvo
 from astropy.utils.exceptions import AstropyDeprecationWarning
 
 from . import conf

--- a/astroquery/esa/hubble/core.py
+++ b/astroquery/esa/hubble/core.py
@@ -13,6 +13,7 @@ European Space Agency (ESA)
 import os
 
 import astroquery.esa.utils.utils as esautils
+from astroquery.esa.utils import EsaTap
 
 from astropy import units
 from astropy.coordinates import SkyCoord
@@ -28,7 +29,7 @@ from astroquery import log
 __all__ = ['ESAHubble', 'ESAHubbleClass']
 
 
-class ESAHubbleClass(esautils.EsaTap):
+class ESAHubbleClass(EsaTap):
     """
     Class to init ESA Hubble Module and communicate with eHST TAP
     """

--- a/astroquery/esa/hubble/tests/test_esa_hubble.py
+++ b/astroquery/esa/hubble/tests/test_esa_hubble.py
@@ -58,7 +58,7 @@ class TestESAHubble:
                                   product_type="DUMMY")
         assert "This product_type is not allowed" in err.value.args[0]
 
-    @patch('astroquery.esa.integral.core.pyvo.dal.TAPService.capabilities', [])
+    @patch('astroquery.esa.utils.utils.pyvo.dal.TAPService.capabilities', [])
     @patch('astroquery.esa.utils.utils.download_file')
     @patch('astroquery.esa.utils.utils.check_rename_to_gz')
     def test_download_product_by_calibration(self, rename_mock, download_mock, tmp_path):
@@ -78,7 +78,7 @@ class TestESAHubble:
         assert download_mock.call_count == 1
         assert result == path
 
-    @patch('astroquery.esa.integral.core.pyvo.dal.TAPService.capabilities', [])
+    @patch('astroquery.esa.utils.utils.pyvo.dal.TAPService.capabilities', [])
     @patch('astroquery.esa.utils.utils.download_file')
     @patch('astroquery.esa.utils.utils.check_rename_to_gz')
     def test_download_product_by_product_type(self, rename_mock, download_mock, tmp_path):
@@ -122,7 +122,7 @@ class TestESAHubble:
         assert download_mock.call_count == 3
         assert result == path
 
-    @patch('astroquery.esa.integral.core.pyvo.dal.TAPService.capabilities', [])
+    @patch('astroquery.esa.utils.utils.pyvo.dal.TAPService.capabilities', [])
     @patch('astroquery.esa.utils.utils.download_file')
     def test_get_postcard(self, download_mock, tmp_path):
         path = Path(tmp_path, "X0MC5101T.vot")
@@ -146,7 +146,7 @@ class TestESAHubble:
         assert download_mock.call_count == 2
         assert result == path.__str__()
 
-    @patch('astroquery.esa.integral.core.pyvo.dal.TAPService.capabilities', [])
+    @patch('astroquery.esa.utils.utils.pyvo.dal.TAPService.capabilities', [])
     @patch.object(ESAHubbleClass, 'cone_search')
     @patch('astroquery.esa.utils.utils.execute_servlet_request')
     def test_query_target(self, mock_servlet_request, mock_cone_search):
@@ -156,7 +156,7 @@ class TestESAHubble:
         table = ehst.query_target(name="test")
         assert table == "test"
 
-    @patch('astroquery.esa.integral.core.pyvo.dal.TAPService.capabilities', [])
+    @patch('astroquery.esa.utils.utils.pyvo.dal.TAPService.capabilities', [])
     def test_cone_search(self):
         coords = coordinates.SkyCoord("00h42m44.51s +41d16m08.45s",
                                       frame='icrs')
@@ -196,7 +196,7 @@ class TestESAHubble:
 
                 assert len(unique_list) == len(result)
 
-    @patch('astroquery.esa.integral.core.pyvo.dal.TAPService')
+    @patch('astroquery.esa.utils.utils.pyvo.dal.TAPService')
     def test_cone_search_coords(self, mock_tap):
         coords = "00h42m44.51s +41d16m08.45s"
 
@@ -219,8 +219,8 @@ class TestESAHubble:
         assert "Coordinates must be either a string or " \
                "astropy.coordinates" in err.value.args[0]
 
-    @patch('astroquery.esa.integral.core.pyvo.dal.TAPService.capabilities', [])
-    @patch('astroquery.esa.integral.core.pyvo.dal.TAPService.search')
+    @patch('astroquery.esa.utils.utils.pyvo.dal.TAPService.capabilities', [])
+    @patch('astroquery.esa.utils.utils.pyvo.dal.TAPService.search')
     def test_query_tap(self, mock_search):
         parameters = {'query': "select top 10 * from hsc_v2.hubble_sc2",
                       'async_job': False,
@@ -241,13 +241,13 @@ class TestESAHubble:
         table_set = PropertyMock()
         table_set.keys.return_value = ['caom2.harveststate', 'caom2.publications']
         table_set.values.return_value = ['caom2.harveststate', 'caom2.publications']
-        with patch('astroquery.esa.integral.core.pyvo.dal.TAPService', autospec=True) as hubble_mock:
+        with patch('astroquery.esa.utils.utils.pyvo.dal.TAPService', autospec=True) as hubble_mock:
             hubble_mock.return_value.tables = table_set
             ehst = ESAHubbleClass(show_messages=False)
             tables = ehst.get_tables()
             assert len(tables) == 2
 
-    @patch('astroquery.esa.integral.core.pyvo.dal.TAPService.capabilities', [])
+    @patch('astroquery.esa.utils.utils.pyvo.dal.TAPService.capabilities', [])
     @patch('astroquery.esa.utils.utils.download_file')
     @patch('astroquery.esa.utils.utils.check_rename_to_gz')
     def test_get_artifact(self, rename_mock, download_mock, tmp_path):
@@ -257,7 +257,7 @@ class TestESAHubble:
         rename_mock.return_value = path
         assert ehst.get_artifact(artifact_id=path) == path
 
-    @patch('astroquery.esa.integral.core.pyvo.dal.TAPService.capabilities', [])
+    @patch('astroquery.esa.utils.utils.pyvo.dal.TAPService.capabilities', [])
     @patch('astroquery.esa.utils.utils.download_file')
     @patch('astroquery.esa.utils.utils.check_rename_to_gz')
     def test_download_file(self, rename_mock, download_mock, tmp_path):
@@ -309,7 +309,7 @@ class TestESAHubble:
             f.write(b'')
         assert esautils.check_rename_to_gz(target_file) in f"{target_file}.fits.gz"
 
-    @patch('astroquery.esa.integral.core.pyvo.dal.TAPService.capabilities', [])
+    @patch('astroquery.esa.utils.utils.pyvo.dal.TAPService.capabilities', [])
     @patch.object(ESAHubbleClass, 'get_tables')
     def test_get_columns(self, get_tables_mock):
         # Create a mock VOSITable object
@@ -332,7 +332,7 @@ class TestESAHubble:
         assert result[0] == "column1"
         assert result[1] == "column2"
 
-    @patch('astroquery.esa.integral.core.pyvo.dal.TAPService.capabilities', [])
+    @patch('astroquery.esa.utils.utils.pyvo.dal.TAPService.capabilities', [])
     def test_query_criteria_proposal(self):
         parameters1 = {'proposal': 12345,
                        'async_job': False,
@@ -349,7 +349,7 @@ class TestESAHubble:
                                          get_query=parameters1['get_query'])
         assert test_query == "select * from ehst.archive where(proposal_id = '12345')"
 
-    @patch('astroquery.esa.integral.core.pyvo.dal.TAPService.capabilities', [])
+    @patch('astroquery.esa.utils.utils.pyvo.dal.TAPService.capabilities', [])
     @patch.object(ESAHubbleClass, 'query_tap')
     def test_retrieve_observations_from_proposal(self, mock_query_tap):
         program = 12345
@@ -735,7 +735,7 @@ class TestESAHubble:
             ehst = ESAHubbleClass(show_messages=False)
             ehst.cone_search_criteria(coordinates="00h42m44.51s +41d16m08.45s", target="m11", radius=1)
 
-    @patch('astroquery.esa.integral.core.pyvo.dal.TAPService.capabilities', [])
+    @patch('astroquery.esa.utils.utils.pyvo.dal.TAPService.capabilities', [])
     @patch('astroquery.esa.utils.utils.execute_servlet_request')
     def test_show_messages(self, mock_execute_servlet_request):
         ESAHubbleClass(show_messages=True)
@@ -757,7 +757,7 @@ class TestESAHubble:
         assert len(messages) == 3
         assert messages == ["msg1", "msg2", "msgn"]
 
-    @patch('astroquery.esa.integral.core.pyvo.dal.TAPService.capabilities', [])
+    @patch('astroquery.esa.utils.utils.pyvo.dal.TAPService.capabilities', [])
     @patch.object(ESAHubbleClass, 'query_tap')
     @patch.object(ESAHubbleClass, '_get_decoded_string')
     def test_get_datalabs_path(self, mock_get_decoded_string, mock_query_tap):

--- a/astroquery/esa/hubble/tests/test_esa_hubble.py
+++ b/astroquery/esa/hubble/tests/test_esa_hubble.py
@@ -220,7 +220,7 @@ class TestESAHubble:
                "astropy.coordinates" in err.value.args[0]
 
     @patch('astroquery.esa.integral.core.pyvo.dal.TAPService.capabilities', [])
-    @patch('astroquery.esa.integral.core.pyvo.dal.TAPService.run_sync')
+    @patch('astroquery.esa.integral.core.pyvo.dal.TAPService.search')
     def test_query_tap(self, mock_search):
         parameters = {'query': "select top 10 * from hsc_v2.hubble_sc2",
                       'async_job': False,
@@ -278,7 +278,7 @@ class TestESAHubble:
         mock_table = "mocked table result"
         mock_search_result = MagicMock()
         mock_search_result.to_table.return_value = mock_table
-        mock_tap_service.run_sync.return_value = mock_search_result
+        mock_tap_service.search.return_value = mock_search_result
 
         ehst = ESAHubbleClass(show_messages=False)
         result = ehst.get_associated_files(observation_id=observation_id)
@@ -738,7 +738,7 @@ class TestESAHubble:
     @patch('astroquery.esa.integral.core.pyvo.dal.TAPService.capabilities', [])
     @patch('astroquery.esa.utils.utils.execute_servlet_request')
     def test_show_messages(self, mock_execute_servlet_request):
-        ESAHubbleClass()
+        ESAHubbleClass(show_messages=True)
         mock_execute_servlet_request.assert_called()
 
     def test_parse_messages_response(self):

--- a/astroquery/esa/hubble/tests/test_esa_hubble_remote.py
+++ b/astroquery/esa/hubble/tests/test_esa_hubble_remote.py
@@ -43,7 +43,7 @@ class TestEsaHubbleRemoteData:
     top_obs_query = "select top 100 a.observation_id from ehst.archive a"
 
     hst_query = "select top 50 a.observation_id from ehst.archive " \
-                "a where a.collection='HST'"
+                "a where a.collection='HST' and a.release_date <= '2025-12-01 00:00:00.0'"
 
     top_artifact_query = "select a.artifact_id, a.observation_id from ehst.artifact a " \
                          "where a.observation_id = 'iexn02e9q'"

--- a/astroquery/esa/integral/core.py
+++ b/astroquery/esa/integral/core.py
@@ -15,12 +15,13 @@ from requests import HTTPError
 
 from . import conf
 import astroquery.esa.utils.utils as esautils
+from astroquery.esa.utils import EsaTap
 from datetime import datetime
 
 __all__ = ['Integral', 'IntegralClass']
 
 
-class IntegralClass(esautils.EsaTap):
+class IntegralClass(EsaTap):
 
     """
     This module connects with ESA Integral TAP

--- a/astroquery/esa/integral/core.py
+++ b/astroquery/esa/integral/core.py
@@ -14,7 +14,6 @@ from astroquery.utils import commons
 from requests import HTTPError
 
 from . import conf
-import time
 import astroquery.esa.utils.utils as esautils
 from datetime import datetime
 

--- a/astroquery/esa/integral/core.py
+++ b/astroquery/esa/integral/core.py
@@ -9,10 +9,8 @@ European Space Agency (ESA)
 
 """
 from astropy.table import Table
-from astroquery.query import BaseQuery, BaseVOQuery
 from astroquery import log
 from astroquery.utils import commons
-import pyvo
 from requests import HTTPError
 
 from . import conf

--- a/astroquery/esa/integral/core.py
+++ b/astroquery/esa/integral/core.py
@@ -129,7 +129,7 @@ class IntegralClass(EsaTap):
             raise TypeError("Please use only target or coordinates as "
                             "parameter.")
         # Radius in degrees
-        if radius:
+        if radius is not None:
             radius = esautils.get_degree_radius(radius)
 
         # Resolve target or coordinates to get coordinates
@@ -234,7 +234,7 @@ class IntegralClass(EsaTap):
             timeline: An astropy.table object containing the results for scwExpo, scwRevs, scwTimes and scwOffAxis
         """
 
-        if radius:
+        if radius is not None:
             radius = esautils.get_degree_radius(radius)
 
         c = commons.parse_coordinates(coordinates=coordinates)

--- a/astroquery/esa/integral/tests/test_isla_tap.py
+++ b/astroquery/esa/integral/tests/test_isla_tap.py
@@ -53,6 +53,7 @@ def close_files(file_list):
 
 class TestIntegralTap:
 
+    @patch('astroquery.esa.utils.utils.pyvo.dal.TAPService.capabilities', [])
     def test_get_tables(self):
         # default parameters
         table_set = PropertyMock()
@@ -64,6 +65,7 @@ class TestIntegralTap:
             assert len(isla.get_tables(only_names=True)) == 2
             assert len(isla.get_tables()) == 2
 
+    @patch('astroquery.esa.utils.utils.pyvo.dal.TAPService.capabilities', [])
     def test_get_table(self):
         table_set = PropertyMock()
         tables_result = [Mock() for _ in range(3)]
@@ -186,19 +188,15 @@ class TestIntegralTap:
         search_mock.assert_called_with(query)
         table_mock.assert_called()
 
-    @patch('astroquery.esa.integral.core.pyvo.dal.TAPService.capabilities', [])
-    @patch('pyvo.dal.AsyncTAPJob')
-    @patch('astroquery.esa.integral.core.IntegralClass.get_instrument_band_map')
-    @patch('astroquery.esa.integral.core.pyvo.dal.TAPService.submit_job')
-    def test_query_tap_async(self, submit_job_mock, instrument_band_mock, async_job_mock):
-        instrument_band_mock.return_value = mocks.get_instrument_bands()
-        async_job_mock.phase.return_value = 'COMPLETE'
-        async_job_mock.fetch_result.return_value = mocks.get_dal_table()
+    @patch('astroquery.esa.utils.utils.pyvo.dal.TAPService.capabilities', [])
+    @patch('astroquery.esa.utils.utils.pyvo.dal.TAPService.run_async')
+    def test_query_tap_async(self, async_job_mock):
+        async_job_mock.return_value = mocks.get_dal_table()
 
         query = 'select * from ivoa.obscore'
         isla = IntegralClass()
         isla.query_tap(query=query, async_job=True)
-        submit_job_mock.assert_called_with(query)
+        async_job_mock.assert_called_with(query)
 
     @patch('astroquery.esa.integral.core.pyvo.dal.TAPService.capabilities', [])
     @patch('astroquery.esa.integral.core.IntegralClass.query_tap')

--- a/astroquery/esa/integral/tests/test_isla_tap.py
+++ b/astroquery/esa/integral/tests/test_isla_tap.py
@@ -59,7 +59,7 @@ class TestIntegralTap:
         table_set = PropertyMock()
         table_set.keys.return_value = ['ila.epoch', 'ila.cons_pub_obs']
         table_set.values.return_value = ['ila.epoch', 'ila.cons_pub_obs']
-        with patch('astroquery.esa.integral.core.pyvo.dal.TAPService', autospec=True) as isla_mock:
+        with patch('astroquery.esa.utils.utils.pyvo.dal.TAPService', autospec=True) as isla_mock:
             isla_mock.return_value.tables = table_set
             isla = IntegralClass()
             assert len(isla.get_tables(only_names=True)) == 2
@@ -73,15 +73,15 @@ class TestIntegralTap:
         tables_result[1].name = 'ila.cons_pub_obs'
         table_set.values.return_value = tables_result
 
-        with patch('astroquery.esa.integral.core.pyvo.dal.TAPService', autospec=True) as isla_mock:
+        with patch('astroquery.esa.utils.utils.pyvo.dal.TAPService', autospec=True) as isla_mock:
             isla_mock.return_value.tables = table_set
             isla = IntegralClass()
             assert isla.get_table('ila.cons_pub_obs').name == 'ila.cons_pub_obs'
             assert isla.get_table('test') is None
 
-    @patch('astroquery.esa.integral.core.pyvo.dal.TAPService.capabilities', [])
+    @patch('astroquery.esa.utils.utils.pyvo.dal.TAPService.capabilities', [])
     @patch('astroquery.esa.integral.core.IntegralClass.tap')
-    @patch('astroquery.esa.integral.core.pyvo.dal.AsyncTAPJob')
+    @patch('astroquery.esa.utils.utils.pyvo.dal.AsyncTAPJob')
     def test_load_job(self, isla_job_mock, mock_tap):
         jobid = '101'
         mock_job = Mock()
@@ -93,7 +93,7 @@ class TestIntegralTap:
         job = isla.get_job(jobid=jobid)
         assert job.job_id == '101'
 
-    @patch('astroquery.esa.integral.core.pyvo.dal.TAPService.capabilities', [])
+    @patch('astroquery.esa.utils.utils.pyvo.dal.TAPService.capabilities', [])
     @patch('astroquery.esa.integral.core.IntegralClass.tap')
     def test_get_job_list(self, mock_get_job_list):
         mock_job = Mock()
@@ -104,7 +104,7 @@ class TestIntegralTap:
         jobs = isla.get_job_list()
         assert len(jobs) == 1
 
-    @patch('astroquery.esa.integral.core.pyvo.dal.TAPService.capabilities', [])
+    @patch('astroquery.esa.utils.utils.pyvo.dal.TAPService.capabilities', [])
     @patch('astroquery.esa.integral.core.IntegralClass.get_instrument_band_map')
     @patch('astroquery.esa.utils.utils.ESAAuthSession.post')
     def test_login_success(self, mock_post, instrument_band_mock):
@@ -124,7 +124,7 @@ class TestIntegralTap:
                                           headers={'Content-type': 'application/x-www-form-urlencoded',
                                                    'Accept': 'text/plain'})
 
-    @patch('astroquery.esa.integral.core.pyvo.dal.TAPService.capabilities', [])
+    @patch('astroquery.esa.utils.utils.pyvo.dal.TAPService.capabilities', [])
     @patch('astroquery.esa.integral.core.IntegralClass.get_instrument_band_map')
     @patch('astroquery.esa.utils.utils.ESAAuthSession.post')
     def test_login_error(self, mock_post, instrument_band_mock):
@@ -139,7 +139,7 @@ class TestIntegralTap:
             isla.login(user='dummyUser', password='dummyPassword')
         assert error_message in err.value.args[0]
 
-    @patch('astroquery.esa.integral.core.pyvo.dal.TAPService.capabilities', [])
+    @patch('astroquery.esa.utils.utils.pyvo.dal.TAPService.capabilities', [])
     @patch('astroquery.esa.integral.core.IntegralClass.get_instrument_band_map')
     @patch('astroquery.esa.utils.utils.ESAAuthSession.post')
     def test_logout_success(self, mock_post, instrument_band_mock):
@@ -158,7 +158,7 @@ class TestIntegralTap:
                                           headers={'Content-type': 'application/x-www-form-urlencoded',
                                                    'Accept': 'text/plain'})
 
-    @patch('astroquery.esa.integral.core.pyvo.dal.TAPService.capabilities', [])
+    @patch('astroquery.esa.utils.utils.pyvo.dal.TAPService.capabilities', [])
     @patch('astroquery.esa.integral.core.IntegralClass.get_instrument_band_map')
     @patch('astroquery.esa.utils.utils.ESAAuthSession.post')
     def test_logout_error(self, mock_post, instrument_band_mock):
@@ -174,10 +174,10 @@ class TestIntegralTap:
             isla.logout()
         assert error_message in err.value.args[0]
 
-    @patch('astroquery.esa.integral.core.pyvo.dal.TAPService.capabilities', [])
+    @patch('astroquery.esa.utils.utils.pyvo.dal.TAPService.capabilities', [])
     @patch('astropy.table.Table.write')
     @patch('astroquery.esa.integral.core.IntegralClass.get_instrument_band_map')
-    @patch('astroquery.esa.integral.core.pyvo.dal.TAPService.search')
+    @patch('astroquery.esa.utils.utils.pyvo.dal.TAPService.search')
     def test_query_tap_sync(self, search_mock, instrument_band_mock, table_mock):
         instrument_band_mock.return_value = mocks.get_instrument_bands()
         search_mock.return_value = mocks.get_dal_table()
@@ -198,7 +198,7 @@ class TestIntegralTap:
         isla.query_tap(query=query, async_job=True)
         async_job_mock.assert_called_with(query)
 
-    @patch('astroquery.esa.integral.core.pyvo.dal.TAPService.capabilities', [])
+    @patch('astroquery.esa.utils.utils.pyvo.dal.TAPService.capabilities', [])
     @patch('astroquery.esa.integral.core.IntegralClass.query_tap')
     @patch('astroquery.esa.integral.core.IntegralClass.get_instrument_band_map')
     def test_get_sources_success_catalogue(self, instrument_band_mock, query_tap_mock):
@@ -212,7 +212,7 @@ class TestIntegralTap:
                                                 "ila.v_cat_source src where src.name ilike '%Crab%' order by "
                                                 "src.name asc", async_job=False, output_file=None, output_format=None)
 
-    @patch('astroquery.esa.integral.core.pyvo.dal.TAPService.capabilities', [])
+    @patch('astroquery.esa.utils.utils.pyvo.dal.TAPService.capabilities', [])
     @patch('astroquery.esa.utils.utils.resolve_target')
     @patch('astroquery.esa.integral.core.IntegralClass.query_tap')
     @patch('astroquery.esa.integral.core.IntegralClass.get_instrument_band_map')
@@ -227,7 +227,7 @@ class TestIntegralTap:
 
         query_tap_mock.assert_called_with(query=query, async_job=False, output_file=None, output_format=None)
 
-    @patch('astroquery.esa.integral.core.pyvo.dal.TAPService.capabilities', [])
+    @patch('astroquery.esa.utils.utils.pyvo.dal.TAPService.capabilities', [])
     @patch('astroquery.esa.utils.utils.resolve_target')
     @patch('astroquery.esa.integral.core.IntegralClass.query_tap')
     @patch('astroquery.esa.integral.core.IntegralClass.get_instrument_band_map')
@@ -241,7 +241,7 @@ class TestIntegralTap:
             isla.get_sources(target_name='test')
         assert 'Target test cannot be resolved for ISLA' in err.value.args[0]
 
-    @patch('astroquery.esa.integral.core.pyvo.dal.TAPService.capabilities', [])
+    @patch('astroquery.esa.utils.utils.pyvo.dal.TAPService.capabilities', [])
     @patch('astroquery.esa.integral.core.IntegralClass.query_tap')
     @patch('astroquery.esa.integral.core.IntegralClass.get_instrument_band_map')
     def test_get_observations_error(self, instrument_band_mock, query_tap_mock):
@@ -253,7 +253,7 @@ class TestIntegralTap:
             isla.get_observations(target_name='test', coordinates='test')
         assert 'Please use only target or coordinates as parameter.' in err.value.args[0]
 
-    @patch('astroquery.esa.integral.core.pyvo.dal.TAPService.capabilities', [])
+    @patch('astroquery.esa.utils.utils.pyvo.dal.TAPService.capabilities', [])
     @patch('astroquery.esa.integral.core.IntegralClass.query_tap')
     @patch('astroquery.esa.integral.core.IntegralClass.get_sources')
     @patch('astroquery.esa.integral.core.IntegralClass.get_instrument_band_map')
@@ -273,7 +273,7 @@ class TestIntegralTap:
                                           output_file=None,
                                           output_format=None)
 
-    @patch('astroquery.esa.integral.core.pyvo.dal.TAPService.capabilities', [])
+    @patch('astroquery.esa.utils.utils.pyvo.dal.TAPService.capabilities', [])
     @patch('astroquery.esa.integral.core.IntegralClass.query_tap')
     @patch('astroquery.esa.integral.core.IntegralClass.get_sources')
     @patch('astroquery.esa.integral.core.IntegralClass.get_instrument_band_map')
@@ -295,7 +295,7 @@ class TestIntegralTap:
                                           output_file=None,
                                           output_format=None)
 
-    @patch('astroquery.esa.integral.core.pyvo.dal.TAPService.capabilities', [])
+    @patch('astroquery.esa.utils.utils.pyvo.dal.TAPService.capabilities', [])
     @patch('astroquery.esa.integral.core.IntegralClass.query_tap')
     @patch('astroquery.esa.integral.core.IntegralClass.get_sources')
     @patch('astroquery.esa.integral.core.IntegralClass.get_instrument_band_map')
@@ -314,7 +314,7 @@ class TestIntegralTap:
                          "endtime >= '2024-12-13 00:00:00' AND starttime <= "
                          "'2024-12-14 00:00:00' order by obsid")
 
-    @patch('astroquery.esa.integral.core.pyvo.dal.TAPService.capabilities', [])
+    @patch('astroquery.esa.utils.utils.pyvo.dal.TAPService.capabilities', [])
     @patch('astroquery.esa.utils.utils.download_file')
     @patch('astroquery.esa.integral.core.IntegralClass.get_instrument_band_map')
     def test_download_science_windows_error(self, instrument_band_mock, download_mock):
@@ -330,7 +330,7 @@ class TestIntegralTap:
             isla.download_science_windows(science_windows='sc', observation_id='obs')
         assert 'Only one parameter can be provided at a time.' in err.value.args[0]
 
-    @patch('astroquery.esa.integral.core.pyvo.dal.TAPService.capabilities', [])
+    @patch('astroquery.esa.utils.utils.pyvo.dal.TAPService.capabilities', [])
     @patch('astroquery.esa.utils.utils.download_file')
     @patch('astroquery.esa.integral.core.IntegralClass.get_instrument_band_map')
     def test_download_science_windows(self, instrument_band_mock, download_mock):
@@ -358,7 +358,7 @@ class TestIntegralTap:
         close_files(sc)
         temp_path.cleanup()
 
-    @patch('astroquery.esa.integral.core.pyvo.dal.TAPService.capabilities', [])
+    @patch('astroquery.esa.utils.utils.pyvo.dal.TAPService.capabilities', [])
     @patch('astroquery.esa.utils.utils.execute_servlet_request')
     @patch('astroquery.esa.integral.core.IntegralClass.get_instrument_band_map')
     def test_get_timeline(self, instrument_band_mock, servlet_mock):
@@ -371,7 +371,7 @@ class TestIntegralTap:
 
         assert len(timeline['timeline']['scwRevs']) > 0
 
-    @patch('astroquery.esa.integral.core.pyvo.dal.TAPService.capabilities', [])
+    @patch('astroquery.esa.utils.utils.pyvo.dal.TAPService.capabilities', [])
     @patch('astroquery.esa.integral.core.IntegralClass.get_instrument_band_map')
     def test_get_epochs_error(self, instrument_band_mock):
         instrument_band_mock.return_value = mocks.get_instrument_bands()
@@ -381,7 +381,7 @@ class TestIntegralTap:
             isla.get_epochs(target_name='J011705.1-732636', instrument='i2')
         assert 'This is not a valid value for instrument or band.' in err.value.args[0]
 
-    @patch('astroquery.esa.integral.core.pyvo.dal.TAPService.capabilities', [])
+    @patch('astroquery.esa.utils.utils.pyvo.dal.TAPService.capabilities', [])
     @patch('astroquery.esa.integral.core.IntegralClass.query_tap')
     @patch('astroquery.esa.integral.core.IntegralClass.get_instrument_band_map')
     def test_get_epochs(self, instrument_band_mock, query_tap_mock):
@@ -395,7 +395,7 @@ class TestIntegralTap:
                                           "source_id = 'J011705.1-732636' and "
                                           "(instrument_oid = id1 or band_oid = id2)")
 
-    @patch('astroquery.esa.integral.core.pyvo.dal.TAPService.capabilities', [])
+    @patch('astroquery.esa.utils.utils.pyvo.dal.TAPService.capabilities', [])
     @patch('astroquery.esa.utils.utils.download_file')
     @patch('astroquery.esa.integral.core.log')
     @patch('astroquery.esa.integral.core.IntegralClass.get_instrument_band_map')
@@ -410,7 +410,7 @@ class TestIntegralTap:
         isla.get_long_term_timeseries(target_name='J174537.0-290107', band='b1')
         log_mock.error.assert_called_with('No long term timeseries have been found with these inputs. ' + error_message)
 
-    @patch('astroquery.esa.integral.core.pyvo.dal.TAPService.capabilities', [])
+    @patch('astroquery.esa.utils.utils.pyvo.dal.TAPService.capabilities', [])
     @patch('astroquery.esa.utils.utils.download_file')
     @patch('astroquery.esa.integral.core.log')
     @patch('astroquery.esa.integral.core.IntegralClass.get_instrument_band_map')
@@ -425,7 +425,7 @@ class TestIntegralTap:
         isla.get_long_term_timeseries(target_name='J174537.0-290107', band='b1')
         log_mock.error.assert_called_with('Problem when retrieving long term timeseries. ' + error_message)
 
-    @patch('astroquery.esa.integral.core.pyvo.dal.TAPService.capabilities', [])
+    @patch('astroquery.esa.utils.utils.pyvo.dal.TAPService.capabilities', [])
     @patch('astroquery.esa.utils.utils.download_file')
     @patch('astroquery.esa.integral.core.IntegralClass.get_instrument_band_map')
     def test_get_long_term_timeseries(self, instrument_band_mock, download_mock):
@@ -447,7 +447,7 @@ class TestIntegralTap:
         close_files(lt_timeseries_list_extracted)
         temp_path.cleanup()
 
-    @patch('astroquery.esa.integral.core.pyvo.dal.TAPService.capabilities', [])
+    @patch('astroquery.esa.utils.utils.pyvo.dal.TAPService.capabilities', [])
     @patch('astroquery.esa.integral.core.log')
     @patch('astroquery.esa.utils.utils.download_file')
     @patch('astroquery.esa.integral.core.IntegralClass.get_epochs')
@@ -465,7 +465,7 @@ class TestIntegralTap:
         log_mock.error.assert_called_with(
             'No short term timeseries have been found with these inputs. {0}'.format(error_message))
 
-    @patch('astroquery.esa.integral.core.pyvo.dal.TAPService.capabilities', [])
+    @patch('astroquery.esa.utils.utils.pyvo.dal.TAPService.capabilities', [])
     @patch('astroquery.esa.integral.core.log')
     @patch('astroquery.esa.utils.utils.download_file')
     @patch('astroquery.esa.integral.core.IntegralClass.get_epochs')
@@ -482,7 +482,7 @@ class TestIntegralTap:
                                        band='b1', epoch='time')
         log_mock.error.assert_called_with('Problem when retrieving short term timeseries. ' + error_message)
 
-    @patch('astroquery.esa.integral.core.pyvo.dal.TAPService.capabilities', [])
+    @patch('astroquery.esa.utils.utils.pyvo.dal.TAPService.capabilities', [])
     @patch('astroquery.esa.integral.core.IntegralClass.get_epochs')
     @patch('astroquery.esa.integral.core.IntegralClass.get_instrument_band_map')
     def test_get_short_term_timeseries_epoch_error(self, instrument_band_mock, epoch_mock):
@@ -497,7 +497,7 @@ class TestIntegralTap:
                                            band='b1', epoch='time')
         assert 'Epoch time is not available for this target and instrument/band.' in err.value.args[0]
 
-    @patch('astroquery.esa.integral.core.pyvo.dal.TAPService.capabilities', [])
+    @patch('astroquery.esa.utils.utils.pyvo.dal.TAPService.capabilities', [])
     @patch('astroquery.esa.utils.utils.download_file')
     @patch('astroquery.esa.integral.core.IntegralClass.get_epochs')
     @patch('astroquery.esa.integral.core.IntegralClass.get_instrument_band_map')
@@ -523,7 +523,7 @@ class TestIntegralTap:
         close_files(st_timeseries_list_extracted)
         temp_path.cleanup()
 
-    @patch('astroquery.esa.integral.core.pyvo.dal.TAPService.capabilities', [])
+    @patch('astroquery.esa.utils.utils.pyvo.dal.TAPService.capabilities', [])
     @patch('astroquery.esa.integral.core.log')
     @patch('astroquery.esa.utils.utils.execute_servlet_request')
     @patch('astroquery.esa.integral.core.IntegralClass.get_epochs')
@@ -541,7 +541,7 @@ class TestIntegralTap:
         log_mock.error.assert_called_with('Problem when retrieving spectra. '
                                           'Error')
 
-    @patch('astroquery.esa.integral.core.pyvo.dal.TAPService.capabilities', [])
+    @patch('astroquery.esa.utils.utils.pyvo.dal.TAPService.capabilities', [])
     @patch('astroquery.esa.integral.core.log')
     @patch('astroquery.esa.utils.utils.execute_servlet_request')
     @patch('astroquery.esa.integral.core.IntegralClass.get_epochs')
@@ -558,7 +558,7 @@ class TestIntegralTap:
         log_mock.error.assert_called_with('Spectra are not available with these inputs. '
                                           'Please try with different input parameters.')
 
-    @patch('astroquery.esa.integral.core.pyvo.dal.TAPService.capabilities', [])
+    @patch('astroquery.esa.utils.utils.pyvo.dal.TAPService.capabilities', [])
     @patch('astroquery.esa.integral.core.IntegralClass.get_epochs')
     @patch('astroquery.esa.integral.core.log')
     @patch('astroquery.esa.utils.utils.execute_servlet_request')
@@ -576,7 +576,7 @@ class TestIntegralTap:
         log_mock.error.assert_called_with("Problem when retrieving spectra. "
                                           "object of type 'Mock' has no len()")
 
-    @patch('astroquery.esa.integral.core.pyvo.dal.TAPService.capabilities', [])
+    @patch('astroquery.esa.utils.utils.pyvo.dal.TAPService.capabilities', [])
     @patch('astroquery.esa.utils.utils.download_file')
     @patch('astroquery.esa.integral.core.IntegralClass.get_epochs')
     @patch('astroquery.esa.utils.utils.execute_servlet_request')
@@ -603,7 +603,7 @@ class TestIntegralTap:
         close_files(spectra_list_extracted)
         temp_path.cleanup()
 
-    @patch('astroquery.esa.integral.core.pyvo.dal.TAPService.capabilities', [])
+    @patch('astroquery.esa.utils.utils.pyvo.dal.TAPService.capabilities', [])
     @patch('astroquery.esa.integral.core.log')
     @patch('astroquery.esa.utils.utils.execute_servlet_request')
     @patch('astroquery.esa.integral.core.IntegralClass.get_epochs')
@@ -619,7 +619,7 @@ class TestIntegralTap:
         log_mock.error.assert_called_with('Mosaics are not available for these inputs. '
                                           'Please try with different input parameters.')
 
-    @patch('astroquery.esa.integral.core.pyvo.dal.TAPService.capabilities', [])
+    @patch('astroquery.esa.utils.utils.pyvo.dal.TAPService.capabilities', [])
     @patch('astroquery.esa.integral.core.IntegralClass.get_epochs')
     @patch('astroquery.esa.integral.core.log')
     @patch('astroquery.esa.utils.utils.execute_servlet_request')
@@ -636,7 +636,7 @@ class TestIntegralTap:
         log_mock.error.assert_called_with("Problem when retrieving mosaics. "
                                           "Error")
 
-    @patch('astroquery.esa.integral.core.pyvo.dal.TAPService.capabilities', [])
+    @patch('astroquery.esa.utils.utils.pyvo.dal.TAPService.capabilities', [])
     @patch('astroquery.esa.utils.utils.download_file')
     @patch('astroquery.esa.integral.core.IntegralClass.get_epochs')
     @patch('astroquery.esa.utils.utils.execute_servlet_request')
@@ -661,7 +661,7 @@ class TestIntegralTap:
         close_files(mosaics_extracted)
         temp_path.cleanup()
 
-    @patch('astroquery.esa.integral.core.pyvo.dal.TAPService.capabilities', [])
+    @patch('astroquery.esa.utils.utils.pyvo.dal.TAPService.capabilities', [])
     @patch('astroquery.esa.utils.utils.execute_servlet_request')
     @patch('astroquery.esa.integral.core.IntegralClass.get_instrument_band_map')
     def test_get_source_metadata(self, instrument_band_mock, servlet_mock):

--- a/astroquery/esa/utils/__init__.py
+++ b/astroquery/esa/utils/__init__.py
@@ -9,6 +9,6 @@ European Space Agency (ESA)
 
 """
 
-from .utils import EsaTap, download_file, download_table
+from .utils import EsaTap, download_file
 
 __all__ = ['EsaTap', 'download_file']

--- a/astroquery/esa/utils/__init__.py
+++ b/astroquery/esa/utils/__init__.py
@@ -8,3 +8,7 @@ European Space Astronomy Centre (ESAC)
 European Space Agency (ESA)
 
 """
+
+from .utils import EsaTap, download_file, download_table
+
+__all__ = ['EsaTap', 'download_file']

--- a/astroquery/esa/utils/tests/mocks.py
+++ b/astroquery/esa/utils/tests/mocks.py
@@ -1,0 +1,46 @@
+# Licensed under a 3-clause BSD style license - see LICENSE.rst
+"""
+=========================
+ESA TAP Mocks for testing
+=========================
+
+European Space Astronomy Centre (ESAC)
+European Space Agency (ESA)
+
+"""
+from unittest.mock import Mock
+from requests import HTTPError
+
+from pyvo.dal import DALResults
+from astropy.io.votable.tree import VOTableFile
+from astropy.table import Table
+
+instruments_value = ["i1"]
+bands_value = ["b1"]
+
+
+def get_dal_table():
+    data = {
+        "table": ['ivoa.ObsCore', 'ivoa.siap'],
+    }
+
+    # Create an Astropy Table with the mock data
+    astropy_table = Table(data)
+
+    return DALResults(VOTableFile.from_table(astropy_table))
+
+
+def get_empty_table():
+    data = {
+        "table": [],
+    }
+
+    # Create an Astropy Table with the mock data
+    return Table(data)
+
+
+def get_mock_response():
+    error_message = "Mocked HTTP error"
+    mock_response = Mock()
+    mock_response.raise_for_status.side_effect = HTTPError(error_message)
+    return mock_response

--- a/astroquery/esa/utils/tests/test_utils.py
+++ b/astroquery/esa/utils/tests/test_utils.py
@@ -106,7 +106,7 @@ class TestEsaUtils:
         esa_session._request('GET', 'https://dummy.com/service')
 
         mock_get.assert_called_once_with('GET', 'https://dummy.com/service',
-                                         params={'TAPCLIENT': 'ASTROQUERY', 'format': 'votable_plain'})
+                                         params={'TAPCLIENT': 'ASTROQUERY'})
 
     @patch('pyvo.auth.authsession.AuthSession.post')
     def test_login_success(self, mock_post):

--- a/astroquery/esa/utils/tests/test_utils.py
+++ b/astroquery/esa/utils/tests/test_utils.py
@@ -108,56 +108,6 @@ class TestEsaUtils:
         mock_get.assert_called_once_with('GET', 'https://dummy.com/service',
                                          params={'TAPCLIENT': 'ASTROQUERY'})
 
-    @patch('pyvo.auth.authsession.AuthSession.post')
-    def test_login_success(self, mock_post):
-
-        mock_response = Mock()
-        mock_response.raise_for_status.return_value = None  # Simulate no HTTP error
-        mock_response.json.return_value = {"status": "success", "token": "mocked_token"}
-
-        # Configure the mock post method to return the mock Response
-        mock_post.return_value = mock_response
-
-        esa_session = esautils.ESAAuthSession()
-        esa_session.login(login_url='https://dummy.com/login', user='dummyUser', password='dummyPassword')
-
-        mock_post.assert_called_once_with(url='https://dummy.com/login',
-                                          data={'username': 'dummyUser', 'password': 'dummyPassword'},
-                                          headers={'Content-type': 'application/x-www-form-urlencoded',
-                                                   'Accept': 'text/plain'})
-
-    @patch('pyvo.auth.authsession.AuthSession.post')
-    def test_login_error(self, mock_post):
-        error_message = "Mocked HTTP error"
-        mock_post.side_effect = HTTPError(error_message)
-
-        with pytest.raises(HTTPError) as err:
-            esa_session = esautils.ESAAuthSession()
-            esa_session.login(login_url='https://dummy.com/login', user='dummyUser', password='dummyPassword')
-        assert error_message in err.value.args[0]
-
-    @patch('pyvo.auth.authsession.AuthSession.post')
-    def test_logout_success(self, mock_post):
-        mock_post.raise_for_status.return_value = None  # Simulate no HTTP error
-        mock_post.json.return_value = {"status": "success", "token": "mocked_token"}
-
-        esa_session = esautils.ESAAuthSession()
-        esa_session.logout(logout_url='https://dummy.com/logout')
-
-        mock_post.assert_called_once_with(url='https://dummy.com/logout',
-                                          headers={'Content-type': 'application/x-www-form-urlencoded',
-                                                   'Accept': 'text/plain'})
-
-    @patch('pyvo.auth.authsession.AuthSession.post')
-    def test_logout_error(self, mock_post):
-        error_message = "Mocked HTTP error"
-        mock_post.side_effect = HTTPError(error_message)
-
-        esa_session = esautils.ESAAuthSession()
-        with pytest.raises(HTTPError) as err:
-            esa_session.logout(logout_url='https://dummy.com/logout')
-        assert error_message in err.value.args[0]
-
     def test_get_degree_radius(self):
         assert esautils.get_degree_radius(12.0) == 12.0
         assert esautils.get_degree_radius(12) == 12.0
@@ -494,9 +444,9 @@ class TestEsaUtils:
         esa_tap = DummyTapClass()
         esa_tap.query_table(table_name='table1')
         query_tap_mock.assert_called_with(query='SELECT * FROM table1 ',
-                                          async_job= False,
-                                          output_file= None,
-                                          output_format= 'votable',
+                                          async_job=False,
+                                          output_file=None,
+                                          output_format='votable',
                                           verbose=True)
 
     @patch('astroquery.esa.utils.utils.pyvo.dal.TAPService.capabilities', [])

--- a/astroquery/esa/utils/tests/test_utils.py
+++ b/astroquery/esa/utils/tests/test_utils.py
@@ -11,7 +11,7 @@ European Space Agency (ESA)
 import os.path
 import shutil
 import tempfile
-from unittest.mock import patch, Mock
+from unittest.mock import patch, Mock, PropertyMock, MagicMock
 
 import astroquery.esa.utils.utils as esautils
 from astropy.io.registry import IORegistryError
@@ -20,6 +20,8 @@ from requests import HTTPError
 from astropy import units as u
 
 import pytest
+
+from astroquery.esa.utils.tests import mocks
 
 
 def get_dummy_table():
@@ -67,7 +69,34 @@ def copy_to_temporal_path(data_path, temp_folder, filename):
     return temp_data_dir
 
 
-class TestIntegralTap:
+class DummyTapTable:
+    def __init__(self, columns):
+        self.columns = columns
+
+
+class DummyColumn:
+    def __init__(self, name, description, unit, datatype, ucd, utype):
+        self.name = name
+        self.description = description
+        self.unit = unit
+        self.datatype = datatype
+        self.ucd = ucd
+        self.utype = utype
+
+
+class DummyDatatype:
+    def __init__(self, content):
+        self.content = content
+
+
+class DummyTapClass(esautils.EsaTap):
+    ESA_ARCHIVE_NAME = "DummyClass"
+    TAP_URL = "dummyUrl"
+    LOGIN_URL = "dummyLogin"
+    LOGOUT_URL = "dummyLogout"
+
+
+class TestEsaUtils:
 
     @patch('pyvo.auth.authsession.AuthSession._request')
     def test_esa_auth_session_url(self, mock_get):
@@ -144,8 +173,8 @@ class TestIntegralTap:
             esautils.download_table(dummy_table, output_file=filename)
         assert 'Format could not be identified' in err.value.args[0]
 
-    @patch('astroquery.esa.integral.core.pyvo.dal.TAPService.capabilities', [])
-    @patch('astroquery.esa.integral.core.pyvo.dal.TAPService')
+    @patch('astroquery.esa.utils.utils.pyvo.dal.TAPService.capabilities', [])
+    @patch('astroquery.esa.utils.utils.pyvo.dal.TAPService')
     def test_execute_servlet_request(self, mock_tap):
 
         mock_tap._session.get.raise_for_status.return_value = None
@@ -157,8 +186,8 @@ class TestIntegralTap:
         mock_tap._session.get.assert_called_once_with(url='https://dummyurl.com/service',
                                                       params={'test': 'dummy', 'TAPCLIENT': 'ASTROQUERY'})
 
-    @patch('astroquery.esa.integral.core.pyvo.dal.TAPService.capabilities', [])
-    @patch('astroquery.esa.integral.core.pyvo.dal.TAPService')
+    @patch('astroquery.esa.utils.utils.pyvo.dal.TAPService.capabilities', [])
+    @patch('astroquery.esa.utils.utils.pyvo.dal.TAPService')
     def test_execute_servlet_request_with_parser_method(self, mock_tap):
         mock_parser_method = Mock()
         mock_response = Mock()
@@ -177,8 +206,8 @@ class TestIntegralTap:
 
         mock_parser_method.assert_called_once()
 
-    @patch('astroquery.esa.integral.core.pyvo.dal.TAPService.capabilities', [])
-    @patch('astroquery.esa.integral.core.pyvo.dal.TAPService')
+    @patch('astroquery.esa.utils.utils.pyvo.dal.TAPService.capabilities', [])
+    @patch('astroquery.esa.utils.utils.pyvo.dal.TAPService')
     def test_execute_servlet_request_error(self, mock_tap):
         error_message = "Mocked HTTP error"
         mock_tap._session.get.side_effect = HTTPError(error_message)
@@ -309,3 +338,211 @@ class TestIntegralTap:
             esautils.resolve_target(url='http://dummyurl.com/target_resolver', session=esa_session,
                                     target_name='dummy_target', target_resolver='ALL')
         assert 'This target cannot be resolved' in err.value.args[0]
+
+    # Tests to for EsaTap class
+
+    def test_get_alternative_tap(self):
+        esa_tap = DummyTapClass(tap_url="https://dummytap.es")
+        assert esa_tap.TAP_URL == "https://dummytap.es"
+
+    def test_get_tables(self):
+        # default parameters
+        table_set = PropertyMock()
+        table_set.keys.return_value = ['ila.epoch', 'ila.cons_pub_obs']
+        table_set.values.return_value = ['ila.epoch', 'ila.cons_pub_obs']
+        with patch('astroquery.esa.utils.utils.pyvo.dal.TAPService', autospec=True) as esa_tap_mock:
+            esa_tap_mock.return_value.tables = table_set
+            esa_tap = DummyTapClass()
+            assert len(esa_tap.get_tables(only_names=True)) == 2
+            assert len(esa_tap.get_tables()) == 2
+
+    def test_get_table(self):
+        table_set = PropertyMock()
+        tables_result = [Mock() for _ in range(3)]
+        tables_result[0].name = 'ila.epoch'
+        tables_result[1].name = 'ila.cons_pub_obs'
+        table_set.values.return_value = tables_result
+
+        with patch('astroquery.esa.utils.utils.pyvo.dal.TAPService', autospec=True) as esa_tap_mock:
+            esa_tap_mock.return_value.tables = table_set
+            esa_tap = DummyTapClass()
+            assert esa_tap.get_table('ila.cons_pub_obs').name == 'ila.cons_pub_obs'
+            assert esa_tap.get_table('test') is None
+
+    @patch('astroquery.esa.utils.utils.pyvo.dal.TAPService.capabilities', [])
+    @patch('astroquery.esa.utils.utils.EsaTap.tap')
+    @patch('astroquery.esa.utils.utils.pyvo.dal.AsyncTAPJob')
+    def test_load_job(self, esa_tap_job_mock, mock_tap):
+        jobid = '101'
+        mock_job = Mock()
+        mock_job.job_id = '101'
+        esa_tap_job_mock.job_id.return_value = '101'
+        mock_tap.get_job.return_value = mock_job
+        esa_tap = DummyTapClass()
+
+        job = esa_tap.get_job(jobid=jobid)
+        assert job.job_id == '101'
+
+    @patch('astroquery.esa.utils.utils.pyvo.dal.TAPService.capabilities', [])
+    @patch('astroquery.esa.utils.utils.EsaTap.tap')
+    def test_get_job_list(self, mock_get_job_list):
+        mock_job = Mock()
+        mock_job.job_id = '101'
+        mock_get_job_list.get_job_list.return_value = [mock_job]
+        esa_tap = DummyTapClass()
+
+        jobs = esa_tap.get_job_list()
+        assert len(jobs) == 1
+
+    @patch('astroquery.esa.utils.utils.pyvo.dal.TAPService.capabilities', [])
+    @patch('astroquery.esa.utils.utils.ESAAuthSession.post')
+    def test_login_success(self, mock_post):
+        mock_response = Mock()
+        mock_response.raise_for_status.return_value = None  # Simulate no HTTP error
+        mock_response.json.return_value = {"status": "success", "token": "mocked_token"}
+
+        # Configure the mock post method to return the mock Response
+        mock_post.return_value = mock_response
+        esa_tap = DummyTapClass()
+        esa_tap.login(user='dummyUser', password='dummyPassword')
+
+        mock_post.assert_called_once_with(url="dummyLogin",
+                                          data={"username": "dummyUser", "password": "dummyPassword"},
+                                          headers={'Content-type': 'application/x-www-form-urlencoded',
+                                                   'Accept': 'text/plain'})
+
+    @patch('astroquery.esa.utils.utils.pyvo.dal.TAPService.capabilities', [])
+    @patch('astroquery.esa.utils.utils.ESAAuthSession.post')
+    def test_login_error(self, mock_post):
+        error_message = "Mocked HTTP error"
+        mock_response = mocks.get_mock_response()
+
+        # Configure the mock post method to return the mock Response
+        mock_post.return_value = mock_response
+        esa_tap = DummyTapClass()
+        with pytest.raises(HTTPError) as err:
+            esa_tap.login(user='dummyUser', password='dummyPassword')
+        assert error_message in err.value.args[0]
+
+    @patch('astroquery.esa.utils.utils.pyvo.dal.TAPService.capabilities', [])
+    @patch('astroquery.esa.utils.utils.ESAAuthSession.post')
+    def test_logout_success(self, mock_post):
+        mock_response = Mock()
+        mock_response.raise_for_status.return_value = None  # Simulate no HTTP error
+        mock_response.json.return_value = {"status": "success", "token": "mocked_token"}
+
+        # Configure the mock post method to return the mock Response
+        mock_post.return_value = mock_response
+        esa_tap = DummyTapClass()
+        esa_tap.logout()
+
+        mock_post.assert_called_once_with(url="dummyLogout",
+                                          headers={'Content-type': 'application/x-www-form-urlencoded',
+                                                   'Accept': 'text/plain'})
+
+    @patch('astroquery.esa.utils.utils.pyvo.dal.TAPService.capabilities', [])
+    @patch('astroquery.esa.utils.utils.ESAAuthSession.post')
+    def test_logout_error(self, mock_post):
+
+        error_message = "Mocked HTTP error"
+        mock_response = mocks.get_mock_response()
+
+        # Configure the mock post method to return the mock Response
+        mock_post.return_value = mock_response
+        esa_tap = DummyTapClass()
+        with pytest.raises(HTTPError) as err:
+            esa_tap.logout()
+        assert error_message in err.value.args[0]
+
+    @patch('astroquery.esa.utils.utils.pyvo.dal.TAPService.capabilities', [])
+    @patch('astropy.table.Table.write')
+    @patch('astroquery.esa.utils.utils.pyvo.dal.TAPService.search')
+    def test_query_tap_sync(self, search_mock, table_mock):
+        search_mock.return_value = mocks.get_dal_table()
+
+        query = 'select * from ivoa.obscore'
+        esa_tap = DummyTapClass()
+        esa_tap.query_tap(query=query, output_file='dummy.vot')
+        search_mock.assert_called_with(query)
+        table_mock.assert_called()
+
+    @patch('astroquery.esa.utils.utils.pyvo.dal.TAPService.capabilities', [])
+    @patch('astroquery.esa.utils.utils.pyvo.dal.TAPService.run_async')
+    def test_query_tap_async(self, async_job_mock):
+        async_job_mock.return_value = mocks.get_dal_table()
+
+        query = 'select * from ivoa.obscore'
+        esa_tap = DummyTapClass()
+        esa_tap.query_tap(query=query, async_job=True)
+        async_job_mock.assert_called_with(query)
+
+    @patch('astroquery.esa.utils.utils.pyvo.dal.TAPService.capabilities', [])
+    @patch('astroquery.esa.utils.utils.pyvo.dal.TAPService.search')
+    def test_query_table(self, async_job_mock):
+        async_job_mock.return_value = mocks.get_dal_table()
+
+        query = 'select * from ivoa.obscore'
+        esa_tap = DummyTapClass()
+        esa_tap.query_tap(query=query, async_job=False)
+        async_job_mock.assert_called_with(query)
+
+    @patch('astroquery.esa.utils.utils.pyvo.dal.TAPService.capabilities', [])
+    @patch('astroquery.esa.utils.utils.EsaTap.query_tap')
+    def test_query_table_basic(self, query_tap_mock):
+        query_tap_mock.return_value = mocks.get_dal_table()
+
+        esa_tap = DummyTapClass()
+        esa_tap.query_table(table_name='table1')
+        query_tap_mock.assert_called_with(query='SELECT * FROM table1 ',
+                                          async_job= False,
+                                          output_file= None,
+                                          output_format= 'votable',
+                                          verbose=True)
+
+    @patch('astroquery.esa.utils.utils.pyvo.dal.TAPService.capabilities', [])
+    @patch('astroquery.esa.utils.utils.EsaTap.query_tap')
+    def test_query_table_custom_filter(self, query_tap_mock):
+        query_tap_mock.return_value = mocks.get_dal_table()
+
+        esa_tap = DummyTapClass()
+        esa_tap.query_table(table_name='table1', columns=['column1', 'column2'], custom_filters="column1 = 12",
+                            get_metadata=False)
+        query_tap_mock.assert_called_with(query="SELECT column1, column2 FROM table1 WHERE column1 = 12",
+                                          async_job=False,
+                                          output_file=None,
+                                          output_format='votable',
+                                          verbose=True)
+
+    @patch('astroquery.esa.utils.utils.pyvo.dal.TAPService.capabilities', [])
+    @patch('astroquery.esa.utils.utils.EsaTap.query_tap')
+    def test_query_table_filtered(self, query_tap_mock):
+        query_tap_mock.return_value = mocks.get_dal_table()
+
+        esa_tap = DummyTapClass()
+        esa_tap.query_table(table_name='table1', columns=['column1', 'column2'], custom_filters=None,
+                            get_metadata=False, table_filter='value1')
+        query_tap_mock.assert_called_with(query="SELECT column1, column2 FROM table1  WHERE table_filter = 'value1'",
+                                          async_job=False,
+                                          output_file=None,
+                                          output_format='votable',
+                                          verbose=True)
+
+    @patch('astroquery.esa.utils.utils.pyvo.dal.TAPService.capabilities', [])
+    @patch('astroquery.esa.utils.utils.EsaTap.get_table')
+    def test_get_metadata(self, table_mock):
+        # Prepare mock TAP columns
+        columns = [DummyColumn('ra', 'Right Ascension',
+                               'deg', DummyDatatype('float'), 'pos.eq.ra', None)]
+
+        table = DummyTapTable(columns)
+
+        tap_class = DummyTapClass()
+        table_mock.return_value = table
+
+        meta = tap_class.get_metadata("dummy_table")
+
+        assert type(meta) is Table
+
+        # Validate first row
+        assert meta[0]["Column"] == "ra"
+        assert meta[0]["Description"] == "Right Ascension"

--- a/astroquery/esa/utils/tests/test_utils.py
+++ b/astroquery/esa/utils/tests/test_utils.py
@@ -14,6 +14,7 @@ import tempfile
 from unittest.mock import patch, Mock, PropertyMock
 
 import astroquery.esa.utils.utils as esautils
+from astroquery.esa.utils import EsaTap
 from astropy.io.registry import IORegistryError
 from astropy.table import Table
 from requests import HTTPError
@@ -89,7 +90,7 @@ class DummyDatatype:
         self.content = content
 
 
-class DummyTapClass(esautils.EsaTap):
+class DummyTapClass(EsaTap):
     ESA_ARCHIVE_NAME = "DummyClass"
     TAP_URL = "dummyUrl"
     LOGIN_URL = "dummyLogin"
@@ -320,7 +321,7 @@ class TestEsaUtils:
             assert esa_tap.get_table('test') is None
 
     @patch('astroquery.esa.utils.utils.pyvo.dal.TAPService.capabilities', [])
-    @patch('astroquery.esa.utils.utils.EsaTap.tap')
+    @patch('astroquery.esa.utils.EsaTap.tap')
     @patch('astroquery.esa.utils.utils.pyvo.dal.AsyncTAPJob')
     def test_load_job(self, esa_tap_job_mock, mock_tap):
         jobid = '101'
@@ -334,7 +335,7 @@ class TestEsaUtils:
         assert job.job_id == '101'
 
     @patch('astroquery.esa.utils.utils.pyvo.dal.TAPService.capabilities', [])
-    @patch('astroquery.esa.utils.utils.EsaTap.tap')
+    @patch('astroquery.esa.utils.EsaTap.tap')
     def test_get_job_list(self, mock_get_job_list):
         mock_job = Mock()
         mock_job.job_id = '101'
@@ -437,7 +438,7 @@ class TestEsaUtils:
         async_job_mock.assert_called_with(query)
 
     @patch('astroquery.esa.utils.utils.pyvo.dal.TAPService.capabilities', [])
-    @patch('astroquery.esa.utils.utils.EsaTap.query_tap')
+    @patch('astroquery.esa.utils.EsaTap.query_tap')
     def test_query_table_basic(self, query_tap_mock):
         query_tap_mock.return_value = mocks.get_dal_table()
 
@@ -450,7 +451,7 @@ class TestEsaUtils:
                                           verbose=True)
 
     @patch('astroquery.esa.utils.utils.pyvo.dal.TAPService.capabilities', [])
-    @patch('astroquery.esa.utils.utils.EsaTap.query_tap')
+    @patch('astroquery.esa.utils.EsaTap.query_tap')
     def test_query_table_custom_filter(self, query_tap_mock):
         query_tap_mock.return_value = mocks.get_dal_table()
 
@@ -464,7 +465,7 @@ class TestEsaUtils:
                                           verbose=True)
 
     @patch('astroquery.esa.utils.utils.pyvo.dal.TAPService.capabilities', [])
-    @patch('astroquery.esa.utils.utils.EsaTap.query_tap')
+    @patch('astroquery.esa.utils.EsaTap.query_tap')
     def test_query_table_filtered(self, query_tap_mock):
         query_tap_mock.return_value = mocks.get_dal_table()
 
@@ -478,7 +479,7 @@ class TestEsaUtils:
                                           verbose=True)
 
     @patch('astroquery.esa.utils.utils.pyvo.dal.TAPService.capabilities', [])
-    @patch('astroquery.esa.utils.utils.EsaTap.get_table')
+    @patch('astroquery.esa.utils.EsaTap.get_table')
     def test_get_metadata(self, table_mock):
         # Prepare mock TAP columns
         columns = [DummyColumn('ra', 'Right Ascension',

--- a/astroquery/esa/utils/tests/test_utils.py
+++ b/astroquery/esa/utils/tests/test_utils.py
@@ -11,7 +11,7 @@ European Space Agency (ESA)
 import os.path
 import shutil
 import tempfile
-from unittest.mock import patch, Mock, PropertyMock, MagicMock
+from unittest.mock import patch, Mock, PropertyMock
 
 import astroquery.esa.utils.utils as esautils
 from astropy.io.registry import IORegistryError

--- a/astroquery/esa/utils/utils.py
+++ b/astroquery/esa/utils/utils.py
@@ -606,12 +606,12 @@ class EsaTap(BaseVOQuery, BaseQuery):
         # For numeric values, a tuple shall be provided
         if isinstance(value, tuple):
             if len(value) != 2:
-                raise ValueError(f"For numeric values, a tuple (comparator, value) shall be provided")
+                raise ValueError('For numeric values, a tuple (comparator, value) shall be provided')
             # First value can be a comparator or a minimum value
             # Second value should always be a number
             first_value, second_value = value
             if not isinstance(second_value, numbers.Number):
-                raise ValueError(f"Comparator can only be applied to numeric values.")
+                raise ValueError('Comparator can only be applied to numeric values.')
             # If first value is also a number, the filter is between two numbers
             if isinstance(first_value, numbers.Number):
                 min_value_filter = self.__create_number_criteria(column, first_value, ">=")

--- a/astroquery/esa/utils/utils.py
+++ b/astroquery/esa/utils/utils.py
@@ -136,8 +136,7 @@ class ESAAuthSession(pyvo.auth.authsession.AuthSession):
         """
 
         # Add the custom query parameter to the URL
-        additional_params = {'TAPCLIENT': 'ASTROQUERY',
-                             'format': 'votable_plain'}
+        additional_params = {'TAPCLIENT': 'ASTROQUERY'}
         # Merge the default parameters with the additional request parameters
         additional_params = additional_params | self.request_parameters
         if kwargs is not None and 'params' in kwargs:

--- a/astroquery/esa/utils/utils.py
+++ b/astroquery/esa/utils/utils.py
@@ -24,9 +24,6 @@ from astropy.io import fits
 from astropy.table import Table
 import pyvo
 
-import requests
-from io import BytesIO
-
 import numbers
 
 from astroquery.query import BaseVOQuery, BaseQuery

--- a/astroquery/esa/utils/utils.py
+++ b/astroquery/esa/utils/utils.py
@@ -24,13 +24,15 @@ from astropy.io import fits
 from astropy.table import Table
 import pyvo
 
-from PIL import Image
 import requests
 from io import BytesIO
 
 import numbers
 
 from astroquery.query import BaseVOQuery, BaseQuery
+
+__all__ = ['ESAAuthSession', 'EsaTap']
+
 
 TARGET_RESOLVERS = ['ALL', 'SIMBAD', 'NED', 'VIZIER']
 
@@ -167,6 +169,7 @@ class EsaTap(BaseVOQuery, BaseQuery):
     LOGOUT_URL: str  # must be defined for each module
     TIMEOUT = 60
     REQUEST_PARAMETERS = {}  # Additional parameters to be added to all requests
+    THRESHOLD = 1e-5
 
     """
     Class to init ESA TAP Module to communicate with {ESA_ARCHIVE_NAME} Science Archive
@@ -178,9 +181,10 @@ class EsaTap(BaseVOQuery, BaseQuery):
         LOGOUT_URL: str
         TIMEOUT (Optional) =  60
         REQUEST_PARAMETERS = {}
+        THRESHOLD = 1e-5
     """
 
-    def __init__(self, auth_session=None, tap_url=None):
+    def __init__(self, *, auth_session=None, tap_url=None):
         """
         Set the session, alternative TAP url, initial parameter for the TAP connection
 
@@ -253,7 +257,7 @@ class EsaTap(BaseVOQuery, BaseQuery):
 
         Returns
         -------
-        A pyvo.dal.TAPService object connected to {ESA_ARCHIVE_NAME} TAP
+        A `~pyvo.dal.TAPService` object connected to {ESA_ARCHIVE_NAME} TAP
         """
         if self._tap is None:
             self._tap = pyvo.dal.TAPService(
@@ -484,7 +488,7 @@ class EsaTap(BaseVOQuery, BaseQuery):
 
         # If filters are defined, generate the associated query criteria
         query_filters = (
-            self.__create_sql_criteria(filters)
+            self.__create_adql_criteria(filters)
             if filters and len(filters) > 0 else ''
         )
 
@@ -501,7 +505,7 @@ class EsaTap(BaseVOQuery, BaseQuery):
         return self.query_tap(query=query, async_job=async_job, output_file=output_file,
                               output_format=output_format, verbose=True)
 
-    def __create_sql_criteria(self, filters):
+    def __create_adql_criteria(self, filters):
         """
         Create the SQL clause associated to the query_criteria filters
 
@@ -577,10 +581,9 @@ class EsaTap(BaseVOQuery, BaseQuery):
         """
         # For exact searches in not integer values, check the number is
         # within a threshold of 1e-5
-        threshold = 1e-5
         if not isinstance(value, numbers.Integral) and comparator == '=':
-            return (f"({column} >= {value - threshold} and "
-                    f"{column} <= {value + threshold})")
+            return (f"({column} >= {value - self.THRESHOLD} and "
+                    f"{column} <= {value + self.THRESHOLD})")
         else:
             return f"{column} {comparator} {value}"
 
@@ -977,9 +980,3 @@ def resolve_target(url, session, target_name, target_resolver):
             return SkyCoord(ra=ra, dec=dec, unit="deg")
     except (ValueError, KeyError) as err:
         raise ValueError('This target cannot be resolved. {}'.format(err))
-
-
-def load_image_from_url(url):
-    response = requests.get(url)
-    response.raise_for_status()        # raise an error if download failed
-    return Image.open(BytesIO(response.content))

--- a/astroquery/esa/xmm_newton/tests/test_xmm_newton_remote.py
+++ b/astroquery/esa/xmm_newton/tests/test_xmm_newton_remote.py
@@ -212,7 +212,7 @@ class TestXMMNewtonRemote:
             xsa.download_data(**parameters)
 
     def test_download_proprietary_data_without_credentials(self, tmp_cwd):
-        parameters = {'observation_id': "0861270201",
+        parameters = {'observation_id': "0984300101",
                       'level': "PPS",
                       'name': 'OBSMLI',
                       'filename': 'single',

--- a/docs/esa/emds/einsteinprobe/einsteinprobe.rst
+++ b/docs/esa/emds/einsteinprobe/einsteinprobe.rst
@@ -41,8 +41,8 @@ Examples
 1. Login/Logout
 ---------------
 Some EMDS missions may require authentication to access proprietary or advanced data products.
-The Astroquery EMDS interface provides :meth:`~astroquery.esa.emds.EMDSClass.login` and
-:meth:`~astroquery.esa.emds.EMDSClass.logout` for this purpose.
+The Astroquery EMDS interface provides :meth:`~astroquery.esa.utils.EsaTap.login` and
+:meth:`~astroquery.esa.utils.EsaTap.logout` for this purpose.
 
 Einstein Probe data accessed through this module are public and do not require authentication, but the methods are
 available for consistency and are inherited from the base EMDS interface.
@@ -56,7 +56,7 @@ available for consistency and are inherited from the base EMDS interface.
 
 .. note::
 
-   The :meth:`login` and :meth:`logout` methods are inherited from the base EMDS interface.
+   The :meth:`~astroquery.esa.utils.EsaTap.login` and :meth:`~astroquery.esa.utils.EsaTap.logout` methods are inherited from the base EMDS interface.
    They are not required for Einstein Probe, but are provided for consistency across EMDS mission
    modules.
 
@@ -413,3 +413,5 @@ Reference/API
 
 .. automodapi:: astroquery.esa.emds.einsteinprobe
     :no-inheritance-diagram:
+    :inherited-members:
+    :show-inheritance:

--- a/docs/esa/emds/einsteinprobe/einsteinprobe.rst
+++ b/docs/esa/emds/einsteinprobe/einsteinprobe.rst
@@ -6,13 +6,13 @@ EinsteinProbe Space Archive (EPSA) (`astroquery.esa.emds.einsteinprobe`)
 
 Einstein Probe is an X-ray astronomy mission led by the Chinese Academy of Sciences (CAS),
 with international collaboration from the European Space Agency (ESA) and the Max Planck
-Institute for Extraterrestrial Physics (MPE). Einstein Probe data are distributed through
-the ESA Multi-Mission Data Services (EMDS) archive, which provides unified access to
-multiple space missions through a single service.
+Institute for Extraterrestrial Physics (MPE). Einstein Probe data (level 2 and level 3
+public products) are distributed through the ESA Multi-Mission Data Services (EMDS), which
+provides unified access to data from multiple space missions via a single service.
 
-The mission is designed to monitor the X-ray sky and discover transient and variable
+Einstein Probe is is designed to monitor the X-ray sky and discover transient and variable
 phenomena across the Universe. It carries two primary scientific instruments: the
-wide-field X-ray Telescope (WXT), which provides a very large field of view for sky
+Wide-field X-ray Telescope (WXT), which provides a very large field of view for sky
 monitoring, and the Follow-up X-ray Telescope (FXT), which enables more detailed
 observations of selected sources.
 
@@ -64,7 +64,7 @@ available for consistency and are inherited from the base EMDS interface.
 2. Get available tables and columns
 -----------------------------------
 
-Einstein Probe Astroquery module allows users to explore the data structure of the TAP by listing available
+The Einstein Probe Astroquery module allows users to explore the data structure of the TAP by listing available
 tables and their columns. This is useful for understanding what data is accessible before running ADQL queries.
 
 .. doctest-remote-data::

--- a/docs/esa/emds/einsteinprobe/einsteinprobe.rst
+++ b/docs/esa/emds/einsteinprobe/einsteinprobe.rst
@@ -224,9 +224,7 @@ options, that can be combined to extract the required data:
 
   >>> from astroquery.esa.emds.einsteinprobe import EinsteinProbeClass
   >>> epsa = EinsteinProbeClass()
-  >>> epsa.get_observations(
-   ...     target_name="V1589 Cyg", columns=["s_ra", "s_dec", "obs_id", "s_xel1"]
-   ... )  # doctest: +IGNORE_OUTPUT
+  >>> epsa.get_observations(target_name="V1589 Cyg", columns=["s_ra", "s_dec", "obs_id", "s_xel1"])  # doctest: +IGNORE_OUTPUT
     Executed query:SELECT s_ra, s_dec, obs_id, s_xel1 FROM ivoa.ObsCore WHERE
                     1=CONTAINS(POINT('ICRS', s_ra, s_dec),
                     CIRCLE('ICRS', 310.7048109, 41.3833259, 1.0))
@@ -251,9 +249,7 @@ options, that can be combined to extract the required data:
 
   >>> from astroquery.esa.emds.einsteinprobe import EinsteinProbeClass
   >>> epsa = EinsteinProbeClass()
-  >>> epsa.get_observations(
-   ...     target_name="V1589 Cyg", columns=["s_ra", "s_dec", "obs_id", "s_xel1"],
-   ...     s_xel1=(">", 100))  # doctest: +IGNORE_OUTPUT
+  >>> epsa.get_observations(target_name="V1589 Cyg", columns=["s_ra", "s_dec", "obs_id", "s_xel1"], s_xel1=(">", 100))  # doctest: +IGNORE_OUTPUT
     Executed query:SELECT s_ra, s_dec, obs_id, s_xel1 FROM ivoa.ObsCore
         WHERE s_xel1 > 100 AND
         1=CONTAINS(POINT('ICRS', s_ra, s_dec),
@@ -283,10 +279,7 @@ Some examples and their corresponding ADQL transformations are provided below:
 
 .. doctest-remote-data::
 
-  >>> emds.get_observations(
-  ...     columns=["dataproduct_type", "obs_collection", "target_name", "obs_id",
-  ...              "s_ra", "s_dec", "instrument_name"]
-  ... )  # doctest: +IGNORE_OUTPUT
+  >>> emds.get_observations(columns=["dataproduct_type", "obs_collection", "target_name", "obs_id", "s_ra", "s_dec", "instrument_name"])  # doctest: +IGNORE_OUTPUT
 
 + Exact match (string):
     - ``obs_collection="EPSA"`` → ``obs_collection = 'EPSA'``
@@ -294,11 +287,7 @@ Some examples and their corresponding ADQL transformations are provided below:
 
 .. doctest-remote-data::
 
-  >>> emds.get_observations(
-  ...     columns=["obs_id", "obs_collection", "instrument_name", "dataproduct_type"],
-  ...     obs_collection="EPSA",
-  ...     instrument_name="FXT",
-  ... )  # doctest: +IGNORE_OUTPUT
+  >>> emds.get_observations(columns=["obs_id", "obs_collection", "instrument_name", "dataproduct_type"], obs_collection="EPSA",instrument_name="FXT")  # doctest: +IGNORE_OUTPUT
 
 + Wildcards (string):
     - ``target_name="AT 2023%"`` → ``target_name ILIKE 'AT 2023%'``
@@ -307,28 +296,17 @@ Depending on the configuration, ``*`` may also be accepted as an alias for ``%``
 
 .. doctest-remote-data::
 
-  >>> emds.get_observations(
-  ...     columns=["obs_id", "target_name"],
-  ...     target_name="V1589 Cyg",
-  ... )  # doctest: +IGNORE_OUTPUT
+  >>> emds.get_observations(columns=["obs_id", "target_name"],target_name="V1589 Cyg")  # doctest: +IGNORE_OUTPUT
 
 + Wildcards (string): ``coordinates`` and ``radius``
 
 .. doctest-remote-data::
 
-  >>> emds.get_observations(
-  ...     coordinates="81.1238 17.4175",
-  ...     radius=0.1,
-  ...     columns=["obs_id", "s_ra", "s_dec", "instrument_name"],
-  ... )  # doctest: +IGNORE_OUTPUT
+  >>> emds.get_observations(coordinates="81.1238 17.4175", radius=0.1, columns=["obs_id", "s_ra", "s_dec", "instrument_name"], )  # doctest: +IGNORE_OUTPUT
 
 .. doctest-remote-data::
 
-  >>> emds.get_observations(
-  ...     target_name="V1589 Cyg",
-  ...     radius=0.1,
-  ...     columns=["obs_id", "s_ra", "s_dec", "target_name"],
-  ... )  # doctest: +IGNORE_OUTPUT
+  >>> emds.get_observations( target_name="V1589 Cyg", radius=0.1, columns=["obs_id", "s_ra", "s_dec", "target_name"], )  # doctest: +IGNORE_OUTPUT
 
 + String list:
     - ``dataproduct_type=["img", "pha"]``
@@ -336,31 +314,21 @@ Depending on the configuration, ``*`` may also be accepted as an alias for ``%``
 
 .. doctest-remote-data::
 
-  >>> emds.get_observations(
-  ...     columns=["obs_id", "dataproduct_type"],
-  ...     dataproduct_type=["img", "pha"],
-  ... )  # doctest: +IGNORE_OUTPUT
+  >>> emds.get_observations(columns=["obs_id", "dataproduct_type"], dataproduct_type=["img", "pha"])  # doctest: +IGNORE_OUTPUT
 
 + Numeric comparison:
     - ``t_min=(">", 60000)`` -> ``t_min > 60000``
 
 .. doctest-remote-data::
 
-  >>> emds.get_observations(
-  ...     columns=["obs_id", "t_min", "t_max"],
-  ...     t_min=(">", 60000),
-  ... )  # doctest: +IGNORE_OUTPUT
+  >>> emds.get_observations(columns=["obs_id", "t_min", "t_max"], t_min=(">", 60000))  # doctest: +IGNORE_OUTPUT
 
 + Filter by numeric interval:
     - ``s_ra=(80, 82)`` -> ``s_ra >= 80 AND s_ra <= 82``
 
 .. doctest-remote-data::
 
-  >>> emds.get_observations(
-  ...     columns=["obs_id", "s_ra", "s_dec"],
-  ...     s_ra=(80, 82),
-  ...     s_dec=(16, 18),
-  ... )  # doctest: +IGNORE_OUTPUT
+  >>> emds.get_observations(columns=["obs_id", "s_ra", "s_dec"], s_ra=(80, 82), s_dec=(16, 18))  # doctest: +IGNORE_OUTPUT
 
 + Combined filters: Multiple keyword filters are combined with ``AND``.
 
@@ -369,13 +337,7 @@ Depending on the configuration, ``*`` may also be accepted as an alias for ``%``
 
 .. doctest-remote-data::
 
-  >>> emds.get_observations(
-  ...     columns=["dataproduct_type", "obs_collection", "target_name", "obs_id",
-  ...              "s_ra", "s_dec", "instrument_name"],
-  ...     obs_collection="EPSA",
-  ...     dataproduct_type=["img", "pha"],
-  ...     instrument_name="FXT",
-  ... )  # doctest: +IGNORE_OUTPUT
+  >>> emds.get_observations(columns=["dataproduct_type", "obs_collection", "target_name", "obs_id", "s_ra", "s_dec", "instrument_name"], obs_collection="EPSA", dataproduct_type=["img", "pha"], instrument_name="FXT")  # doctest: +IGNORE_OUTPUT
 
 
 

--- a/docs/esa/emds/einsteinprobe/einsteinprobe.rst
+++ b/docs/esa/emds/einsteinprobe/einsteinprobe.rst
@@ -400,7 +400,7 @@ individual files directly from the EMDS data service.
 
   >>> from astroquery.esa.emds.einsteinprobe import EinsteinProbeClass
   >>> epsa = EinsteinProbeClass()
-  >>> t = epsa.get_products(obs_id=" 11900008319")
+  >>> t = epsa.get_products(obs_id="11900008319")
   Executed query:SELECT obs_id, filename, filepath
         FROM einsteinprobe.obscore_extended WHERE obs_id = ' 11900008319'
   >>> t["filepath"].format = "%.20s"
@@ -438,6 +438,7 @@ By default, the file is downloaded to the current working directory.
 .. doctest-remote-data::
 
     >>> from astroquery.esa.emds.einsteinprobe import EinsteinProbeClass
+    >>> epsa = EinsteinProbeClass()
     >>> epsa.download_product(filename='fxt_b_11900008319_ff_01_po_3bb.rmf') # doctest: +IGNORE_OUTPUT
     'fxt_b_11900008319_ff_01_po_3bb.rmf'
 

--- a/docs/esa/emds/einsteinprobe/einsteinprobe.rst
+++ b/docs/esa/emds/einsteinprobe/einsteinprobe.rst
@@ -126,7 +126,7 @@ and can be queried directly using fully-qualified table names.
   >>> epsa.query_tap(
   ...       query=(
   ...           "SELECT dataproduct_type, obs_collection, obs_id, s_ra, s_dec "
-  ...           "FROM einsteinprobe.obscore_extended"
+  ...           "FROM einsteinprobe.obscore_extended "
   ...           "ORDER BY target_name DESC"
   ...       )
   ...   )  # doctest: +IGNORE_OUTPUT
@@ -279,7 +279,7 @@ Some examples and their corresponding ADQL transformations are provided below:
 
 .. doctest-remote-data::
 
-  >>> emds.get_observations(columns=["dataproduct_type", "obs_collection", "target_name", "obs_id", "s_ra", "s_dec", "instrument_name"])  # doctest: +IGNORE_OUTPUT
+  >>> epsa.get_observations(columns=["dataproduct_type", "obs_collection", "target_name", "obs_id", "s_ra", "s_dec", "instrument_name"])  # doctest: +IGNORE_OUTPUT
 
 + Exact match (string):
     - ``obs_collection="EPSA"`` → ``obs_collection = 'EPSA'``
@@ -287,7 +287,7 @@ Some examples and their corresponding ADQL transformations are provided below:
 
 .. doctest-remote-data::
 
-  >>> emds.get_observations(columns=["obs_id", "obs_collection", "instrument_name", "dataproduct_type"], obs_collection="EPSA",instrument_name="FXT")  # doctest: +IGNORE_OUTPUT
+  >>> epsa.get_observations(columns=["obs_id", "obs_collection", "instrument_name", "dataproduct_type"], obs_collection="EPSA",instrument_name="FXT")  # doctest: +IGNORE_OUTPUT
 
 + Wildcards (string):
     - ``target_name="AT 2023%"`` → ``target_name ILIKE 'AT 2023%'``
@@ -296,17 +296,17 @@ Depending on the configuration, ``*`` may also be accepted as an alias for ``%``
 
 .. doctest-remote-data::
 
-  >>> emds.get_observations(columns=["obs_id", "target_name"],target_name="V1589 Cyg")  # doctest: +IGNORE_OUTPUT
+  >>> epsa.get_observations(columns=["obs_id", "target_name"],target_name="V1589 Cyg")  # doctest: +IGNORE_OUTPUT
 
 + Wildcards (string): ``coordinates`` and ``radius``
 
 .. doctest-remote-data::
 
-  >>> emds.get_observations(coordinates="81.1238 17.4175", radius=0.1, columns=["obs_id", "s_ra", "s_dec", "instrument_name"], )  # doctest: +IGNORE_OUTPUT
+  >>> epsa.get_observations(coordinates="81.1238 17.4175", radius=0.1, columns=["obs_id", "s_ra", "s_dec", "instrument_name"], )  # doctest: +IGNORE_OUTPUT
 
 .. doctest-remote-data::
 
-  >>> emds.get_observations( target_name="V1589 Cyg", radius=0.1, columns=["obs_id", "s_ra", "s_dec", "target_name"], )  # doctest: +IGNORE_OUTPUT
+  >>> epsa.get_observations( target_name="V1589 Cyg", radius=0.1, columns=["obs_id", "s_ra", "s_dec", "target_name"], )  # doctest: +IGNORE_OUTPUT
 
 + String list:
     - ``dataproduct_type=["img", "pha"]``
@@ -314,21 +314,21 @@ Depending on the configuration, ``*`` may also be accepted as an alias for ``%``
 
 .. doctest-remote-data::
 
-  >>> emds.get_observations(columns=["obs_id", "dataproduct_type"], dataproduct_type=["img", "pha"])  # doctest: +IGNORE_OUTPUT
+  >>> epsa.get_observations(columns=["obs_id", "dataproduct_type"], dataproduct_type=["img", "pha"])  # doctest: +IGNORE_OUTPUT
 
 + Numeric comparison:
     - ``t_min=(">", 60000)`` -> ``t_min > 60000``
 
 .. doctest-remote-data::
 
-  >>> emds.get_observations(columns=["obs_id", "t_min", "t_max"], t_min=(">", 60000))  # doctest: +IGNORE_OUTPUT
+  >>> epsa.get_observations(columns=["obs_id", "t_min", "t_max"], t_min=(">", 60000))  # doctest: +IGNORE_OUTPUT
 
 + Filter by numeric interval:
     - ``s_ra=(80, 82)`` -> ``s_ra >= 80 AND s_ra <= 82``
 
 .. doctest-remote-data::
 
-  >>> emds.get_observations(columns=["obs_id", "s_ra", "s_dec"], s_ra=(80, 82), s_dec=(16, 18))  # doctest: +IGNORE_OUTPUT
+  >>> epsa.get_observations(columns=["obs_id", "s_ra", "s_dec"], s_ra=(80, 82), s_dec=(16, 18))  # doctest: +IGNORE_OUTPUT
 
 + Combined filters: Multiple keyword filters are combined with ``AND``.
 
@@ -337,7 +337,7 @@ Depending on the configuration, ``*`` may also be accepted as an alias for ``%``
 
 .. doctest-remote-data::
 
-  >>> emds.get_observations(columns=["dataproduct_type", "obs_collection", "target_name", "obs_id", "s_ra", "s_dec", "instrument_name"], obs_collection="EPSA", dataproduct_type=["img", "pha"], instrument_name="FXT")  # doctest: +IGNORE_OUTPUT
+  >>> epsa.get_observations(columns=["dataproduct_type", "obs_collection", "target_name", "obs_id", "s_ra", "s_dec", "instrument_name"], obs_collection="EPSA", dataproduct_type=["img", "pha"], instrument_name="FXT")  # doctest: +IGNORE_OUTPUT
 
 
 

--- a/docs/esa/emds/einsteinprobe/einsteinprobe.rst
+++ b/docs/esa/emds/einsteinprobe/einsteinprobe.rst
@@ -98,7 +98,6 @@ and can be queried directly using fully-qualified table names.
   ...         "ORDER BY target_name DESC"
   ...     )
   ... )  # doctest: +IGNORE_OUTPUT
-
     <Table length=12298>
     dataproduct_type obs_collection target_name    obs_id           s_ra             s_dec
          object          object        object      object         float64           float64
@@ -136,7 +135,6 @@ using ``get_metadata=True``:
   >>> from astroquery.esa.emds.einsteinprobe import EinsteinProbeClass
   >>> epsa = EinsteinProbeClass()
   >>> epsa.get_observations(get_metadata=True)  # doctest: +IGNORE_OUTPUT
-
     <Table masked=True length=34>
         Column     Description  Unit  Data Type  UCD   UType
         str17         object   object    str7   object object
@@ -158,7 +156,6 @@ options, that can be combined to extract the required data:
   >>> from astroquery.esa.emds.einsteinprobe import EinsteinProbeClass
   >>> epsa = EinsteinProbeClass()
   >>> epsa.get_observations(target_name='V1589 Cyg')  # doctest: +IGNORE_OUTPUT
-
     Executed query:SELECT * FROM ivoa.ObsCore WHERE 1=CONTAINS(POINT('ICRS', s_ra, s_dec),CIRCLE('ICRS', 310.7048109, 41.3833259, 1.0))
     <Table length=12>
     access_estsize        access_format        ... t_xel target_name
@@ -182,7 +179,6 @@ options, that can be combined to extract the required data:
   >>> from astroquery.esa.emds.einsteinprobe import EinsteinProbeClass
   >>> epsa = EinsteinProbeClass()
   >>> epsa.get_observations(target_name='V1589 Cyg', columns=['s_ra', 's_dec', 'obs_id', 's_xel1'])  # doctest: +IGNORE_OUTPUT
-
     Executed query:SELECT s_ra, s_dec, obs_id, s_xel1 FROM ivoa.ObsCore WHERE 1=CONTAINS(POINT('ICRS', s_ra, s_dec),CIRCLE('ICRS', 310.7048109, 41.3833259, 1.0))
     <Table length=12>
            s_ra             s_dec           obs_id   s_xel1
@@ -206,7 +202,6 @@ options, that can be combined to extract the required data:
   >>> from astroquery.esa.emds.einsteinprobe import EinsteinProbeClass
   >>> epsa = EinsteinProbeClass()
   >>> epsa.get_observations(target_name='V1589 Cyg', columns=['s_ra', 's_dec', 'obs_id', 's_xel1'], s_xel1=('>', 100))  # doctest: +IGNORE_OUTPUT
-
     Executed query:SELECT s_ra, s_dec, obs_id, s_xel1 FROM ivoa.ObsCore  WHERE s_xel1 > 100 AND 1=CONTAINS(POINT('ICRS', s_ra, s_dec),CIRCLE('ICRS', 310.7048109, 41.3833259, 1.0))
     <Table length=8>
            s_ra             s_dec           obs_id   s_xel1
@@ -228,73 +223,99 @@ translates these filters into the corresponding ADQL constraints executed by the
 
 Some examples and their corresponding ADQL transformations are provided below:
 
-+ Exact match (string): ``obs_collection="EPSA"`` -> ``obs_collection = 'EPSA'``
++ By columns:
 
-+ Exact match (string): ``instrument_name="FXT"`` -> ``instrument_name = 'FXT'``
+.. doctest-remote-data::
 
-+ Wildcards (string): ``target_name="AT 2023%"`` -> ``target_name ILIKE 'AT 2023%'``
-  (``*`` may also be accepted as an alias for ``%`` depending on the backend configuration)
-
-+ String list: ``dataproduct_type=["img", "pha"]`` -> ``dataproduct_type = 'img' OR dataproduct_type = 'pha'``
-  (some TAP services may translate this to an equivalent ``IN ('img','pha')`` clause)
-
-+ Numeric comparison: ``t_min=(">", 60000)`` -> ``t_min > 60000``
-
-+ Filter by numeric interval: ``s_ra=(80, 82)`` -> ``s_ra >= 80 AND s_ra <= 82``
-
-+ Combined filters: ``obs_collection="EPSA", instrument_name="FXT"`` -> ``obs_collection = 'EPSA' AND instrument_name = 'FXT'``
-
-  >>> epsa.get_observations(
+  >>> emds.get_observations(
   ...     columns=["dataproduct_type", "obs_collection", "target_name", "obs_id",
   ...              "s_ra", "s_dec", "instrument_name"]
   ... )  # doctest: +IGNORE_OUTPUT
 
-  >>> epsa.get_observations(
++ Exact match (string):
+    - ``obs_collection="EPSA"`` → ``obs_collection = 'EPSA'``
+    - ``instrument_name="FXT"`` → ``instrument_name = 'FXT'``
+
+.. doctest-remote-data::
+
+  >>> emds.get_observations(
   ...     columns=["obs_id", "obs_collection", "instrument_name", "dataproduct_type"],
   ...     obs_collection="EPSA",
   ...     instrument_name="FXT",
   ... )  # doctest: +IGNORE_OUTPUT
 
-  >>> epsa.get_observations(
++ Wildcards (string): ``target_name="AT 2023%"`` → ``target_name ILIKE 'AT 2023%'``
+
+Depending on the configuration, ``*`` may also be accepted as an alias for ``%``.
+
+.. doctest-remote-data::
+
+  >>> emds.get_observations(
   ...     columns=["obs_id", "target_name"],
   ...     target_name="V1589 Cyg",
   ... )  # doctest: +IGNORE_OUTPUT
 
-  >>> epsa.get_observations(
-  ...     columns=["obs_id", "dataproduct_type"],
-  ...     dataproduct_type=["img", "pha"],
-  ... )  # doctest: +IGNORE_OUTPUT
++ Wildcards (string): ``coordinates`` and ``radius``
 
-  >>> epsa.get_observations(
-  ...     columns=["obs_id", "t_min", "t_max"],
-  ...     t_min=(">", 60000),
-  ... )  # doctest: +IGNORE_OUTPUT
+.. doctest-remote-data::
 
-  >>> epsa.get_observations(
-  ...     columns=["obs_id", "s_ra", "s_dec"],
-  ...     s_ra=(80, 82),
-  ...     s_dec=(16, 18),
-  ... )  # doctest: +IGNORE_OUTPUT
-
-  >>> epsa.get_observations(
+  >>> emds.get_observations(
   ...     coordinates="81.1238 17.4175",
   ...     radius=0.1,
   ...     columns=["obs_id", "s_ra", "s_dec", "instrument_name"],
   ... )  # doctest: +IGNORE_OUTPUT
 
-  >>> epsa.get_observations(
+.. doctest-remote-data::
+
+  >>> emds.get_observations(
   ...     target_name="V1589 Cyg",
   ...     radius=0.1,
   ...     columns=["obs_id", "s_ra", "s_dec", "target_name"],
   ... )  # doctest: +IGNORE_OUTPUT
 
-  >>> epsa.get_observations(
++ String list: ``dataproduct_type=["img", "pha"]`` → ``dataproduct_type = 'img' OR dataproduct_type = 'pha'``
+
+.. doctest-remote-data::
+
+  >>> emds.get_observations(
+  ...     columns=["obs_id", "dataproduct_type"],
+  ...     dataproduct_type=["img", "pha"],
+  ... )  # doctest: +IGNORE_OUTPUT
+
++ Numeric comparison: ``t_min=(">", 60000)`` -> ``t_min > 60000``
+
+.. doctest-remote-data::
+
+  >>> emds.get_observations(
+  ...     columns=["obs_id", "t_min", "t_max"],
+  ...     t_min=(">", 60000),
+  ... )  # doctest: +IGNORE_OUTPUT
+
++ Filter by numeric interval: ``s_ra=(80, 82)`` -> ``s_ra >= 80 AND s_ra <= 82``
+
+.. doctest-remote-data::
+
+  >>> emds.get_observations(
+  ...     columns=["obs_id", "s_ra", "s_dec"],
+  ...     s_ra=(80, 82),
+  ...     s_dec=(16, 18),
+  ... )  # doctest: +IGNORE_OUTPUT
+
++ Combined filters: Multiple keyword filters are combined with ``AND``.
+
+    - ``obs_collection="EPSA", instrument_name="FXT"`` → ``obs_collection = 'EPSA' AND instrument_name = 'FXT'``
+
+.. doctest-remote-data::
+
+  >>> emds.get_observations(
   ...     columns=["dataproduct_type", "obs_collection", "target_name", "obs_id",
   ...              "s_ra", "s_dec", "instrument_name"],
   ...     obs_collection="EPSA",
   ...     dataproduct_type=["img", "pha"],
   ...     instrument_name="FXT",
   ... )  # doctest: +IGNORE_OUTPUT
+
+
 
 -------------------------
 5. Download file product
@@ -317,7 +338,6 @@ individual files directly from the EMDS data service.
   >>> from astroquery.esa.emds.einsteinprobe import EinsteinProbeClass
   >>> epsa = EinsteinProbeClass()
   >>> epsa.get_products(obs_id=' 11900008319') # doctest: +IGNORE_OUTPUT
-
     Executed query:SELECT obs_id, filename, filepath FROM einsteinprobe.obscore_extended WHERE obs_id = ' 11900008319'
     <Table length=20>
        obs_id                    filename                              filepath

--- a/docs/esa/emds/einsteinprobe/einsteinprobe.rst
+++ b/docs/esa/emds/einsteinprobe/einsteinprobe.rst
@@ -1,0 +1,339 @@
+.. _astroquery.esa.emds.einsteinprobe:
+
+*****************************************************************************
+EinsteinProbe Space Archive (EPSA) (`astroquery.esa.emds.einsteinprobe`)
+*****************************************************************************
+
+Einstein Probe is an X-ray astronomy mission led by the Chinese Academy of Sciences (CAS),
+with international collaboration from the European Space Agency (ESA) and the Max Planck
+Institute for Extraterrestrial Physics (MPE). The Einstein Probe data are distributed
+through the EMDS archive, which provides access to multiple missions via a single service.
+
+The mission is designed to monitor the X-ray sky and discover transient and variable
+phenomena across the Universe. It carries two main scientific instruments: the Wide-field
+X-ray Telescope (WXT), which provides a very large field of view for sky monitoring, and
+the Follow-up X-ray Telescope (FXT), which enables more detailed observations of selected
+sources.
+
+Using its wide field of view, the mission performs a systematic survey of the X-ray sky and
+can monitor a large fraction of the Universe simultaneously. This allows the detection of
+X-ray emission from a wide range of astrophysical sources, including accreting compact
+objects such as black holes and neutron stars, gamma-ray bursts, supernovae, stellar
+flares, and transient events within the Solar System, such as X-ray emission from comets.
+
+The mission also searches for tidal disruption events, in which stars are torn apart by the
+strong gravitational field of supermassive black holes that are otherwise dormant and
+difficult to detect. In addition, it plays an important role in multi-messenger astronomy
+by detecting X-ray counterparts of gravitational-wave events, such as mergers of neutron
+stars or neutron stars and black holes, helping to localize these events and study their
+physical properties.
+
+========
+Examples
+========
+
+---------------
+1. Login/Logout
+---------------
+Some tables and data require authentication to access proprietary or advanced data. Authentication is managed
+through the ``login()`` and ``logout()`` methods provided by the EMDS Astroquery module.
+
+.. doctest-remote-data::
+
+  >>> from astroquery.esa.emds.einsteinprobe import EinsteinProbeClass
+  >>> epsa = EinsteinProbeClass()
+  >>> epsa.login() # doctest: +IGNORE_OUTPUT
+  >>> epsa.logout() # doctest: +IGNORE_OUTPUT
+
+-----------------------------------
+2. Get available tables and columns
+-----------------------------------
+
+Einstein Probe Astroquery module allows users to explore the data structure of the TAP by listing available
+tables and their columns. This is useful for understanding what data is accessible before running ADQL queries.
+
+  >>> from astroquery.esa.emds.einsteinprobe import EinsteinProbeClass
+  >>> epsa = EinsteinProbeClass()
+  >>> epsa.get_tables()
+  [<VODataServiceTable name="einsteinprobe.fxt_product">... 24 columns ...</VODataServiceTable>, <VODataServiceTable name="einsteinprobe.obscore">... 30 columns ...</VODataServiceTable>, <VODataServiceTable name="einsteinprobe.obscore_extended">... 34 columns ...</VODataServiceTable>, <VODataServiceTable name="einsteinprobe.preview_products">... 2 columns ...</VODataServiceTable>, <VODataServiceTable name="einsteinprobe.wxt_product">... 22 columns ...</VODataServiceTable>]
+
+  >>> epsa.get_tables(only_names=True)
+  ['einsteinprobe.fxt_product', 'einsteinprobe.obscore', 'einsteinprobe.obscore_extended', 'einsteinprobe.preview_products', 'einsteinprobe.wxt_product']
+
+  >>> obscore_table = epsa.get_table('einsteinprobe.obscore_extended')
+  >>> obscore_table.columns
+  [<BaseParam name="access_estsize"/>, <BaseParam name="access_format"/>, <BaseParam name="access_url"/>, <BaseParam name="calib_level"/>, <BaseParam name="dataproduct_type"/>, <BaseParam name="em_max"/>, <BaseParam name="em_min"/>, <BaseParam name="em_res_power"/>, <BaseParam name="em_xel"/>, <BaseParam name="facility_name"/>, <BaseParam name="filename"/>, <BaseParam name="filepath"/>, <BaseParam name="has_preview"/>, <BaseParam name="instrument_name"/>, <BaseParam name="o_ucd"/>, <BaseParam name="obs_collection"/>, <BaseParam name="obs_id"/>, <BaseParam name="obs_publisher_did"/>, <BaseParam name="pol_states"/>, <BaseParam name="pol_xel"/>, <BaseParam name="preview"/>, <BaseParam name="s_dec"/>, <BaseParam name="s_fov"/>, <BaseParam name="s_ra"/>, <BaseParam name="s_region"/>, <BaseParam name="s_resolution"/>, <BaseParam name="s_xel1"/>, <BaseParam name="s_xel2"/>, <BaseParam name="t_exptime"/>, <BaseParam name="t_max"/>, <BaseParam name="t_min"/>, <BaseParam name="t_resolution"/>, <BaseParam name="t_xel"/>, <BaseParam name="target_name"/>]
+
+----------------------------
+3. ADQL Queries to EMDS TAP
+----------------------------
+
+The Query TAP functionality facilitates the execution of custom Table Access Protocol (TAP)
+queries within the EMDS service. Queries can be executed synchronously or asynchronously,
+and results may be exported in different output formats.
+
+When using the Einstein Probe client, ADQL queries are executed against the EMDS TAP service.
+Mission-specific tables are exposed under their corresponding TAP schemas (e.g. ``einsteinprobe``),
+and can be queried directly using fully-qualified table names.
+
+.. doctest-remote-data::
+
+  >>> from astroquery.esa.emds.einsteinprobe import EinsteinProbeClass
+  >>> epsa = EinsteinProbeClass()
+  >>> epsa.query_tap(
+  ...     query=(
+  ...         "SELECT dataproduct_type, obs_collection, target_name, obs_id, s_ra, s_dec "
+  ...         "FROM einsteinprobe.obscore_extended "
+  ...         "ORDER BY target_name DESC"
+  ...     )
+  ... )  # doctest: +IGNORE_OUTPUT
+
+    <Table length=12298>
+    dataproduct_type obs_collection target_name    obs_id           s_ra             s_dec
+         object          object        object      object         float64           float64
+    ---------------- -------------- ----------- ------------ ----------------- ------------------
+                 arf           EPSA              10202076929                --                 --
+                 png           EPSA              11900006256                --                 --
+                 ...            ...         ...          ...               ...                ...
+                  lc           EPSA   * 111 Tau  11900008319 81.12383618253855  17.41749240154885
+                 pha           EPSA   * 111 Tau  11900008319 81.12383621375398 17.417492453817907
+
+
+-------------------------------------
+4. Filtering the Obs Core Catalogue
+-------------------------------------
+
+The EMDS TAP service provides a catalogue with observation-level information, such as sky
+position, time coverage, instrument details, and data product identifiers. Since EMDS is a
+multi-mission archive, each mission exposes its own observation catalogue.
+
+When using the Einstein Probe client, queries are performed on the Einstein Probe catalogue,
+which is exposed under a mission-specific schema.
+
+These catalogues can be large, so it is usually not practical to retrieve all rows and
+columns at once. Instead, users are encouraged to select only the columns they need and
+apply filters, for example by sky position, data product type, or observation collection.
+
+The ``get_observations`` method provides a convenient way to query the Einstein Probe
+observation catalogue and apply such filters.
+
+To inspect the available columns in the catalogue, the following method can be executed
+using ``get_metadata=True``:
+
+.. doctest-remote-data::
+
+  >>> from astroquery.esa.emds.einsteinprobe import EinsteinProbeClass
+  >>> epsa = EinsteinProbeClass()
+  >>> epsa.get_observations(get_metadata=True)  # doctest: +IGNORE_OUTPUT
+
+    <Table masked=True length=34>
+        Column     Description  Unit  Data Type  UCD   UType
+        str17         object   object    str7   object object
+    -------------- ----------- ------ --------- ------ ------
+    access_estsize        None   None      long   None   None
+     access_format        None   None      char   None   None
+               ...         ...    ...       ...    ...    ...
+      t_resolution        None   None    double   None   None
+             t_xel        None   None    double   None   None
+       target_name        None   None      char   None   None
+
+Once the columns of interest have been extracted, it is possible to execute the same function with the following
+options, that can be combined to extract the required data:
+
++ Define the reference target or coordinates where a cone search will be executed.
+
+.. doctest-remote-data::
+
+  >>> from astroquery.esa.emds.einsteinprobe import EinsteinProbeClass
+  >>> epsa = EinsteinProbeClass()
+  >>> epsa.get_observations(target_name='V1589 Cyg')  # doctest: +IGNORE_OUTPUT
+
+    Executed query:SELECT * FROM ivoa.ObsCore WHERE 1=CONTAINS(POINT('ICRS', s_ra, s_dec),CIRCLE('ICRS', 310.7048109, 41.3833259, 1.0))
+    <Table length=12>
+    access_estsize        access_format        ... t_xel target_name
+        kbyte                                  ...
+        int64                 object           ... int64    object
+    -------------- --------------------------- ... ----- -----------
+            463680 application/x-fits-bintable ... 19233   V1589 Cyg
+           2888640 application/x-fits-bintable ...    --           0
+             51840 application/x-fits-bintable ...   961   V1589 Cyg
+            745920 application/x-fits-bintable ... 19233   V1589 Cyg
+               ...                         ... ...   ...         ...
+           2888640 application/x-fits-bintable ...    --           0
+           1465920 application/x-fits-bintable ... 19234   V1589 Cyg
+            362880 application/x-fits-bintable ... 19234   V1589 Cyg
+           1465920 application/x-fits-bintable ... 19233   V1589 Cyg
+
++ Retrieve only a specific set of columns.
+
+.. doctest-remote-data::
+
+  >>> from astroquery.esa.emds.einsteinprobe import EinsteinProbeClass
+  >>> epsa = EinsteinProbeClass()
+  >>> epsa.get_observations(target_name='V1589 Cyg', columns=['s_ra', 's_dec', 'obs_id', 's_xel1'])  # doctest: +IGNORE_OUTPUT
+
+    Executed query:SELECT s_ra, s_dec, obs_id, s_xel1 FROM ivoa.ObsCore WHERE 1=CONTAINS(POINT('ICRS', s_ra, s_dec),CIRCLE('ICRS', 310.7048109, 41.3833259, 1.0))
+    <Table length=12>
+           s_ra             s_dec           obs_id   s_xel1
+           deg               deg
+         float64           float64          object   int64
+    ----------------- ------------------ ----------- ------
+    310.6757640621578 41.351414087733275 11900012239     95
+    310.6755985583337 41.351202980612555 11900012239    600
+    310.6755985583337 41.351202980612555 11900012239     20
+    310.6755985583337 41.351202980612555 11900012239    418
+                  ...                ...         ...    ...
+    310.6755985583337 41.351202980612555 11900012239    600
+    310.6756375374491 41.351278441170614 11900012239    600
+    310.6756375374491 41.351278441170614 11900012239     95
+    310.6757640621578 41.351414087733275 11900012239    600
+
++ Filter by any other column available in the previous method.
+
+.. doctest-remote-data::
+
+  >>> from astroquery.esa.emds.einsteinprobe import EinsteinProbeClass
+  >>> epsa = EinsteinProbeClass()
+  >>> epsa.get_observations(target_name='V1589 Cyg', columns=['s_ra', 's_dec', 'obs_id', 's_xel1'], s_xel1=('>', 100))  # doctest: +IGNORE_OUTPUT
+
+    Executed query:SELECT s_ra, s_dec, obs_id, s_xel1 FROM ivoa.ObsCore  WHERE s_xel1 > 100 AND 1=CONTAINS(POINT('ICRS', s_ra, s_dec),CIRCLE('ICRS', 310.7048109, 41.3833259, 1.0))
+    <Table length=8>
+           s_ra             s_dec           obs_id   s_xel1
+           deg               deg
+         float64           float64          object   int64
+    ----------------- ------------------ ----------- ------
+    310.6755985583337 41.351202980612555 11900012239    600
+    310.6755985583337 41.351202980612555 11900012239    418
+    310.6755993340324  41.35120289084306 11900012239    600
+    310.6755993340324  41.35120289084306 11900012239    600
+    310.6755993340324  41.35120289084306 11900012239    418
+    310.6755985583337 41.351202980612555 11900012239    600
+    310.6756375374491 41.351278441170614 11900012239    600
+    310.6757640621578 41.351414087733275 11900012239    600
+
+As it can be observed in the previous examples, additional constraints can be provided using the ``**filters`` syntax,
+where the keyword corresponds to an ObsCore column name and the value defines the filter to be applied. The method
+translates these filters into the corresponding ADQL constraints executed by the TAP service.
+
+Some examples and their corresponding ADQL transformations are provided below:
+
++ Exact match (string): ``obs_collection="EPSA"`` -> ``obs_collection = 'EPSA'``
+
++ Exact match (string): ``instrument_name="FXT"`` -> ``instrument_name = 'FXT'``
+
++ Wildcards (string): ``target_name="AT 2023%"`` -> ``target_name ILIKE 'AT 2023%'``
+  (``*`` may also be accepted as an alias for ``%`` depending on the backend configuration)
+
++ String list: ``dataproduct_type=["img", "pha"]`` -> ``dataproduct_type = 'img' OR dataproduct_type = 'pha'``
+  (some TAP services may translate this to an equivalent ``IN ('img','pha')`` clause)
+
++ Numeric comparison: ``t_min=(">", 60000)`` -> ``t_min > 60000``
+
++ Filter by numeric interval: ``s_ra=(80, 82)`` -> ``s_ra >= 80 AND s_ra <= 82``
+
++ Combined filters: ``obs_collection="EPSA", instrument_name="FXT"`` -> ``obs_collection = 'EPSA' AND instrument_name = 'FXT'``
+
+  >>> epsa.get_observations(
+  ...     columns=["dataproduct_type", "obs_collection", "target_name", "obs_id",
+  ...              "s_ra", "s_dec", "instrument_name"]
+  ... )  # doctest: +IGNORE_OUTPUT
+
+  >>> epsa.get_observations(
+  ...     columns=["obs_id", "obs_collection", "instrument_name", "dataproduct_type"],
+  ...     obs_collection="EPSA",
+  ...     instrument_name="FXT",
+  ... )  # doctest: +IGNORE_OUTPUT
+
+  >>> epsa.get_observations(
+  ...     columns=["obs_id", "target_name"],
+  ...     target_name="V1589 Cyg",
+  ... )  # doctest: +IGNORE_OUTPUT
+
+  >>> epsa.get_observations(
+  ...     columns=["obs_id", "dataproduct_type"],
+  ...     dataproduct_type=["img", "pha"],
+  ... )  # doctest: +IGNORE_OUTPUT
+
+  >>> epsa.get_observations(
+  ...     columns=["obs_id", "t_min", "t_max"],
+  ...     t_min=(">", 60000),
+  ... )  # doctest: +IGNORE_OUTPUT
+
+  >>> epsa.get_observations(
+  ...     columns=["obs_id", "s_ra", "s_dec"],
+  ...     s_ra=(80, 82),
+  ...     s_dec=(16, 18),
+  ... )  # doctest: +IGNORE_OUTPUT
+
+  >>> epsa.get_observations(
+  ...     coordinates="81.1238 17.4175",
+  ...     radius=0.1,
+  ...     columns=["obs_id", "s_ra", "s_dec", "instrument_name"],
+  ... )  # doctest: +IGNORE_OUTPUT
+
+  >>> epsa.get_observations(
+  ...     target_name="V1589 Cyg",
+  ...     radius=0.1,
+  ...     columns=["obs_id", "s_ra", "s_dec", "target_name"],
+  ... )  # doctest: +IGNORE_OUTPUT
+
+  >>> epsa.get_observations(
+  ...     columns=["dataproduct_type", "obs_collection", "target_name", "obs_id",
+  ...              "s_ra", "s_dec", "instrument_name"],
+  ...     obs_collection="EPSA",
+  ...     dataproduct_type=["img", "pha"],
+  ...     instrument_name="FXT",
+  ... )  # doctest: +IGNORE_OUTPUT
+
+-------------------------
+5. Download file product
+-------------------------
+
+Observations in the Einstein Probe catalogue are associated with one or more data products,
+such as science files or preview images. These products are stored as files on the EMDS
+data service and can be accessed once the corresponding observation or product identifiers
+are known.
+
+Typically, users first query the observation catalogue to identify the observations of
+interest and inspect the available metadata (for example product type, filename, or file
+path). Based on this information, individual products can then be downloaded.
+
+This module provides helper methods to retrieve product information and to download
+individual files directly from the EMDS data service.
+
+.. doctest-remote-data::
+
+  >>> from astroquery.esa.emds.einsteinprobe import EinsteinProbeClass
+  >>> epsa = EinsteinProbeClass()
+  >>> epsa.get_products(obs_id=' 11900008319') # doctest: +IGNORE_OUTPUT
+
+    Executed query:SELECT obs_id, filename, filepath FROM einsteinprobe.obscore_extended WHERE obs_id = ' 11900008319'
+    <Table length=20>
+       obs_id                    filename                              filepath
+       object                     object                                object
+    ------------ --------------------------------------- -----------------------------------
+     11900008319  fxt_b_11900008319_ff_01_po_cl_3ac.fits /epsa/repo/11900008319/fxt/products
+     11900008319      fxt_b_11900008319_ff_01_po_3ac.pha /epsa/repo/11900008319/fxt/products
+             ...                                     ...                                 ...
+     11900008319 fxt_a_11900008319_ff_01_po_gti_3bb.fits /epsa/repo/11900008319/fxt/products
+     11900008319      fxt_b_11900008319_ff_01_po_3bb.arf /epsa/repo/11900008319/fxt/products
+     11900008319      fxt_b_11900008319_ff_01_po_3bb.rmf /epsa/repo/11900008319/fxt/products
+
+The following example shows how to download a single data product using its filename.
+By default, the file is downloaded to the current working directory.
+
+.. doctest-remote-data::
+
+    >>> from astroquery.esa.emds.einsteinprobe import EinsteinProbeClass
+    >>> epsa.download_product(filename='fxt_b_11900008319_ff_01_po_3bb.rmf') # doctest: +IGNORE_OUTPUT
+    'fxt_b_11900008319_ff_01_po_3bb.rmf'
+
+Product downloads return the files as stored in the archive. No output format needs to be
+specified when downloading data products.
+
+
+Reference/API
+=============
+
+.. automodapi:: astroquery.esa.emds.einsteinprobe
+    :no-inheritance-diagram:

--- a/docs/esa/emds/einsteinprobe/einsteinprobe.rst
+++ b/docs/esa/emds/einsteinprobe/einsteinprobe.rst
@@ -6,27 +6,32 @@ EinsteinProbe Space Archive (EPSA) (`astroquery.esa.emds.einsteinprobe`)
 
 Einstein Probe is an X-ray astronomy mission led by the Chinese Academy of Sciences (CAS),
 with international collaboration from the European Space Agency (ESA) and the Max Planck
-Institute for Extraterrestrial Physics (MPE). The Einstein Probe data are distributed
-through the EMDS archive, which provides access to multiple missions via a single service.
+Institute for Extraterrestrial Physics (MPE). Einstein Probe data are distributed through
+the ESA Multi-Mission Data Services (EMDS) archive, which provides unified access to
+multiple space missions through a single service.
 
 The mission is designed to monitor the X-ray sky and discover transient and variable
-phenomena across the Universe. It carries two main scientific instruments: the Wide-field
-X-ray Telescope (WXT), which provides a very large field of view for sky monitoring, and
-the Follow-up X-ray Telescope (FXT), which enables more detailed observations of selected
-sources.
+phenomena across the Universe. It carries two primary scientific instruments: the
+wide-field X-ray Telescope (WXT), which provides a very large field of view for sky
+monitoring, and the Follow-up X-ray Telescope (FXT), which enables more detailed
+observations of selected sources.
 
-Using its wide field of view, the mission performs a systematic survey of the X-ray sky and
-can monitor a large fraction of the Universe simultaneously. This allows the detection of
-X-ray emission from a wide range of astrophysical sources, including accreting compact
-objects such as black holes and neutron stars, gamma-ray bursts, supernovae, stellar
-flares, and transient events within the Solar System, such as X-ray emission from comets.
+Using its wide-field capability, the mission performs a systematic survey of the X-ray
+sky and can monitor a large fraction of the sky simultaneously. This facilitates the
+detection of X-ray emission from a wide range of astrophysical sources, including
+accreting compact objects such as black holes and neutron stars, gamma-ray bursts,
+supernovae, stellar flares, and transient events within the Solar System, such as X-ray
+emission from comets.
 
-The mission also searches for tidal disruption events, in which stars are torn apart by the
-strong gravitational field of supermassive black holes that are otherwise dormant and
-difficult to detect. In addition, it plays an important role in multi-messenger astronomy
-by detecting X-ray counterparts of gravitational-wave events, such as mergers of neutron
-stars or neutron stars and black holes, helping to localize these events and study their
-physical properties.
+The mission also searches for tidal disruption events, in which stars are torn apart by
+the strong gravitational field of otherwise dormant supermassive black holes that are
+difficult to detect. In addition, Einstein Probe plays an important role in
+multi-messenger astronomy by detecting X-ray counterparts of gravitational-wave events,
+such as mergers of neutron stars or neutron stars and black holes. These observations
+help to localize such events and study their physical properties.
+
+For additional information about the Einstein Probe mission, see the official mission
+website `https://ep.bao.ac.cn/ep/ <https://ep.bao.ac.cn/ep/>`_.
 
 ========
 Examples
@@ -35,8 +40,12 @@ Examples
 ---------------
 1. Login/Logout
 ---------------
-Some tables and data require authentication to access proprietary or advanced data. Authentication is managed
-through the ``login()`` and ``logout()`` methods provided by the EMDS Astroquery module.
+Some EMDS missions may require authentication to access proprietary or advanced data products.
+The Astroquery EMDS interface provides :meth:`~astroquery.esa.emds.EMDSClass.login` and
+:meth:`~astroquery.esa.emds.EMDSClass.logout` for this purpose.
+
+Einstein Probe data accessed through this module are public and do not require authentication, but the methods are
+available for consistency and are inherited from the base EMDS interface.
 
 .. doctest-remote-data::
 
@@ -45,6 +54,12 @@ through the ``login()`` and ``logout()`` methods provided by the EMDS Astroquery
   >>> epsa.login() # doctest: +IGNORE_OUTPUT
   >>> epsa.logout() # doctest: +IGNORE_OUTPUT
 
+.. note::
+
+   The :meth:`login` and :meth:`logout` methods are inherited from the base EMDS interface.
+   They are not required for Einstein Probe, but are provided for consistency across EMDS mission
+   modules.
+
 -----------------------------------
 2. Get available tables and columns
 -----------------------------------
@@ -52,10 +67,18 @@ through the ``login()`` and ``logout()`` methods provided by the EMDS Astroquery
 Einstein Probe Astroquery module allows users to explore the data structure of the TAP by listing available
 tables and their columns. This is useful for understanding what data is accessible before running ADQL queries.
 
+.. doctest-remote-data::
+
   >>> from astroquery.esa.emds.einsteinprobe import EinsteinProbeClass
   >>> epsa = EinsteinProbeClass()
   >>> epsa.get_tables()
-  [<VODataServiceTable name="einsteinprobe.fxt_product">... 24 columns ...</VODataServiceTable>, <VODataServiceTable name="einsteinprobe.obscore">... 30 columns ...</VODataServiceTable>, <VODataServiceTable name="einsteinprobe.obscore_extended">... 34 columns ...</VODataServiceTable>, <VODataServiceTable name="einsteinprobe.preview_products">... 2 columns ...</VODataServiceTable>, <VODataServiceTable name="einsteinprobe.wxt_product">... 22 columns ...</VODataServiceTable>]
+  [<VODataServiceTable name="einsteinprobe.fxt_product">... 24 columns
+  ...</VODataServiceTable>,
+  <VODataServiceTable name="einsteinprobe.obscore">... 30 columns
+  ...</VODataServiceTable>,
+  <VODataServiceTable name="einsteinprobe.obscore_extended">... 34 columns
+  ...]
+
 
 By default, ``get_tables()`` returns table objects with metadata. If ``only_names=True`` is provided, the method returns
 only the table names as strings. This is useful when you only need to inspect or display the available tables without
@@ -64,7 +87,9 @@ accessing their full metadata.
 .. doctest-remote-data::
 
   >>> epsa.get_tables(only_names=True)
-  ['einsteinprobe.fxt_product', 'einsteinprobe.obscore', 'einsteinprobe.obscore_extended', 'einsteinprobe.preview_products', 'einsteinprobe.wxt_product']
+  ['einsteinprobe.fxt_product', 'einsteinprobe.obscore',
+  'einsteinprobe.obscore_extended','einsteinprobe.preview_products',
+  'einsteinprobe.wxt_product']
 
 Once a specific table is selected using ``get_table()``, the returned object provides access to the table metadata,
 including its columns.
@@ -73,7 +98,14 @@ including its columns.
 
   >>> obscore_table = epsa.get_table('einsteinprobe.obscore_extended')
   >>> obscore_table.columns
-  [<BaseParam name="access_estsize"/>, <BaseParam name="access_format"/>, <BaseParam name="access_url"/>, <BaseParam name="calib_level"/>, <BaseParam name="dataproduct_type"/>, <BaseParam name="em_max"/>, <BaseParam name="em_min"/>, <BaseParam name="em_res_power"/>, <BaseParam name="em_xel"/>, <BaseParam name="facility_name"/>, <BaseParam name="filename"/>, <BaseParam name="filepath"/>, <BaseParam name="has_preview"/>, <BaseParam name="instrument_name"/>, <BaseParam name="o_ucd"/>, <BaseParam name="obs_collection"/>, <BaseParam name="obs_id"/>, <BaseParam name="obs_publisher_did"/>, <BaseParam name="pol_states"/>, <BaseParam name="pol_xel"/>, <BaseParam name="preview"/>, <BaseParam name="s_dec"/>, <BaseParam name="s_fov"/>, <BaseParam name="s_ra"/>, <BaseParam name="s_region"/>, <BaseParam name="s_resolution"/>, <BaseParam name="s_xel1"/>, <BaseParam name="s_xel2"/>, <BaseParam name="t_exptime"/>, <BaseParam name="t_max"/>, <BaseParam name="t_min"/>, <BaseParam name="t_resolution"/>, <BaseParam name="t_xel"/>, <BaseParam name="target_name"/>]
+  [<BaseParam name="access_estsize"/>, <BaseParam name="access_format"/>,
+  <BaseParam name="access_url"/>, <BaseParam name="calib_level"/>,
+  <BaseParam name="dataproduct_type"/>, <BaseParam name="em_max"/>,
+  ...]
+
+.. note::
+
+   Only a subset of the available tables and columns is shown in the examples above.
 
 ----------------------------
 3. ADQL Queries to EMDS TAP
@@ -92,21 +124,34 @@ and can be queried directly using fully-qualified table names.
   >>> from astroquery.esa.emds.einsteinprobe import EinsteinProbeClass
   >>> epsa = EinsteinProbeClass()
   >>> epsa.query_tap(
-  ...     query=(
-  ...         "SELECT dataproduct_type, obs_collection, target_name, obs_id, s_ra, s_dec "
-  ...         "FROM einsteinprobe.obscore_extended "
-  ...         "ORDER BY target_name DESC"
-  ...     )
-  ... )  # doctest: +IGNORE_OUTPUT
-    <Table length=12298>
-    dataproduct_type obs_collection target_name    obs_id           s_ra             s_dec
-         object          object        object      object         float64           float64
-    ---------------- -------------- ----------- ------------ ----------------- ------------------
-                 arf           EPSA              10202076929                --                 --
-                 png           EPSA              11900006256                --                 --
-                 ...            ...         ...          ...               ...                ...
-                  lc           EPSA   * 111 Tau  11900008319 81.12383618253855  17.41749240154885
-                 pha           EPSA   * 111 Tau  11900008319 81.12383621375398 17.417492453817907
+  ...       query=(
+  ...           "SELECT dataproduct_type, obs_collection, obs_id, s_ra, s_dec "
+  ...           "FROM einsteinprobe.obscore_extended"
+  ...           "ORDER BY target_name DESC"
+  ...       )
+  ...   )  # doctest: +IGNORE_OUTPUT
+  <Table length=12298>
+  dataproduct_type obs_collection    obs_id           s_ra              s_dec
+       object          object        object         float64            float64
+  ---------------- -------------- ------------ ------------------ ------------------
+               arf           EPSA  10202076929                 --                 --
+               png           EPSA  11900006256                 --                 --
+               png           EPSA  11900006200                 --                 --
+               rmf           EPSA  11900012239                 --                 --
+               pds           EPSA  11900006204                 --                 --
+               arf           EPSA  11900012239                 --                 --
+               rmf           EPSA  11900012239                 --                 --
+               pds           EPSA  11900006231                 --                 --
+               ...            ...          ...                ...                ...
+                lc           EPSA  11900010908 344.33858806609254 20.740901740634797
+               img           EPSA  11900008319  81.12383621375398 17.417492453817907
+                lc           EPSA  11900008319  81.12383621375398 17.417492453817907
+               pha           EPSA  11900008319  81.12383618253855  17.41749240154885
+             event           EPSA  11900008319  81.12383621375398 17.417492453817907
+               img           EPSA  11900008319  81.12383618253855  17.41749240154885
+             event           EPSA  11900008319  81.12383618253855  17.41749240154885
+                lc           EPSA  11900008319  81.12383618253855  17.41749240154885
+               pha           EPSA  11900008319  81.12383621375398 17.417492453817907
 
 
 -------------------------------------
@@ -156,7 +201,8 @@ options, that can be combined to extract the required data:
   >>> from astroquery.esa.emds.einsteinprobe import EinsteinProbeClass
   >>> epsa = EinsteinProbeClass()
   >>> epsa.get_observations(target_name='V1589 Cyg')  # doctest: +IGNORE_OUTPUT
-    Executed query:SELECT * FROM ivoa.ObsCore WHERE 1=CONTAINS(POINT('ICRS', s_ra, s_dec),CIRCLE('ICRS', 310.7048109, 41.3833259, 1.0))
+    Executed query:SELECT * FROM ivoa.ObsCore WHERE 1=CONTAINS(POINT('ICRS', s_ra, s_dec),
+                    CIRCLE('ICRS', 310.7048109, 41.3833259, 1.0))
     <Table length=12>
     access_estsize        access_format        ... t_xel target_name
         kbyte                                  ...
@@ -178,8 +224,12 @@ options, that can be combined to extract the required data:
 
   >>> from astroquery.esa.emds.einsteinprobe import EinsteinProbeClass
   >>> epsa = EinsteinProbeClass()
-  >>> epsa.get_observations(target_name='V1589 Cyg', columns=['s_ra', 's_dec', 'obs_id', 's_xel1'])  # doctest: +IGNORE_OUTPUT
-    Executed query:SELECT s_ra, s_dec, obs_id, s_xel1 FROM ivoa.ObsCore WHERE 1=CONTAINS(POINT('ICRS', s_ra, s_dec),CIRCLE('ICRS', 310.7048109, 41.3833259, 1.0))
+  >>> epsa.get_observations(
+   ...     target_name="V1589 Cyg", columns=["s_ra", "s_dec", "obs_id", "s_xel1"]
+   ... )  # doctest: +IGNORE_OUTPUT
+    Executed query:SELECT s_ra, s_dec, obs_id, s_xel1 FROM ivoa.ObsCore WHERE
+                    1=CONTAINS(POINT('ICRS', s_ra, s_dec),
+                    CIRCLE('ICRS', 310.7048109, 41.3833259, 1.0))
     <Table length=12>
            s_ra             s_dec           obs_id   s_xel1
            deg               deg
@@ -201,8 +251,13 @@ options, that can be combined to extract the required data:
 
   >>> from astroquery.esa.emds.einsteinprobe import EinsteinProbeClass
   >>> epsa = EinsteinProbeClass()
-  >>> epsa.get_observations(target_name='V1589 Cyg', columns=['s_ra', 's_dec', 'obs_id', 's_xel1'], s_xel1=('>', 100))  # doctest: +IGNORE_OUTPUT
-    Executed query:SELECT s_ra, s_dec, obs_id, s_xel1 FROM ivoa.ObsCore  WHERE s_xel1 > 100 AND 1=CONTAINS(POINT('ICRS', s_ra, s_dec),CIRCLE('ICRS', 310.7048109, 41.3833259, 1.0))
+  >>> epsa.get_observations(
+   ...     target_name="V1589 Cyg", columns=["s_ra", "s_dec", "obs_id", "s_xel1"],
+   ...     s_xel1=(">", 100))  # doctest: +IGNORE_OUTPUT
+    Executed query:SELECT s_ra, s_dec, obs_id, s_xel1 FROM ivoa.ObsCore
+        WHERE s_xel1 > 100 AND
+        1=CONTAINS(POINT('ICRS', s_ra, s_dec),
+        CIRCLE('ICRS', 310.7048109, 41.3833259, 1.0))
     <Table length=8>
            s_ra             s_dec           obs_id   s_xel1
            deg               deg
@@ -217,9 +272,10 @@ options, that can be combined to extract the required data:
     310.6756375374491 41.351278441170614 11900012239    600
     310.6757640621578 41.351414087733275 11900012239    600
 
-As it can be observed in the previous examples, additional constraints can be provided using the ``**filters`` syntax,
-where the keyword corresponds to an ObsCore column name and the value defines the filter to be applied. The method
-translates these filters into the corresponding ADQL constraints executed by the TAP service.
+As it can be observed in the previous examples, additional constraints can be provided
+using the ``**filters`` syntax, where the keyword corresponds to an ObsCore column name
+and the value defines the filter to be applied. The method translates these filters
+into the corresponding ADQL constraints executed by the TAP service.
 
 Some examples and their corresponding ADQL transformations are provided below:
 
@@ -244,7 +300,8 @@ Some examples and their corresponding ADQL transformations are provided below:
   ...     instrument_name="FXT",
   ... )  # doctest: +IGNORE_OUTPUT
 
-+ Wildcards (string): ``target_name="AT 2023%"`` → ``target_name ILIKE 'AT 2023%'``
++ Wildcards (string):
+    - ``target_name="AT 2023%"`` → ``target_name ILIKE 'AT 2023%'``
 
 Depending on the configuration, ``*`` may also be accepted as an alias for ``%``.
 
@@ -273,7 +330,9 @@ Depending on the configuration, ``*`` may also be accepted as an alias for ``%``
   ...     columns=["obs_id", "s_ra", "s_dec", "target_name"],
   ... )  # doctest: +IGNORE_OUTPUT
 
-+ String list: ``dataproduct_type=["img", "pha"]`` → ``dataproduct_type = 'img' OR dataproduct_type = 'pha'``
++ String list:
+    - ``dataproduct_type=["img", "pha"]``
+                    → ``dataproduct_type = 'img' OR dataproduct_type = 'pha'``
 
 .. doctest-remote-data::
 
@@ -282,7 +341,8 @@ Depending on the configuration, ``*`` may also be accepted as an alias for ``%``
   ...     dataproduct_type=["img", "pha"],
   ... )  # doctest: +IGNORE_OUTPUT
 
-+ Numeric comparison: ``t_min=(">", 60000)`` -> ``t_min > 60000``
++ Numeric comparison:
+    - ``t_min=(">", 60000)`` -> ``t_min > 60000``
 
 .. doctest-remote-data::
 
@@ -291,7 +351,8 @@ Depending on the configuration, ``*`` may also be accepted as an alias for ``%``
   ...     t_min=(">", 60000),
   ... )  # doctest: +IGNORE_OUTPUT
 
-+ Filter by numeric interval: ``s_ra=(80, 82)`` -> ``s_ra >= 80 AND s_ra <= 82``
++ Filter by numeric interval:
+    - ``s_ra=(80, 82)`` -> ``s_ra >= 80 AND s_ra <= 82``
 
 .. doctest-remote-data::
 
@@ -303,7 +364,8 @@ Depending on the configuration, ``*`` may also be accepted as an alias for ``%``
 
 + Combined filters: Multiple keyword filters are combined with ``AND``.
 
-    - ``obs_collection="EPSA", instrument_name="FXT"`` → ``obs_collection = 'EPSA' AND instrument_name = 'FXT'``
+    - ``obs_collection="EPSA", instrument_name="FXT"``
+        → ``obs_collection = 'EPSA' AND instrument_name = 'FXT'``
 
 .. doctest-remote-data::
 
@@ -321,14 +383,15 @@ Depending on the configuration, ``*`` may also be accepted as an alias for ``%``
 5. Download file product
 -------------------------
 
-Observations in the Einstein Probe catalogue are associated with one or more data products,
-such as science files or preview images. These products are stored as files on the EMDS
-data service and can be accessed once the corresponding observation or product identifiers
-are known.
+Observations in the Einstein Probe catalogue are associated with one or more data
+products, such as science files or preview images. These products are stored as
+files on the EMDS data service and can be accessed once the corresponding
+observation or product identifiers are known.
 
-Typically, users first query the observation catalogue to identify the observations of
-interest and inspect the available metadata (for example product type, filename, or file
-path). Based on this information, individual products can then be downloaded.
+Typically, users first query the observation catalogue to identify the
+observations of interest and inspect the available metadata (for example product
+type, filename, or file path). Based on this information, individual products can
+then be downloaded.
 
 This module provides helper methods to retrieve product information and to download
 individual files directly from the EMDS data service.
@@ -337,18 +400,37 @@ individual files directly from the EMDS data service.
 
   >>> from astroquery.esa.emds.einsteinprobe import EinsteinProbeClass
   >>> epsa = EinsteinProbeClass()
-  >>> epsa.get_products(obs_id=' 11900008319') # doctest: +IGNORE_OUTPUT
-    Executed query:SELECT obs_id, filename, filepath FROM einsteinprobe.obscore_extended WHERE obs_id = ' 11900008319'
-    <Table length=20>
-       obs_id                    filename                              filepath
-       object                     object                                object
-    ------------ --------------------------------------- -----------------------------------
-     11900008319  fxt_b_11900008319_ff_01_po_cl_3ac.fits /epsa/repo/11900008319/fxt/products
-     11900008319      fxt_b_11900008319_ff_01_po_3ac.pha /epsa/repo/11900008319/fxt/products
-             ...                                     ...                                 ...
-     11900008319 fxt_a_11900008319_ff_01_po_gti_3bb.fits /epsa/repo/11900008319/fxt/products
-     11900008319      fxt_b_11900008319_ff_01_po_3bb.arf /epsa/repo/11900008319/fxt/products
-     11900008319      fxt_b_11900008319_ff_01_po_3bb.rmf /epsa/repo/11900008319/fxt/products
+  >>> t = epsa.get_products(obs_id=" 11900008319")
+  Executed query:SELECT obs_id, filename, filepath
+        FROM einsteinprobe.obscore_extended WHERE obs_id = ' 11900008319'
+  >>> t["filepath"].format = "%.20s"
+  >>> t  # doctest: +ELLIPSIS
+  <Table length=20>
+     obs_id                        filename                           filepath
+     object                         object                             object
+  ------------ ------------------------------------------------ --------------------
+   11900008319           fxt_b_11900008319_ff_01_po_cl_3ac.fits /epsa/repo/119000083
+   11900008319               fxt_b_11900008319_ff_01_po_3ac.pha /epsa/repo/119000083
+   11900008319              fxt_b_11900008319_ff_01_po_3ac.expo /epsa/repo/119000083
+   11900008319          fxt_b_11900008319_ff_01_po_gti_3bb.fits /epsa/repo/119000083
+   11900008319 fxt_a_11900008319_ff_01_po_3ac-without_vign.expo /epsa/repo/119000083
+   11900008319               fxt_b_11900008319_ff_01_po_3ac.pds /epsa/repo/119000083
+   11900008319 fxt_b_11900008319_ff_01_po_3ac-without_vign.expo /epsa/repo/119000083
+   11900008319                fxt_b_11900008319_ff_01_po_3ac.lc /epsa/repo/119000083
+           ...                                              ...                  ...
+   11900008319               fxt_b_11900008319_ff_01_po_3ac.img /epsa/repo/119000083
+   11900008319               fxt_a_11900008319_ff_01_po_3ac.pha /epsa/repo/119000083
+   11900008319                fxt_a_11900008319_ff_01_po_3ac.lc /epsa/repo/119000083
+   11900008319           fxt_a_11900008319_ff_01_po_cl_3ac.fits /epsa/repo/119000083
+   11900008319               fxt_a_11900008319_ff_01_po_3bb.arf /epsa/repo/119000083
+   11900008319               fxt_a_11900008319_ff_01_po_3bb.rmf /epsa/repo/119000083
+   11900008319          fxt_a_11900008319_ff_01_po_gti_3bb.fits /epsa/repo/119000083
+   11900008319               fxt_b_11900008319_ff_01_po_3bb.arf /epsa/repo/119000083
+   11900008319               fxt_b_11900008319_ff_01_po_3bb.rmf /epsa/repo/119000083
+
+.. note::
+
+   The output is truncated for brevity.
 
 The following example shows how to download a single data product using its filename.
 By default, the file is downloaded to the current working directory.

--- a/docs/esa/emds/einsteinprobe/einsteinprobe.rst
+++ b/docs/esa/emds/einsteinprobe/einsteinprobe.rst
@@ -414,4 +414,3 @@ Reference/API
 .. automodapi:: astroquery.esa.emds.einsteinprobe
     :no-inheritance-diagram:
     :inherited-members:
-    :show-inheritance:

--- a/docs/esa/emds/einsteinprobe/einsteinprobe.rst
+++ b/docs/esa/emds/einsteinprobe/einsteinprobe.rst
@@ -10,7 +10,7 @@ Institute for Extraterrestrial Physics (MPE). Einstein Probe data (level 2 and l
 public products) are distributed through the ESA Multi-Mission Data Services (EMDS), which
 provides unified access to data from multiple space missions via a single service.
 
-Einstein Probe is is designed to monitor the X-ray sky and discover transient and variable
+Einstein Probe is designed to monitor the X-ray sky and discover transient and variable
 phenomena across the Universe. It carries two primary scientific instruments: the
 Wide-field X-ray Telescope (WXT), which provides a very large field of view for sky
 monitoring, and the Follow-up X-ray Telescope (FXT), which enables more detailed

--- a/docs/esa/emds/einsteinprobe/einsteinprobe.rst
+++ b/docs/esa/emds/einsteinprobe/einsteinprobe.rst
@@ -57,8 +57,19 @@ tables and their columns. This is useful for understanding what data is accessib
   >>> epsa.get_tables()
   [<VODataServiceTable name="einsteinprobe.fxt_product">... 24 columns ...</VODataServiceTable>, <VODataServiceTable name="einsteinprobe.obscore">... 30 columns ...</VODataServiceTable>, <VODataServiceTable name="einsteinprobe.obscore_extended">... 34 columns ...</VODataServiceTable>, <VODataServiceTable name="einsteinprobe.preview_products">... 2 columns ...</VODataServiceTable>, <VODataServiceTable name="einsteinprobe.wxt_product">... 22 columns ...</VODataServiceTable>]
 
+By default, ``get_tables()`` returns table objects with metadata. If ``only_names=True`` is provided, the method returns
+only the table names as strings. This is useful when you only need to inspect or display the available tables without
+accessing their full metadata.
+
+.. doctest-remote-data::
+
   >>> epsa.get_tables(only_names=True)
   ['einsteinprobe.fxt_product', 'einsteinprobe.obscore', 'einsteinprobe.obscore_extended', 'einsteinprobe.preview_products', 'einsteinprobe.wxt_product']
+
+Once a specific table is selected using ``get_table()``, the returned object provides access to the table metadata,
+including its columns.
+
+.. doctest-remote-data::
 
   >>> obscore_table = epsa.get_table('einsteinprobe.obscore_extended')
   >>> obscore_table.columns

--- a/docs/esa/emds/einsteinprobe/einsteinprobe.rst
+++ b/docs/esa/emds/einsteinprobe/einsteinprobe.rst
@@ -357,7 +357,7 @@ individual files directly from the EMDS data service.
 
   >>> from astroquery.esa.emds.einsteinprobe import EinsteinProbeClass
   >>> epsa = EinsteinProbeClass()
-  >>> result = epsa.get_products(obs_id="11900008319")
+  >>> result = epsa.get_products(observation_id="11900008319")
   Executed query:SELECT obs_id, filename, filepath FROM einsteinprobe.obscore_extended WHERE obs_id = '11900008319'
 
 .. note::

--- a/docs/esa/emds/einsteinprobe/einsteinprobe.rst
+++ b/docs/esa/emds/einsteinprobe/einsteinprobe.rst
@@ -357,24 +357,8 @@ individual files directly from the EMDS data service.
 
   >>> from astroquery.esa.emds.einsteinprobe import EinsteinProbeClass
   >>> epsa = EinsteinProbeClass()
-  >>> epsa.get_products(obs_id="11900008319")
+  >>> result = epsa.get_products(obs_id="11900008319")
   Executed query:SELECT obs_id, filename, filepath FROM einsteinprobe.obscore_extended WHERE obs_id = '11900008319'
-  <Table length=20>
-     obs_id                   filename                              filepath
-     object                    object                                object
-  ----------- --------------------------------------- -----------------------------------
-  11900008319  fxt_b_11900008319_ff_01_po_cl_3ac.fits /epsa/repo/11900008319/fxt/products
-  11900008319      fxt_b_11900008319_ff_01_po_3ac.pha /epsa/repo/11900008319/fxt/products
-  11900008319     fxt_a_11900008319_ff_01_po_3ac.expo /epsa/repo/11900008319/fxt/products
-  11900008319      fxt_a_11900008319_ff_01_po_3ac.img /epsa/repo/11900008319/fxt/products
-  11900008319      fxt_a_11900008319_ff_01_po_3ac.pds /epsa/repo/11900008319/fxt/products
-          ...                                     ...                                 ...
-  11900008319      fxt_b_11900008319_ff_01_po_3ac.img /epsa/repo/11900008319/fxt/products
-  11900008319      fxt_a_11900008319_ff_01_po_3bb.arf /epsa/repo/11900008319/fxt/products
-  11900008319      fxt_a_11900008319_ff_01_po_3bb.rmf /epsa/repo/11900008319/fxt/products
-  11900008319 fxt_a_11900008319_ff_01_po_gti_3bb.fits /epsa/repo/11900008319/fxt/products
-  11900008319      fxt_b_11900008319_ff_01_po_3bb.arf /epsa/repo/11900008319/fxt/products
-  11900008319      fxt_b_11900008319_ff_01_po_3bb.rmf /epsa/repo/11900008319/fxt/products
 
 .. note::
 

--- a/docs/esa/emds/einsteinprobe/einsteinprobe.rst
+++ b/docs/esa/emds/einsteinprobe/einsteinprobe.rst
@@ -51,8 +51,8 @@ available for consistency and are inherited from the base EMDS interface.
 
   >>> from astroquery.esa.emds.einsteinprobe import EinsteinProbeClass
   >>> epsa = EinsteinProbeClass()
-  >>> epsa.login() # doctest: +IGNORE_OUTPUT
-  >>> epsa.logout() # doctest: +IGNORE_OUTPUT
+  >>> epsa.login() # doctest: +SKIP
+  >>> epsa.logout() # doctest: +SKIP
 
 .. note::
 
@@ -87,9 +87,7 @@ accessing their full metadata.
 .. doctest-remote-data::
 
   >>> epsa.get_tables(only_names=True)
-  ['einsteinprobe.fxt_product', 'einsteinprobe.obscore',
-  'einsteinprobe.obscore_extended','einsteinprobe.preview_products',
-  'einsteinprobe.wxt_product']
+  ['einsteinprobe.fxt_product', 'einsteinprobe.obscore', 'einsteinprobe.obscore_extended', 'einsteinprobe.preview_products', 'einsteinprobe.wxt_product']
 
 Once a specific table is selected using ``get_table()``, the returned object provides access to the table metadata,
 including its columns.
@@ -130,28 +128,22 @@ and can be queried directly using fully-qualified table names.
   ...           "ORDER BY target_name DESC"
   ...       )
   ...   )  # doctest: +IGNORE_OUTPUT
-  <Table length=12298>
-  dataproduct_type obs_collection    obs_id           s_ra              s_dec
-       object          object        object         float64            float64
-  ---------------- -------------- ------------ ------------------ ------------------
-               arf           EPSA  10202076929                 --                 --
-               png           EPSA  11900006256                 --                 --
-               png           EPSA  11900006200                 --                 --
-               rmf           EPSA  11900012239                 --                 --
-               pds           EPSA  11900006204                 --                 --
-               arf           EPSA  11900012239                 --                 --
-               rmf           EPSA  11900012239                 --                 --
-               pds           EPSA  11900006231                 --                 --
-               ...            ...          ...                ...                ...
-                lc           EPSA  11900010908 344.33858806609254 20.740901740634797
-               img           EPSA  11900008319  81.12383621375398 17.417492453817907
-                lc           EPSA  11900008319  81.12383621375398 17.417492453817907
-               pha           EPSA  11900008319  81.12383618253855  17.41749240154885
-             event           EPSA  11900008319  81.12383621375398 17.417492453817907
-               img           EPSA  11900008319  81.12383618253855  17.41749240154885
-             event           EPSA  11900008319  81.12383618253855  17.41749240154885
-                lc           EPSA  11900008319  81.12383618253855  17.41749240154885
-               pha           EPSA  11900008319  81.12383621375398 17.417492453817907
+  <Table length=12278>
+  dataproduct_type obs_collection    obs_id         s_ra            s_dec
+       object          object        object       float64          float64
+  ---------------- -------------- ----------- ---------------- ----------------
+               arf           EPSA 11900001851               --               --
+               rmf           EPSA 11900010835               --               --
+               rmf           EPSA 11900001853               --               --
+               arf           EPSA 11900001853               --               --
+               pds           EPSA 11900001854               --               --
+               ...            ...         ...              ...              ...
+                lc           EPSA 11900008319 81.1238361825386 17.4174924015488
+             event           EPSA 11900008319  81.123836213754 17.4174924538179
+               pha           EPSA 11900008319 81.1238361825386 17.4174924015488
+               img           EPSA 11900008319  81.123836213754 17.4174924538179
+                lc           EPSA 11900008319  81.123836213754 17.4174924538179
+               pha           EPSA 11900008319  81.123836213754 17.4174924538179
 
 
 -------------------------------------
@@ -180,13 +172,19 @@ using ``get_metadata=True``:
   >>> from astroquery.esa.emds.einsteinprobe import EinsteinProbeClass
   >>> epsa = EinsteinProbeClass()
   >>> epsa.get_observations(get_metadata=True)  # doctest: +IGNORE_OUTPUT
-    <Table masked=True length=34>
-        Column     Description  Unit  Data Type  UCD   UType
-        str17         object   object    str7   object object
-    -------------- ----------- ------ --------- ------ ------
+  <Table masked=True length=34>
+       Column      Description  Unit  Data Type  UCD   UType
+       str17          object   object    str7   object object
+  ---------------- ----------- ------ --------- ------ ------
     access_estsize        None   None      long   None   None
      access_format        None   None      char   None   None
+        access_url        None   None      char   None   None
+       calib_level        None   None       int   None   None
+  dataproduct_type        None   None      char   None   None
                ...         ...    ...       ...    ...    ...
+         t_exptime        None   None      char   None   None
+             t_max        None   None      char   None   None
+             t_min        None   None      char   None   None
       t_resolution        None   None    double   None   None
              t_xel        None   None    double   None   None
        target_name        None   None      char   None   None
@@ -201,22 +199,23 @@ options, that can be combined to extract the required data:
   >>> from astroquery.esa.emds.einsteinprobe import EinsteinProbeClass
   >>> epsa = EinsteinProbeClass()
   >>> epsa.get_observations(target_name='V1589 Cyg')  # doctest: +IGNORE_OUTPUT
-    Executed query:SELECT * FROM ivoa.ObsCore WHERE 1=CONTAINS(POINT('ICRS', s_ra, s_dec),
-                    CIRCLE('ICRS', 310.7048109, 41.3833259, 1.0))
-    <Table length=12>
-    access_estsize        access_format        ... t_xel target_name
-        kbyte                                  ...
-        int64                 object           ... int64    object
-    -------------- --------------------------- ... ----- -----------
-            463680 application/x-fits-bintable ... 19233   V1589 Cyg
-           2888640 application/x-fits-bintable ...    --           0
-             51840 application/x-fits-bintable ...   961   V1589 Cyg
-            745920 application/x-fits-bintable ... 19233   V1589 Cyg
-               ...                         ... ...   ...         ...
-           2888640 application/x-fits-bintable ...    --           0
-           1465920 application/x-fits-bintable ... 19234   V1589 Cyg
-            362880 application/x-fits-bintable ... 19234   V1589 Cyg
-           1465920 application/x-fits-bintable ... 19233   V1589 Cyg
+  Executed query:SELECT * FROM einsteinprobe.obscore_extended WHERE 1=CONTAINS(POINT('ICRS', s_ra, s_dec),CIRCLE('ICRS', 310.7048109, 41.3833259, 1.0))
+  <Table length=12>
+  access_estsize        access_format        ...  t_xel  target_name
+      int64                 object           ... float64    object
+  -------------- --------------------------- ... ------- -----------
+          463680 application/x-fits-bintable ...      --   V1589 Cyg
+         2888640 application/x-fits-bintable ...      --           0
+          760320 application/x-fits-bintable ...      --   V1589 Cyg
+         2888640 application/x-fits-bintable ...      --           0
+           51840 application/x-fits-bintable ...      --   V1589 Cyg
+          745920 application/x-fits-bintable ...      --   V1589 Cyg
+         2888640 application/x-fits-bintable ...      --           0
+           51840 application/x-fits-bintable ...      --   V1589 Cyg
+         2888640 application/x-fits-bintable ...      --           0
+         1465920 application/x-fits-bintable ...      --   V1589 Cyg
+          362880 application/x-fits-bintable ...      --   V1589 Cyg
+         1465920 application/x-fits-bintable ...      --   V1589 Cyg
 
 + Retrieve only a specific set of columns.
 
@@ -225,23 +224,23 @@ options, that can be combined to extract the required data:
   >>> from astroquery.esa.emds.einsteinprobe import EinsteinProbeClass
   >>> epsa = EinsteinProbeClass()
   >>> epsa.get_observations(target_name="V1589 Cyg", columns=["s_ra", "s_dec", "obs_id", "s_xel1"])  # doctest: +IGNORE_OUTPUT
-    Executed query:SELECT s_ra, s_dec, obs_id, s_xel1 FROM ivoa.ObsCore WHERE
-                    1=CONTAINS(POINT('ICRS', s_ra, s_dec),
-                    CIRCLE('ICRS', 310.7048109, 41.3833259, 1.0))
-    <Table length=12>
-           s_ra             s_dec           obs_id   s_xel1
-           deg               deg
-         float64           float64          object   int64
-    ----------------- ------------------ ----------- ------
-    310.6757640621578 41.351414087733275 11900012239     95
-    310.6755985583337 41.351202980612555 11900012239    600
-    310.6755985583337 41.351202980612555 11900012239     20
-    310.6755985583337 41.351202980612555 11900012239    418
-                  ...                ...         ...    ...
-    310.6755985583337 41.351202980612555 11900012239    600
-    310.6756375374491 41.351278441170614 11900012239    600
-    310.6756375374491 41.351278441170614 11900012239     95
-    310.6757640621578 41.351414087733275 11900012239    600
+  Executed query:SELECT s_ra, s_dec, obs_id, s_xel1 FROM einsteinprobe.obscore_extended WHERE 1=CONTAINS(POINT('ICRS', s_ra, s_dec),CIRCLE('ICRS', 310.7048109, 41.3833259, 1.0))
+  <Table length=12>
+        s_ra            s_dec          obs_id   s_xel1
+      float64          float64         object   int64
+  ---------------- ---------------- ----------- ------
+  310.675764062158 41.3514140877333 11900012239     95
+  310.675598558334 41.3512029806126 11900012239    600
+  310.675599334032 41.3512028908431 11900012239    418
+  310.675598558334 41.3512029806126 11900012239    600
+  310.675598558334 41.3512029806126 11900012239     20
+  310.675598558334 41.3512029806126 11900012239    418
+  310.675599334032 41.3512028908431 11900012239    600
+  310.675599334032 41.3512028908431 11900012239     20
+  310.675599334032 41.3512028908431 11900012239    600
+  310.675637537449 41.3512784411706 11900012239    600
+  310.675637537449 41.3512784411706 11900012239     95
+  310.675764062158 41.3514140877333 11900012239    600
 
 + Filter by any other column available in the previous method.
 
@@ -250,23 +249,19 @@ options, that can be combined to extract the required data:
   >>> from astroquery.esa.emds.einsteinprobe import EinsteinProbeClass
   >>> epsa = EinsteinProbeClass()
   >>> epsa.get_observations(target_name="V1589 Cyg", columns=["s_ra", "s_dec", "obs_id", "s_xel1"], s_xel1=(">", 100))  # doctest: +IGNORE_OUTPUT
-    Executed query:SELECT s_ra, s_dec, obs_id, s_xel1 FROM ivoa.ObsCore
-        WHERE s_xel1 > 100 AND
-        1=CONTAINS(POINT('ICRS', s_ra, s_dec),
-        CIRCLE('ICRS', 310.7048109, 41.3833259, 1.0))
-    <Table length=8>
-           s_ra             s_dec           obs_id   s_xel1
-           deg               deg
-         float64           float64          object   int64
-    ----------------- ------------------ ----------- ------
-    310.6755985583337 41.351202980612555 11900012239    600
-    310.6755985583337 41.351202980612555 11900012239    418
-    310.6755993340324  41.35120289084306 11900012239    600
-    310.6755993340324  41.35120289084306 11900012239    600
-    310.6755993340324  41.35120289084306 11900012239    418
-    310.6755985583337 41.351202980612555 11900012239    600
-    310.6756375374491 41.351278441170614 11900012239    600
-    310.6757640621578 41.351414087733275 11900012239    600
+  Executed query:SELECT s_ra, s_dec, obs_id, s_xel1 FROM einsteinprobe.obscore_extended  WHERE s_xel1 > 100 AND 1=CONTAINS(POINT('ICRS', s_ra, s_dec),CIRCLE('ICRS', 310.7048109, 41.3833259, 1.0))
+  <Table length=8>
+        s_ra            s_dec          obs_id   s_xel1
+      float64          float64         object   int64
+  ---------------- ---------------- ----------- ------
+  310.675598558334 41.3512029806126 11900012239    600
+  310.675599334032 41.3512028908431 11900012239    418
+  310.675598558334 41.3512029806126 11900012239    600
+  310.675598558334 41.3512029806126 11900012239    418
+  310.675599334032 41.3512028908431 11900012239    600
+  310.675599334032 41.3512028908431 11900012239    600
+  310.675637537449 41.3512784411706 11900012239    600
+  310.675764062158 41.3514140877333 11900012239    600
 
 As it can be observed in the previous examples, additional constraints can be provided
 using the ``**filters`` syntax, where the keyword corresponds to an ObsCore column name
@@ -362,33 +357,24 @@ individual files directly from the EMDS data service.
 
   >>> from astroquery.esa.emds.einsteinprobe import EinsteinProbeClass
   >>> epsa = EinsteinProbeClass()
-  >>> t = epsa.get_products(obs_id="11900008319")
-  Executed query:SELECT obs_id, filename, filepath
-        FROM einsteinprobe.obscore_extended WHERE obs_id = ' 11900008319'
-  >>> t["filepath"].format = "%.20s"
-  >>> t  # doctest: +ELLIPSIS
+  >>> epsa.get_products(obs_id="11900008319")
+  Executed query:SELECT obs_id, filename, filepath FROM einsteinprobe.obscore_extended WHERE obs_id = '11900008319'
   <Table length=20>
-     obs_id                        filename                           filepath
-     object                         object                             object
-  ------------ ------------------------------------------------ --------------------
-   11900008319           fxt_b_11900008319_ff_01_po_cl_3ac.fits /epsa/repo/119000083
-   11900008319               fxt_b_11900008319_ff_01_po_3ac.pha /epsa/repo/119000083
-   11900008319              fxt_b_11900008319_ff_01_po_3ac.expo /epsa/repo/119000083
-   11900008319          fxt_b_11900008319_ff_01_po_gti_3bb.fits /epsa/repo/119000083
-   11900008319 fxt_a_11900008319_ff_01_po_3ac-without_vign.expo /epsa/repo/119000083
-   11900008319               fxt_b_11900008319_ff_01_po_3ac.pds /epsa/repo/119000083
-   11900008319 fxt_b_11900008319_ff_01_po_3ac-without_vign.expo /epsa/repo/119000083
-   11900008319                fxt_b_11900008319_ff_01_po_3ac.lc /epsa/repo/119000083
-           ...                                              ...                  ...
-   11900008319               fxt_b_11900008319_ff_01_po_3ac.img /epsa/repo/119000083
-   11900008319               fxt_a_11900008319_ff_01_po_3ac.pha /epsa/repo/119000083
-   11900008319                fxt_a_11900008319_ff_01_po_3ac.lc /epsa/repo/119000083
-   11900008319           fxt_a_11900008319_ff_01_po_cl_3ac.fits /epsa/repo/119000083
-   11900008319               fxt_a_11900008319_ff_01_po_3bb.arf /epsa/repo/119000083
-   11900008319               fxt_a_11900008319_ff_01_po_3bb.rmf /epsa/repo/119000083
-   11900008319          fxt_a_11900008319_ff_01_po_gti_3bb.fits /epsa/repo/119000083
-   11900008319               fxt_b_11900008319_ff_01_po_3bb.arf /epsa/repo/119000083
-   11900008319               fxt_b_11900008319_ff_01_po_3bb.rmf /epsa/repo/119000083
+     obs_id                   filename                              filepath
+     object                    object                                object
+  ----------- --------------------------------------- -----------------------------------
+  11900008319  fxt_b_11900008319_ff_01_po_cl_3ac.fits /epsa/repo/11900008319/fxt/products
+  11900008319      fxt_b_11900008319_ff_01_po_3ac.pha /epsa/repo/11900008319/fxt/products
+  11900008319     fxt_a_11900008319_ff_01_po_3ac.expo /epsa/repo/11900008319/fxt/products
+  11900008319      fxt_a_11900008319_ff_01_po_3ac.img /epsa/repo/11900008319/fxt/products
+  11900008319      fxt_a_11900008319_ff_01_po_3ac.pds /epsa/repo/11900008319/fxt/products
+          ...                                     ...                                 ...
+  11900008319      fxt_b_11900008319_ff_01_po_3ac.img /epsa/repo/11900008319/fxt/products
+  11900008319      fxt_a_11900008319_ff_01_po_3bb.arf /epsa/repo/11900008319/fxt/products
+  11900008319      fxt_a_11900008319_ff_01_po_3bb.rmf /epsa/repo/11900008319/fxt/products
+  11900008319 fxt_a_11900008319_ff_01_po_gti_3bb.fits /epsa/repo/11900008319/fxt/products
+  11900008319      fxt_b_11900008319_ff_01_po_3bb.arf /epsa/repo/11900008319/fxt/products
+  11900008319      fxt_b_11900008319_ff_01_po_3bb.rmf /epsa/repo/11900008319/fxt/products
 
 .. note::
 
@@ -401,7 +387,7 @@ By default, the file is downloaded to the current working directory.
 
     >>> from astroquery.esa.emds.einsteinprobe import EinsteinProbeClass
     >>> epsa = EinsteinProbeClass()
-    >>> epsa.download_product(filename='fxt_b_11900008319_ff_01_po_3bb.rmf') # doctest: +IGNORE_OUTPUT
+    >>> epsa.download_product(filename='fxt_b_11900008319_ff_01_po_3bb.rmf') # doctest: +SKIP
     'fxt_b_11900008319_ff_01_po_3bb.rmf'
 
 Product downloads return the files as stored in the archive. No output format needs to be

--- a/docs/esa/emds/emds.rst
+++ b/docs/esa/emds/emds.rst
@@ -44,7 +44,7 @@ tables and their columns. This is useful for understanding what data is accessib
 
   >>> from astroquery.esa.emds import EmdsClass
   >>> emds = EmdsClass()
-  >>> emds.get_tables()
+  >>> emds.get_tables() # doctest: +IGNORE_OUTPUT
   [<VODataServiceTable name="einsteinprobe.fxt_product">... 24 columns
   ...</VODataServiceTable>,
   <VODataServiceTable name="einsteinprobe.obscore">... 30 columns
@@ -59,7 +59,7 @@ accessing their full metadata.
 
 .. doctest-remote-data::
 
-  >>> emds.get_tables(only_names=True)
+  >>> emds.get_tables(only_names=True) # doctest: +IGNORE_OUTPUT
   ['einsteinprobe.fxt_product', 'einsteinprobe.obscore',
   'einsteinprobe.obscore_extended', 'einsteinprobe.preview_products',
   'einsteinprobe.wxt_product', 'ivoa.ObsCore', 'smile.cdf_item',
@@ -72,8 +72,8 @@ including its columns.
 
 .. doctest-remote-data::
 
-  >>> ivoa_obscore_table = emds.get_table(table='ivoa.ObsCore')
-  >>> ivoa_obscore_table.columns
+  >>> ivoa_obscore_table = emds.get_table(table='ivoa.ObsCore') # doctest: +IGNORE_OUTPUT
+  >>> ivoa_obscore_table.columns # doctest: +IGNORE_OUTPUT
   [<BaseParam name="access_estsize"/>, <BaseParam name="access_format"/>,
   <BaseParam name="access_url"/>, <BaseParam name="calib_level"/>,
   <BaseParam name="dataproduct_type"/>, <BaseParam name="em_max"/>,
@@ -92,8 +92,8 @@ TAP endpoint. Each mission typically appears as a distinct value in the ``obs_co
 ObsCore view.
 
    >>> from astroquery.esa.emds import EmdsClass
-   >>> emds = EmdsClass()
-   >>> emds.get_missions()
+   >>> emds = EmdsClass() # doctest: +IGNORE_OUTPUT
+   >>> emds.get_missions() # doctest: +IGNORE_OUTPUT
     <Table length=1>
     obs_collection
         object
@@ -152,7 +152,7 @@ To check the columns available in this catalogue, the following method can be ex
   >>> obs_metadata = emds.get_observations(get_metadata=True)
   >>> obs_metadata["Description"].format = "%.10s"
   >>> obs_metadata["UType"].format = "%.20s"
-  >>> obs_metadata
+  >>> obs_metadata # doctest: +IGNORE_OUTPUT
   <Table masked=True length=30>
       Column     Description  Unit  Data Type         UCD                UType
       str17         object   object    str6          object              object

--- a/docs/esa/emds/emds.rst
+++ b/docs/esa/emds/emds.rst
@@ -91,8 +91,10 @@ The EMDS TAP service is a *multi-mission* archive: multiple missions and data co
 TAP endpoint. Each mission typically appears as a distinct value in the ``obs_collection`` field of the EMDS global
 ObsCore view.
 
+.. doctest-remote-data::
+
    >>> from astroquery.esa.emds import EmdsClass
-   >>> emds = EmdsClass() # doctest: +IGNORE_OUTPUT
+   >>> emds = EmdsClass()
    >>> emds.get_missions() # doctest: +IGNORE_OUTPUT
     <Table length=1>
     obs_collection
@@ -413,6 +415,8 @@ Reference/API
 
 .. automodapi:: astroquery.esa.emds
     :no-inheritance-diagram:
+    :inherited-members:
+    :show-inheritance:
 
 EMDS submodules
 ===============

--- a/docs/esa/emds/emds.rst
+++ b/docs/esa/emds/emds.rst
@@ -39,12 +39,19 @@ through the ``login()`` and ``logout()`` methods provided by the EMDS Astroquery
 EMDS Astroquery module allows users to explore the data structure of the TAP by listing available
 tables and their columns. This is useful for understanding what data is accessible before running ADQL queries.
 
+
 .. doctest-remote-data::
 
   >>> from astroquery.esa.emds import EmdsClass
   >>> emds = EmdsClass()
   >>> emds.get_tables()
-  [<VODataServiceTable name="einsteinprobe.fxt_product">... 24 columns ...</VODataServiceTable>, <VODataServiceTable name="einsteinprobe.obscore">... 30 columns ...</VODataServiceTable>, <VODataServiceTable name="einsteinprobe.obscore_extended">... 34 columns ...</VODataServiceTable>, <VODataServiceTable name="einsteinprobe.preview_products">... 2 columns ...</VODataServiceTable>, <VODataServiceTable name="einsteinprobe.wxt_product">... 22 columns ...</VODataServiceTable>, <VODataServiceTable name="ivoa.ObsCore">... 30 columns ...</VODataServiceTable>, <VODataServiceTable name="public.dual">... 1 columns ...</VODataServiceTable>, <VODataServiceTable name="smile.cdf_item">... 11 columns ...</VODataServiceTable>, <VODataServiceTable name="smile.cdf_modification">... 5 columns ...</VODataServiceTable>, <VODataServiceTable name="smile.cdf_parameter">... 6 columns ...</VODataServiceTable>, <VODataServiceTable name="smile.cdf_parent">... 2 columns ...</VODataServiceTable>, <VODataServiceTable name="smile.cdf_variable">... 47 columns ...</VODataServiceTable>, <VODataServiceTable name="smile.dataset">... 21 columns ...</VODataServiceTable>, <VODataServiceTable name="smile.descriptor">... 1 columns ...</VODataServiceTable>, <VODataServiceTable name="smile.instrument">... 5 columns ...</VODataServiceTable>, <VODataServiceTable name="smile.leap_second">... 3 columns ...</VODataServiceTable>, <VODataServiceTable name="smile.mission">... 2 columns ...</VODataServiceTable>, <VODataServiceTable name="smile.processing_level">... 3 columns ...</VODataServiceTable>, <VODataServiceTable name="smile.proprietary_period_configuration">... 3 columns ...</VODataServiceTable>, <VODataServiceTable name="smile.v_data_file">... 18 columns ...</VODataServiceTable>, <VODataServiceTable name="smile.v_data_file_latest">... 18 columns ...</VODataServiceTable>, <VODataServiceTable name="smile.v_data_item">... 12 columns ...</VODataServiceTable>, <VODataServiceTable name="smile.v_ql_data_file">... 15 columns ...</VODataServiceTable>, <VODataServiceTable name="smile.v_ql_data_file_latest">... 15 columns ...</VODataServiceTable>, <VODataServiceTable name="smile.v_ql_data_item">... 8 columns ...</VODataServiceTable>, <VODataServiceTable name="tap_config.coord_sys">... 5 columns ...</VODataServiceTable>, <VODataServiceTable name="tap_config.properties">... 2 columns ...</VODataServiceTable>, <VODataServiceTable name="tap_schema.columns">... 16 columns ...</VODataServiceTable>, <VODataServiceTable name="tap_schema.key_columns">... 3 columns ...</VODataServiceTable>, <VODataServiceTable name="tap_schema.keys">... 5 columns ...</VODataServiceTable>, <VODataServiceTable name="tap_schema.schemas">... 5 columns ...</VODataServiceTable>, <VODataServiceTable name="tap_schema.tables">... 9 columns ...</VODataServiceTable>]
+  [<VODataServiceTable name="einsteinprobe.fxt_product">... 24 columns
+  ...</VODataServiceTable>,
+  <VODataServiceTable name="einsteinprobe.obscore">... 30 columns
+  ...</VODataServiceTable>,
+  <VODataServiceTable name="ivoa.ObsCore">... 30 columns
+  ...]
+
 
 By default, ``get_tables()`` returns table objects with metadata. If ``only_names=True`` is provided, the method returns
 only the table names as strings. This is useful when you only need to inspect or display the available tables without
@@ -53,7 +60,12 @@ accessing their full metadata.
 .. doctest-remote-data::
 
   >>> emds.get_tables(only_names=True)
-  ['einsteinprobe.fxt_product', 'einsteinprobe.obscore', 'einsteinprobe.obscore_extended', 'einsteinprobe.preview_products', 'einsteinprobe.wxt_product', 'ivoa.ObsCore', 'public.dual', 'smile.cdf_item', 'smile.cdf_modification', 'smile.cdf_parameter', 'smile.cdf_parent', 'smile.cdf_variable', 'smile.dataset', 'smile.descriptor', 'smile.instrument', 'smile.leap_second', 'smile.mission', 'smile.processing_level', 'smile.proprietary_period_configuration', 'smile.v_data_file', 'smile.v_data_file_latest', 'smile.v_data_item', 'smile.v_ql_data_file', 'smile.v_ql_data_file_latest', 'smile.v_ql_data_item', 'tap_config.coord_sys', 'tap_config.properties', 'tap_schema.columns', 'tap_schema.key_columns', 'tap_schema.keys', 'tap_schema.schemas', 'tap_schema.tables']
+  ['einsteinprobe.fxt_product', 'einsteinprobe.obscore',
+  'einsteinprobe.obscore_extended', 'einsteinprobe.preview_products',
+  'einsteinprobe.wxt_product', 'ivoa.ObsCore', 'smile.cdf_item',
+  'smile.cdf_modification', 'smile.cdf_parameter', 'smile.cdf_parent',
+  'smile.cdf_variable', 'smile.dataset', 'smile.descriptor',
+  ...]
 
 Once a specific table is selected using ``get_table()``, the returned object provides access to the table metadata,
 including its columns.
@@ -62,7 +74,14 @@ including its columns.
 
   >>> ivoa_obscore_table = emds.get_table(table='ivoa.ObsCore')
   >>> ivoa_obscore_table.columns
-  [<BaseParam name="access_estsize"/>, <BaseParam name="access_format"/>, <BaseParam name="access_url"/>, <BaseParam name="calib_level"/>, <BaseParam name="dataproduct_type"/>, <BaseParam name="em_max"/>, <BaseParam name="em_min"/>, <BaseParam name="em_res_power"/>, <BaseParam name="em_xel"/>, <BaseParam name="facility_name"/>, <BaseParam name="instrument_name"/>, <BaseParam name="o_ucd"/>, <BaseParam name="obs_collection"/>, <BaseParam name="obs_id"/>, <BaseParam name="obs_publisher_did"/>, <BaseParam name="pol_states"/>, <BaseParam name="pol_xel"/>, <BaseParam name="s_dec"/>, <BaseParam name="s_fov"/>, <BaseParam name="s_ra"/>, <BaseParam name="s_region"/>, <BaseParam name="s_resolution"/>, <BaseParam name="s_xel1"/>, <BaseParam name="s_xel2"/>, <BaseParam name="t_exptime"/>, <BaseParam name="t_max"/>, <BaseParam name="t_min"/>, <BaseParam name="t_resolution"/>, <BaseParam name="t_xel"/>, <BaseParam name="target_name"/>]
+  [<BaseParam name="access_estsize"/>, <BaseParam name="access_format"/>,
+  <BaseParam name="access_url"/>, <BaseParam name="calib_level"/>,
+  <BaseParam name="dataproduct_type"/>, <BaseParam name="em_max"/>,
+  ...]
+
+.. note::
+
+   Only a subset of the available tables and columns is shown in the examples above.
 
 -------------------------
 3. Get available missions
@@ -93,26 +112,22 @@ Results can be exported to a specified file in the chosen format, and queries ma
   >>> from astroquery.esa.emds import EmdsClass
   >>> emds = EmdsClass()
   >>> emds.query_tap(
-  ...     query=(
-  ...         "SELECT dataproduct_type, obs_collection, target_name, obs_id, s_ra, s_dec "
-  ...         "FROM ivoa.ObsCore "
-  ...         "ORDER BY target_name DESC"
-  ...     )
-  ... )  # doctest: +IGNORE_OUTPUT
-    <Table length=12298>
-    dataproduct_type obs_collection target_name    obs_id          s_ra             s_dec
-                                                                   deg               deg
-         object          object        object      object        float64           float64
-    ---------------- -------------- ----------- ----------- ----------------- ------------------
-                 arf           EPSA             10202076929                --                 --
-                 png           EPSA             11900006256                --                 --
-                 png           EPSA             11900006200                --                 --
-                 rmf           EPSA             11900012239                --                 --
-                 ...            ...         ...         ...               ...                ...
-                 img           EPSA   * 111 Tau 11900008319 81.12383618253855  17.41749240154885
-               event           EPSA   * 111 Tau 11900008319 81.12383618253855  17.41749240154885
-                  lc           EPSA   * 111 Tau 11900008319 81.12383618253855  17.41749240154885
-                 pha           EPSA   * 111 Tau 11900008319 81.12383621375398 17.417492453817907
+  ...        query=(
+  ...            "SELECT dataproduct_type, obs_collection, obs_id, s_ra, s_dec "
+  ...            "FROM ivoa.ObsCore "
+  ...            "ORDER BY target_name DESC"
+  ...        )
+  ...    )  # doctest: +IGNORE_OUTPUT
+  <Table length=12298>
+  dataproduct_type obs_collection    obs_id           s_ra             s_dec
+                                                      deg               deg
+       object          object        object         float64           float64
+  ---------------- -------------- ------------ ----------------- ------------------
+               arf           EPSA  10202076929                --                 --
+               png           EPSA  11900006256                --                 --
+               ...            ...          ...               ...                ...
+                lc           EPSA  11900008319 81.12383618253855  17.41749240154885
+               pha           EPSA  11900008319 81.12383621375398 17.417492453817907
 
 -------------------------------------
 5. Filtering the Obs Core Catalogue
@@ -134,19 +149,20 @@ To check the columns available in this catalogue, the following method can be ex
 
   >>> from astroquery.esa.emds import EmdsClass
   >>> emds = EmdsClass()
-  >>> emds.get_observations(get_metadata=True)  # doctest: +IGNORE_OUTPUT
-    <Table masked=True length=30>
-        Column                   Description                Unit  Data Type           UCD                                   UType
-        str17                       object                 object    str6            object                                 object
-    -------------- --------------------------------------- ------ --------- ----------------------- ------------------------------------------------------
-    access_estsize Estimated size of dataset: in kilobytes  kbyte      long     phys.size;meta.file                                    obscore:Access.size
-     access_format           Content format of the dataset   None      char          meta.code.mime                                  obscore:Access.format
-        access_url              URL used to access dataset   None      char            meta.ref.url                               obscore:Access.reference
-               ...                                     ...    ...       ...                     ...                                                    ...
-             t_min                       Start time in MJD      d    double time.start;obs.exposure obscore:Char.TimeAxis.Coverage.Bounds.Limits.StartTime
-      t_resolution                Temporal resolution FWHM      s    double         time.resolution          obscore:Char.TimeAxis.Resolution.Refval.value
-             t_xel  Number of elements along the time axis   None      long             meta.number                          obscore:Char.TimeAxis.numBins
-       target_name                      Object of interest   None      char             meta.id;src                                    obscore:Target.name
+  >>> obs_metadata = emds.get_observations(get_metadata=True)
+  >>> obs_metadata["Description"].format = "%.10s"
+  >>> obs_metadata["UType"].format = "%.20s"
+  >>> obs_metadata
+  <Table masked=True length=30>
+      Column     Description  Unit  Data Type         UCD                UType
+      str17         object   object    str6          object              object
+  -------------- ----------- ------ --------- ------------------- --------------------
+  access_estsize  Estimated   kbyte      long phys.size;meta.file  obscore:Access.size
+   access_format  Content fo   None      char      meta.code.mime obscore:Access.forma
+             ...         ...    ...       ...                 ...                  ...
+    t_resolution  Temporal r      s    double     time.resolution obscore:Char.TimeAxi
+           t_xel  Number of    None      long         meta.number obscore:Char.TimeAxi
+     target_name  Object of    None      char         meta.id;src  obscore:Target.name
 
 Once the columns of interest have been extracted, it is possible to execute the same function with the following
 options, that can be combined to extract the required data:
@@ -158,7 +174,9 @@ options, that can be combined to extract the required data:
   >>> from astroquery.esa.emds import EmdsClass
   >>> emds = EmdsClass()
   >>> emds.get_observations(target_name='V1589 Cyg')  # doctest: +IGNORE_OUTPUT
-    Executed query:SELECT * FROM ivoa.ObsCore WHERE 1=CONTAINS(POINT('ICRS', s_ra, s_dec),CIRCLE('ICRS', 310.7048109, 41.3833259, 1.0))
+    Executed query:SELECT * FROM ivoa.ObsCore
+        WHERE 1=CONTAINS(POINT('ICRS', s_ra, s_dec),
+        CIRCLE('ICRS', 310.7048109, 41.3833259, 1.0))
     <Table length=12>
     access_estsize        access_format        ... t_xel target_name
         kbyte                                  ...
@@ -180,8 +198,13 @@ options, that can be combined to extract the required data:
 
   >>> from astroquery.esa.emds import EmdsClass
   >>> emds = EmdsClass()
-  >>> emds.get_observations(target_name='V1589 Cyg', columns=['s_ra', 's_dec', 'obs_id', 's_xel1'])  # doctest: +IGNORE_OUTPUT
-    Executed query:SELECT s_ra, s_dec, obs_id, s_xel1 FROM ivoa.ObsCore WHERE 1=CONTAINS(POINT('ICRS', s_ra, s_dec),CIRCLE('ICRS', 310.7048109, 41.3833259, 1.0))
+  >>> emds.get_observations(
+  ...         target_name="V1589 Cyg", columns=["s_ra", "s_dec", "obs_id", "s_xel1"]
+  ...     )  # doctest: +IGNORE_OUTPUT
+    Executed query:SELECT s_ra, s_dec, obs_id, s_xel1
+        FROM ivoa.ObsCore
+        WHERE 1=CONTAINS(POINT('ICRS', s_ra, s_dec),
+        CIRCLE('ICRS', 310.7048109, 41.3833259, 1.0))
     <Table length=12>
            s_ra             s_dec           obs_id   s_xel1
            deg               deg
@@ -203,8 +226,14 @@ options, that can be combined to extract the required data:
 
   >>> from astroquery.esa.emds import EmdsClass
   >>> emds = EmdsClass()
-  >>> emds.get_observations(target_name='V1589 Cyg', columns=['s_ra', 's_dec', 'obs_id', 's_xel1'], s_xel1=('>', 100))  # doctest: +IGNORE_OUTPUT
-    Executed query:SELECT s_ra, s_dec, obs_id, s_xel1 FROM ivoa.ObsCore  WHERE s_xel1 > 100 AND 1=CONTAINS(POINT('ICRS', s_ra, s_dec),CIRCLE('ICRS', 310.7048109, 41.3833259, 1.0))
+  >>> emds.get_observations(
+  ...     target_name="V1589 Cyg", columns=["s_ra", "s_dec", "obs_id", "s_xel1"], s_xel1=(">", 100)
+  ... )  # doctest: +IGNORE_OUTPUT
+    Executed query:SELECT s_ra, s_dec, obs_id, s_xel1
+        FROM ivoa.ObsCore
+        WHERE s_xel1 > 100
+        AND 1=CONTAINS(POINT('ICRS', s_ra, s_dec),
+            CIRCLE('ICRS', 310.7048109, 41.3833259, 1.0))
     <Table length=8>
            s_ra             s_dec           obs_id   s_xel1
            deg               deg

--- a/docs/esa/emds/emds.rst
+++ b/docs/esa/emds/emds.rst
@@ -99,7 +99,6 @@ Results can be exported to a specified file in the chosen format, and queries ma
   ...         "ORDER BY target_name DESC"
   ...     )
   ... )  # doctest: +IGNORE_OUTPUT
-
     <Table length=12298>
     dataproduct_type obs_collection target_name    obs_id          s_ra             s_dec
                                                                    deg               deg
@@ -136,7 +135,6 @@ To check the columns available in this catalogue, the following method can be ex
   >>> from astroquery.esa.emds import EmdsClass
   >>> emds = EmdsClass()
   >>> emds.get_observations(get_metadata=True)  # doctest: +IGNORE_OUTPUT
-
     <Table masked=True length=30>
         Column                   Description                Unit  Data Type           UCD                                   UType
         str17                       object                 object    str6            object                                 object
@@ -160,7 +158,6 @@ options, that can be combined to extract the required data:
   >>> from astroquery.esa.emds import EmdsClass
   >>> emds = EmdsClass()
   >>> emds.get_observations(target_name='V1589 Cyg')  # doctest: +IGNORE_OUTPUT
-
     Executed query:SELECT * FROM ivoa.ObsCore WHERE 1=CONTAINS(POINT('ICRS', s_ra, s_dec),CIRCLE('ICRS', 310.7048109, 41.3833259, 1.0))
     <Table length=12>
     access_estsize        access_format        ... t_xel target_name
@@ -184,7 +181,6 @@ options, that can be combined to extract the required data:
   >>> from astroquery.esa.emds import EmdsClass
   >>> emds = EmdsClass()
   >>> emds.get_observations(target_name='V1589 Cyg', columns=['s_ra', 's_dec', 'obs_id', 's_xel1'])  # doctest: +IGNORE_OUTPUT
-
     Executed query:SELECT s_ra, s_dec, obs_id, s_xel1 FROM ivoa.ObsCore WHERE 1=CONTAINS(POINT('ICRS', s_ra, s_dec),CIRCLE('ICRS', 310.7048109, 41.3833259, 1.0))
     <Table length=12>
            s_ra             s_dec           obs_id   s_xel1
@@ -208,7 +204,6 @@ options, that can be combined to extract the required data:
   >>> from astroquery.esa.emds import EmdsClass
   >>> emds = EmdsClass()
   >>> emds.get_observations(target_name='V1589 Cyg', columns=['s_ra', 's_dec', 'obs_id', 's_xel1'], s_xel1=('>', 100))  # doctest: +IGNORE_OUTPUT
-
     Executed query:SELECT s_ra, s_dec, obs_id, s_xel1 FROM ivoa.ObsCore  WHERE s_xel1 > 100 AND 1=CONTAINS(POINT('ICRS', s_ra, s_dec),CIRCLE('ICRS', 310.7048109, 41.3833259, 1.0))
     <Table length=8>
            s_ra             s_dec           obs_id   s_xel1
@@ -230,26 +225,20 @@ translates these filters into the corresponding ADQL constraints executed by the
 
 Some examples and their corresponding ADQL transformations are provided below:
 
-+ Exact match (string): ``obs_collection="EPSA"`` -> ``obs_collection = 'EPSA'``
++ By columns:
 
-+ Exact match (string): ``instrument_name="FXT"`` -> ``instrument_name = 'FXT'``
-
-+ Wildcards (string): ``target_name="AT 2023%"`` -> ``target_name ILIKE 'AT 2023%'``
-  (``*`` may also be accepted as an alias for ``%`` depending on the backend configuration)
-
-+ String list: ``dataproduct_type=["img", "pha"]`` -> ``dataproduct_type = 'img' OR dataproduct_type = 'pha'``
-  (some TAP services may translate this to an equivalent ``IN ('img','pha')`` clause)
-
-+ Numeric comparison: ``t_min=(">", 60000)`` -> ``t_min > 60000``
-
-+ Filter by numeric interval: ``s_ra=(80, 82)`` -> ``s_ra >= 80 AND s_ra <= 82``
-
-+ Combined filters: ``obs_collection="EPSA", instrument_name="FXT"`` -> ``obs_collection = 'EPSA' AND instrument_name = 'FXT'``
+.. doctest-remote-data::
 
   >>> emds.get_observations(
   ...     columns=["dataproduct_type", "obs_collection", "target_name", "obs_id",
   ...              "s_ra", "s_dec", "instrument_name"]
   ... )  # doctest: +IGNORE_OUTPUT
+
++ Exact match (string):
+    - ``obs_collection="EPSA"`` → ``obs_collection = 'EPSA'``
+    - ``instrument_name="FXT"`` → ``instrument_name = 'FXT'``
+
+.. doctest-remote-data::
 
   >>> emds.get_observations(
   ...     columns=["obs_id", "obs_collection", "instrument_name", "dataproduct_type"],
@@ -257,26 +246,20 @@ Some examples and their corresponding ADQL transformations are provided below:
   ...     instrument_name="FXT",
   ... )  # doctest: +IGNORE_OUTPUT
 
++ Wildcards (string): ``target_name="AT 2023%"`` → ``target_name ILIKE 'AT 2023%'``
+
+Depending on the configuration, ``*`` may also be accepted as an alias for ``%``.
+
+.. doctest-remote-data::
+
   >>> emds.get_observations(
   ...     columns=["obs_id", "target_name"],
   ...     target_name="V1589 Cyg",
   ... )  # doctest: +IGNORE_OUTPUT
 
-  >>> emds.get_observations(
-  ...     columns=["obs_id", "dataproduct_type"],
-  ...     dataproduct_type=["img", "pha"],
-  ... )  # doctest: +IGNORE_OUTPUT
++ Wildcards (string): ``coordinates`` and ``radius``
 
-  >>> emds.get_observations(
-  ...     columns=["obs_id", "t_min", "t_max"],
-  ...     t_min=(">", 60000),
-  ... )  # doctest: +IGNORE_OUTPUT
-
-  >>> emds.get_observations(
-  ...     columns=["obs_id", "s_ra", "s_dec"],
-  ...     s_ra=(80, 82),
-  ...     s_dec=(16, 18),
-  ... )  # doctest: +IGNORE_OUTPUT
+.. doctest-remote-data::
 
   >>> emds.get_observations(
   ...     coordinates="81.1238 17.4175",
@@ -284,11 +267,47 @@ Some examples and their corresponding ADQL transformations are provided below:
   ...     columns=["obs_id", "s_ra", "s_dec", "instrument_name"],
   ... )  # doctest: +IGNORE_OUTPUT
 
+.. doctest-remote-data::
+
   >>> emds.get_observations(
   ...     target_name="V1589 Cyg",
   ...     radius=0.1,
   ...     columns=["obs_id", "s_ra", "s_dec", "target_name"],
   ... )  # doctest: +IGNORE_OUTPUT
+
++ String list: ``dataproduct_type=["img", "pha"]`` → ``dataproduct_type = 'img' OR dataproduct_type = 'pha'``
+
+.. doctest-remote-data::
+
+  >>> emds.get_observations(
+  ...     columns=["obs_id", "dataproduct_type"],
+  ...     dataproduct_type=["img", "pha"],
+  ... )  # doctest: +IGNORE_OUTPUT
+
++ Numeric comparison: ``t_min=(">", 60000)`` -> ``t_min > 60000``
+
+.. doctest-remote-data::
+
+  >>> emds.get_observations(
+  ...     columns=["obs_id", "t_min", "t_max"],
+  ...     t_min=(">", 60000),
+  ... )  # doctest: +IGNORE_OUTPUT
+
++ Filter by numeric interval: ``s_ra=(80, 82)`` -> ``s_ra >= 80 AND s_ra <= 82``
+
+.. doctest-remote-data::
+
+  >>> emds.get_observations(
+  ...     columns=["obs_id", "s_ra", "s_dec"],
+  ...     s_ra=(80, 82),
+  ...     s_dec=(16, 18),
+  ... )  # doctest: +IGNORE_OUTPUT
+
++ Combined filters: Multiple keyword filters are combined with ``AND``.
+
+    - ``obs_collection="EPSA", instrument_name="FXT"`` → ``obs_collection = 'EPSA' AND instrument_name = 'FXT'``
+
+.. doctest-remote-data::
 
   >>> emds.get_observations(
   ...     columns=["dataproduct_type", "obs_collection", "target_name", "obs_id",
@@ -297,6 +316,7 @@ Some examples and their corresponding ADQL transformations are provided below:
   ...     dataproduct_type=["img", "pha"],
   ...     instrument_name="FXT",
   ... )  # doctest: +IGNORE_OUTPUT
+
 
 
 Reference/API

--- a/docs/esa/emds/emds.rst
+++ b/docs/esa/emds/emds.rst
@@ -416,7 +416,6 @@ Reference/API
 .. automodapi:: astroquery.esa.emds
     :no-inheritance-diagram:
     :inherited-members:
-    :show-inheritance:
 
 EMDS submodules
 ===============

--- a/docs/esa/emds/emds.rst
+++ b/docs/esa/emds/emds.rst
@@ -227,7 +227,7 @@ options, that can be combined to extract the required data:
   >>> from astroquery.esa.emds import EmdsClass
   >>> emds = EmdsClass()
   >>> emds.get_observations(
-  ...     target_name="V1589 Cyg", columns=["s_ra", "s_dec", "obs_id", "s_xel1"], s_xel1=(">", 100)
+  ... target_name="V1589 Cyg", columns=["s_ra", "s_dec", "obs_id", "s_xel1"], s_xel1=(">", 100)
   ... )  # doctest: +IGNORE_OUTPUT
     Executed query:SELECT s_ra, s_dec, obs_id, s_xel1
         FROM ivoa.ObsCore
@@ -346,6 +346,66 @@ Depending on the configuration, ``*`` may also be accepted as an alias for ``%``
   ...     instrument_name="FXT",
   ... )  # doctest: +IGNORE_OUTPUT
 
+----------------------------
+6. Downloading data products
+----------------------------
+
+Observations in the EMDS catalogue are associated with one or more data products,
+such as science files or preview images. These products are stored as files on the
+EMDS data service and can be accessed once the corresponding observation or product
+identifiers are known.
+
+Typically, users first query the product catalogue to identify products of interest
+and inspect the available metadata. This module provides helper methods to retrieve
+product information based on a target name or specific selection criteria, such as
+observation ID, data product type, or other filters.
+
+From the selected products, the module exposes the ObsCore metadata required to
+download the associated files: ``obs_id``, ``obs_publisher_did``, and
+``access_url``.
+
+In this example, a set of products associated with a given ``target_name`` is
+retrieved.
+
+.. doctest-remote-data::
+
+  >>> from astroquery.esa.emds import EmdsClass
+  >>> emds = EmdsClass()
+  >>> products=emds.get_products(target_name='RXCJ0120.9-1351') # doctest: +IGNORE_OUTPUT
+   Executed query:SELECT obs_id, obs_publisher_did, access_url FROM ivoa.ObsCore
+    WHERE 1=CONTAINS(POINT('ICRS', s_ra, s_dec),CIRCLE('ICRS', 20.24491667, -13.85194444, 1.0))
+  >>> products
+    <Table length=10>
+       obs_id                 obs_publisher_did                        access_url
+       object                      object                                object
+    ----------- --------------------------------------------- ------------------------------
+    11900004579 ivo://esavo/EPSA?11900.../fxt_a_11900...img  https://emds.esac.esa.int/...'
+    11900004579 ivo://esavo/EPSA?11900.../fxt_b_11900...expo https://emds.esac.esa.int/...'
+            ...                                           ...                            ...
+    11900004579 ivo://esavo/EPSA?11900.../fxt_b_11900...lc   https://emds.esac.esa.int/...'
+    11900004579 ivo://esavo/EPSA?11900.../fxt_a_11900...expo https://emds.esac.esa.int/...'
+    11900004579 ivo://esavo/EPSA?11900.../fxt_a_11900...fits https://emds.esac.esa.int/...'
+
+.. note::
+
+   The output is truncated for brevity.
+
+The following example shows how to download a list of files associated with a set of
+products selected using specific criteria (such as ``target_name`` and other ``filters``).
+
+.. doctest-remote-data::
+
+  >>> emds.download_products(products) # doctest: +IGNORE_OUTPUT
+   ['fxt_a_11900004579_ff_01_po_3ac.img',
+   'fxt_b_11900004579_ff_01_po_3ac-without_vign.expo',
+   'fxt_b_11900004579_ff_01_po_3ac.expo', 'fxt_a_11900004579_ff_01_po_3ac.expo',
+   'fxt_a_11900004579_ff_01_po_3ac.lc', 'fxt_b_11900004579_ff_01_po_cl_3ac.fits',
+   'fxt_b_11900004579_ff_01_po_3ac.img', 'fxt_b_11900004579_ff_01_po_3ac.lc',
+   'fxt_a_11900004579_ff_01_po_3ac-without_vign.expo',
+   'fxt_a_11900004579_ff_01_po_cl_3ac.fits']
+
+Products download method returns the stored files in the archive, and
+provides a list of these downloaded files.
 
 
 Reference/API
@@ -353,3 +413,11 @@ Reference/API
 
 .. automodapi:: astroquery.esa.emds
     :no-inheritance-diagram:
+
+EMDS submodules
+===============
+
+.. toctree::
+   :maxdepth: 1
+
+   einsteinprobe/einsteinprobe

--- a/docs/esa/emds/emds.rst
+++ b/docs/esa/emds/emds.rst
@@ -39,13 +39,29 @@ through the ``login()`` and ``logout()`` methods provided by the EMDS Astroquery
 EMDS Astroquery module allows users to explore the data structure of the TAP by listing available
 tables and their columns. This is useful for understanding what data is accessible before running ADQL queries.
 
+.. doctest-remote-data::
+
   >>> from astroquery.esa.emds import EmdsClass
   >>> emds = EmdsClass()
   >>> emds.get_tables()
-  [<VODataServiceTable name="ivoa.ObsCore">... 30 columns ...</VODataServiceTable>]
+  [<VODataServiceTable name="einsteinprobe.fxt_product">... 24 columns ...</VODataServiceTable>, <VODataServiceTable name="einsteinprobe.obscore">... 30 columns ...</VODataServiceTable>, <VODataServiceTable name="einsteinprobe.obscore_extended">... 34 columns ...</VODataServiceTable>, <VODataServiceTable name="einsteinprobe.preview_products">... 2 columns ...</VODataServiceTable>, <VODataServiceTable name="einsteinprobe.wxt_product">... 22 columns ...</VODataServiceTable>, <VODataServiceTable name="ivoa.ObsCore">... 30 columns ...</VODataServiceTable>, <VODataServiceTable name="public.dual">... 1 columns ...</VODataServiceTable>, <VODataServiceTable name="smile.cdf_item">... 11 columns ...</VODataServiceTable>, <VODataServiceTable name="smile.cdf_modification">... 5 columns ...</VODataServiceTable>, <VODataServiceTable name="smile.cdf_parameter">... 6 columns ...</VODataServiceTable>, <VODataServiceTable name="smile.cdf_parent">... 2 columns ...</VODataServiceTable>, <VODataServiceTable name="smile.cdf_variable">... 47 columns ...</VODataServiceTable>, <VODataServiceTable name="smile.dataset">... 21 columns ...</VODataServiceTable>, <VODataServiceTable name="smile.descriptor">... 1 columns ...</VODataServiceTable>, <VODataServiceTable name="smile.instrument">... 5 columns ...</VODataServiceTable>, <VODataServiceTable name="smile.leap_second">... 3 columns ...</VODataServiceTable>, <VODataServiceTable name="smile.mission">... 2 columns ...</VODataServiceTable>, <VODataServiceTable name="smile.processing_level">... 3 columns ...</VODataServiceTable>, <VODataServiceTable name="smile.proprietary_period_configuration">... 3 columns ...</VODataServiceTable>, <VODataServiceTable name="smile.v_data_file">... 18 columns ...</VODataServiceTable>, <VODataServiceTable name="smile.v_data_file_latest">... 18 columns ...</VODataServiceTable>, <VODataServiceTable name="smile.v_data_item">... 12 columns ...</VODataServiceTable>, <VODataServiceTable name="smile.v_ql_data_file">... 15 columns ...</VODataServiceTable>, <VODataServiceTable name="smile.v_ql_data_file_latest">... 15 columns ...</VODataServiceTable>, <VODataServiceTable name="smile.v_ql_data_item">... 8 columns ...</VODataServiceTable>, <VODataServiceTable name="tap_config.coord_sys">... 5 columns ...</VODataServiceTable>, <VODataServiceTable name="tap_config.properties">... 2 columns ...</VODataServiceTable>, <VODataServiceTable name="tap_schema.columns">... 16 columns ...</VODataServiceTable>, <VODataServiceTable name="tap_schema.key_columns">... 3 columns ...</VODataServiceTable>, <VODataServiceTable name="tap_schema.keys">... 5 columns ...</VODataServiceTable>, <VODataServiceTable name="tap_schema.schemas">... 5 columns ...</VODataServiceTable>, <VODataServiceTable name="tap_schema.tables">... 9 columns ...</VODataServiceTable>]
 
-  >>> obscore_table = emds.get_table(table='ivoa.ObsCore')
-  >>> obscore_table.columns
+By default, ``get_tables()`` returns table objects with metadata. If ``only_names=True`` is provided, the method returns
+only the table names as strings. This is useful when you only need to inspect or display the available tables without
+accessing their full metadata.
+
+.. doctest-remote-data::
+
+  >>> emds.get_tables(only_names=True)
+  ['einsteinprobe.fxt_product', 'einsteinprobe.obscore', 'einsteinprobe.obscore_extended', 'einsteinprobe.preview_products', 'einsteinprobe.wxt_product', 'ivoa.ObsCore', 'public.dual', 'smile.cdf_item', 'smile.cdf_modification', 'smile.cdf_parameter', 'smile.cdf_parent', 'smile.cdf_variable', 'smile.dataset', 'smile.descriptor', 'smile.instrument', 'smile.leap_second', 'smile.mission', 'smile.processing_level', 'smile.proprietary_period_configuration', 'smile.v_data_file', 'smile.v_data_file_latest', 'smile.v_data_item', 'smile.v_ql_data_file', 'smile.v_ql_data_file_latest', 'smile.v_ql_data_item', 'tap_config.coord_sys', 'tap_config.properties', 'tap_schema.columns', 'tap_schema.key_columns', 'tap_schema.keys', 'tap_schema.schemas', 'tap_schema.tables']
+
+Once a specific table is selected using ``get_table()``, the returned object provides access to the table metadata,
+including its columns.
+
+.. doctest-remote-data::
+
+  >>> ivoa_obscore_table = emds.get_table(table='ivoa.ObsCore')
+  >>> ivoa_obscore_table.columns
   [<BaseParam name="access_estsize"/>, <BaseParam name="access_format"/>, <BaseParam name="access_url"/>, <BaseParam name="calib_level"/>, <BaseParam name="dataproduct_type"/>, <BaseParam name="em_max"/>, <BaseParam name="em_min"/>, <BaseParam name="em_res_power"/>, <BaseParam name="em_xel"/>, <BaseParam name="facility_name"/>, <BaseParam name="instrument_name"/>, <BaseParam name="o_ucd"/>, <BaseParam name="obs_collection"/>, <BaseParam name="obs_id"/>, <BaseParam name="obs_publisher_did"/>, <BaseParam name="pol_states"/>, <BaseParam name="pol_xel"/>, <BaseParam name="s_dec"/>, <BaseParam name="s_fov"/>, <BaseParam name="s_ra"/>, <BaseParam name="s_region"/>, <BaseParam name="s_resolution"/>, <BaseParam name="s_xel1"/>, <BaseParam name="s_xel2"/>, <BaseParam name="t_exptime"/>, <BaseParam name="t_max"/>, <BaseParam name="t_min"/>, <BaseParam name="t_resolution"/>, <BaseParam name="t_xel"/>, <BaseParam name="target_name"/>]
 
 -------------------------
@@ -58,7 +74,7 @@ ObsCore view.
 
    >>> from astroquery.esa.emds import EmdsClass
    >>> emds = EmdsClass()
-   >>> emds.get_emds_missions()
+   >>> emds.get_missions()
     <Table length=1>
     obs_collection
         object

--- a/docs/esa/emds/emds.rst
+++ b/docs/esa/emds/emds.rst
@@ -1,0 +1,290 @@
+.. _astroquery.esa.emds:
+
+**********************************************************************
+ESDC Multi-Mission Data Services (EMDS) (`astroquery.esa.emds`)
+**********************************************************************
+
+The ESAC Science Data Center (ESDC) develops and operates science archives for ESA missions, providing the community
+with access to Planetary, Heliophysics, and Astronomy data collections. As many mission archives transition into a
+legacy phase, operating multiple independent archives becomes increasingly resource-intensive and can lead to software
+obsolescence, limited standardization, reduced interoperability, and fragmented long-term evolution.
+
+The ESDC Multi-Mission Data Services (EMDS) initiative addresses these challenges by integrating stand-alone mission
+archives into a unified and scalable backend system. EMDS promotes cross-disciplinary data discovery and access through
+standardized interoperability mechanisms, including the IVOA Table Access Protocol (TAP), and by harmonizing interfaces
+across scientific domains. This approach improves maintainability and scalability, supports the migration of existing
+archives, and provides a common foundation for future missions and shared user interfaces.
+
+========
+Examples
+========
+
+---------------
+1. Login/Logout
+---------------
+Some tables and data require authentication to access proprietary or advanced data. Authentication is managed
+through the ``login()`` and ``logout()`` methods provided by the EMDS Astroquery module.
+
+.. doctest-remote-data::
+
+  >>> from astroquery.esa.emds import EmdsClass
+  >>> emds = EmdsClass()
+  >>> emds.login() # doctest: +IGNORE_OUTPUT
+  >>> emds.logout() # doctest: +IGNORE_OUTPUT
+
+-----------------------------------
+2. Get available tables and columns
+-----------------------------------
+
+EMDS Astroquery module allows users to explore the data structure of the TAP by listing available
+tables and their columns. This is useful for understanding what data is accessible before running ADQL queries.
+
+  >>> from astroquery.esa.emds import EmdsClass
+  >>> emds = EmdsClass()
+  >>> emds.get_tables()
+  [<VODataServiceTable name="ivoa.ObsCore">... 30 columns ...</VODataServiceTable>]
+
+  >>> obscore_table = emds.get_table(table='ivoa.ObsCore')
+  >>> obscore_table.columns
+  [<BaseParam name="access_estsize"/>, <BaseParam name="access_format"/>, <BaseParam name="access_url"/>, <BaseParam name="calib_level"/>, <BaseParam name="dataproduct_type"/>, <BaseParam name="em_max"/>, <BaseParam name="em_min"/>, <BaseParam name="em_res_power"/>, <BaseParam name="em_xel"/>, <BaseParam name="facility_name"/>, <BaseParam name="instrument_name"/>, <BaseParam name="o_ucd"/>, <BaseParam name="obs_collection"/>, <BaseParam name="obs_id"/>, <BaseParam name="obs_publisher_did"/>, <BaseParam name="pol_states"/>, <BaseParam name="pol_xel"/>, <BaseParam name="s_dec"/>, <BaseParam name="s_fov"/>, <BaseParam name="s_ra"/>, <BaseParam name="s_region"/>, <BaseParam name="s_resolution"/>, <BaseParam name="s_xel1"/>, <BaseParam name="s_xel2"/>, <BaseParam name="t_exptime"/>, <BaseParam name="t_max"/>, <BaseParam name="t_min"/>, <BaseParam name="t_resolution"/>, <BaseParam name="t_xel"/>, <BaseParam name="target_name"/>]
+
+-------------------------
+3. Get available missions
+-------------------------
+
+The EMDS TAP service is a *multi-mission* archive: multiple missions and data collections are exposed through a single
+TAP endpoint. Each mission typically appears as a distinct value in the ``obs_collection`` field of the EMDS global
+ObsCore view.
+
+   >>> from astroquery.esa.emds import EmdsClass
+   >>> emds = EmdsClass()
+   >>> emds.get_emds_missions()
+    <Table length=1>
+    obs_collection
+        object
+    --------------
+              EPSA
+
+----------------------------
+4. ADQL Queries to EMDS TAP
+----------------------------
+
+The Query TAP functionality facilitates the execution of custom Table Access Protocol (TAP) queries within the EMDS.
+Results can be exported to a specified file in the chosen format, and queries may be executed asynchronously.
+
+.. doctest-remote-data::
+
+  >>> from astroquery.esa.emds import EmdsClass
+  >>> emds = EmdsClass()
+  >>> emds.query_tap(
+  ...     query=(
+  ...         "SELECT dataproduct_type, obs_collection, target_name, obs_id, s_ra, s_dec "
+  ...         "FROM ivoa.ObsCore "
+  ...         "ORDER BY target_name DESC"
+  ...     )
+  ... )  # doctest: +IGNORE_OUTPUT
+
+    <Table length=12298>
+    dataproduct_type obs_collection target_name    obs_id          s_ra             s_dec
+                                                                   deg               deg
+         object          object        object      object        float64           float64
+    ---------------- -------------- ----------- ----------- ----------------- ------------------
+                 arf           EPSA             10202076929                --                 --
+                 png           EPSA             11900006256                --                 --
+                 png           EPSA             11900006200                --                 --
+                 rmf           EPSA             11900012239                --                 --
+                 ...            ...         ...         ...               ...                ...
+                 img           EPSA   * 111 Tau 11900008319 81.12383618253855  17.41749240154885
+               event           EPSA   * 111 Tau 11900008319 81.12383618253855  17.41749240154885
+                  lc           EPSA   * 111 Tau 11900008319 81.12383618253855  17.41749240154885
+                 pha           EPSA   * 111 Tau 11900008319 81.12383621375398 17.417492453817907
+
+-------------------------------------
+5. Filtering the Obs Core Catalogue
+-------------------------------------
+
+The EMDS TAP service exposes an ObsCore-compliant catalogue (``ivoa.ObsCore``) that contains observation-level metadata
+(e.g. sky position, time coverage, instrument/collection identifiers, and access information). Depending on the mission
+and instrument, the catalogue can contain a large number of rows and many columns, so it is not recommended to retrieve
+all columns and all rows by default.
+
+Instead, users should filter the catalogue by selecting only the columns required for their use case and applying
+constraints (for example by sky region, observation collection, instrument, data product type, or other ObsCore fields).
+
+This module provides a dedicated method to query the EMDS ObsCore view and apply filters based on any available column.
+
+To check the columns available in this catalogue, the following method can be executed using ``get_metadata=True``:
+
+.. doctest-remote-data::
+
+  >>> from astroquery.esa.emds import EmdsClass
+  >>> emds = EmdsClass()
+  >>> emds.get_observations(get_metadata=True)  # doctest: +IGNORE_OUTPUT
+
+    <Table masked=True length=30>
+        Column                   Description                Unit  Data Type           UCD                                   UType
+        str17                       object                 object    str6            object                                 object
+    -------------- --------------------------------------- ------ --------- ----------------------- ------------------------------------------------------
+    access_estsize Estimated size of dataset: in kilobytes  kbyte      long     phys.size;meta.file                                    obscore:Access.size
+     access_format           Content format of the dataset   None      char          meta.code.mime                                  obscore:Access.format
+        access_url              URL used to access dataset   None      char            meta.ref.url                               obscore:Access.reference
+               ...                                     ...    ...       ...                     ...                                                    ...
+             t_min                       Start time in MJD      d    double time.start;obs.exposure obscore:Char.TimeAxis.Coverage.Bounds.Limits.StartTime
+      t_resolution                Temporal resolution FWHM      s    double         time.resolution          obscore:Char.TimeAxis.Resolution.Refval.value
+             t_xel  Number of elements along the time axis   None      long             meta.number                          obscore:Char.TimeAxis.numBins
+       target_name                      Object of interest   None      char             meta.id;src                                    obscore:Target.name
+
+Once the columns of interest have been extracted, it is possible to execute the same function with the following
+options, that can be combined to extract the required data:
+
++ Define the reference target or coordinates where a cone search will be executed.
+
+.. doctest-remote-data::
+
+  >>> from astroquery.esa.emds import EmdsClass
+  >>> emds = EmdsClass()
+  >>> emds.get_observations(target_name='V1589 Cyg')  # doctest: +IGNORE_OUTPUT
+
+    Executed query:SELECT * FROM ivoa.ObsCore WHERE 1=CONTAINS(POINT('ICRS', s_ra, s_dec),CIRCLE('ICRS', 310.7048109, 41.3833259, 1.0))
+    <Table length=12>
+    access_estsize        access_format        ... t_xel target_name
+        kbyte                                  ...
+        int64                 object           ... int64    object
+    -------------- --------------------------- ... ----- -----------
+            463680 application/x-fits-bintable ... 19233   V1589 Cyg
+           2888640 application/x-fits-bintable ...    --           0
+             51840 application/x-fits-bintable ...   961   V1589 Cyg
+            745920 application/x-fits-bintable ... 19233   V1589 Cyg
+               ...                         ... ...   ...         ...
+           2888640 application/x-fits-bintable ...    --           0
+           1465920 application/x-fits-bintable ... 19234   V1589 Cyg
+            362880 application/x-fits-bintable ... 19234   V1589 Cyg
+           1465920 application/x-fits-bintable ... 19233   V1589 Cyg
+
++ Retrieve only a specific set of columns.
+
+.. doctest-remote-data::
+
+  >>> from astroquery.esa.emds import EmdsClass
+  >>> emds = EmdsClass()
+  >>> emds.get_observations(target_name='V1589 Cyg', columns=['s_ra', 's_dec', 'obs_id', 's_xel1'])  # doctest: +IGNORE_OUTPUT
+
+    Executed query:SELECT s_ra, s_dec, obs_id, s_xel1 FROM ivoa.ObsCore WHERE 1=CONTAINS(POINT('ICRS', s_ra, s_dec),CIRCLE('ICRS', 310.7048109, 41.3833259, 1.0))
+    <Table length=12>
+           s_ra             s_dec           obs_id   s_xel1
+           deg               deg
+         float64           float64          object   int64
+    ----------------- ------------------ ----------- ------
+    310.6757640621578 41.351414087733275 11900012239     95
+    310.6755985583337 41.351202980612555 11900012239    600
+    310.6755985583337 41.351202980612555 11900012239     20
+    310.6755985583337 41.351202980612555 11900012239    418
+                  ...                ...         ...    ...
+    310.6755985583337 41.351202980612555 11900012239    600
+    310.6756375374491 41.351278441170614 11900012239    600
+    310.6756375374491 41.351278441170614 11900012239     95
+    310.6757640621578 41.351414087733275 11900012239    600
+
++ Filter by any other column available in the previous method.
+
+.. doctest-remote-data::
+
+  >>> from astroquery.esa.emds import EmdsClass
+  >>> emds = EmdsClass()
+  >>> emds.get_observations(target_name='V1589 Cyg', columns=['s_ra', 's_dec', 'obs_id', 's_xel1'], s_xel1=('>', 100))  # doctest: +IGNORE_OUTPUT
+
+    Executed query:SELECT s_ra, s_dec, obs_id, s_xel1 FROM ivoa.ObsCore  WHERE s_xel1 > 100 AND 1=CONTAINS(POINT('ICRS', s_ra, s_dec),CIRCLE('ICRS', 310.7048109, 41.3833259, 1.0))
+    <Table length=8>
+           s_ra             s_dec           obs_id   s_xel1
+           deg               deg
+         float64           float64          object   int64
+    ----------------- ------------------ ----------- ------
+    310.6755985583337 41.351202980612555 11900012239    600
+    310.6755985583337 41.351202980612555 11900012239    418
+    310.6755993340324  41.35120289084306 11900012239    600
+    310.6755993340324  41.35120289084306 11900012239    600
+    310.6755993340324  41.35120289084306 11900012239    418
+    310.6755985583337 41.351202980612555 11900012239    600
+    310.6756375374491 41.351278441170614 11900012239    600
+    310.6757640621578 41.351414087733275 11900012239    600
+
+As it can be observed in the previous examples, additional constraints can be provided using the ``**filters`` syntax,
+where the keyword corresponds to an ObsCore column name and the value defines the filter to be applied. The method
+translates these filters into the corresponding ADQL constraints executed by the TAP service.
+
+Some examples and their corresponding ADQL transformations are provided below:
+
++ Exact match (string): ``obs_collection="EPSA"`` -> ``obs_collection = 'EPSA'``
+
++ Exact match (string): ``instrument_name="FXT"`` -> ``instrument_name = 'FXT'``
+
++ Wildcards (string): ``target_name="AT 2023%"`` -> ``target_name ILIKE 'AT 2023%'``
+  (``*`` may also be accepted as an alias for ``%`` depending on the backend configuration)
+
++ String list: ``dataproduct_type=["img", "pha"]`` -> ``dataproduct_type = 'img' OR dataproduct_type = 'pha'``
+  (some TAP services may translate this to an equivalent ``IN ('img','pha')`` clause)
+
++ Numeric comparison: ``t_min=(">", 60000)`` -> ``t_min > 60000``
+
++ Filter by numeric interval: ``s_ra=(80, 82)`` -> ``s_ra >= 80 AND s_ra <= 82``
+
++ Combined filters: ``obs_collection="EPSA", instrument_name="FXT"`` -> ``obs_collection = 'EPSA' AND instrument_name = 'FXT'``
+
+  >>> emds.get_observations(
+  ...     columns=["dataproduct_type", "obs_collection", "target_name", "obs_id",
+  ...              "s_ra", "s_dec", "instrument_name"]
+  ... )  # doctest: +IGNORE_OUTPUT
+
+  >>> emds.get_observations(
+  ...     columns=["obs_id", "obs_collection", "instrument_name", "dataproduct_type"],
+  ...     obs_collection="EPSA",
+  ...     instrument_name="FXT",
+  ... )  # doctest: +IGNORE_OUTPUT
+
+  >>> emds.get_observations(
+  ...     columns=["obs_id", "target_name"],
+  ...     target_name="V1589 Cyg",
+  ... )  # doctest: +IGNORE_OUTPUT
+
+  >>> emds.get_observations(
+  ...     columns=["obs_id", "dataproduct_type"],
+  ...     dataproduct_type=["img", "pha"],
+  ... )  # doctest: +IGNORE_OUTPUT
+
+  >>> emds.get_observations(
+  ...     columns=["obs_id", "t_min", "t_max"],
+  ...     t_min=(">", 60000),
+  ... )  # doctest: +IGNORE_OUTPUT
+
+  >>> emds.get_observations(
+  ...     columns=["obs_id", "s_ra", "s_dec"],
+  ...     s_ra=(80, 82),
+  ...     s_dec=(16, 18),
+  ... )  # doctest: +IGNORE_OUTPUT
+
+  >>> emds.get_observations(
+  ...     coordinates="81.1238 17.4175",
+  ...     radius=0.1,
+  ...     columns=["obs_id", "s_ra", "s_dec", "instrument_name"],
+  ... )  # doctest: +IGNORE_OUTPUT
+
+  >>> emds.get_observations(
+  ...     target_name="V1589 Cyg",
+  ...     radius=0.1,
+  ...     columns=["obs_id", "s_ra", "s_dec", "target_name"],
+  ... )  # doctest: +IGNORE_OUTPUT
+
+  >>> emds.get_observations(
+  ...     columns=["dataproduct_type", "obs_collection", "target_name", "obs_id",
+  ...              "s_ra", "s_dec", "instrument_name"],
+  ...     obs_collection="EPSA",
+  ...     dataproduct_type=["img", "pha"],
+  ...     instrument_name="FXT",
+  ... )  # doctest: +IGNORE_OUTPUT
+
+
+Reference/API
+=============
+
+.. automodapi:: astroquery.esa.emds
+    :no-inheritance-diagram:

--- a/docs/esa/emds/emds.rst
+++ b/docs/esa/emds/emds.rst
@@ -4,7 +4,7 @@
 ESDC Multi-Mission Data Services (EMDS) (`astroquery.esa.emds`)
 **********************************************************************
 
-The ESAC Science Data Center (ESDC) develops and operates science archives for ESA missions, providing the community
+The ESAC Science Data Centre (ESDC) develops and operates science archives for ESA missions, providing the community
 with access to Planetary, Heliophysics, and Astronomy data collections. As many mission archives transition into a
 legacy phase, operating multiple independent archives becomes increasingly resource-intensive and can lead to software
 obsolescence, limited standardization, reduced interoperability, and fragmented long-term evolution.
@@ -36,7 +36,7 @@ through the ``login()`` and ``logout()`` methods provided by the EMDS Astroquery
 2. Get available tables and columns
 -----------------------------------
 
-EMDS Astroquery module allows users to explore the data structure of the TAP by listing available
+The EMDS Astroquery module allows users to explore the data structure of the TAP by listing available
 tables and their columns. This is useful for understanding what data is accessible before running ADQL queries.
 
 

--- a/docs/esa/emds/emds.rst
+++ b/docs/esa/emds/emds.rst
@@ -29,8 +29,8 @@ through the ``login()`` and ``logout()`` methods provided by the EMDS Astroquery
 
   >>> from astroquery.esa.emds import EmdsClass
   >>> emds = EmdsClass()
-  >>> emds.login() # doctest: +IGNORE_OUTPUT
-  >>> emds.logout() # doctest: +IGNORE_OUTPUT
+  >>> emds.login() # doctest: +SKIP
+  >>> emds.logout() # doctest: +SKIP
 
 -----------------------------------
 2. Get available tables and columns
@@ -374,19 +374,22 @@ retrieved.
   >>> from astroquery.esa.emds import EmdsClass
   >>> emds = EmdsClass()
   >>> products=emds.get_products(target_name='RXCJ0120.9-1351') # doctest: +IGNORE_OUTPUT
-   Executed query:SELECT obs_id, obs_publisher_did, access_url FROM ivoa.ObsCore
-    WHERE 1=CONTAINS(POINT('ICRS', s_ra, s_dec),CIRCLE('ICRS', 20.24491667, -13.85194444, 1.0))
+  Executed query:SELECT obs_id, obs_publisher_did, access_url FROM ivoa.ObsCore WHERE 1=CONTAINS(POINT('ICRS', s_ra, s_dec),CIRCLE('ICRS', 20.244917, -13.851944, 1.0))
   >>> products
-    <Table length=10>
-       obs_id                 obs_publisher_did                        access_url
-       object                      object                                object
-    ----------- --------------------------------------------- ------------------------------
-    11900004579 ivo://esavo/EPSA?11900.../fxt_a_11900...img  https://emds.esac.esa.int/...'
-    11900004579 ivo://esavo/EPSA?11900.../fxt_b_11900...expo https://emds.esac.esa.int/...'
-            ...                                           ...                            ...
-    11900004579 ivo://esavo/EPSA?11900.../fxt_b_11900...lc   https://emds.esac.esa.int/...'
-    11900004579 ivo://esavo/EPSA?11900.../fxt_a_11900...expo https://emds.esac.esa.int/...'
-    11900004579 ivo://esavo/EPSA?11900.../fxt_a_11900...fits https://emds.esac.esa.int/...'
+  <Table length=10>
+     obs_id   ...                                                                                           access_url
+     object   ...                                                                                             object
+  ----------- ... ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+  11900004579 ...               https://emds.esac.esa.int/service/data?retrieval_type=PRODUCT&QUERY=SELECT+filepath,filename+from+einsteinprobe.fxt_product+WHERE+filename='fxt_a_11900004579_ff_01_po_3ac.img'
+  11900004579 ... https://emds.esac.esa.int/service/data?retrieval_type=PRODUCT&QUERY=SELECT+filepath,filename+from+einsteinprobe.fxt_product+WHERE+filename='fxt_b_11900004579_ff_01_po_3ac-without_vign.expo'
+  11900004579 ...              https://emds.esac.esa.int/service/data?retrieval_type=PRODUCT&QUERY=SELECT+filepath,filename+from+einsteinprobe.fxt_product+WHERE+filename='fxt_b_11900004579_ff_01_po_3ac.expo'
+  11900004579 ...              https://emds.esac.esa.int/service/data?retrieval_type=PRODUCT&QUERY=SELECT+filepath,filename+from+einsteinprobe.fxt_product+WHERE+filename='fxt_a_11900004579_ff_01_po_3ac.expo'
+  11900004579 ...           https://emds.esac.esa.int/service/data?retrieval_type=PRODUCT&QUERY=SELECT+filepath,filename+from+einsteinprobe.fxt_product+WHERE+filename='fxt_b_11900004579_ff_01_po_cl_3ac.fits'
+  11900004579 ... https://emds.esac.esa.int/service/data?retrieval_type=PRODUCT&QUERY=SELECT+filepath,filename+from+einsteinprobe.fxt_product+WHERE+filename='fxt_a_11900004579_ff_01_po_3ac-without_vign.expo'
+  11900004579 ...           https://emds.esac.esa.int/service/data?retrieval_type=PRODUCT&QUERY=SELECT+filepath,filename+from+einsteinprobe.fxt_product+WHERE+filename='fxt_a_11900004579_ff_01_po_cl_3ac.fits'
+  11900004579 ...                https://emds.esac.esa.int/service/data?retrieval_type=PRODUCT&QUERY=SELECT+filepath,filename+from+einsteinprobe.fxt_product+WHERE+filename='fxt_a_11900004579_ff_01_po_3ac.lc'
+  11900004579 ...               https://emds.esac.esa.int/service/data?retrieval_type=PRODUCT&QUERY=SELECT+filepath,filename+from+einsteinprobe.fxt_product+WHERE+filename='fxt_b_11900004579_ff_01_po_3ac.img'
+  11900004579 ...                https://emds.esac.esa.int/service/data?retrieval_type=PRODUCT&QUERY=SELECT+filepath,filename+from+einsteinprobe.fxt_product+WHERE+filename='fxt_b_11900004579_ff_01_po_3ac.lc'
 
 .. note::
 

--- a/docs/esa/emds/emds.rst
+++ b/docs/esa/emds/emds.rst
@@ -95,7 +95,7 @@ ObsCore view.
 
    >>> from astroquery.esa.emds import EmdsClass
    >>> emds = EmdsClass()
-   >>> emds.get_missions() # doctest: +IGNORE_OUTPUT
+   >>> emds.list_missions() # doctest: +IGNORE_OUTPUT
     <Table length=1>
     obs_collection
         object

--- a/docs/esa/integral/integral.rst
+++ b/docs/esa/integral/integral.rst
@@ -28,16 +28,21 @@ file in the chosen format, and queries may be executed asynchronously.
   >>> isla = IntegralClass()
   >>> isla.query_tap(query='select * from ivoa.obscore')  # doctest: +IGNORE_OUTPUT
   <Table length=6743>
-  access_estsize   access_format                                     access_url                                   calib_level ...    t_max       t_min    t_resolution t_xel
-      int64            object                                          object                                        int32    ...   float64     float64     float64    int64
-  -------------- ----------------- ------------------------------------------------------------------------------ ----------- ... ----------- ----------- ------------ -----
-           26923 application/x-tar https://isla.esac.esa.int/tap/data?retrieval_type=SCW&b2JzaWQ9MDA2MDAwMjAwMDE=           2 ... 52594.80985 52593.47308      6.1e-05     1
-          488697 application/x-tar https://isla.esac.esa.int/tap/data?retrieval_type=SCW&b2JzaWQ9MDA2MDAwNDAwMDE=           2 ... 52596.64583 52596.46613      6.1e-05     1
-         3459831 application/x-tar https://isla.esac.esa.int/tap/data?retrieval_type=SCW&b2JzaWQ9MDA2MDAwNjAwMDI=           2 ... 52600.54167  52599.4592      6.1e-05     1
-             ...               ...                                                                            ...         ... ...         ...         ...          ...   ...
-          351253 application/x-tar https://isla.esac.esa.int/tap/data?retrieval_type=SCW&b2JzaWQ9ODg4MDExMzAwMDQ=           2 ... 57188.63542 57188.28125      6.1e-05     1
-           10195 application/x-tar https://isla.esac.esa.int/tap/data?retrieval_type=SCW&b2JzaWQ9ODg4MDExMzAwMDU=           2 ... 57189.64284 57189.28867      6.1e-05     1
-          817730 application/x-tar https://isla.esac.esa.int/tap/data?retrieval_type=SCW&b2JzaWQ9ODg5OTgwMTAzMDE=           2 ... 52636.82597 52636.49534      6.1e-05     1
+  access_estsize   access_format                                     access_url                                   calib_level dataproduct_type         em_max        ... t_exptime    t_max       t_min    t_resolution t_xel
+      int64            object                                          object                                        int32         object             float64        ...  float64    float64     float64     float64    int64
+  -------------- ----------------- ------------------------------------------------------------------------------ ----------- ---------------- --------------------- ... --------- ----------- ----------- ------------ -----
+           26923 application/x-tar https://isla.esac.esa.int/tap/data?retrieval_type=SCW&b2JzaWQ9MDA2MDAwMjAwMDE=           2            image 1.241528257871965e-13 ...  115497.0 52594.80985 52593.47308      6.1e-05     1
+          488697 application/x-tar https://isla.esac.esa.int/tap/data?retrieval_type=SCW&b2JzaWQ9MDA2MDAwNDAwMDE=           2            image 1.241528257871965e-13 ...   15526.0 52596.64583 52596.46613      6.1e-05     1
+         3459831 application/x-tar https://isla.esac.esa.int/tap/data?retrieval_type=SCW&b2JzaWQ9MDA2MDAwNjAwMDI=           2            image 1.241528257871965e-13 ...   93525.0 52600.54167  52599.4592      6.1e-05     1
+          829304 application/x-tar https://isla.esac.esa.int/tap/data?retrieval_type=SCW&b2JzaWQ9MDA2MDAwNjAwMDM=           2            image 1.241528257871965e-13 ...   32400.0 52601.52083 52601.14583      6.1e-05     1
+         2690370 application/x-tar https://isla.esac.esa.int/tap/data?retrieval_type=SCW&b2JzaWQ9MDA2MDAwNjAwMDU=           2            image 1.241528257871965e-13 ...  103739.0 52603.65248 52602.45179      6.1e-05     1
+             ...               ...                                                                            ...         ...              ...                   ... ...       ...         ...         ...          ...   ...
+          680110 application/x-tar https://isla.esac.esa.int/tap/data?retrieval_type=SCW&b2JzaWQ9ODg4MDExMzAwMDE=           2            image 1.241528257871965e-13 ...   29700.0 57181.66231 57181.28125      6.1e-05     1
+          802534 application/x-tar https://isla.esac.esa.int/tap/data?retrieval_type=SCW&b2JzaWQ9ODg4MDExMzAwMDI=           2            image 1.241528257871965e-13 ...   30600.0 57183.65356 57183.28074      6.1e-05     1
+          861813 application/x-tar https://isla.esac.esa.int/tap/data?retrieval_type=SCW&b2JzaWQ9ODg4MDExMzAwMDM=           2            image 1.241528257871965e-13 ...   30600.0 57184.66102 57184.28819      6.1e-05     1
+          351253 application/x-tar https://isla.esac.esa.int/tap/data?retrieval_type=SCW&b2JzaWQ9ODg4MDExMzAwMDQ=           2            image 1.241528257871965e-13 ...   30600.0 57188.63542 57188.28125      6.1e-05     1
+           10195 application/x-tar https://isla.esac.esa.int/tap/data?retrieval_type=SCW&b2JzaWQ9ODg4MDExMzAwMDU=           2            image 1.241528257871965e-13 ...   30600.0 57189.64284 57189.28867      6.1e-05     1
+          817730 application/x-tar https://isla.esac.esa.int/tap/data?retrieval_type=SCW&b2JzaWQ9ODg5OTgwMTAzMDE=           2            image 1.241528257871965e-13 ...   24200.0 52636.82597 52636.49534      6.1e-05     1
 
 ------------------
 2. Getting sources
@@ -70,7 +75,7 @@ identified by its target name. The metadata provides in-depth information about 
   >>> isla = IntegralClass()
   >>> metadata = isla.get_source_metadata(target_name='Crab')
   >>> metadata  # doctest: +IGNORE_OUTPUT
-  [{'name': 'Integral', 'link': None, 'metadata': [{'param': 'Name', 'value': 'Crab'}, {'param': 'Id', 'value': 'J053432.0+220052'}, {'param': 'Coordinates degrees', 'value': '83.6324 22.0174'}, {'param': 'Coordinates', 'value': '05 34 31.78 22 01 02.64'}, {'param': 'Galactic', 'value': '184.55 -5.78'}, {'param': 'Isgri flag2', 'value': 'very bright source'}, {'param': 'Jemx flag', 'value': 'detected'}, {'param': 'Spi flag', 'value': 'detected'}, {'param': 'Picsit flag', 'value': 'detected'}]}, {'name': 'Simbad', 'link': 'https://simbad.cds.unistra.fr/simbad/sim-id?Ident=Crab', 'metadata': [{'param': 'Id', 'value': 'NAME Crab'}, {'param': 'Type', 'value': 'SuperNova Remnant'}, {'param': 'Other types', 'value': 'HII|IR|Psr|Rad|SNR|X|gam'}]}]
+  [{'name': 'Integral', 'link': None, 'metadata': {'columns': ['description', 'value'], 'rows': [{'description': 'Name', 'value': 'Crab'}, {'description': 'Id', 'value': 'J053432.0+220052'}, {'description': 'Coordinates degrees', 'value': '83.6324 22.0174'}, {'description': 'Coordinates', 'value': '05:34:31.78 22:01:02.64'}, {'description': 'Galactic', 'value': '184.55 -5.78'}, {'description': 'Isgri flag2', 'value': 'very bright source'}, {'description': 'Jemx flag', 'value': 'detected'}, {'description': 'Spi flag', 'value': 'detected'}, {'description': 'Picsit flag', 'value': 'detected'}]}}, {'name': 'Simbad', 'link': 'https://simbad.cds.unistra.fr/simbad/sim-id?Ident=Crab', 'metadata': {'columns': ['description', 'value'], 'rows': [{'description': 'Id', 'value': 'NAME Crab'}, {'description': 'Type', 'value': 'SuperNova Remnant'}, {'description': 'Other types', 'value': 'gam|HII|IR|Psr|Rad|SNR|X'}]}}, {'name': 'Publications', 'link': None, 'metadata': None}]
 
 ------------------------------------
 4. Retrieving observations from ISLA
@@ -86,17 +91,22 @@ operation asynchronously.
   >>> from astroquery.esa.integral import IntegralClass
   >>> isla = IntegralClass()
   >>> isla.get_observations(target_name='crab', radius=12.0, start_revno='0290', end_revno='0599')  # doctest: +IGNORE_OUTPUT
-  <Table length=27>
-      dec                 email              end_revno       endtime       ...      starttime       surname                               title
-   float64               str60                object         object       ...        object         str20                                str120
-  ---------- ------------------------------ --------- ------------------- ... ------------------- ---------- --------------------------------------------------------------
-  26.3157778 peter.kretschmar!@obs.unige.ch      0352 2005-09-02 21:20:59 ... 2005-08-31 11:07:06 Kretschmar Target of Opportunity Observations of an Outburst in A 0535+26
-      22.684             isdc-iswt@unige.ch      0300 2005-03-30 22:42:38 ... 2005-03-30 10:34:41       ISWT                                 Crab spring/05 IBIS 10 deg arc
-      20.611             isdc-iswt@unige.ch      0300 2005-03-31 13:35:11 ... 2005-03-30 22:44:07       ISWT                                 Crab spring/05 IBIS 10 deg arc
-         ...                            ...       ...                 ... ...                 ...        ...                                                            ...
-  22.0144444         inthelp@sciops.esa.int      0541 2007-03-21 00:08:52 ... 2007-03-20 21:30:30     Public                       Crab-2007 Spring: JEM-X VC settings test
-  22.0144444         inthelp@sciops.esa.int      0541 2007-03-22 03:16:24 ... 2007-03-21 00:10:22     Public                         Crab-2007 Spring: IBIS on-axis staring
-  22.0144444         inthelp@sciops.esa.int      0541 2007-03-20 15:35:22 ... 2007-03-19 12:53:21     Public                              Crab-2007 Spring: SPI 5x5 pattern
+  <Table length=28>
+     dec     end_revno       endtime       exposure    obsid    prop_id     ra     ... scw_number  scw_size       srcname       start_revno      starttime       surname                               title
+   float64     object         object        int64      object     str7   float64   ...   int64      int64          str20           object          object         str20                                str120
+  ---------- --------- ------------------- -------- ----------- ------- ---------- ... ---------- ---------- ------------------ ----------- ------------------- ---------- --------------------------------------------------------------
+  26.3157778      0352 2005-09-02 21:20:59   200032 03200490001 0320049  84.727375 ...        110 8865617044          A 0535+26        0352 2005-08-31 11:07:06 Kretschmar Target of Opportunity Observations of an Outburst in A 0535+26
+  21.5003972      0301 2005-04-01 15:16:17    55000 03998020003 0399802 90.9793537 ...         47 2220095363                GPS        0301 2005-03-31 21:33:56       ISWT                    Galactic Plane Survey for AO 03, Pattern 02
+      22.684      0300 2005-03-30 22:42:38    41400 88600690001 8860069     94.424 ...         45 1714289129 10 deg around Crab        0300 2005-03-30 10:34:41       ISWT                                 Crab spring/05 IBIS 10 deg arc
+      20.611      0300 2005-03-31 13:35:11    41400 88600690002 8860069     73.003 ...         45 1881430682 10 deg around Crab        0300 2005-03-30 22:44:07       ISWT                                 Crab spring/05 IBIS 10 deg arc
+  17.1577222      0300 2005-03-30 01:19:34    45000 88600710001 8860071 80.5439167 ...         49 1981344397  Crab SPI/IBIS 5x5        0300 2005-03-29 12:01:31       ISWT                                    Crab spring/05 SPI/IBIS 5*5
+         ...       ...                 ...      ...         ...     ...        ... ...        ...        ...                ...         ...                 ...        ...                                                            ...
+  22.0144722      0483 2006-09-29 16:31:27    45000 88601140004 8860114 83.6332083 ...         48 2048814449  Crab cal IBIS/SPI        0483 2006-09-29 01:41:20     Public                                   Crab calibration autumn 2006
+  22.0144444      0541 2007-03-20 18:38:03    10000 88601230001 8860123 83.6329167 ...          3  460762160     Crab cal JEM-X        0541 2007-03-20 15:51:22     Public                       Crab-2007 Spring: JEM-X grey filter test
+  22.0144444      0541 2007-03-20 21:29:01     8500 88601240001 8860124 83.6329167 ...          3  392713076     Crab cal JEM-X        0541 2007-03-20 18:39:32     Public                    Crab-2007 Spring: JEM-X anode segments test
+  22.0144444      0541 2007-03-21 00:08:52     9500 88601250001 8860125 83.6329167 ...          3  418415105     Crab cal JEM-X        0541 2007-03-20 21:30:30     Public                       Crab-2007 Spring: JEM-X VC settings test
+  22.0144444      0541 2007-03-22 03:16:24    96041 88601260001 8860126 83.6329167 ...         26 4305461837      Crab cal IBIS        0541 2007-03-21 00:10:22     Public                         Crab-2007 Spring: IBIS on-axis staring
+  22.0144444      0541 2007-03-20 15:35:22    90000 88601270001 8860127 83.6329167 ...         99 4305389452  Crab cal IBIS/SPI        0541 2007-03-19 12:53:21     Public                              Crab-2007 Spring: SPI 5x5 pattern
 
 
 ------------------------------
@@ -115,7 +125,7 @@ An additional parameter, read_fits (default value True) reads automatically the 
 
   >>> from astroquery.esa.integral import IntegralClass
   >>> isla = IntegralClass()
-  >>> results = isla.download_science_windows(science_windows=['008100430010', '033400230030'], output_file=None)  # doctest: +IGNORE_OUTPUT
+  >>> results = isla.download_science_windows(science_windows=['008100430010', '033400230030'], output_file=None, read_fits=False)  # doctest: +IGNORE_OUTPUT
 
 
 ---------------------
@@ -192,7 +202,7 @@ Users can refine their results by selecting an instrument or energy band.
 
   >>> from astroquery.esa.integral import IntegralClass
   >>> isla = IntegralClass()
-  >>> ltt = isla.get_long_term_timeseries(target_name='J174537.0-290107', instrument='jem-x')  # doctest: +IGNORE_OUTPUT
+  >>> ltt = isla.get_long_term_timeseries(target_name='J174537.0-290107', instrument='jem-x', read_fits=False)  # doctest: +IGNORE_OUTPUT
 
 
 8.2. Retrieving Short-Term Timeseries
@@ -206,7 +216,7 @@ the results are saved to a file for detailed examination.
 
   >>> from astroquery.esa.integral import IntegralClass
   >>> isla = IntegralClass()
-  >>> stt = isla.get_short_term_timeseries(target_name='J011705.1-732636', band='28_40', epoch='0745_06340000001')  # doctest: +IGNORE_OUTPUT
+  >>> stt = isla.get_short_term_timeseries(target_name='J011705.1-732636', band='28_40', epoch='0745_06340000001', read_fits=False)  # doctest: +IGNORE_OUTPUT
 
 
 8.3. Retrieving spectra
@@ -220,7 +230,7 @@ output file for further processing.
 
   >>> from astroquery.esa.integral import IntegralClass
   >>> isla = IntegralClass()
-  >>> spectra = isla.get_spectra(target_name='J011705.1-732636', instrument='ibis', epoch='0745_06340000001')  # doctest: +IGNORE_OUTPUT
+  >>> spectra = isla.get_spectra(target_name='J011705.1-732636', instrument='ibis', epoch='0745_06340000001', read_fits=False)  # doctest: +IGNORE_OUTPUT
 
 
 8.4. Retrieving mosaics
@@ -233,7 +243,7 @@ Users can filter by instrument or energy band and save the resulting image to a 
 
   >>> from astroquery.esa.integral import IntegralClass
   >>> isla = IntegralClass()
-  >>> mosaics = isla.get_mosaic(epoch='0727_88601650001', instrument='ibis')  # doctest: +IGNORE_OUTPUT +IGNORE_WARNINGS
+  >>> mosaics = isla.get_mosaic(epoch='0727_88601650001', instrument='ibis', read_fits=False)  # doctest: +IGNORE_OUTPUT +IGNORE_WARNINGS
 
 Reference/API
 =============

--- a/docs/esa/utils/utils.rst
+++ b/docs/esa/utils/utils.rst
@@ -30,4 +30,4 @@ Reference/API
 =============
 
 .. automodapi:: astroquery.esa.utils
-    :members:
+    :no-inheritance-diagram:

--- a/docs/esa/utils/utils.rst
+++ b/docs/esa/utils/utils.rst
@@ -1,0 +1,33 @@
+.. _astroquery.esa.utils:
+
+*****************************************
+ESA Utils Module (`astroquery.esa.utils`)
+*****************************************
+
+The ``astroquery.esa.utils`` module provides the shared infrastructure used by ESA-related services.
+It centralizes common logic that is reused across multiple ESA query interfaces migrated to PyVO, reducing code
+duplication and ensuring consistent behavior across modules.
+
+At the core of this module is the abstract base class :class:`~astroquery.esa.utils.EsaTap`, which defines common
+functionality for interacting with ESA TAP-based services. This class is not intended to be instantiated directly.
+
+The :class:`~astroquery.esa.utils.EsaTap` class provides reusable mechanisms for:
+
+- Authentication and session management with ESA services
+  (e.g. :meth:`~astroquery.esa.utils.EsaTap.login` and
+  :meth:`~astroquery.esa.utils.EsaTap.logout`)
+- Configuration and handling of TAP service endpoints.
+- Management of authenticated HTTP requests.
+- Common interaction patterns shared by ESA archive and discovery services.
+
+In addition to :class:`~astroquery.esa.utils.EsaTap`, this module includes utility
+functions that support ESA modules more generally, such as helpers for file
+downloads, request handling, and other low-level operations required by multiple
+ESA services.
+
+
+Reference/API
+=============
+
+.. automodapi:: astroquery.esa.utils
+    :members:

--- a/docs/esa/xmm_newton/xmm_newton.rst
+++ b/docs/esa/xmm_newton/xmm_newton.rst
@@ -122,18 +122,7 @@ stored in the file 'results10.csv'. The result of this query can be printed by d
   INFO: Retrieving tables... [astroquery.utils.tap.core]
   INFO: Parsing tables... [astroquery.utils.tap.core]
   INFO: Done. [astroquery.utils.tap.core]
-  ['public.dual', 'tap_config.coord_sys', 'tap_config.properties', 'tap_schema.columns',
-   'tap_schema.key_columns', 'tap_schema.keys', 'tap_schema.schemas',
-   'tap_schema.tables', 'xsa.v_all_observations', 'xsa.v_epic_source',
-   'xsa.v_epic_source_cat', 'xsa.v_epic_xmm_stack_cat', 'xsa.v_exposure',
-   'xsa.v_instrument_mode', 'xsa.v_om_source', 'xsa.v_om_source_cat',
-   'xsa.v_proposal', 'xsa.v_proposal_observation_info', 'xsa.v_publication',
-   'xsa.v_publication_observation', 'xsa.v_publication_slew_observation',
-   'xsa.v_public_observations', 'xsa.v_public_observations_new_odf_ingestion',
-   'xsa.v_public_observations_new_pps_ingestion', 'xsa.v_rgs_source',
-   'xsa.v_slew_exposure', 'xsa.v_slew_observation', 'xsa.v_slew_source',
-   'xsa.v_slew_source_cat', 'xsa.v_target_type', 'xsa.v_uls_exposure_image',
-   'xsa.v_uls_slew_exposure_image']
+  ['public.dual', 'tap_config.coord_sys', 'tap_config.properties', 'tap_schema.columns', 'tap_schema.key_columns', 'tap_schema.keys', 'tap_schema.schemas', 'tap_schema.tables', 'xsa.data_product', 'xsa.image_gallery_categories', 'xsa.image_gallery_subcategories', 'xsa.joint_exposure_info', 'xsa.joint_observation_info', 'xsa.v_all_observations', 'xsa.v_epic_source', 'xsa.v_epic_source_cat', 'xsa.v_epic_xmm_stack_cat', 'xsa.v_exposure', 'xsa.v_image_gallery', 'xsa.v_ingestions', 'xsa.v_instrument_mode', 'xsa.v_om_source', 'xsa.v_om_source_cat', 'xsa.v_proposal', 'xsa.v_proposal_observation_info', 'xsa.v_publication', 'xsa.v_publication_observation', 'xsa.v_publication_slew_observation', 'xsa.v_public_observations', 'xsa.v_public_observations_new_odf_ingestion', 'xsa.v_public_observations_new_pps_ingestion', 'xsa.v_rgs_source', 'xsa.v_slew_exposure', 'xsa.v_slew_observation', 'xsa.v_slew_source', 'xsa.v_slew_source_cat', 'xsa.v_target_type', 'xsa.v_uls_exposure_image', 'xsa.v_uls_slew_exposure_image']
 
 This will show the available tables in XSA TAP service in the XMM-Newton Science Archive.
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -267,6 +267,7 @@ The following modules have been completed using a common API:
   esa/jwst/jwst.rst
   esa/xmm_newton/xmm_newton.rst
   esasky/esasky.rst
+  esa/utils/utils.rst
   eso/eso.rst
   image_cutouts/first/first.rst
   gaia/gaia.rst
@@ -374,7 +375,13 @@ generally return a table listing the available data first.
   alma/alma.rst
   cadc/cadc.rst
   casda/casda.rst
+  esa/euclid/euclid.rst
+  esa/hsa/hsa.rst
   esa/hubble/hubble.rst
+  esa/emds/emds.rst
+  esa/emds/einsteinprobe/einsteinprobe.rst
+  esa/integral/integral.rst
+  esa/iso/iso.rst
   esa/jwst/jwst.rst
   esa/xmm_newton/xmm_newton.rst
   eso/eso.rst

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -267,7 +267,6 @@ The following modules have been completed using a common API:
   esa/jwst/jwst.rst
   esa/xmm_newton/xmm_newton.rst
   esasky/esasky.rst
-  esa/utils/utils.rst
   eso/eso.rst
   image_cutouts/first/first.rst
   gaia/gaia.rst
@@ -444,6 +443,7 @@ above categories. Those services are here:
   jplsbdb/jplsbdb.rst
   nasa_ads/nasa_ads.rst
   solarsystem/neodys/neodys.rst
+  esa/utils/utils.rst
   utils/tap.rst
 
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -260,6 +260,8 @@ The following modules have been completed using a common API:
   esa/euclid/euclid.rst
   esa/hsa/hsa.rst
   esa/hubble/hubble.rst
+  esa/emds/emds.rst
+  esa/emds/einsteinprobe/einsteinprobe.rst
   esa/integral/integral.rst
   esa/iso/iso.rst
   esa/jwst/jwst.rst


### PR DESCRIPTION
Dear Astroquery team,

We come from PR 3501: https://github.com/astropy/astroquery/pull/3501

As part of the migration to PyVO, we have generated a more general class called EsaTap, extending PyVO capabilities with custom code (authentication, parameters in the request, methods to query tables with specific filters...). We will be using this class to extend ESA modules, so the common code will remain under EsaTap and the mission-specific methods will be defined in their specific modules. As a reference, we have already applied this approach to eHST and ISLA. 

In addition to this, we have generated a new module called ESDC Multi-Mission Data Services (EMDS). Then, inside it, we have generated the module for Einstein Probe module, that depends on the EMDS one.

Please let us know if this is ok with you.

Happy to receive your feedback and implement any change you require!

Kind regards,
@jespinosaar and @pdmElisa

cc @esdc-esac-esa-int 
