### PR TITLE
ENH: SVO FPS - add method to easily retrieve filter metadata

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -37,7 +37,7 @@ Service fixes and enhancements
 svo_fps
 ^^^^^^^
 
-- Add ``get_filter_params`` to allow retrieval of filter metadata. [#3528]
+- Add ``get_filter_metadata`` to allow retrieval of filter metadata. [#3528]
 
 heasarc
 ^^^^^^^

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -34,6 +34,11 @@ vizier
 Service fixes and enhancements
 ------------------------------
 
+svo_fps
+^^^^^^^
+
+- Add ``get_filter_params`` to allow retrieval of filter metadata. [#3528]
+
 heasarc
 ^^^^^^^
 - Add ``query_constraints`` to allow querying of different catalog columns. [#3403]

--- a/astroquery/svo_fps/core.py
+++ b/astroquery/svo_fps/core.py
@@ -108,8 +108,8 @@ class SvoFpsClass(BaseQuery):
                 "succeed. Try increasing the timeout limit if a large range is needed."
             )
 
-    def get_filter_params(self, filter_id, cache=True, timeout=None):
-        f"""Get metadata/parameters for the requested Filter ID from SVO
+    def get_filter_metadata(self, filter_id, *, cache=True, timeout=None):
+        """Get metadata/parameters for the requested Filter ID from SVO
 
         Parameters
         ----------
@@ -121,7 +121,7 @@ class SvoFpsClass(BaseQuery):
             Defaults to True. If set overrides global caching behavior.
             See :ref:`caching documentation <astroquery_cache>`.
         timeout : int
-            Timeout in seconds. If not specified, defaults to {conf.timeout}.
+            Timeout in seconds. If not specified, defaults to ``conf.timeout``.
 
         Returns
         -------

--- a/astroquery/svo_fps/tests/test_svo_fps_remote.py
+++ b/astroquery/svo_fps/tests/test_svo_fps_remote.py
@@ -25,8 +25,8 @@ class TestSvoFpsClass:
 
     @pytest.mark.parametrize('test_filter_id',
                              ['NewHorizons/MVIC.Blue', 'Palomar/ZTF.r'])
-    def test_get_filter_params(self, test_filter_id):
-        params = SvoFps.get_filter_params(test_filter_id)
+    def test_get_filter_metadata(self, test_filter_id):
+        params = SvoFps.get_filter_metadata(test_filter_id)
         # Check if expected keys are present
         assert "WavelengthEff" in params
         assert "ZeroPoint" in params

--- a/astroquery/svo_fps/tests/test_svo_fps_remote.py
+++ b/astroquery/svo_fps/tests/test_svo_fps_remote.py
@@ -23,6 +23,16 @@ class TestSvoFpsClass:
         # Check if data is downloaded properly, with > 0 rows
         assert len(table) > 0
 
+    @pytest.mark.parametrize('test_filter_id',
+                             ['NewHorizons/MVIC.Blue', 'Palomar/ZTF.r'])
+    def test_get_filter_params(self, test_filter_id):
+        params = SvoFps.get_filter_params(test_filter_id)
+        # Check if expected keys are present
+        assert "WavelengthEff" in params
+        assert "ZeroPoint" in params
+        # Check existence and value of what should be a constant
+        assert params.get("FilterProfileService") == "ivo://svo/fps"
+
     @pytest.mark.parametrize('test_facility, test_instrument',
                              [('HST', 'WFPC2'), ('Keck', None)])
     def test_get_filter_list(self, test_facility, test_instrument):

--- a/docs/svo_fps/svo_fps.rst
+++ b/docs/svo_fps/svo_fps.rst
@@ -173,6 +173,22 @@ These are the data needed to plot the transmission curve for filter:
 
    The 2MASS H-band transmission curve
 
+Get metadata for a specific filter
+----------------------------------
+
+Given a ``filterID``, a dictionary of metadata associated with that filter can be retrieved
+from the FPS using `~astroquery.svo_fps.SvoFpsClass.get_filter_metadata`:
+
+.. doctest-remote-data::
+
+    >>> info = SvoFps.get_filter_metadata('PAN-STARRS/PS1.r')
+    >>> print(info['WavelengthEff'])
+    6155.4659814728 Angstrom
+    >>> print(info['FWHM'])
+    1397.7332085088 Angstrom
+    >>> print(info['components'])
+    Filter + Instrument + Atmosphere
+
 
 Troubleshooting
 ===============


### PR DESCRIPTION
This PR adds a new method: `SvoFpsClass.get_filter_params()`. It follows the same call signature as the existing `SvoFpsClass.get_transmission_data()`, and returns a `dict` containing the VOTable PARAMs returned by the FPS. This includes things like the filter zero point, min/max/effective wavelength, description, etc.

For example, one often needs the effective wavelength of a filter. Without this method, the practical options were either to retrieve the full transmission profile and do the numerical integration yourself, or manually go to the FPS website and find it on the webpage, then hardcode it. With this new method, it is as simple as `lambda_eff = SvoFps.get_filter_params(my_filter_id)["WavelengthEff"]`.