### PR TITLE
Limit setuptools to <82

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@
 # dependency.
 
 [build-system]
-requires = ["setuptools", "wheel"]
+requires = ["setuptools<82", "wheel"]
 build-backend = 'setuptools.build_meta'
 
 [tool.black]


### PR DESCRIPTION
Fixes #3522 for Python 3.11 to 3.13 (at least, I have not tested others).

The PR is very tiny so feel free to just close it and implement the fix directly. I just wanted to put it out there (mainly so I could point my codes that depend on the git branch to this version.

Thanks!