### PR TITLE
MAINT: installing all dependencies for docs build

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -86,7 +86,7 @@ commands = flake8 astroquery --count
 [testenv:build_docs]
 changedir = {toxinidir}/docs
 description = Building the narrative and API docs
-extras = docs
+extras = docs, all
 commands =
     python -m pip freeze
     sphinx-build -W . _build/html
@@ -95,7 +95,7 @@ commands =
 [testenv:linkcheck]
 changedir = {toxinidir}/docs
 description = check the links in the HTML docs
-extras = docs
+extras = docs, all
 commands =
     python -m pip freeze
     sphinx-build -W --keep-going -b linkcheck . _build/html


### PR DESCRIPTION
This has been done for RTD, but not for the tox jobs, so it bubbled up for the cron jobs