### PR TITLE
TST: ignore deprecation from numpy/astropy 

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -97,6 +97,8 @@ filterwarnings =
 # CoverageWarnings triggered by one of the other plugins(?). Either case, explicitely
 # ignore it here to have passing test for pytest 8.4.
     ignore:Module astroquery was previously imported, but not measured:coverage.exceptions.CoverageWarning
+# Remove when https://github.com/astropy/astropy/issues/19216 is resolved
+    ignore:The chararray class is deprecated and will be removed in a future release:DeprecationWarning
 
 markers =
     bigdata: marks tests that are expected to trigger a large download (deselect with '-m "not bigdata"')


### PR DESCRIPTION
We currently have CI failures in the devdeps job.

It looks like the problem is a bit more complex and we better do this ignore now rather than just sit it out waiting for a quick solution upstream.