### PR TITLE
EUCLID: new parameters in  `get_observation_products`, `get_product_list`, `get_product `and `get_scientific_product_list ` to retrieve the products by the dataset release

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -173,6 +173,8 @@ esa.euclid
   products. [#3313]
 
 - New cross-match method [#3386]
+- New parameters in the methods get_observation_products, get_product_list, get_product and get_scientific_product_list
+  to retrieve the products by the dataset release [#3514]
 
 esa.hubble
 ^^^^^^^^^^

--- a/astroquery/esa/euclid/__init__.py
+++ b/astroquery/esa/euclid/__init__.py
@@ -25,14 +25,22 @@ class Conf(_config.ConfigNamespace):
                                             "ID is given preference. To give name preference, set the value to True:")
 
     ENVIRONMENTS = {'IDR': {'url_server': 'https://easidr.esac.esa.int/', 'main_table': 'catalogue.mer_catalogue',
-                            'main_table_ra_column': 'right_ascension', 'main_table_dec_column': 'declination'},
+                            'main_table_ra_column': 'right_ascension', 'main_table_dec_column': 'declination',
+                            'data_set_release_part1': 'environment', 'data_set_release_part2': 'activity_code',
+                            'data_set_release_part3': 'version'},
                     'OTF': {'url_server': 'https://easotf.esac.esa.int/', 'main_table': 'catalogue.mer_catalogue',
-                            'main_table_ra_column': 'right_ascension', 'main_table_dec_column': 'declination'},
+                            'main_table_ra_column': 'right_ascension', 'main_table_dec_column': 'declination',
+                            'data_set_release_part1': 'activity_code', 'data_set_release_part2': 'patch_id',
+                            'data_set_release_part3': 'version'},
                     'REG': {'url_server': 'https://easreg.esac.esa.int/',
                             'main_table': 'catalogue.mer_final_catalog_fits_file_regreproc1_r2',
-                            'main_table_ra_column': 'right_ascension', 'main_table_dec_column': 'declination'},
+                            'main_table_ra_column': 'right_ascension', 'main_table_dec_column': 'declination',
+                            'data_set_release_part1': 'environment', 'data_set_release_part2': 'activity_code',
+                            'data_set_release_part3': 'version'},
                     'PDR': {'url_server': 'https://eas.esac.esa.int/', 'main_table': 'catalogue.mer_catalogue',
-                            'main_table_ra_column': 'right_ascension', 'main_table_dec_column': 'declination'}
+                            'main_table_ra_column': 'right_ascension', 'main_table_dec_column': 'declination',
+                            'data_set_release_part1': 'environment', 'data_set_release_part2': 'activity_code',
+                            'data_set_release_part3': 'version'}
                     }
 
     OBSERVATION_STACK_PRODUCTS = ['DpdNirStackedFrame', 'DpdVisStackedFrame']

