### PR TITLE
Added `get_query_payload kwarg` to Ogle

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -125,8 +125,7 @@ ogle
 ^^^^
 
 - Added ``get_query_payload`` kwarg to aid in debugging. [#3533]
-- Deprecated support for non-coordinate use in queries. [#3533]
-- Refactor: Moved the entirety of ``OgleClass._args_to_payload`` into ``OgleClass.query_region``. [#3533]
+- Removed support for deprecated non-coordinate use in queries. [#3533]
 
 xmatch
 ^^^^^^

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -121,6 +121,13 @@ linelists
 - General tools for both CDMS/JPL moved to linelists.core [#3456]
 - Added jplspec, moved from its previous location (astroquery.jplspec to astroquery.linelists.jplspec) [#3455]
 
+ogle
+^^^^
+
+- Added ``get_query_payload`` kwarg to aid in debugging. [#3533]
+- Deprecated support for non-coordinate use in queries. [#3533]
+- Refactor: Moved the entirety of ``OgleClass._args_to_payload`` into ``OgleClass.query_region``. [#3533]
+
 xmatch
 ^^^^^^
 

--- a/astroquery/ogle/core.py
+++ b/astroquery/ogle/core.py
@@ -125,7 +125,7 @@ class OgleClass(BaseQuery):
         return files
 
     @prepend_docstr_nosections(_args_to_payload.__doc__)
-    def query_region_async(self, *args, **kwargs):
+    def query_region_async(self, *args, get_query_payload=False, **kwargs):
         """
         Returns
         -------
@@ -133,6 +133,8 @@ class OgleClass(BaseQuery):
             The HTTP response returned from the service.
         """
         files = self._args_to_payload(*args, **kwargs)
+        if get_query_payload:
+            return files
         # Make request
         params = {'dnfile': 'submit'}
         response = self._request("POST", url=self.DATA_URL, data=params,

--- a/astroquery/ogle/core.py
+++ b/astroquery/ogle/core.py
@@ -5,7 +5,6 @@ import warnings
 import functools
 import numpy as np
 from astropy.table import Table
-from astropy.utils.exceptions import AstropyDeprecationWarning
 
 from ..query import BaseQuery
 from ..utils import commons, async_to_sync, prepend_docstr_nosections
@@ -184,11 +183,6 @@ class OgleClass(BaseQuery):
                     return lon, lat
                 except ValueError:
                     raise CoordParseError()
-            # list-like of values
-            elif (len(shape) == 2) & (shape[0] == 2):
-                warnings.warn('Non-Astropy coordinates may not be supported '
-                              'in a future version.', AstropyDeprecationWarning)
-                return coord
             else:
                 raise CoordParseError()
         else:

--- a/astroquery/ogle/core.py
+++ b/astroquery/ogle/core.py
@@ -1,13 +1,12 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 
 
-import warnings
 import functools
 import numpy as np
 from astropy.table import Table
 
 from ..query import BaseQuery
-from ..utils import commons, async_to_sync, prepend_docstr_nosections
+from ..utils import commons, async_to_sync
 
 from . import conf
 
@@ -53,8 +52,8 @@ class OgleClass(BaseQuery):
     coord_systems = ['RD', 'LB']
 
     @_validate_params
-    def _args_to_payload(self, *, coord=None, algorithm='NG', quality='GOOD',
-                         coord_sys='RD'):
+    def query_region_async(self, *, coord=None, algorithm='NG', quality='GOOD',
+                           coord_sys='RD', get_query_payload=False):
         """
         Query the OGLE-III interstellar extinction calculator.
 
@@ -66,8 +65,6 @@ class OgleClass(BaseQuery):
 
                 * single astropy coordinate instance
                 * list-like object (1 x N) of astropy coordinate instances
-                * list-like object (2 x N) of RA/Decs or Glon/Glat as strings
-                or  floats. (May not be supported in future versions.)
 
         algorithm : string
             Algorithm to interpolate data for desired coordinate.
@@ -89,9 +86,14 @@ class OgleClass(BaseQuery):
                 * 'RD': equatorial coordinates
                 * 'LB': Galactic coordinates.
 
+        get_query_payload : bool, optional
+            If `True` then returns the generated query payload.
+            Defaults to `False`.
+
         Returns
         -------
-        table : `~astropy.table.Table`
+        response : `requests.Response`
+            The HTTP response returned from the service.
 
         Raises
         ------
@@ -121,17 +123,6 @@ class OgleClass(BaseQuery):
                              zip(lon, lat)])
         file_data = query_header + sources
         files = {'file1': file_data}
-        return files
-
-    @prepend_docstr_nosections(_args_to_payload.__doc__)
-    def query_region_async(self, *args, get_query_payload=False, **kwargs):
-        """
-        Returns
-        -------
-        response : `requests.Response`
-            The HTTP response returned from the service.
-        """
-        files = self._args_to_payload(*args, **kwargs)
         if get_query_payload:
             return files
         # Make request

--- a/astroquery/ogle/tests/test_ogle.py
+++ b/astroquery/ogle/tests/test_ogle.py
@@ -61,3 +61,53 @@ def test_ogle_list_values(patch_post):
     co_list = [[0, 0, 0], [3, 3, 3]]
     with pytest.warns(AstropyDeprecationWarning):
         ogle.core.Ogle.query_region(coord=co_list)
+
+
+def test_ogle_single_payload():
+    """
+    Test single pointing payload
+    """
+    co = SkyCoord(0*u.deg, 3*u.deg, frame='galactic')
+    payload = ogle.core.Ogle.query_region(coord=co, get_query_payload=True)
+    fk5 = co.transform_to('fk5')
+    ra = fk5.ra.hour
+    dec = fk5.dec.degree
+    assert len(payload) == 1
+    expected_payload = f'# RD NG GOOD\n{ra} {dec}'
+    assert payload['file1'] == expected_payload
+
+
+def test_ogle_multipointing_payload():
+    """
+    Test payload of multiple pointings using a list of astropy coordinates
+    """
+    co1 = SkyCoord(0*u.deg, 3*u.deg, frame='galactic')
+    co2 = SkyCoord(4*u.deg, 5*u.deg, frame='galactic')
+    pointings = [co1, co2]
+    payload = ogle.core.Ogle.query_region(
+        coord=pointings,
+        get_query_payload=True
+    )
+    conversions = []
+    for co in pointings:
+        fk5 = co.transform_to('fk5')
+        ra_str = f"{fk5.ra.hour}"
+        dec_str = f"{fk5.dec.degree}"
+        conversions.append(f"{ra_str} {dec_str}")
+    expected_payload = "# RD NG GOOD\n" + "\n".join(conversions)
+    assert payload['file1'] == expected_payload
+
+
+def test_ogle_nested_list_payload(patch_post):
+    """
+    Test the payload of multiple pointings using a nested-list of decimal
+    degree Galactic coordinates
+    """
+    co_list = [[0, 0, 0], [3, 3, 3]]
+    expected_payload = '# RD NG GOOD\n0 3\n0 3\n0 3'
+    with pytest.warns(AstropyDeprecationWarning):
+        payload = ogle.core.Ogle.query_region(
+            coord=co_list,
+            get_query_payload=True
+        )
+        assert payload['file1'] == expected_payload

--- a/astroquery/ogle/tests/test_ogle.py
+++ b/astroquery/ogle/tests/test_ogle.py
@@ -53,16 +53,6 @@ def test_ogle_list(patch_post):
     ogle.core.Ogle.query_region(coord=co_list)
 
 
-def test_ogle_list_values(patch_post):
-    """
-    Test multiple pointings using a nested-list of decimal degree Galactic
-    coordinates
-    """
-    co_list = [[0, 0, 0], [3, 3, 3]]
-    with pytest.warns(AstropyDeprecationWarning):
-        ogle.core.Ogle.query_region(coord=co_list)
-
-
 def test_ogle_single_payload():
     """
     Test single pointing payload
@@ -97,17 +87,3 @@ def test_ogle_multipointing_payload():
     expected_payload = "# RD NG GOOD\n" + "\n".join(conversions)
     assert payload['file1'] == expected_payload
 
-
-def test_ogle_nested_list_payload(patch_post):
-    """
-    Test the payload of multiple pointings using a nested-list of decimal
-    degree Galactic coordinates
-    """
-    co_list = [[0, 0, 0], [3, 3, 3]]
-    expected_payload = '# RD NG GOOD\n0 3\n0 3\n0 3'
-    with pytest.warns(AstropyDeprecationWarning):
-        payload = ogle.core.Ogle.query_region(
-            coord=co_list,
-            get_query_payload=True
-        )
-        assert payload['file1'] == expected_payload

--- a/astroquery/ogle/tests/test_ogle.py
+++ b/astroquery/ogle/tests/test_ogle.py
@@ -5,7 +5,6 @@ import os
 import pytest
 from astropy.coordinates import SkyCoord
 from astropy import units as u
-from astropy.utils.exceptions import AstropyDeprecationWarning
 
 from astroquery.utils.mocks import MockResponse
 
@@ -86,4 +85,3 @@ def test_ogle_multipointing_payload():
         conversions.append(f"{ra_str} {dec_str}")
     expected_payload = "# RD NG GOOD\n" + "\n".join(conversions)
     assert payload['file1'] == expected_payload
-

--- a/astroquery/ogle/tests/test_ogle_remote.py
+++ b/astroquery/ogle/tests/test_ogle_remote.py
@@ -22,11 +22,3 @@ def test_ogle_list():
     assert len(response) == 3
     assert response['RA[hr]'][0] == response['RA[hr]'][1] == response['RA[hr]'][2]
 
-
-@pytest.mark.remote_data
-def test_ogle_list_values():
-    co_list = [[0, 0, 0], [3, 3, 3]]
-    with pytest.warns(AstropyDeprecationWarning):
-        response = Ogle.query_region(coord=co_list)
-    assert len(response) == 3
-    assert response['RA[hr]'][0] == response['RA[hr]'][1] == response['RA[hr]'][2]

--- a/astroquery/ogle/tests/test_ogle_remote.py
+++ b/astroquery/ogle/tests/test_ogle_remote.py
@@ -2,7 +2,6 @@
 import pytest
 import astropy.units as u
 from astropy.coordinates import SkyCoord
-from astropy.utils.exceptions import AstropyDeprecationWarning
 
 from .. import Ogle
 
@@ -21,4 +20,3 @@ def test_ogle_list():
     response = Ogle.query_region(coord=co_list)
     assert len(response) == 3
     assert response['RA[hr]'][0] == response['RA[hr]'][1] == response['RA[hr]'][2]
-

--- a/docs/ogle/ogle.rst
+++ b/docs/ogle/ogle.rst
@@ -15,16 +15,15 @@ using an `astropy.coordinates` instance use:
 
 .. doctest-remote-data::
 
-    >>> from astropy import coordinates
+    >>> from astropy.coordinates import SkyCoord
     >>> from astropy import units as u
     >>> from astroquery.ogle import Ogle
-    >>> co = coordinates.SkyCoord(0*u.deg, 3*u.deg, frame='galactic')
+    >>> co = SkyCoord(0*u.deg, 3*u.deg, frame='galactic')
     >>> t = Ogle.query_region(coord=co)
 
 Arguments can be passed to choose the interpolation algorithm, quality factor,
 and coordinate system. Multiple coordinates may be queried simultaneously by
-passing a list-like object of string/float values or a list-like object of
-`astropy.coordinates` instances. All of coordinates will be internally converted
+passing a vector SkyCoord object. All of coordinates will be internally converted
 to FK5.
 
 .. doctest-remote-data::
@@ -33,8 +32,8 @@ to FK5.
     >>> co_list = [co, co, co]
     >>> t1 = Ogle.query_region(coord=co_list)
     >>> # (2 x N) list of values
-    >>> co_list_values = [[0, 0, 0], [3, 3, 3]]
-    >>> t2 = Ogle.query_region(coord=co_list_values, coord_sys='LB')  # doctest: +IGNORE_WARNINGS
+    >>> co_list_values = SkyCoord([0, 1, 2], [3, 3, 3], unit=u.deg, frame='galactic')
+    >>> t2 = Ogle.query_region(coord=co_list_values, coord_sys='LB')
 
 Note that non-Astropy coordinates may not be supported in a future version.
 


### PR DESCRIPTION
Hey yall!

I added in the `get_query_payload` kwarg into the Ogle module per #2040.
Its a relatively small addition.
For the tests my thought process was to cover all the existing test cases payloads. 
I wasn't sure about the nested lists because of the potential deprecation, but I figured there's no harm in including tests for it since its working right now.