### PR TITLE
MAINT: adding python 314 to CI and bump CI python versions

### DIFF
--- a/.github/workflows/ci_crontests.yml
+++ b/.github/workflows/ci_crontests.yml
@@ -22,16 +22,16 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - name: py3.12 pre-release all deps
+          - name: py3.13 pre-release all deps
             os: ubuntu-latest
-            python: '3.12'
-            toxenv: py312-test-alldeps-predeps
+            python: '3.13'
+            toxenv: py313-test-alldeps-predeps
             toxargs: -v
             toxposargs: -v
 
           - name: Documentation build with linkcheck
             os: ubuntu-latest
-            python: '3.10'
+            python: '3.12'
             toxenv: linkcheck
 
     steps:

--- a/.github/workflows/ci_devtests.yml
+++ b/.github/workflows/ci_devtests.yml
@@ -32,14 +32,14 @@ jobs:
         include:
           - name: dev dependencies with all dependencies with coverage
             os: ubuntu-latest
-            python: '3.12'
-            toxenv: py312-test-alldeps-devdeps-cov
+            python: '3.13'
+            toxenv: py313-test-alldeps-devdeps-cov
             toxargs: -v
 
-          - name: Python 3.13
+          - name: Python 3.14
             os: ubuntu-latest
-            python: '3.13'
-            toxenv: py313-test
+            python: '3.14'
+            toxenv: py314-test
             toxargs: -v
 
     steps:

--- a/.github/workflows/ci_online_crontests.yml
+++ b/.github/workflows/ci_online_crontests.yml
@@ -22,17 +22,17 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - name: py3.12 all dev deps online
+          - name: py3.13 all dev deps online
             os: ubuntu-latest
-            python: '3.12'
-            toxenv: py312-test-alldeps-devdeps-online
+            python: '3.13'
+            toxenv: py313-test-alldeps-devdeps-online
             toxargs: -v
             toxposargs: -v --durations=50
 
-          - name: Windows py3.9 all deps online
+          - name: Windows py3.12 all deps online
             os: windows-latest
-            python: '3.9'
-            toxenv: py39-test-alldeps-online
+            python: '3.12'
+            toxenv: py312-test-alldeps-online
             toxargs: -v
             toxposargs: -v --durations=50
 

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 envlist =
-    py{310,311,312,313}-test{,-alldeps,-oldestdeps,-devdeps,-predeps}{,-online}{,-cov}
+    py{310,311,312,313,314}-test{,-alldeps,-oldestdeps,-devdeps,-predeps}{,-online}{,-cov}
     codestyle
     linkcheck
     build_docs
@@ -27,8 +27,6 @@ setenv =
     online: PYTEST_ARGS_2 =  --remote-data=any -m "not bigdata" -vv --last-failed --last-failed-no-failures none --suppress-no-test-exit-code
     online: SINGLE_RUN = False
     devdeps: PIP_EXTRA_INDEX_URL =  https://pypi.anaconda.org/scientific-python-nightly-wheels/simple https://pypi.anaconda.org/astropy/simple https://pypi.anaconda.org/liberfa/simple
-    # astropy doesn't yet have a 3.13 compatible release
-    py313: PIP_EXTRA_INDEX_URL = https://pypi.anaconda.org/astropy/simple https://pypi.anaconda.org/liberfa/simple
 
 deps =
     devdeps: numpy>=0.0.dev0


### PR DESCRIPTION
Borderline if we need a changelog for this and the AH refactor, I may reconsider adding one to the previous PR.