--- a/astroquery/esa/euclid/core.py
+++ b/astroquery/esa/euclid/core.py
@@ -1342,7 +1342,7 @@ class EuclidClass(TapPlus):
         return files
 
     def get_cutout(self, *, file_path=None, instrument=None, id=None, coordinate, radius, output_file=None,
-                   dsr_part1=None, dsr_part2=None, dsr_part3=None, verbose=False):
+                   verbose=False):
         """
         Downloads a cutout given its file path, instrument and obs_id, and the cutout region
 
@@ -1358,14 +1358,6 @@ class EuclidClass(TapPlus):
             coordinates center point
         radius : astropy.units, mandatory
             the radius of the cutout to generate
-        dsr_part1: str, optional, default None
-            the data set release part 1: for OTF environment, the activity code; for REG and IDR, the target environment
-        dsr_part2: str, optional, default None
-            the data set release part 2: for OTF environment, the patch id (a positive integer); for REG and IDR,
-            the activity code
-        dsr_part3: str, optional, default None
-            the data set release part 3: for OTF, REG and IDR environment, the version (a integer greater than 1)
-
         output_file : str, optional
             output file. If no value is provided, a temporary one is created
 
@@ -1391,15 +1383,6 @@ class EuclidClass(TapPlus):
 
         params_dict = {'TAPCLIENT': 'ASTROQUERY', 'FILEPATH': file_path, 'COLLECTION': instrument, 'OBSID': id,
                        'POS': pos}
-
-        if dsr_part1 is not None:
-            params_dict['DSP1'] = dsr_part1
-
-        if dsr_part2 is not None:
-            params_dict['DSP2'] = dsr_part2
-
-        if dsr_part3 is not None:
-            params_dict['DSP3'] = dsr_part3
 
         output_file_full_path, output_dir = self.__set_dirs(output_file=output_file, observation_id='temp')
         try:

--- a/astroquery/esa/euclid/core.py
+++ b/astroquery/esa/euclid/core.py
@@ -1144,30 +1144,34 @@ class EuclidClass(TapPlus):
         if product_type in conf.OBSERVATION_STACK_PRODUCTS:
             table = 'sedm.observation_stack'
 
-            dsr_condition = self.get_data_set_release_condition(dsr_part1, dsr_part2, dsr_part3, 'observation_stack')
-            extra_condition = '' if dsr_condition is None else f'AND {dsr_condition}'
+            dsr_condition = self.__get_data_set_release_condition(dsr_part1, dsr_part2, dsr_part3, 'observation_stack')
+            extra_condition = '' if dsr_condition is None else f' AND {dsr_condition}'
 
             query = (f"SELECT observation_stack.file_name, observation_stack.observation_stack_oid, "
                      f"observation_stack.observation_id, observation_stack.ra, observation_stack.dec, "
                      f"observation_stack.instrument_name, observation_stack.filter_name, "
                      "observation_stack.release_name, observation_stack.category, observation_stack.second_type, "
                      f"observation_stack.technique, observation_stack.product_type, observation_stack.start_time, "
-                     f"observation_stack.duration FROM {table} WHERE "
+                     f"observation_stack.duration, observation_stack.data_set_release_part1, "
+                     f"observation_stack.data_set_release_part2, observation_stack.data_set_release_part3 FROM "
+                     f"{table} WHERE "
                      f" observation_stack.observation_id = '{observation_id}' AND observation_stack.product_type = '"
                      f"{product_type}' {extra_condition};")
 
         if product_type in conf.BASIC_DOWNLOAD_DATA_PRODUCTS:
             table = 'sedm.basic_download_data'
 
-            dsr_condition = self.get_data_set_release_condition(dsr_part1, dsr_part2, dsr_part3, 'basic_download_data')
-            extra_condition = '' if dsr_condition is None else f'AND {dsr_condition}'
+            dsr_condition = self.__get_data_set_release_condition(dsr_part1, dsr_part2, dsr_part3,
+                                                                  'basic_download_data')
+            extra_condition = '' if dsr_condition is None else f' AND {dsr_condition}'
 
             query = (
                 f"SELECT basic_download_data.basic_download_data_oid, basic_download_data.product_type, "
                 f"basic_download_data.product_id, CAST(basic_download_data.observation_id_list as text) AS "
                 f"observation_id_list, CAST(basic_download_data.tile_index_list as text) AS tile_index_list, "
                 f"CAST(basic_download_data.patch_id_list as text) AS patch_id_list, "
-                f"CAST(basic_download_data.filter_name as text) AS filter_name, basic_download_data.release_name FROM "
+                f"CAST(basic_download_data.filter_name as text) AS filter_name, basic_download_data.release_name, "
+                f"basic_download_data.data_set_release_part2, basic_download_data.data_set_release_part3 FROM "
                 f"{table} WHERE '{observation_id}'=ANY(observation_id_list) AND product_type = '"
                 f"{product_type}' {extra_condition}"
                 f"ORDER BY observation_id_list ASC;")
@@ -1175,14 +1179,17 @@ class EuclidClass(TapPlus):
         if product_type in conf.MER_SEGMENTATION_MAP_PRODUCTS:
             table = 'sedm.mer_segmentation_map'
 
-            dsr_condition = self.get_data_set_release_condition(dsr_part1, dsr_part2, dsr_part3, 'mer_segmentation_map')
-            extra_condition = '' if dsr_condition is None else f'AND {dsr_condition}'
+            dsr_condition = self.__get_data_set_release_condition(dsr_part1, dsr_part2, dsr_part3,
+                                                                  'mer_segmentation_map')
+            extra_condition = '' if dsr_condition is None else f' AND {dsr_condition}'
 
             query = (
                 f"SELECT mer_segmentation_map.file_name, mer_segmentation_map.segmentation_map_oid, "
                 f"mer_segmentation_map.ra, mer_segmentation_map.dec, mer_segmentation_map.stc_s, "
                 f"mer_segmentation_map.tile_index, "
-                f"mer_segmentation_map.product_type, mer_segmentation_map.product_id FROM {table} "
+                f"mer_segmentation_map.product_type, mer_segmentation_map.product_id, "
+                f"mer_segmentation_map.release_name, mer_segmentation_map.data_set_release_part2, "
+                f"mer_segmentation_map.data_set_release_part3 FROM {table} "
                 f"WHERE ( observation_id_list = '{observation_id}' OR observation_id_list like '{observation_id},"
                 f"%' OR observation_id_list "
                 f"like '%,{observation_id}' OR CAST(observation_id_list as TEXT) like '%,{observation_id},%' ) AND "
@@ -1191,8 +1198,8 @@ class EuclidClass(TapPlus):
         if product_type in conf.RAW_FRAME_PRODUCTS:
             table = 'sedm.raw_frame'
 
-            dsr_condition = self.get_data_set_release_condition(dsr_part1, dsr_part2, dsr_part3, 'raw_frame')
-            extra_condition = '' if dsr_condition is None else f'AND {dsr_condition}'
+            dsr_condition = self.__get_data_set_release_condition(dsr_part1, dsr_part2, dsr_part3, 'raw_frame')
+            extra_condition = '' if dsr_condition is None else f' AND {dsr_condition}'
 
             if product_type == "dpdNispRawFrame":
                 instrument_name = "NISP"
@@ -1204,47 +1211,52 @@ class EuclidClass(TapPlus):
                 f"raw_frame.instrument_name, raw_frame.data_set_release, raw_frame.filter_name, "
                 f"raw_frame.observation_mode, raw_frame.grism_wheel_pos, raw_frame.cal_block_id, "
                 f"raw_frame.cal_block_variant, raw_frame.ra, raw_frame.dec, raw_frame.obs_time_utc, "
-                f"raw_frame.exposure_time FROM {table} WHERE raw_frame.observation_id = '{observation_id}' "
+                f"raw_frame.exposure_time, raw_frame.release_name, raw_frame.data_set_release_part1, "
+                f"raw_frame.data_set_release_part2, raw_frame.data_set_release_part3 FROM {table} WHERE "
+                f"raw_frame.observation_id = '{observation_id}' "
                 f"AND raw_frame.instrument_name = '{instrument_name}' {extra_condition};")
 
         if product_type in conf.CALIBRATED_FRAME_PRODUCTS:
             table = 'sedm.calibrated_frame'
 
-            dsr_condition = self.get_data_set_release_condition(dsr_part1, dsr_part2, dsr_part3, 'calibrated_frame')
-            extra_condition = '' if dsr_condition is None else f'AND {dsr_condition}'
+            dsr_condition = self.__get_data_set_release_condition(dsr_part1, dsr_part2, dsr_part3, 'calibrated_frame')
+            extra_condition = '' if dsr_condition is None else f' AND {dsr_condition}'
 
             query = (
                 f"SELECT calibrated_frame.file_name, calibrated_frame.calibrated_frame_oid, "
                 f"calibrated_frame.observation_id, calibrated_frame.instrument_name, calibrated_frame.filter_name, "
                 f"calibrated_frame.ra, calibrated_frame.dec, calibrated_frame.stc_s, calibrated_frame.start_time, "
-                f"calibrated_frame.end_time, calibrated_frame.duration "
+                f"calibrated_frame.end_time, calibrated_frame.duration, calibrated_frame.data_set_release_part1, "
+                f"calibrated_frame.data_set_release_part2, calibrated_frame.data_set_release_part3 "
                 f"FROM {table} WHERE calibrated_frame.observation_id = '{observation_id}' AND "
                 f"calibrated_frame.product_type = '{product_type}' {extra_condition};")
 
         if product_type in conf.FRAME_CATALOG_PRODUCTS:
             table = 'sedm.frame_catalog'
 
-            dsr_condition = self.get_data_set_release_condition(dsr_part1, dsr_part2, dsr_part3, 'frame_catalog')
-            extra_condition = '' if dsr_condition is None else f'AND {dsr_condition}'
+            dsr_condition = self.__get_data_set_release_condition(dsr_part1, dsr_part2, dsr_part3, 'frame_catalog')
+            extra_condition = '' if dsr_condition is None else f' AND {dsr_condition}'
 
             query = (
                 f"SELECT frame_catalog.file_name, frame_catalog.catalog_oid, frame_catalog.observation_id, "
                 f"frame_catalog.instrument_name, frame_catalog.filter_name, frame_catalog.ra, frame_catalog.dec, "
                 f"frame_catalog.datarange_start_time, frame_catalog.datarange_end_time, "
-                f"frame_catalog.product_type, frame_catalog.product_id FROM {table} "
+                f"frame_catalog.product_type, frame_catalog.product_id, frame_catalog.data_set_release_part1, "
+                f"frame_catalog.data_set_release_part2, frame_catalog.data_set_release_part3 FROM {table} "
                 f"WHERE frame_catalog.observation_id = '{observation_id}' AND frame_catalog.product_type = '"
                 f"{product_type}' {extra_condition};")
 
         if product_type in conf.COMBINED_SPECTRA_PRODUCTS:
             table = 'sedm.combined_spectra'
 
-            dsr_condition = self.get_data_set_release_condition(dsr_part1, dsr_part2, dsr_part3, 'combined_spectra')
-            extra_condition = '' if dsr_condition is None else f'AND {dsr_condition}'
+            dsr_condition = self.__get_data_set_release_condition(dsr_part1, dsr_part2, dsr_part3, 'combined_spectra')
+            extra_condition = '' if dsr_condition is None else f' AND {dsr_condition}'
 
             query = (
                 f"SELECT combined_spectra.combined_spectra_oid, combined_spectra.lambda_range, "
                 f"combined_spectra.tile_index, combined_spectra.stc_s, combined_spectra.product_type, "
-                f"combined_spectra.product_id FROM {table} "
+                f"combined_spectra.product_id, combined_spectra.data_set_release_part1, "
+                f"combined_spectra.data_set_release_part2, combined_spectra.data_set_release_part3 FROM {table} "
                 f"WHERE ( observation_id_list = '{observation_id}' OR observation_id_list like '{observation_id} %' "
                 f"OR observation_id_list "
                 f"like '% {observation_id}' OR observation_id_list like '% {observation_id} %' ) AND "
@@ -1253,15 +1265,16 @@ class EuclidClass(TapPlus):
         if product_type in conf.SIR_SCIENCE_FRAME_PRODUCTS:
             table = 'sedm.sir_science_frame'
 
-            dsr_condition = self.get_data_set_release_condition(dsr_part1, dsr_part2, dsr_part3, 'sir_science_frame')
-            extra_condition = '' if dsr_condition is None else f'AND {dsr_condition}'
+            dsr_condition = self.__get_data_set_release_condition(dsr_part1, dsr_part2, dsr_part3, 'sir_science_frame')
+            extra_condition = '' if dsr_condition is None else f' AND {dsr_condition}'
 
             instrument_name = "NISP"
 
             query = (
                 f"SELECT sir_science_frame.file_name, sir_science_frame.science_frame_oid, "
                 f"sir_science_frame.observation_id, sir_science_frame.instrument_name, sir_science_frame.stc_s, "
-                f"sir_science_frame.prod_sdc FROM {table} "
+                f"sir_science_frame.prod_sdc, sir_science_frame.data_set_release_part1, "
+                f"sir_science_frame.data_set_release_part2, sir_science_frame.data_set_release_part3 FROM {table} "
                 f"WHERE sir_science_frame.observation_id = '{observation_id}' AND sir_science_frame.instrument_name = '"
                 f"{instrument_name}' {extra_condition};")
 
@@ -1272,7 +1285,31 @@ class EuclidClass(TapPlus):
                                  format_with_results_compressed=('votable_gzip',))
         return job.get_results()
 
-    def get_data_set_release_condition(self, dsr_1_value=None, dsr_2_value=None, dsr_3_value=None, alias=None):
+    def __get_data_set_release_condition(self, dsr_1_value=None, dsr_2_value=None, dsr_3_value=None, alias=None):
+
+        query = None
+        if dsr_1_value is not None:
+            dsr_1_final = '.'.join(filter(None, [alias, 'data_set_release_part1']))
+            query = f"{dsr_1_final} = '{dsr_1_value}'"
+
+        if dsr_2_value is not None:
+            dsr_2_final = '.'.join(filter(None, [alias, 'data_set_release_part2']))
+            if query is not None:
+                query = f"{query} AND {dsr_2_final} = '{dsr_2_value}'"
+            else:
+                query = f"{dsr_2_final} = '{dsr_2_value}'"
+
+        if dsr_3_value is not None:
+            dsr_3_final = '.'.join(filter(None, [alias, 'data_set_release_part3']))
+            if query is not None:
+                query = f"{query} AND {dsr_3_final} = {dsr_3_value}"
+            else:
+                query = f"{dsr_3_final} = {dsr_3_value}"
+
+        return query
+
+    def __get_data_set_release_condition_from_environment(self, dsr_1_value=None, dsr_2_value=None, dsr_3_value=None,
+                                                          alias=None):
 
         query = None
         if dsr_1_value is not None:
@@ -1604,7 +1641,7 @@ class EuclidClass(TapPlus):
         if tile_index is not None:
             query_extra_condition = f" AND '{tile_index}' = ANY(tile_index_list) "
 
-        dsr_condition = self.get_data_set_release_condition(dsr_part1, dsr_part2, dsr_part3)
+        dsr_condition = self.__get_data_set_release_condition(dsr_part1, dsr_part2, dsr_part3)
         dsr_extra_condition = '' if dsr_condition is None else f'AND {dsr_condition}'
 
         if observation_id is not None:
@@ -1710,7 +1747,9 @@ class EuclidClass(TapPlus):
             f"basic_download_data.product_id, CAST(basic_download_data.observation_id_list as text) AS "
             f"observation_id_list, CAST(basic_download_data.tile_index_list as text) AS tile_index_list, "
             f"CAST(basic_download_data.patch_id_list as text) AS patch_id_list, "
-            f"CAST(basic_download_data.filter_name as text) AS filter_name FROM {table} WHERE "
+            f"CAST(basic_download_data.filter_name as text) AS filter_name, "
+            f"basic_download_data.data_set_release_part1, basic_download_data.data_set_release_part2, "
+            f"basic_download_data.data_set_release_part3 FROM {table} WHERE "
             f"release_name='{dataset_release}' {query_extra_condition} {dsr_extra_condition} ORDER BY "
             f"observation_id_list ASC")
 

--- a/astroquery/esa/euclid/core.py
+++ b/astroquery/esa/euclid/core.py
@@ -1140,12 +1140,12 @@ class EuclidClass(TapPlus):
         if tile_index is not None:
             return self.__get_tile_catalogue_list(tile_index=tile_index, product_type=product_type, verbose=verbose)
 
-        dsr_condition = self.get_data_set_release_condition(dsr_part1, dsr_part2, dsr_part3)
-        extra_condition = '' if dsr_condition is None else f'AND {dsr_condition}'
-
         query = None
         if product_type in conf.OBSERVATION_STACK_PRODUCTS:
             table = 'sedm.observation_stack'
+
+            dsr_condition = self.get_data_set_release_condition(dsr_part1, dsr_part2, dsr_part3, 'observation_stack')
+            extra_condition = '' if dsr_condition is None else f'AND {dsr_condition}'
 
             query = (f"SELECT observation_stack.file_name, observation_stack.observation_stack_oid, "
                      f"observation_stack.observation_id, observation_stack.ra, observation_stack.dec, "
@@ -1158,6 +1158,10 @@ class EuclidClass(TapPlus):
 
         if product_type in conf.BASIC_DOWNLOAD_DATA_PRODUCTS:
             table = 'sedm.basic_download_data'
+
+            dsr_condition = self.get_data_set_release_condition(dsr_part1, dsr_part2, dsr_part3, 'basic_download_data')
+            extra_condition = '' if dsr_condition is None else f'AND {dsr_condition}'
+
             query = (
                 f"SELECT basic_download_data.basic_download_data_oid, basic_download_data.product_type, "
                 f"basic_download_data.product_id, CAST(basic_download_data.observation_id_list as text) AS "
@@ -1170,6 +1174,10 @@ class EuclidClass(TapPlus):
 
         if product_type in conf.MER_SEGMENTATION_MAP_PRODUCTS:
             table = 'sedm.mer_segmentation_map'
+
+            dsr_condition = self.get_data_set_release_condition(dsr_part1, dsr_part2, dsr_part3, 'mer_segmentation_map')
+            extra_condition = '' if dsr_condition is None else f'AND {dsr_condition}'
+
             query = (
                 f"SELECT mer_segmentation_map.file_name, mer_segmentation_map.segmentation_map_oid, "
                 f"mer_segmentation_map.ra, mer_segmentation_map.dec, mer_segmentation_map.stc_s, "
@@ -1182,6 +1190,9 @@ class EuclidClass(TapPlus):
 
         if product_type in conf.RAW_FRAME_PRODUCTS:
             table = 'sedm.raw_frame'
+
+            dsr_condition = self.get_data_set_release_condition(dsr_part1, dsr_part2, dsr_part3, 'raw_frame')
+            extra_condition = '' if dsr_condition is None else f'AND {dsr_condition}'
 
             if product_type == "dpdNispRawFrame":
                 instrument_name = "NISP"
@@ -1198,6 +1209,10 @@ class EuclidClass(TapPlus):
 
         if product_type in conf.CALIBRATED_FRAME_PRODUCTS:
             table = 'sedm.calibrated_frame'
+
+            dsr_condition = self.get_data_set_release_condition(dsr_part1, dsr_part2, dsr_part3, 'calibrated_frame')
+            extra_condition = '' if dsr_condition is None else f'AND {dsr_condition}'
+
             query = (
                 f"SELECT calibrated_frame.file_name, calibrated_frame.calibrated_frame_oid, "
                 f"calibrated_frame.observation_id, calibrated_frame.instrument_name, calibrated_frame.filter_name, "
@@ -1208,6 +1223,10 @@ class EuclidClass(TapPlus):
 
         if product_type in conf.FRAME_CATALOG_PRODUCTS:
             table = 'sedm.frame_catalog'
+
+            dsr_condition = self.get_data_set_release_condition(dsr_part1, dsr_part2, dsr_part3, 'frame_catalog')
+            extra_condition = '' if dsr_condition is None else f'AND {dsr_condition}'
+
             query = (
                 f"SELECT frame_catalog.file_name, frame_catalog.catalog_oid, frame_catalog.observation_id, "
                 f"frame_catalog.instrument_name, frame_catalog.filter_name, frame_catalog.ra, frame_catalog.dec, "
@@ -1218,6 +1237,10 @@ class EuclidClass(TapPlus):
 
         if product_type in conf.COMBINED_SPECTRA_PRODUCTS:
             table = 'sedm.combined_spectra'
+
+            dsr_condition = self.get_data_set_release_condition(dsr_part1, dsr_part2, dsr_part3, 'combined_spectra')
+            extra_condition = '' if dsr_condition is None else f'AND {dsr_condition}'
+
             query = (
                 f"SELECT combined_spectra.combined_spectra_oid, combined_spectra.lambda_range, "
                 f"combined_spectra.tile_index, combined_spectra.stc_s, combined_spectra.product_type, "
@@ -1229,6 +1252,10 @@ class EuclidClass(TapPlus):
 
         if product_type in conf.SIR_SCIENCE_FRAME_PRODUCTS:
             table = 'sedm.sir_science_frame'
+
+            dsr_condition = self.get_data_set_release_condition(dsr_part1, dsr_part2, dsr_part3, 'sir_science_frame')
+            extra_condition = '' if dsr_condition is None else f'AND {dsr_condition}'
+
             instrument_name = "NISP"
 
             query = (
@@ -1245,23 +1272,26 @@ class EuclidClass(TapPlus):
                                  format_with_results_compressed=('votable_gzip',))
         return job.get_results()
 
-    def get_data_set_release_condition(self, dsr_1_value=None, dsr_2_value=None, dsr_3_value=None):
+    def get_data_set_release_condition(self, dsr_1_value=None, dsr_2_value=None, dsr_3_value=None, alias=None):
 
         query = None
         if dsr_1_value is not None:
-            query = f"{self.dsr_1} = '{dsr_1_value}'"
+            dsr_1_final = '.'.join(filter(None, [alias, self.dsr_1]))
+            query = f"{dsr_1_final} = '{dsr_1_value}'"
 
         if dsr_2_value is not None:
+            dsr_2_final = '.'.join(filter(None, [alias, self.dsr_2]))
             if query is not None:
-                query = f"{query} AND {self.dsr_2} = {dsr_2_value}"
+                query = f"{query} AND {dsr_2_final} = '{dsr_2_value}'"
             else:
-                query = f"{self.dsr_2} = {dsr_2_value}"
+                query = f"{dsr_2_final} = '{dsr_2_value}'"
 
         if dsr_3_value is not None:
+            dsr_3_final = '.'.join(filter(None, [alias, str(self.dsr_3)]))
             if query is not None:
-                query = f"{query} AND {self.dsr_3} = {dsr_3_value}"
+                query = f"{query} AND {dsr_3_final} = {dsr_3_value}"
             else:
-                query = f"{self.dsr_3} = {dsr_3_value}"
+                query = f"{dsr_3_final} = {dsr_3_value}"
 
         return query
 
@@ -1360,7 +1390,6 @@ class EuclidClass(TapPlus):
             the radius of the cutout to generate
         output_file : str, optional
             output file. If no value is provided, a temporary one is created
-
         verbose : bool, optional, default 'False'
             flag to display information about the process
 
@@ -1475,6 +1504,8 @@ class EuclidClass(TapPlus):
         if os.listdir(output_dir):
             raise IOError(f'The directory is not empty: {output_dir}')
 
+        files = []
+
         try:
             self.__eucliddata.load_data(params_dict=params_dict, output_file=output_file_full_path, verbose=verbose)
         except HTTPError as err:
@@ -1484,7 +1515,6 @@ class EuclidClass(TapPlus):
             log.error(f'Cannot retrieve spectrum for source_id {source_id}, schema {schema}: {str(exx)}')
             return None
 
-        files = []
         self.__extract_file(output_file_full_path=output_file_full_path, output_dir=output_dir, files=files)
 
         if files:

--- a/astroquery/esa/euclid/tests/test_euclidtap.py
+++ b/astroquery/esa/euclid/tests/test_euclidtap.py
@@ -667,6 +667,28 @@ def test_get_product_list():
         results = tap.get_product_list(observation_id='13', product_type=product_type)
         assert results is not None, "Expected a valid table"
 
+    ##############
+
+    for product_type in conf.SIR_SCIENCE_FRAME_PRODUCTS:
+        results = tap.get_product_list(observation_id='13', product_type=product_type, dsr_part1='CALBLOCK',
+                                       verbose=True)
+        assert results is not None, "Expected a valid table"
+
+    for product_type in conf.SIR_SCIENCE_FRAME_PRODUCTS:
+        results = tap.get_product_list(observation_id='13', product_type=product_type, dsr_part1='CALBLOCK',
+                                       dsr_part2='PV-023', verbose=True)
+        assert results is not None, "Expected a valid table"
+
+    for product_type in conf.SIR_SCIENCE_FRAME_PRODUCTS:
+        results = tap.get_product_list(observation_id='13', product_type=product_type, dsr_part1='CALBLOCK',
+                                       dsr_part2='PV-023', dsr_part3=1, verbose=True)
+        assert results is not None, "Expected a valid table"
+
+    for product_type in conf.SIR_SCIENCE_FRAME_PRODUCTS:
+        results = tap.get_product_list(observation_id='13', product_type=product_type, dsr_part2='PV-023', dsr_part3=1,
+                                       verbose=True)
+        assert results is not None, "Expected a valid table"
+
 
 def test_get_product_list_by_tile_index():
     conn_handler = DummyConnHandler()
@@ -754,6 +776,39 @@ def test_get_product_by_product_id(tmp_path_factory):
     fits_file = os.path.join(tmp_path_factory.mktemp("euclid_tmp"), 'my_fits_file.fits')
 
     result = tap.get_product(product_id='123456789', output_file=fits_file)
+
+    assert result is not None
+
+
+def test_get_product_by_product_id_data_set_release(tmp_path_factory):
+    conn_handler = DummyConnHandler()
+    tap_plus = TapPlus(url="http://test:1111/tap", data_context='data', client_id='ASTROQUERY',
+                       connhandler=conn_handler)
+    # Launch response: we use default response because the query contains decimals
+    responseLaunchJob = DummyResponse(200)
+    responseLaunchJob.set_data(method='POST', context=None, body='', headers=None)
+
+    conn_handler.set_default_response(responseLaunchJob)
+
+    tap = EuclidClass(tap_plus_conn_handler=conn_handler, datalink_handler=tap_plus, show_server_messages=False)
+
+    result = tap.get_product(product_id='123456789', output_file=None, dsr_part1='CALBLOCK',
+                             dsr_part2='PV-023', dsr_part3=1)
+
+    assert result is not None
+
+    now = datetime.now()
+    dirs = glob.glob(os.path.join(os.getcwd(), "temp_" + now.strftime("%Y%m%d") + '_*'))
+
+    assert len(dirs) == 1
+    assert dirs[0] is not None
+
+    remove_temp_dir()
+
+    fits_file = os.path.join(tmp_path_factory.mktemp("euclid_tmp"), 'my_fits_file.fits')
+
+    result = tap.get_product(product_id='123456789', output_file=fits_file, dsr_part1='CALBLOCK',
+                             dsr_part2='PV-023', dsr_part3=1)
 
     assert result is not None
 
@@ -867,6 +922,44 @@ def test_get_observation_products(tmp_path_factory):
     fits_file = os.path.join(tmp_path_factory.mktemp("euclid_tmp"), 'my_fits_file.fits')
 
     result = tap.get_observation_products(id='13', product_type='mosaic', filter='VIS', output_file=fits_file)
+
+    assert result is not None
+
+
+def test_get_observation_products_data_set_release(tmp_path_factory):
+    conn_handler = DummyConnHandler()
+    tap_plus = TapPlus(url="http://test:1111/tap", data_context='data', client_id='ASTROQUERY',
+                       connhandler=conn_handler)
+    # Launch response: we use default response because the query contains decimals
+    responseLaunchJob = DummyResponse(200)
+    responseLaunchJob.set_data(method='POST', context=None, body='', headers=None)
+
+    conn_handler.set_default_response(responseLaunchJob)
+
+    tap = EuclidClass(tap_plus_conn_handler=conn_handler, datalink_handler=tap_plus, show_server_messages=False)
+
+    result = tap.get_observation_products(id='13', product_type='observation', filter='VIS', output_file=None,
+                                          dsr_part1='CALBLOCK', dsr_part2='PV-023', dsr_part3=1)
+
+    assert result is not None
+
+    result = tap.get_observation_products(id='13', product_type='mosaic', filter='VIS', output_file=None,
+                                          dsr_part1='CALBLOCK', dsr_part2='PV-023', dsr_part3=1)
+
+    assert result is not None
+
+    now = datetime.now()
+    dirs = glob.glob(os.path.join(os.getcwd(), "temp_" + now.strftime("%Y%m%d") + '_*'))
+
+    assert len(dirs) == 1
+    assert dirs[0] is not None
+
+    remove_temp_dir()
+
+    fits_file = os.path.join(tmp_path_factory.mktemp("euclid_tmp"), 'my_fits_file.fits')
+
+    result = tap.get_observation_products(id='13', product_type='mosaic', filter='VIS', output_file=fits_file,
+                                          dsr_part1='CALBLOCK', dsr_part2='PV-023', dsr_part3=1)
 
     assert result is not None
 
@@ -1129,46 +1222,58 @@ def test_get_scientific_data_product_list():
     euclid = EuclidClass(tap_plus_conn_handler=conn_handler, datalink_handler=tap_plus, show_server_messages=False)
 
     results = euclid.get_scientific_product_list(observation_id=11111)
-
     assert results is not None, "Expected a valid table"
 
     results = euclid.get_scientific_product_list(tile_index=11111)
-
     assert results is not None, "Expected a valid table"
 
     results = euclid.get_scientific_product_list(category='Clusters of Galaxies', group='GrpCatalog',
                                                  product_type='DpdLE3clAmicoAux')
-
     assert results is not None, "Expected a valid table"
 
     results = euclid.get_scientific_product_list(category='Weak Lensing Products', group='2PCF',
                                                  product_type='DpdCovarTwoPCFWLClPosPos2D')
-
     assert results is not None, "Expected a valid table"
 
     results = euclid.get_scientific_product_list(category='Weak Lensing Products')
-
     assert results is not None, "Expected a valid table"
 
     results = euclid.get_scientific_product_list(group='GrpCatalog')
-
     assert results is not None, "Expected a valid table"
 
     results = euclid.get_scientific_product_list(category='Weak Lensing Products', group='2PCF')
-
     assert results is not None, "Expected a valid table"
 
     results = euclid.get_scientific_product_list(group='2PCF', product_type='DpdCovarTwoPCFWLClPosPos2D')
-
     assert results is not None, "Expected a valid table"
 
     results = euclid.get_scientific_product_list(category='Weak Lensing Products',
                                                  product_type='DpdCovarTwoPCFWLClPosPos2D')
-
     assert results is not None, "Expected a valid table"
 
     results = euclid.get_scientific_product_list(product_type='DpdCovarTwoPCFWLClPosPos2D')
+    assert results is not None, "Expected a valid table"
 
+    ########
+
+    results = euclid.get_scientific_product_list(product_type='DpdCovarTwoPCFWLClPosPos2D', dsr_part1='CALBLOCK',
+                                                 verbose=True)
+    assert results is not None, "Expected a valid table"
+
+    results = euclid.get_scientific_product_list(product_type='DpdCovarTwoPCFWLClPosPos2D', dsr_part1='CALBLOCK',
+                                                 dsr_part2='PV-023', verbose=True)
+    assert results is not None, "Expected a valid table"
+
+    results = euclid.get_scientific_product_list(product_type='DpdCovarTwoPCFWLClPosPos2D', dsr_part1='CALBLOCK',
+                                                 dsr_part2='PV-023', dsr_part3=1, verbose=True)
+    assert results is not None, "Expected a valid table"
+
+    results = euclid.get_scientific_product_list(product_type='DpdCovarTwoPCFWLClPosPos2D', dsr_part1='CALBLOCK',
+                                                 dsr_part3=1, verbose=True)
+    assert results is not None, "Expected a valid table"
+
+    results = euclid.get_scientific_product_list(product_type='DpdCovarTwoPCFWLClPosPos2D',
+                                                 dsr_part2='PV-023', dsr_part3=1, verbose=True)
     assert results is not None, "Expected a valid table"
 
 

--- a/astroquery/esa/utils/utils.py
+++ b/astroquery/esa/utils/utils.py
@@ -439,7 +439,7 @@ def prepare_output_dir(file_path):
 
 def resolve_target(url, session, target_name, target_resolver):
     """
-    Download a file in streaming mode using a existing session
+    Download a file in streaming mode using an existing session
 
     Parameters
     ----------


### PR DESCRIPTION
Dear astroquery team,

we would like to upgrade the signature of the methods `get_observation_products`, `get_product_list`, `get_product `and `get_scientific_product_list ` so that they now include the new parameters dsr_part1, dsr_part2, dsr_part3 that can be used to retrieve the products by dataset release (that is made of of 3 parts).

cc @esdc-esac-esa-int 
jira:EUCLIDMNGT-1430