### PR TITLE
MAST: Enable cloud dataset by default

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -121,6 +121,10 @@ mast
 - ``MastMissions`` query functions now support single or multiple targets via ``coordinates`` and
   ``object_names`` (including combined use in ``query_criteria``). [#3540]
 
+- The cloud dataset in ``Observations`` is now enabled by default if the ``boto3`` and ``botocore`` packages are installed. This
+  default can be overridden by setting the ``enable_cloud_dataset`` configuration option to False. [#3534]
+
+
 jplspec
 ^^^^^^^
 

--- a/astroquery/exceptions.py
+++ b/astroquery/exceptions.py
@@ -119,3 +119,11 @@ class BlankResponseWarning(AstropyWarning):
     Astroquery warning to be raised if one or more rows in a table are bad, but
     not all rows are.
     """
+    pass
+
+
+class CloudAccessWarning(AstropyWarning):
+    """
+    Astroquery warning to be raised if cloud access cannot be enabled.
+    """
+    pass

--- a/astroquery/mast/__init__.py
+++ b/astroquery/mast/__init__.py
@@ -29,6 +29,10 @@ class Conf(_config.ConfigNamespace):
     pagesize = _config.ConfigItem(
         50000,
         'Number of results to request at once from the STScI server.')
+    enable_cloud_dataset = _config.ConfigItem(
+        True,
+        'Enable access to cloud-hosted datasets (e.g. on AWS S3) by default. '
+        'Requires the `boto3` and `botocore` packages to be installed.')
 
 
 conf = Conf()

--- a/astroquery/mast/__init__.py
+++ b/astroquery/mast/__init__.py
@@ -32,7 +32,7 @@ class Conf(_config.ConfigNamespace):
     enable_cloud_dataset = _config.ConfigItem(
         True,
         'Enable access to cloud-hosted datasets (e.g. on AWS S3) by default. '
-        'Requires the `boto3` and `botocore` packages to be installed.')
+        'Requires the ``boto3`` and ``botocore`` packages to be installed.')
 
 
 conf = Conf()

--- a/astroquery/mast/cloud.py
+++ b/astroquery/mast/cloud.py
@@ -13,12 +13,22 @@ import threading
 from astroquery import log
 from astropy.utils.console import ProgressBarOrSpinner
 from astropy.utils.exceptions import AstropyDeprecationWarning
-from botocore.exceptions import ClientError, BotoCoreError
 
 from ..exceptions import RemoteServiceError, NoResultsWarning
 
 from . import utils
 
+try:
+    import boto3
+    HAS_BOTO3 = True
+except ImportError:
+    HAS_BOTO3 = False
+try:
+    import botocore
+    from botocore.exceptions import ClientError, BotoCoreError
+    HAS_BOTOCORE = True
+except ImportError:
+    HAS_BOTOCORE = False
 
 __all__ = []
 
@@ -44,14 +54,13 @@ class CloudAccess:  # pragma:no-cover
         verbose : bool
             Default False. Display extra info and warnings if true.
         """
+        if not HAS_BOTO3 or not HAS_BOTOCORE:
+            raise ImportError("Please install the `boto3` and `botocore` packages to enable cloud dataset access.")
 
         # Dealing with deprecated argument
         if profile is not None:
             warnings.warn(("MAST Open Data on AWS is now free to access and does "
                            "not require an AWS account"), AstropyDeprecationWarning)
-
-        import boto3
-        import botocore
 
         self.boto3 = boto3
         self.botocore = botocore

--- a/astroquery/mast/cloud.py
+++ b/astroquery/mast/cloud.py
@@ -18,6 +18,7 @@ from ..exceptions import RemoteServiceError, NoResultsWarning
 
 from . import utils
 
+# Optional dependencies for cloud access functionality
 try:
     import boto3
     HAS_BOTO3 = True

--- a/astroquery/mast/observations.py
+++ b/astroquery/mast/observations.py
@@ -16,7 +16,6 @@ import numpy as np
 import astropy.units as u
 import astropy.coordinates as coord
 from requests import HTTPError
-from botocore.exceptions import ClientError, BotoCoreError
 from astropy.table import Table, Row, vstack
 from astropy.utils.decorators import deprecated_renamed_argument
 
@@ -34,9 +33,15 @@ from .core import MastQueryWithLogin
 try:
     from botocore.exceptions import ClientError, BotoCoreError
 except ImportError:
-    ClientError = BotoCoreError = ()
+    pass
 
 __all__ = ['Observations', 'ObservationsClass', 'MastClass', 'Mast']
+
+CLOUD_DISABLED_MESSAGE = (
+    'Cloud data access is not enabled. You may be missing prerequisite packages, or cloud access may not be '
+    'enabled by default in module configuration. To enable, try calling the '
+    '`~astroquery.mast.ObservationsClass.enable_cloud_dataset` method.'
+)
 
 
 @async_to_sync
@@ -62,15 +67,19 @@ class ObservationsClass(MastQueryWithLogin):
         """Ensure cloud access is initialized if appropriate."""
         # User explicitly disabled
         if self._cloud_enabled_explicitly is False:
-            return
+            return False
 
         # Already initialized
         if self._cloud_connection is not None:
-            return
+            return True
 
         # Default behavior is to enable cloud access if the config option is set, so we check that here
         if self._cloud_enabled_explicitly is None and conf.enable_cloud_dataset:
             self.enable_cloud_dataset(_internal=True)
+
+        # Return False if cloud access failed to initialize
+        if self._cloud_connection is not None:
+            return True
 
     def _parse_result(self, responses, *, verbose=False):  # Used by the async_to_sync decorator functionality
         """
@@ -203,8 +212,7 @@ class ObservationsClass(MastQueryWithLogin):
 
     def enable_cloud_dataset(self, provider="AWS", profile=None, verbose=True, *, _internal=False):
         """
-        Enable downloading public files from S3 instead of MAST.
-        Requires the boto3 library to function.
+        Enable downloading public files from S3 instead of MAST. Requires the botocore and boto3 libraries.
 
         Parameters
         ----------
@@ -221,9 +229,16 @@ class ObservationsClass(MastQueryWithLogin):
             self._cloud_connection = CloudAccess(provider, profile, verbose)
             if not _internal:
                 self._cloud_enabled_explicitly = True
-        except ImportError as e:
-            # boto3 or botocore is not installed
+        except (Exception) as e:
+            # Some error occurred trying to initialize cloud access
+            # Use a generic Exception catch here because there are various ways this can fail depending
+            # on the user's setup (e.g. missing dependencies, missing credentials, network issues), and
+            # we want to catch them all
             self._cloud_connection = None
+            if not _internal:
+                # If the user is calling this method directly, error should be raised
+                raise
+            # If called internally, just warn and continue without cloud access
             warnings.warn(e.msg, CloudAccessWarning)
 
     def disable_cloud_dataset(self):
@@ -1002,12 +1017,10 @@ class ObservationsClass(MastQueryWithLogin):
             List of dataset prefixes that support cloud data access.
         """
         # Ensure cloud access is enabled
-        self._ensure_cloud_access()
+        cloud_enabled = self._ensure_cloud_access()
 
-        if self._cloud_connection is None:
-            raise RemoteServiceError(
-                'Please enable anonymous cloud access by calling `enable_cloud_dataset` method. '
-                'Refer to `~astroquery.mast.ObservationsClass.enable_cloud_dataset` documentation for more info.')
+        if not cloud_enabled:
+            raise RemoteServiceError(CLOUD_DISABLED_MESSAGE)
 
         return self._cloud_connection.get_supported_datasets()
 
@@ -1071,12 +1084,10 @@ class ObservationsClass(MastQueryWithLogin):
             if data_products includes products not found in the cloud.
         """
         # Ensure cloud access is enabled
-        self._ensure_cloud_access()
+        cloud_enabled = self._ensure_cloud_access()
 
-        if self._cloud_connection is None:
-            raise RemoteServiceError(
-                'Please enable anonymous cloud access by calling `enable_cloud_dataset` method. '
-                'Refer to `~astroquery.mast.ObservationsClass.enable_cloud_dataset` documentation for more info.')
+        if not cloud_enabled:
+            raise RemoteServiceError(CLOUD_DISABLED_MESSAGE)
 
         if data_products is None:
             if not criteria:
@@ -1156,12 +1167,10 @@ class ObservationsClass(MastQueryWithLogin):
             found in the cloud, None is returned.
         """
         # Ensure cloud access is enabled
-        self._ensure_cloud_access()
+        cloud_enabled = self._ensure_cloud_access()
 
-        if self._cloud_connection is None:
-            raise RemoteServiceError(
-                'Please enable anonymous cloud access by calling `enable_cloud_dataset` method. '
-                'Refer to `~astroquery.mast.ObservationsClass.enable_cloud_dataset` documentation for more info.')
+        if not cloud_enabled:
+            raise RemoteServiceError(CLOUD_DISABLED_MESSAGE)
 
         # Query for product URIs
         return self._cloud_connection.get_cloud_uri(data_product, include_bucket, full_url)

--- a/astroquery/mast/observations.py
+++ b/astroquery/mast/observations.py
@@ -26,13 +26,17 @@ from astroquery.utils import commons
 
 from ..utils import async_to_sync
 from ..utils.class_or_instance import class_or_instance
-from ..exceptions import (InvalidQueryError, RemoteServiceError, NoResultsWarning, InputWarning)
+from ..exceptions import (InvalidQueryError, RemoteServiceError, NoResultsWarning, InputWarning, CloudAccessWarning)
 
-from . import utils
+from . import utils, conf
 from .core import MastQueryWithLogin
 
-__all__ = ['Observations', 'ObservationsClass',
-           'MastClass', 'Mast']
+try:
+    from botocore.exceptions import ClientError, BotoCoreError
+except ImportError:
+    ClientError = BotoCoreError = ()
+
+__all__ = ['Observations', 'ObservationsClass', 'MastClass', 'Mast']
 
 
 @async_to_sync
@@ -49,6 +53,24 @@ class ObservationsClass(MastQueryWithLogin):
     _caom_filtered_position = 'Mast.Caom.Filtered.Position'
     _caom_filtered = 'Mast.Caom.Filtered'
     _caom_products = 'Mast.Caom.Products'
+
+    def __init__(self, mast_token=None):
+        super().__init__(mast_token)
+        self._cloud_enabled_explicitly = None  # Track whether cloud access was explicitly enabled by the user
+
+    def _ensure_cloud_access(self):
+        """Ensure cloud access is initialized if appropriate."""
+        # User explicitly disabled
+        if self._cloud_enabled_explicitly is False:
+            return
+
+        # Already initialized
+        if self._cloud_connection is not None:
+            return
+
+        # Default behavior is to enable cloud access if the config option is set, so we check that here
+        if self._cloud_enabled_explicitly is None and conf.enable_cloud_dataset:
+            self.enable_cloud_dataset(_internal=True)
 
     def _parse_result(self, responses, *, verbose=False):  # Used by the async_to_sync decorator functionality
         """
@@ -179,7 +201,7 @@ class ObservationsClass(MastQueryWithLogin):
 
         return position, mashup_filters
 
-    def enable_cloud_dataset(self, provider="AWS", profile=None, verbose=True):
+    def enable_cloud_dataset(self, provider="AWS", profile=None, verbose=True, *, _internal=False):
         """
         Enable downloading public files from S3 instead of MAST.
         Requires the boto3 library to function.
@@ -195,13 +217,21 @@ class ObservationsClass(MastQueryWithLogin):
             Default True.
             Logger to display extra info and warning.
         """
-        self._cloud_connection = CloudAccess(provider, profile, verbose)
+        try:
+            self._cloud_connection = CloudAccess(provider, profile, verbose)
+            if not _internal:
+                self._cloud_enabled_explicitly = True
+        except ImportError as e:
+            # boto3 or botocore is not installed
+            self._cloud_connection = None
+            warnings.warn(e.msg, CloudAccessWarning)
 
     def disable_cloud_dataset(self):
         """
         Disables downloading public files from S3 instead of MAST.
         """
         self._cloud_connection = None
+        self._cloud_enabled_explicitly = False
 
     @class_or_instance
     def query_region_async(self, coordinates, *, radius=0.2*u.deg, pagesize=None, page=None):
@@ -657,6 +687,9 @@ class ObservationsClass(MastQueryWithLogin):
         url : str
             The full url download path
         """
+        # Ensure cloud access is enabled
+        self._ensure_cloud_access()
+
         if not uri or not isinstance(uri, str):
             raise InvalidQueryError("A valid data product URI must be provided.")
 
@@ -694,8 +727,9 @@ class ObservationsClass(MastQueryWithLogin):
                                       NoResultsWarning)
                         return 'SKIPPED', None, None
 
-                    warnings.warn(f'The product {uri} was not found in the cloud. '
-                                  'Falling back to MAST download.', InputWarning)
+                    if self._cloud_enabled_explicitly:
+                        warnings.warn(f'The product {uri} was not found in the cloud. '
+                                      'Falling back to MAST download.', InputWarning)
                     self._download_file(escaped_url, local_path, cache=cache, head_safe=True, verbose=verbose)
                 except (ClientError, BotoCoreError) as ex:
                     # Should be in cloud, but download failed
@@ -704,8 +738,9 @@ class ObservationsClass(MastQueryWithLogin):
                                       NoResultsWarning)
                         return 'SKIPPED', None, None
 
-                    warnings.warn(f'Could not download {uri} from cloud: {ex}. Falling back to MAST download.',
-                                  InputWarning)
+                    if self._cloud_enabled_explicitly:
+                        warnings.warn(f'Could not download {uri} from cloud: {ex}. Falling back to MAST download.',
+                                      InputWarning)
                     self._download_file(escaped_url, local_path, cache=cache, head_safe=True, verbose=verbose)
             else:
                 if cloud_only:
@@ -772,7 +807,6 @@ class ObservationsClass(MastQueryWithLogin):
             status, msg, url = 'ERROR', None, None
 
             cloud_uri = cloud_uri_map.get(mast_uri) if cloud_uri_map else None
-
             if cloud_uri:
                 try:
                     self._cloud_connection.download_file_from_cloud(cloud_uri, local_path, cache, verbose)
@@ -785,8 +819,9 @@ class ObservationsClass(MastQueryWithLogin):
                         status = 'SKIPPED'
                         msg = str(ex)
                     else:
-                        warnings.warn(f'Could not download {cloud_uri} from cloud: {ex}. '
-                                      'Falling back to MAST download.', InputWarning)
+                        if self._cloud_enabled_explicitly:
+                            warnings.warn(f'Could not download {cloud_uri} from cloud: {ex}. '
+                                          'Falling back to MAST download.', InputWarning)
                         status, msg, url = self.download_file(mast_uri, local_path=local_path, cache=cache,
                                                               force_on_prem=True, verbose=verbose)
             else:
@@ -798,8 +833,9 @@ class ObservationsClass(MastQueryWithLogin):
                         status = 'SKIPPED'
                         msg = 'Product not found in cloud'
                     else:
-                        warnings.warn(f'The product {mast_uri} was not found in the cloud. '
-                                      'Falling back to MAST download.', InputWarning)
+                        if self._cloud_enabled_explicitly:
+                            warnings.warn(f'The product {mast_uri} was not found in the cloud. '
+                                          'Falling back to MAST download.', InputWarning)
                         status, msg, url = self.download_file(mast_uri, local_path=local_path, cache=cache,
                                                               force_on_prem=True, verbose=verbose)
                 else:
@@ -900,6 +936,9 @@ class ObservationsClass(MastQueryWithLogin):
         response : `~astropy.table.Table`
             The manifest of files downloaded, or status of files on disk if curl option chosen.
         """
+        # Ensure cloud access is enabled
+        self._ensure_cloud_access()
+
         # If the products list is a row we need to cast it as a table
         if isinstance(products, Row):
             products = Table(products, masked=True)
@@ -962,6 +1001,9 @@ class ObservationsClass(MastQueryWithLogin):
         response : list
             List of dataset prefixes that support cloud data access.
         """
+        # Ensure cloud access is enabled
+        self._ensure_cloud_access()
+
         if self._cloud_connection is None:
             raise RemoteServiceError(
                 'Please enable anonymous cloud access by calling `enable_cloud_dataset` method. '
@@ -1028,6 +1070,8 @@ class ObservationsClass(MastQueryWithLogin):
             List of URIs generated from the data products. May contain entries that are None
             if data_products includes products not found in the cloud.
         """
+        # Ensure cloud access is enabled
+        self._ensure_cloud_access()
 
         if self._cloud_connection is None:
             raise RemoteServiceError(
@@ -1111,6 +1155,8 @@ class ObservationsClass(MastQueryWithLogin):
             Cloud URI generated from the data product. If the product cannot be
             found in the cloud, None is returned.
         """
+        # Ensure cloud access is enabled
+        self._ensure_cloud_access()
 
         if self._cloud_connection is None:
             raise RemoteServiceError(

--- a/astroquery/mast/observations.py
+++ b/astroquery/mast/observations.py
@@ -31,6 +31,7 @@ from . import utils, conf
 from .core import MastQueryWithLogin
 
 try:
+    # Optional dependency import for cloud access functionality
     from botocore.exceptions import ClientError, BotoCoreError
 except ImportError:
     pass

--- a/astroquery/mast/tests/test_mast.py
+++ b/astroquery/mast/tests/test_mast.py
@@ -27,7 +27,7 @@ from astroquery.exceptions import (BlankResponseWarning, InvalidQueryError, Inpu
 try:
     from botocore.exceptions import ClientError
 except ImportError:
-    ClientError = BotoCoreError = ()
+    ClientError = ()
 
 DATA_FILES = {'Mast.Caom.Cone': 'caom.json',
               'Mast.Name.Lookup': 'resolver.json',

--- a/astroquery/mast/tests/test_mast.py
+++ b/astroquery/mast/tests/test_mast.py
@@ -89,7 +89,7 @@ def patch_post(request):
 
 
 @pytest.fixture()
-def patch_boto3(monkeypatch):
+def patch_boto3(monkeypatch, reset_cloud_state):
     """Fixture to patch boto3 client and resource for cloud access tests."""
     pytest.importorskip('boto3')
     mock_client = MagicMock()
@@ -1053,7 +1053,7 @@ def test_observations_filter_products():
 
 
 @patch.object(Path, "is_file", return_value=True)
-def test_observations_download_products(mock_is_file, patch_boto3, monkeypatch, reset_cloud_state):
+def test_observations_download_products(mock_is_file, patch_boto3, monkeypatch):
     mock_resource = patch_boto3[1]
     obsid = '2003738726'
     data_uri = 'mast:HST/product/u9o40504m_c3m.fits'
@@ -1137,7 +1137,7 @@ def test_observations_download_products(mock_is_file, patch_boto3, monkeypatch, 
 
 
 @patch.object(Path, "is_file", return_value=True)
-def test_observations_download_file(mock_is_file, patch_boto3, reset_cloud_state, tmpdir):
+def test_observations_download_file(mock_is_file, patch_boto3, tmpdir):
     mock_client, mock_resource = patch_boto3
     mock_client.head_object.return_value = {'ContentLength': 12345}
     mock_resource.Bucket.return_value.download_file.return_value = None
@@ -1185,7 +1185,7 @@ def test_observations_download_file(mock_is_file, patch_boto3, reset_cloud_state
         assert result == ('COMPLETE', None, None)
 
 
-def test_observations_download_file_not_found(patch_boto3, reset_cloud_state):
+def test_observations_download_file_not_found(patch_boto3):
     mast_uri = 'mast:HST/product/u9o40504m_c3m.fits'
     result = Observations.download_file(mast_uri)
     assert result[0] == 'ERROR'
@@ -1197,7 +1197,7 @@ def test_observations_download_file_not_found(patch_boto3, reset_cloud_state):
     assert result[1] == 'File was not downloaded'
 
 
-def test_observations_list_cloud_missions(patch_boto3, reset_cloud_state):
+def test_observations_list_cloud_missions(patch_boto3):
     mock_client = patch_boto3[0]
     mock_client.list_objects_v2.return_value = {
         'CommonPrefixes': [{'Prefix': 'hst/'}, {'Prefix': 'jwst/'}, {'Prefix': 'mast/'}]
@@ -1210,7 +1210,7 @@ def test_observations_list_cloud_missions(patch_boto3, reset_cloud_state):
     assert 'mast' in supported
 
 
-def test_observations_list_cloud_missions_error(patch_boto3, reset_cloud_state):
+def test_observations_list_cloud_missions_error(patch_boto3):
     # Mock an error when listing objects
     mock_client = patch_boto3[0]
     client_error = ClientError({'Error': {'Code': 'AWS error'}}, 'ListObjectsV2')
@@ -1225,7 +1225,7 @@ def test_observations_list_cloud_missions_error(patch_boto3, reset_cloud_state):
         Observations.list_cloud_datasets()
 
 
-def test_observations_get_cloud_uri(patch_boto3, reset_cloud_state):
+def test_observations_get_cloud_uri(patch_boto3):
     mast_uri = 'mast:HST/product/u9o40504m_c3m.fits'
     expected = 's3://stpubdata/hst/public/u9o4/u9o40504m/u9o40504m_c3m.fits'
 
@@ -1250,7 +1250,7 @@ def test_observations_get_cloud_uri(patch_boto3, reset_cloud_state):
         Observations.get_cloud_uri(mast_uri)
 
 
-def test_observations_get_cloud_uris(patch_boto3, reset_cloud_state):
+def test_observations_get_cloud_uris(patch_boto3):
     mast_uri = 'mast:HST/product/u9o40504m_c3m.fits'
     expected = 's3://stpubdata/hst/public/u9o4/u9o40504m/u9o40504m_c3m.fits'
 
@@ -1295,7 +1295,7 @@ def test_observations_get_cloud_uris(patch_boto3, reset_cloud_state):
         Observations.get_cloud_uris([mast_uri])
 
 
-def test_observations_get_cloud_uris_error(patch_boto3, reset_cloud_state):
+def test_observations_get_cloud_uris_error(patch_boto3):
     mock_client = patch_boto3[0]
 
     # Mock head_object to raise an exception
@@ -1315,7 +1315,7 @@ def test_observations_get_cloud_uris_error(patch_boto3, reset_cloud_state):
     assert uris == []
 
 
-def test_observations_get_cloud_uris_query(patch_boto3, reset_cloud_state):
+def test_observations_get_cloud_uris_query(patch_boto3):
     # get uris with streamlined function
     uris = Observations.get_cloud_uris(target_name=234295610,
                                        filter_products={'productSubGroupDescription': 'C3M'})
@@ -1331,7 +1331,7 @@ def test_observations_get_cloud_uris_query(patch_boto3, reset_cloud_state):
                                     filter_products={'productSubGroupDescription': 'LC'})
 
 
-def test_observations_enable_cloud_dataset(patch_boto3, reset_cloud_state):
+def test_observations_enable_cloud_dataset(patch_boto3):
     # Enable cloud dataset
     Observations.enable_cloud_dataset()
     assert Observations._cloud_connection is not None
@@ -1347,7 +1347,7 @@ def test_observations_enable_cloud_dataset(patch_boto3, reset_cloud_state):
     cloud.HAS_BOTO3 = True
 
 
-def test_observations_disable_cloud_dataset(patch_boto3, reset_cloud_state):
+def test_observations_disable_cloud_dataset(patch_boto3):
     # Explicitly disable cloud dataset
     Observations.disable_cloud_dataset()
     assert Observations._cloud_connection is None

--- a/astroquery/mast/tests/test_mast.py
+++ b/astroquery/mast/tests/test_mast.py
@@ -25,6 +25,7 @@ from astroquery.exceptions import (BlankResponseWarning, InvalidQueryError, Inpu
                                    NoResultsWarning, RemoteServiceError, ResolverError)
 
 try:
+    # Optional dependency import for cloud access functionality
     from botocore.exceptions import ClientError
 except ImportError:
     pass

--- a/astroquery/mast/tests/test_mast.py
+++ b/astroquery/mast/tests/test_mast.py
@@ -22,12 +22,12 @@ from astroquery.mast import (Catalogs, MastMissions, Observations, Tesscut, Zcut
 from astroquery.mast.cloud import CloudAccess
 from astroquery.utils.mocks import MockResponse
 from astroquery.exceptions import (BlankResponseWarning, InvalidQueryError, InputWarning, MaxResultsWarning,
-                                   NoResultsWarning, RemoteServiceError, ResolverError, CloudAccessWarning)
+                                   NoResultsWarning, RemoteServiceError, ResolverError)
 
 try:
     from botocore.exceptions import ClientError
 except ImportError:
-    ClientError = ()
+    pass
 
 DATA_FILES = {'Mast.Caom.Cone': 'caom.json',
               'Mast.Name.Lookup': 'resolver.json',
@@ -1221,7 +1221,7 @@ def test_observations_list_cloud_missions_error(patch_boto3):
 
     # Cloud access not enabled
     Observations.disable_cloud_dataset()
-    with pytest.raises(RemoteServiceError, match='Please enable anonymous cloud access'):
+    with pytest.raises(RemoteServiceError, match='Cloud data access is not enabled.'):
         Observations.list_cloud_datasets()
 
 
@@ -1246,7 +1246,7 @@ def test_observations_get_cloud_uri(patch_boto3):
 
     # Cloud access not enabled
     Observations.disable_cloud_dataset()
-    with pytest.raises(RemoteServiceError, match='Please enable anonymous cloud access'):
+    with pytest.raises(RemoteServiceError, match='Cloud data access is not enabled.'):
         Observations.get_cloud_uri(mast_uri)
 
 
@@ -1291,7 +1291,7 @@ def test_observations_get_cloud_uris(patch_boto3):
 
     # Cloud access not enabled
     Observations.disable_cloud_dataset()
-    with pytest.raises(RemoteServiceError, match='Please enable anonymous cloud access'):
+    with pytest.raises(RemoteServiceError, match='Cloud data access is not enabled.'):
         Observations.get_cloud_uris([mast_uri])
 
 
@@ -1340,7 +1340,7 @@ def test_observations_enable_cloud_dataset(patch_boto3):
     # Force an import error when connecting to cloud dataset
     cloud.HAS_BOTO3 = False
     Observations.disable_cloud_dataset()  # reset state
-    with pytest.warns(CloudAccessWarning):
+    with pytest.raises(ImportError, match='to enable cloud dataset access'):
         Observations.enable_cloud_dataset()
 
     # Reset cloud dataset state for other tests

--- a/astroquery/mast/tests/test_mast.py
+++ b/astroquery/mast/tests/test_mast.py
@@ -5,7 +5,7 @@ import os
 import re
 import warnings
 from shutil import copyfile
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 from pathlib import Path
 
 import astropy.units as u
@@ -14,16 +14,20 @@ import numpy as np
 from astropy.table import Table, unique
 from astropy.coordinates import SkyCoord
 from astropy.io import fits
-from botocore.exceptions import ClientError
 from astropy.utils.exceptions import AstropyDeprecationWarning
 from requests import HTTPError, Response
 
 from astroquery.mast import (Catalogs, MastMissions, Observations, Tesscut, Zcut, Mast, utils, services,
-                             discovery_portal, auth, core)
+                             discovery_portal, auth, core, cloud)
 from astroquery.mast.cloud import CloudAccess
 from astroquery.utils.mocks import MockResponse
 from astroquery.exceptions import (BlankResponseWarning, InvalidQueryError, InputWarning, MaxResultsWarning,
-                                   NoResultsWarning, RemoteServiceError, ResolverError)
+                                   NoResultsWarning, RemoteServiceError, ResolverError, CloudAccessWarning)
+
+try:
+    from botocore.exceptions import ClientError
+except ImportError:
+    ClientError = BotoCoreError = ()
 
 DATA_FILES = {'Mast.Caom.Cone': 'caom.json',
               'Mast.Name.Lookup': 'resolver.json',
@@ -68,7 +72,7 @@ def data_path(filename):
     return os.path.join(data_dir, filename)
 
 
-@pytest.fixture
+@pytest.fixture(autouse=True)
 def patch_post(request):
     mp = request.getfixturevalue("monkeypatch")
 
@@ -82,6 +86,32 @@ def patch_post(request):
     mp.setattr(core.MastQueryWithLogin, '_download_file', download_mockreturn)
 
     return mp
+
+
+@pytest.fixture()
+def patch_boto3(monkeypatch):
+    """Fixture to patch boto3 client and resource for cloud access tests."""
+    pytest.importorskip('boto3')
+    mock_client = MagicMock()
+    mock_client.head_object.return_value = {'ContentLength': 12345}
+
+    mock_resource = MagicMock()
+    mock_resource.Bucket.return_value.download_file.return_value = None
+
+    monkeypatch.setattr('boto3.client', lambda *args, **kwargs: mock_client)
+    monkeypatch.setattr('boto3.resource', lambda *args, **kwargs: mock_resource)
+
+    return mock_client, mock_resource
+
+
+@pytest.fixture()
+def reset_cloud_state():
+    """Reset the cloud dataset access state in Observations before and after each test."""
+    Observations.disable_cloud_dataset()
+    Observations._cloud_enabled_explicitly = None
+    yield
+    Observations.disable_cloud_dataset()
+    Observations._cloud_enabled_explicitly = None
 
 
 def post_mockreturn(self, method="POST", url=None, data=None, timeout=10, **kwargs):
@@ -210,23 +240,23 @@ def zcut_download_mockreturn(url, file_path):
 ###########################
 
 
-def test_missions_query_region_async(patch_post):
+def test_missions_query_region_async():
     responses = MastMissions.query_region_async(regionCoords, radius=0.002, sci_pi_last_name='GORDON')
     assert isinstance(responses, MockResponse)
 
 
-def test_missions_query_object_async(patch_post):
+def test_missions_query_object_async():
     responses = MastMissions.query_object_async("M101", radius="0.002 deg")
     assert isinstance(responses, MockResponse)
 
 
-def test_missions_query_object(patch_post):
+def test_missions_query_object():
     result = MastMissions.query_object("M101", radius=".002 deg")
     assert isinstance(result, Table)
     assert len(result) > 0
 
 
-def test_missions_query_region(patch_post):
+def test_missions_query_region():
     result = MastMissions.query_region(regionCoords,
                                        sci_instrume=['ACS', 'WFPC'],
                                        radius=0.002 * u.deg,
@@ -236,7 +266,7 @@ def test_missions_query_region(patch_post):
     assert len(result) > 0
 
 
-def test_missions_query_criteria_async(patch_post):
+def test_missions_query_criteria_async():
     responses = MastMissions.query_criteria_async(
         coordinates=regionCoords,
         radius=3,
@@ -248,7 +278,7 @@ def test_missions_query_criteria_async(patch_post):
     assert isinstance(responses, MockResponse)
 
 
-def test_missions_query_criteria_async_with_missing_results(patch_post):
+def test_missions_query_criteria_async_with_missing_results():
     with pytest.raises(KeyError):
         responses = MastMissions.query_criteria_async(
             coordinates=regionCoords,
@@ -262,7 +292,7 @@ def test_missions_query_criteria_async_with_missing_results(patch_post):
         services._json_to_table(json.loads(responses), 'results')
 
 
-def test_missions_query_criteria(patch_post):
+def test_missions_query_criteria():
     result = MastMissions.query_criteria(
         coordinates=regionCoords,
         radius=3,
@@ -293,7 +323,7 @@ def test_missions_query_criteria(patch_post):
         )
 
 
-def test_missions_parse_select_cols(patch_post):
+def test_missions_parse_select_cols():
     # Default columns
     cols = MastMissions._parse_select_cols(None)  # Default columns for HST
     assert cols is None
@@ -343,7 +373,7 @@ def test_missions_parse_select_cols(patch_post):
         assert col in ullyses_cols
 
 
-def test_missions_parse_multiple_targets(patch_post):
+def test_missions_parse_multiple_targets():
     # Single coordinate object
     coord = SkyCoord(10.684, 41.269, unit='deg')
     result = MastMissions._parse_multiple_targets(coordinates=coord)
@@ -402,7 +432,7 @@ def test_missions_parse_multiple_targets(patch_post):
         MastMissions._parse_multiple_targets(object_names=["invalid_object"])
 
 
-def test_missions_get_product_list_async(patch_post):
+def test_missions_get_product_list_async():
     # String input
     result = MastMissions.get_product_list_async('Z14Z0104T')
     assert isinstance(result, list)
@@ -437,7 +467,7 @@ def test_missions_get_product_list_async(patch_post):
         missions.get_product_list_async(Table({'a': [1, 2, 3]}))
 
 
-def test_missions_get_product_list(patch_post):
+def test_missions_get_product_list():
     # String input
     result = MastMissions.get_product_list('Z14Z0104T')
     assert isinstance(result, Table)
@@ -462,7 +492,7 @@ def test_missions_get_product_list(patch_post):
     assert isinstance(result, Table)
 
 
-def test_missions_get_unique_product_list(patch_post, caplog):
+def test_missions_get_unique_product_list(caplog):
     unique_products = MastMissions.get_unique_product_list('Z14Z0104T')
     assert isinstance(unique_products, Table)
     assert (len(unique_products) == len(unique(unique_products, keys='filename')))
@@ -471,7 +501,7 @@ def test_missions_get_unique_product_list(patch_post, caplog):
         assert caplog.text == ''
 
 
-def test_missions_filter_products(patch_post):
+def test_missions_filter_products():
     # Filter products list by column
     products = MastMissions.get_product_list('Z14Z0104T')
     filtered = MastMissions.filter_products(products, category='CALIBRATED')
@@ -555,7 +585,7 @@ def test_missions_filter_products(patch_post):
         MastMissions.filter_products(products, non_existing='value')
 
 
-def test_missions_download_products(patch_post, tmp_path):
+def test_missions_download_products(tmp_path):
     # Check string input
     test_dataset_id = 'Z14Z0104T'
     result = MastMissions.download_products(test_dataset_id, download_dir=tmp_path)
@@ -608,7 +638,7 @@ def test_missions_download_products(patch_post, tmp_path):
 
 
 @patch.object(Path, 'is_file', return_value=True)
-def test_missions_download_file(mock_is_file, patch_post, tmp_path):
+def test_missions_download_file(mock_is_file, tmp_path):
     # JWST download
     missions = MastMissions()
     missions.mission = 'JWST'
@@ -625,7 +655,7 @@ def test_missions_download_file(mock_is_file, patch_post, tmp_path):
         missions.download_file('classy_test_file.fits', local_path=tmp_path)
 
 
-def test_missions_download_no_auth(patch_post, caplog):
+def test_missions_download_no_auth(caplog):
     # Exclusive access products should not be downloaded if user is not authenticated
     # User is not authenticated
     uri = 'unauthorized.fits'
@@ -648,7 +678,7 @@ def test_missions_download_no_auth(patch_post, caplog):
         assert 'You do not have access to download this data' in caplog.text
 
 
-def test_missions_get_dataset_kwd(patch_post, caplog):
+def test_missions_get_dataset_kwd(caplog):
     m = MastMissions()
 
     # Default is HST
@@ -678,7 +708,7 @@ def test_missions_get_dataset_kwd(patch_post, caplog):
     [['query_region', dict()],
      ['query_criteria', dict(ang_sep=0.6)]]
 )
-def test_missions_radius_too_large(method, kwargs, patch_post):
+def test_missions_radius_too_large(method, kwargs):
     m = MastMissions(mission='jwst')
     coordinates = SkyCoord(0, 0, unit=u.deg)
     radius = m._max_query_radius + 0.1 * u.deg
@@ -693,14 +723,14 @@ def test_missions_radius_too_large(method, kwargs, patch_post):
 ###################
 
 
-def test_list_missions(patch_post):
+def test_list_missions():
     missions = Observations.list_missions()
     assert isinstance(missions, list)
     for m in ['HST', 'HLA', 'GALEX', 'Kepler']:
         assert m in missions
 
 
-def test_mast_service_request_async(patch_post):
+def test_mast_service_request_async():
     service = 'Mast.Name.Lookup'
     params = {'input': "M103",
               'format': 'json'}
@@ -712,7 +742,7 @@ def test_mast_service_request_async(patch_post):
     assert output
 
 
-def test_mast_service_request(patch_post):
+def test_mast_service_request():
     service = 'Mast.Caom.Cone'
     params = {'ra': 23.34086,
               'dec': 60.658,
@@ -722,7 +752,7 @@ def test_mast_service_request(patch_post):
     assert isinstance(result, Table)
 
 
-def test_mast_query(patch_post):
+def test_mast_query():
     # cone search
     result = Mast.mast_query('Mast.Caom.Cone', ra=23.34086, dec=60.658, radius=0.2)
     assert isinstance(result, Table)
@@ -755,7 +785,7 @@ def test_mast_query(patch_post):
         Mast.mast_query('Mast.Caom.Filtered', s_ra={'min': 10.0})
 
 
-def test_resolve_object_single(patch_post):
+def test_resolve_object_single():
     obj = "TIC 307210830"
     tic_coord = SkyCoord(124.531756290083, -68.3129998725044, unit="deg")
     simbad_coord = SkyCoord(124.5317560026638, -68.3130014904408, unit="deg")
@@ -804,7 +834,7 @@ def test_resolve_object_single(patch_post):
         assert isinstance(loc, dict)
 
 
-def test_resolve_object_multi(patch_post):
+def test_resolve_object_multi():
     objects = ["TIC 307210830", "M1", "Barnard's Star"]
 
     # No resolver specified
@@ -844,7 +874,7 @@ def test_resolve_object_multi(patch_post):
         Mast.resolve_object(["nonexisting1", "nonexisting2"])
 
 
-def test_login_logout(patch_post):
+def test_login_logout():
     test_token = "56a9cf3df4c04052atest43feb87f282"
 
     Mast.login(token=test_token)
@@ -856,7 +886,7 @@ def test_login_logout(patch_post):
     assert not Mast._session.cookies.get("mast_token")
 
 
-def test_session_info(patch_post):
+def test_session_info():
     info = Mast.session_info(verbose=False)
     assert isinstance(info, dict)
     assert info['ezid'] == 'alice'
@@ -871,27 +901,27 @@ regionCoords = SkyCoord(23.34086, 60.658, unit=('deg', 'deg'))
 
 
 # query functions
-def test_observations_query_region_async(patch_post):
+def test_observations_query_region_async():
     responses = Observations.query_region_async(regionCoords, radius=0.2)
     assert isinstance(responses, list)
 
 
-def test_observations_query_region(patch_post):
+def test_observations_query_region():
     result = Observations.query_region(regionCoords, radius=0.2 * u.deg)
     assert isinstance(result, Table)
 
 
-def test_observations_query_object_async(patch_post):
+def test_observations_query_object_async():
     responses = Observations.query_object_async("M103", radius="0.2 deg")
     assert isinstance(responses, list)
 
 
-def test_observations_query_object(patch_post):
+def test_observations_query_object():
     result = Observations.query_object("M103", radius=".02 deg")
     assert isinstance(result, Table)
 
 
-def test_query_observations_criteria_async(patch_post):
+def test_query_observations_criteria_async():
     # without position
     responses = Observations.query_criteria_async(dataproduct_type=["image"],
                                                   proposal_pi="Ost*",
@@ -904,7 +934,7 @@ def test_query_observations_criteria_async(patch_post):
     assert isinstance(responses, list)
 
 
-def test_observations_query_criteria(patch_post):
+def test_observations_query_criteria():
     # without position
     result = Observations.query_criteria(dataproduct_type=["image"],
                                          proposal_pi="Ost*",
@@ -926,17 +956,17 @@ def test_observations_query_criteria(patch_post):
 
 
 # count functions
-def test_observations_query_region_count(patch_post):
+def test_observations_query_region_count():
     result = Observations.query_region_count(regionCoords, radius="0.2 deg")
     assert result == 599
 
 
-def test_observations_query_object_count(patch_post):
+def test_observations_query_object_count():
     result = Observations.query_object_count("M8", radius=0.2*u.deg)
     assert result == 599
 
 
-def test_observations_query_criteria_count(patch_post):
+def test_observations_query_criteria_count():
     result = Observations.query_criteria_count(dataproduct_type=["image"],
                                                proposal_pi="Ost*",
                                                s_dec=[43.5, 45.5])
@@ -953,7 +983,7 @@ def test_observations_query_criteria_count(patch_post):
 
 
 # product functions
-def test_observations_get_product_list_async(patch_post):
+def test_observations_get_product_list_async():
     responses = Observations.get_product_list_async('2003738726')
     assert isinstance(responses, list)
 
@@ -968,7 +998,7 @@ def test_observations_get_product_list_async(patch_post):
     assert isinstance(responses, list)
 
 
-def test_observations_get_product_list(patch_post):
+def test_observations_get_product_list():
     result = Observations.get_product_list('2003738726')
     assert isinstance(result, Table)
 
@@ -991,7 +1021,7 @@ def test_observations_get_product_list(patch_post):
         Observations.get_product_list([' '])
 
 
-def test_observations_filter_products(patch_post):
+def test_observations_filter_products():
     products = Observations.get_product_list('2003738726')
     filtered = Observations.filter_products(products,
                                             productType=["sCiEnCE"],
@@ -1022,85 +1052,69 @@ def test_observations_filter_products(patch_post):
         Observations.filter_products(products, invalid=True)
 
 
-def test_observations_download_products(patch_post, tmpdir):
-    # actually download the products
-    result = Observations.download_products('2003738726',
-                                            download_dir=str(tmpdir),
-                                            productType=["SCIENCE"],
-                                            mrp_only=False)
+@patch.object(Path, "is_file", return_value=True)
+def test_observations_download_products(mock_is_file, patch_boto3, monkeypatch, reset_cloud_state):
+    mock_resource = patch_boto3[1]
+    obsid = '2003738726'
+    data_uri = 'mast:HST/product/u9o40504m_c3m.fits'
+
+    # Actually download the products
+    result = Observations.download_products(obsid,
+                                            dataURI=data_uri)
     assert isinstance(result, Table)
 
-    # just get the curl script
-    result = Observations.download_products('2003738726',
-                                            download_dir=str(tmpdir),
+    # Just get the curl script
+    result = Observations.download_products(obsid,
                                             curl_flag=True,
                                             productType=["SCIENCE"],
                                             mrp_only=False)
     assert isinstance(result, Table)
 
-    # without console output
-    result = Observations.download_products('2003738726',
-                                            download_dir=str(tmpdir),
-                                            productType=["SCIENCE"],
+    # Without console output, flat
+    result = Observations.download_products(obsid,
+                                            dataURI=data_uri,
+                                            flat=True,
                                             verbose=False)
     assert isinstance(result, Table)
 
-    # passing row product
-    products = Observations.get_product_list('2003738726')
-    result1 = Observations.download_products(products[0], download_dir=str(tmpdir))
+    # Passing row product
+    products = Observations.get_product_list(obsid)
+    result1 = Observations.download_products(products[0])
     assert isinstance(result1, Table)
 
     # Warn if no products to download
     with pytest.warns(NoResultsWarning, match='No products to download'):
-        result = Observations.download_products('2003738726',
-                                                download_dir=str(tmpdir),
-                                                productType=["INVALID_TYPE"])
+        result = Observations.download_products(obsid, productType=["INVALID_TYPE"])
         assert result is None
 
     # Warn if curl_flag and flags are both set
     with pytest.warns(InputWarning, match='flat=True has no effect on curl downloads.'):
-        result = Observations.download_products('2003738726',
+        result = Observations.download_products(obsid,
                                                 curl_flag=True,
                                                 flat=True)
         assert isinstance(result, Table)
-
-
-@patch('boto3.resource')
-@patch('boto3.client')
-@patch.object(Path, "is_file", return_value=True)
-def test_observations_download_products_cloud(mock_is_file, mock_client, mock_resource, patch_post,
-                                              monkeypatch):
-    pytest.importorskip("boto3")
-    mock_client.return_value.head_object.return_value = {'ContentLength': 12345}
-    mock_resource.return_value.Bucket.return_value.download_file.return_value = None
-    obsid = '2003738726'
-    data_uri = 'mast:HST/product/u9o40504m_c3m.fits'
-
-    # Enable access to public AWS S3 bucket
-    Observations.enable_cloud_dataset()
 
     result = Observations.download_products(obsid,
                                             dataURI=data_uri)
     assert isinstance(result, Table)
     assert result[0]['Status'] == 'COMPLETE'
 
-    # Mock cloud download failure, fallback to on-prem
+    # Mock cloud download failure
+    Observations.enable_cloud_dataset()  # enable cloud dataset to emit warning
     client_err = ClientError({'Error': {'Code': '500', 'Message': 'Internal Server Error'}}, 'HeadObject')
-    mock_resource.return_value.Bucket.return_value.download_file.side_effect = client_err
-    # Check that info message is logged
+    mock_resource.Bucket.return_value.download_file.side_effect = client_err
+    # Warn and fall back to on-prem download
     with pytest.warns(InputWarning, match='Falling back to MAST download'):
-        result = Observations.download_products(obsid,
-                                                dataURI=data_uri)
+        result = Observations.download_products(obsid, dataURI=data_uri)
     assert result[0]['Status'] == 'COMPLETE'
-
-    # Cloud download failure, do not fallback to on-prem
+    # Do not fall back to on-prem download, skip instead
     with pytest.warns(NoResultsWarning, match='Skipping download.'):
         result = Observations.download_products(obsid,
                                                 dataURI=data_uri,
                                                 cloud_only=True)
     assert result[0]['Status'] == 'SKIPPED'
 
-    # Products not found in cloud, skip download
+    # Products not found in cloud
     monkeypatch.setattr(Observations, 'get_cloud_uris', lambda *a, **k: {})
     with pytest.warns(NoResultsWarning, match='was not found in the cloud. Skipping download.'):
         result = Observations.download_products(obsid,
@@ -1108,15 +1122,13 @@ def test_observations_download_products_cloud(mock_is_file, mock_client, mock_re
                                                 cloud_only=True)
     assert result[0]['Status'] == 'SKIPPED'
     assert result[0]['Message'] == 'Product not found in cloud'
-
-    # Products not found in cloud, fall back
+    # Warn and fall back to on-prem download if products not found in cloud and cloud_only is False
     with pytest.warns(InputWarning, match='was not found in the cloud. Falling back to MAST download'):
         result = Observations.download_products(obsid, dataURI=data_uri)
     assert result[0]['Status'] == 'COMPLETE'
 
-    Observations.disable_cloud_dataset()
-
     # Cloud access not enabled, warn if cloud_only is True
+    Observations.disable_cloud_dataset()
     with pytest.warns(InputWarning, match='cloud data access is not enabled'):
         result = Observations.download_products('2003738726',
                                                 dataURI='mast:HST/product/u9o40504m_c3m.fits',
@@ -1125,37 +1137,14 @@ def test_observations_download_products_cloud(mock_is_file, mock_client, mock_re
 
 
 @patch.object(Path, "is_file", return_value=True)
-def test_observations_download_file(mock_is_file, patch_post, tmpdir):
+def test_observations_download_file(mock_is_file, patch_boto3, reset_cloud_state, tmpdir):
+    mock_client, mock_resource = patch_boto3
+    mock_client.head_object.return_value = {'ContentLength': 12345}
+    mock_resource.Bucket.return_value.download_file.return_value = None
     mast_uri = 'mast:HST/product/u9o40504m_c3m.fits'
 
     result = Observations.download_file(mast_uri, local_path=tmpdir)
     assert result == ('COMPLETE', None, None)
-
-    unauth_uri = 'mast:HST/product/unauthorized.fits'
-    result = Observations.download_file(unauth_uri)
-    assert result[0] == 'ERROR'
-    assert 'HTTPError' in result[1]
-
-
-def test_observations_download_file_not_found(patch_post, tmpdir):
-    mast_uri = 'mast:HST/product/u9o40504m_c3m.fits'
-
-    result = Observations.download_file(mast_uri, local_path=tmpdir)
-    assert result[0] == 'ERROR'
-    assert result[1] == 'File was not downloaded'
-
-
-@patch('boto3.resource')
-@patch('boto3.client')
-@patch.object(Path, "is_file", return_value=True)
-def test_observations_download_file_cloud(mock_is_file, mock_client, mock_resource, patch_post):
-    pytest.importorskip("boto3")
-    mock_client.return_value.head_object.return_value = {'ContentLength': 12345}
-    mock_resource.return_value.Bucket.return_value.download_file.return_value = None
-
-    # Enable access to public AWS S3 bucket
-    Observations.enable_cloud_dataset()
-    mast_uri = 'mast:HST/product/u9o40504m_c3m.fits'
 
     # Warn if both cloud_only and force_on_prem are True
     with pytest.raises(InvalidQueryError, match='Invalid argument combination'):
@@ -1168,6 +1157,7 @@ def test_observations_download_file_cloud(mock_is_file, mock_client, mock_resour
         assert result == ('SKIPPED', None, None)
 
     # Use on-prem download if cloud_only is False and file is not in cloud
+    Observations.enable_cloud_dataset()  # enable cloud dataset to emit warning
     with pytest.warns(InputWarning, match=f'The product {nonexistent_uri} was not found in the cloud'):
         result = Observations.download_file(nonexistent_uri, cloud_only=False)
         assert result == ('COMPLETE', None, None)
@@ -1176,66 +1166,68 @@ def test_observations_download_file_cloud(mock_is_file, mock_client, mock_resour
     with pytest.raises(InvalidQueryError, match='A valid data product URI'):
         Observations.download_file(12345, cloud_only=True)
 
-    Observations.disable_cloud_dataset()
+    # Mock cloud download failure, fallback to on-prem
+    client_err = ClientError({'Error': {'Code': '500', 'Message': 'Internal Server Error'}}, 'HeadObject')
+    mock_resource.Bucket.return_value.download_file.side_effect = client_err
+    with pytest.warns(InputWarning, match='Falling back to MAST download'):
+        result = Observations.download_file(mast_uri)
+    assert result == ('COMPLETE', None, None)
+
+    # Skip if cloud download fails and cloud_only is True
+    with pytest.warns(NoResultsWarning, match='Skipping download.'):
+        result = Observations.download_file(mast_uri, cloud_only=True)
+    assert result == ('SKIPPED', None, None)
 
     # Warning if cloud dataset is not enabled
+    Observations.disable_cloud_dataset()
     with pytest.warns(InputWarning, match='cloud data access is not enabled'):
         result = Observations.download_file(mast_uri, cloud_only=True)
         assert result == ('COMPLETE', None, None)
 
 
-@patch('boto3.client')
-def test_observations_list_cloud_missions(mock_client, patch_post):
-    pytest.importorskip('boto3')
-    mock_client.return_value.list_objects_v2.return_value = {
+def test_observations_download_file_not_found(patch_boto3, reset_cloud_state):
+    mast_uri = 'mast:HST/product/u9o40504m_c3m.fits'
+    result = Observations.download_file(mast_uri)
+    assert result[0] == 'ERROR'
+    assert result[1] == 'File was not downloaded'
+
+    mast_uri = 'mast:HST/product/u9o40504m_c3m.fits'
+    result = Observations.download_file(mast_uri)
+    assert result[0] == 'ERROR'
+    assert result[1] == 'File was not downloaded'
+
+
+def test_observations_list_cloud_missions(patch_boto3, reset_cloud_state):
+    mock_client = patch_boto3[0]
+    mock_client.list_objects_v2.return_value = {
         'CommonPrefixes': [{'Prefix': 'hst/'}, {'Prefix': 'jwst/'}, {'Prefix': 'mast/'}]
     }
 
-    with pytest.raises(RemoteServiceError):
-        Observations.list_cloud_datasets()
-
-    Observations.enable_cloud_dataset()
     supported = Observations.list_cloud_datasets()
     assert isinstance(supported, list)
     assert 'hst' in supported
     assert 'jwst' in supported
     assert 'mast' in supported
 
-    Observations.disable_cloud_dataset()
 
-
-@patch('boto3.client')
-def test_observations_list_cloud_missions_error(mock_client, patch_post, caplog):
-    pytest.importorskip('boto3')
-
-    # Error without cloud connection
-    with pytest.raises(RemoteServiceError):
-        Observations.list_cloud_datasets()
-
+def test_observations_list_cloud_missions_error(patch_boto3, reset_cloud_state):
     # Mock an error when listing objects
+    mock_client = patch_boto3[0]
     client_error = ClientError({'Error': {'Code': 'AWS error'}}, 'ListObjectsV2')
-    mock_client.return_value.list_objects_v2.side_effect = client_error
+    mock_client.list_objects_v2.side_effect = client_error
 
-    Observations.enable_cloud_dataset()
     supported = Observations.list_cloud_datasets()
     assert supported == []
 
+    # Cloud access not enabled
     Observations.disable_cloud_dataset()
+    with pytest.raises(RemoteServiceError, match='Please enable anonymous cloud access'):
+        Observations.list_cloud_datasets()
 
 
-@patch('boto3.client')
-def test_observations_get_cloud_uri(mock_client, patch_post):
-    pytest.importorskip("boto3")
-
+def test_observations_get_cloud_uri(patch_boto3, reset_cloud_state):
     mast_uri = 'mast:HST/product/u9o40504m_c3m.fits'
     expected = 's3://stpubdata/hst/public/u9o4/u9o40504m/u9o40504m_c3m.fits'
-
-    # Error without cloud connection
-    with pytest.raises(RemoteServiceError):
-        Observations.get_cloud_uri('mast:HST/product/u9o40504m_c3m.fits')
-
-    # Enable access to public AWS S3 bucket
-    Observations.enable_cloud_dataset()
 
     # Row input
     product = Table()
@@ -1252,22 +1244,15 @@ def test_observations_get_cloud_uri(mock_client, patch_post):
     with pytest.warns(NoResultsWarning, match='Failed to retrieve cloud path'):
         Observations.get_cloud_uri('mast:HST/product/does_not_exist.fits')
 
+    # Cloud access not enabled
     Observations.disable_cloud_dataset()
+    with pytest.raises(RemoteServiceError, match='Please enable anonymous cloud access'):
+        Observations.get_cloud_uri(mast_uri)
 
 
-@patch('boto3.client')
-def test_observations_get_cloud_uris(mock_client, patch_post):
-    pytest.importorskip("boto3")
-
+def test_observations_get_cloud_uris(patch_boto3, reset_cloud_state):
     mast_uri = 'mast:HST/product/u9o40504m_c3m.fits'
     expected = 's3://stpubdata/hst/public/u9o4/u9o40504m/u9o40504m_c3m.fits'
-
-    # Error without cloud connection
-    with pytest.raises(RemoteServiceError):
-        Observations.get_cloud_uris(['mast:HST/product/u9o40504m_c3m.fits'])
-
-    # Enable access to public AWS S3 bucket
-    Observations.enable_cloud_dataset()
 
     # Get the cloud URIs
     # Table input
@@ -1304,40 +1289,33 @@ def test_observations_get_cloud_uris(mock_client, patch_post):
     with pytest.warns(NoResultsWarning, match='Failed to retrieve cloud path'):
         Observations.get_cloud_uris(['mast:HST/product/does_not_exist.fits'])
 
+    # Cloud access not enabled
     Observations.disable_cloud_dataset()
+    with pytest.raises(RemoteServiceError, match='Please enable anonymous cloud access'):
+        Observations.get_cloud_uris([mast_uri])
 
 
-@patch('boto3.client')
-def test_observations_get_cloud_uris_error(mock_client, patch_post):
-    pytest.importorskip("boto3")
+def test_observations_get_cloud_uris_error(patch_boto3, reset_cloud_state):
+    mock_client = patch_boto3[0]
 
     # Mock head_object to raise an exception
     # Raise the error if not a 404
     exc = ClientError({'Error': {'Code': '500', 'Message': 'Internal Server Error'}}, 'HeadObject')
-    mock_client.return_value.head_object.side_effect = exc
+    mock_client.head_object.side_effect = exc
 
-    Observations.enable_cloud_dataset()
     with pytest.raises(ClientError):
         Observations.get_cloud_uris(['mast:HST/product/u9o40504m_c3m.fits'])
 
     # Only warn if the error is a 404
     exc = ClientError({'Error': {'Code': '404', 'Message': 'Not Found'}}, 'HeadObject')
-    mock_client.return_value.head_object.side_effect = exc
+    mock_client.head_object.side_effect = exc
 
     with pytest.warns(NoResultsWarning, match='Failed to retrieve cloud path'):
         uris = Observations.get_cloud_uris(['mast:HST/product/u9o40504m_c3m.fits'])
     assert uris == []
 
-    Observations.disable_cloud_dataset()
 
-
-@patch('boto3.client')
-def test_observations_get_cloud_uris_query(mock_client, patch_post):
-    pytest.importorskip("boto3")
-
-    # enable access to public AWS S3 bucket
-    Observations.enable_cloud_dataset()
-
+def test_observations_get_cloud_uris_query(patch_boto3, reset_cloud_state):
     # get uris with streamlined function
     uris = Observations.get_cloud_uris(target_name=234295610,
                                        filter_products={'productSubGroupDescription': 'C3M'})
@@ -1352,7 +1330,28 @@ def test_observations_get_cloud_uris_query(mock_client, patch_post):
         Observations.get_cloud_uris(target_name=234295610,
                                     filter_products={'productSubGroupDescription': 'LC'})
 
+
+def test_observations_enable_cloud_dataset(patch_boto3, reset_cloud_state):
+    # Enable cloud dataset
+    Observations.enable_cloud_dataset()
+    assert Observations._cloud_connection is not None
+    assert Observations._cloud_enabled_explicitly is True
+
+    # Force an import error when connecting to cloud dataset
+    cloud.HAS_BOTO3 = False
+    Observations.disable_cloud_dataset()  # reset state
+    with pytest.warns(CloudAccessWarning):
+        Observations.enable_cloud_dataset()
+
+    # Reset cloud dataset state for other tests
+    cloud.HAS_BOTO3 = True
+
+
+def test_observations_disable_cloud_dataset(patch_boto3, reset_cloud_state):
+    # Explicitly disable cloud dataset
     Observations.disable_cloud_dataset()
+    assert Observations._cloud_connection is None
+    assert Observations._cloud_enabled_explicitly is False
 
 
 ######################
@@ -1360,17 +1359,17 @@ def test_observations_get_cloud_uris_query(mock_client, patch_post):
 ######################
 
 
-def test_catalogs_query_region_async(patch_post):
+def test_catalogs_query_region_async():
     responses = Catalogs.query_region_async(regionCoords, radius=0.002)
     assert isinstance(responses, list)
 
 
-def test_catalogs_fabric_query_region_async(patch_post):
+def test_catalogs_fabric_query_region_async():
     responses = Catalogs.query_region_async(regionCoords, radius=0.002, catalog="panstarrs", table="mean")
     assert isinstance(responses, MockResponse)
 
 
-def test_catalogs_query_region(patch_post):
+def test_catalogs_query_region():
     result = Catalogs.query_region(regionCoords, radius=0.002 * u.deg)
     assert isinstance(result, Table)
 
@@ -1398,32 +1397,32 @@ def test_catalogs_query_region(patch_post):
     assert isinstance(result, Table)
 
 
-def test_catalogs_fabric_query_region(patch_post):
+def test_catalogs_fabric_query_region():
     result = Catalogs.query_region(regionCoords, radius=0.002 * u.deg, catalog="panstarrs", table="mean")
     assert isinstance(result, Table)
 
 
-def test_catalogs_query_object_async(patch_post):
+def test_catalogs_query_object_async():
     responses = Catalogs.query_object_async("M101", radius="0.002 deg")
     assert isinstance(responses, list)
 
 
-def test_catalogs_fabric_query_object_async(patch_post):
+def test_catalogs_fabric_query_object_async():
     responses = Catalogs.query_object_async("M101", radius="0.002 deg", catalog="panstarrs", table="mean")
     assert isinstance(responses, MockResponse)
 
 
-def test_catalogs_query_object(patch_post):
+def test_catalogs_query_object():
     result = Catalogs.query_object("M101", radius=".002 deg")
     assert isinstance(result, Table)
 
 
-def test_catalogs_fabric_query_object(patch_post):
+def test_catalogs_fabric_query_object():
     result = Catalogs.query_object("M101", radius=".002 deg", catalog="panstarrs", table="mean")
     assert isinstance(result, Table)
 
 
-def test_catalogs_query_criteria_async(patch_post):
+def test_catalogs_query_criteria_async():
     responses = Catalogs.query_criteria_async(catalog="Tic",
                                               Bmag=[30, 50], objType="STAR")
     assert isinstance(responses, list)
@@ -1459,7 +1458,7 @@ def test_catalogs_query_criteria_async(patch_post):
     assert "one of object_name and coordinates" in str(invalid_query.value)
 
 
-def test_catalogs_query_criteria(patch_post):
+def test_catalogs_query_criteria():
     # without position
     result = Catalogs.query_criteria(catalog="Tic",
                                      Bmag=[30, 50], objType="STAR")
@@ -1482,7 +1481,7 @@ def test_catalogs_query_criteria(patch_post):
     assert "non-positional" in str(invalid_query.value)
 
 
-def test_catalogs_query_hsc_matchid_async(patch_post):
+def test_catalogs_query_hsc_matchid_async():
     responses = Catalogs.query_hsc_matchid_async(82371983)
     assert isinstance(responses, list)
 
@@ -1494,22 +1493,22 @@ def test_catalogs_query_hsc_matchid_async(patch_post):
     assert "Invalid HSC version number" in str(i_w[0].message)
 
 
-def test_catalogs_query_hsc_matchid(patch_post):
+def test_catalogs_query_hsc_matchid():
     result = Catalogs.query_hsc_matchid(82371983)
     assert isinstance(result, Table)
 
 
-def test_catalogs_get_hsc_spectra_async(patch_post):
+def test_catalogs_get_hsc_spectra_async():
     responses = Catalogs.get_hsc_spectra_async()
     assert isinstance(responses, list)
 
 
-def test_catalogs_get_hsc_spectra(patch_post):
+def test_catalogs_get_hsc_spectra():
     result = Catalogs.get_hsc_spectra()
     assert isinstance(result, Table)
 
 
-def test_catalogs_download_hsc_spectra(patch_post, tmpdir):
+def test_catalogs_download_hsc_spectra(tmpdir):
     allSpectra = Catalogs.get_hsc_spectra()
 
     # actually download the products
@@ -1526,7 +1525,7 @@ def test_catalogs_download_hsc_spectra(patch_post, tmpdir):
 # TesscutClass tests #
 ######################
 
-def test_tesscut_get_sector(patch_post):
+def test_tesscut_get_sector():
     coord = SkyCoord(324.24368, -27.01029, unit="deg")
     sector_table = Tesscut.get_sectors(coordinates=coord)
     assert isinstance(sector_table, Table)
@@ -1588,7 +1587,7 @@ def test_tesscut_get_sector(patch_post):
     assert "Input product must be SPOC." in str(invalid_query.value)
 
 
-def test_tesscut_download_cutouts(patch_post, tmpdir):
+def test_tesscut_download_cutouts(tmpdir):
     coord = SkyCoord(107.27, -70.0, unit="deg")
 
     # Testing with inflate
@@ -1644,7 +1643,7 @@ def test_tesscut_download_cutouts(patch_post, tmpdir):
     assert "Input product must be SPOC." in str(invalid_query.value)
 
 
-def test_tesscut_get_cutouts(patch_post, tmpdir):
+def test_tesscut_get_cutouts(tmpdir):
     coord = SkyCoord(107.27, -70.0, unit="deg")
     cutout_hdus_list = Tesscut.get_cutouts(coordinates=coord, size=5)
     assert isinstance(cutout_hdus_list, list)
@@ -1685,7 +1684,7 @@ def test_tesscut_get_cutouts(patch_post, tmpdir):
     assert "Input product must be SPOC." in str(invalid_query.value)
 
 
-def test_tesscut_get_cutouts_mt_no_sector(patch_post):
+def test_tesscut_get_cutouts_mt_no_sector():
     """Test get_cutouts with moving target but no sector specified.
 
     When sector is not specified for moving targets, the method should
@@ -1699,7 +1698,7 @@ def test_tesscut_get_cutouts_mt_no_sector(patch_post):
     assert isinstance(cutout_hdus_list[0], fits.HDUList)
 
 
-def test_tesscut_download_cutouts_mt_no_sector(patch_post, tmpdir):
+def test_tesscut_download_cutouts_mt_no_sector(tmpdir):
     """Test download_cutouts with moving target but no sector specified.
 
     When sector is not specified for moving targets, the method should
@@ -1716,7 +1715,7 @@ def test_tesscut_download_cutouts_mt_no_sector(patch_post, tmpdir):
     assert os.path.isfile(manifest[0]["Local Path"])
 
 
-def test_tesscut_get_cutouts_mt_no_sector_empty_results(patch_post, monkeypatch):
+def test_tesscut_get_cutouts_mt_no_sector_empty_results(monkeypatch):
     """Test get_cutouts with moving target when no sectors are available.
 
     When get_sectors returns an empty table, the method should warn and return an empty list.
@@ -1731,7 +1730,7 @@ def test_tesscut_get_cutouts_mt_no_sector_empty_results(patch_post, monkeypatch)
     assert len(cutout_hdus_list) == 0
 
 
-def test_tesscut_download_cutouts_mt_no_sector_empty_results(patch_post, tmpdir, monkeypatch):
+def test_tesscut_download_cutouts_mt_no_sector_empty_results(tmpdir, monkeypatch):
     """Test download_cutouts with moving target when no sectors are available.
 
     When get_sectors returns an empty table, the method should warn and return an empty Table.
@@ -1753,7 +1752,7 @@ def test_tesscut_download_cutouts_mt_no_sector_empty_results(patch_post, tmpdir,
 ######################
 
 
-def test_zcut_get_survey(patch_post):
+def test_zcut_get_survey():
 
     coord = SkyCoord(189.49206, 62.20615, unit="deg")
     survey_list = Zcut.get_surveys(coordinates=coord)
@@ -1771,7 +1770,7 @@ def test_zcut_get_survey(patch_post):
     assert survey_list[2] == 'goods_north'
 
 
-def test_zcut_download_cutouts(patch_post, tmpdir):
+def test_zcut_download_cutouts(tmpdir):
 
     coord = SkyCoord(189.49206, 62.20615, unit="deg")
 
@@ -1799,7 +1798,7 @@ def test_zcut_download_cutouts(patch_post, tmpdir):
     assert os.path.isfile(cutout_table[0]['Local Path'])
 
 
-def test_zcut_get_cutouts(patch_post, tmpdir):
+def test_zcut_get_cutouts(tmpdir):
 
     coord = SkyCoord(189.49206, 62.20615, unit="deg")
     cutout_list = Zcut.get_cutouts(coordinates=coord, size=5)
@@ -1813,7 +1812,7 @@ def test_zcut_get_cutouts(patch_post, tmpdir):
 ################
 
 
-def test_parse_input_location(patch_post):
+def test_parse_input_location():
     # Test with coordinates
     coord = SkyCoord(23.34086, 60.658, unit="deg")
     loc = utils.parse_input_location(coordinates=coord)
@@ -1842,7 +1841,7 @@ def test_parse_input_location(patch_post):
         assert isinstance(loc, SkyCoord)
 
 
-def test_json_to_table_fallback_type_coercion(patch_post):
+def test_json_to_table_fallback_type_coercion():
     json_obj = {'info': [{'name': 'test_int', 'type': 'int'}],
                 'data': [['1'], ['2'], ['not_an_int'], ['3'], [-999]]}
 
@@ -1868,49 +1867,45 @@ def test_json_to_table_fallback_type_coercion(patch_post):
 # Cloud tests #
 ################
 
-@patch("boto3.resource")
-@patch("boto3.client")
-def test_download_file_from_cloud(mock_client, mock_resource, patch_post):
-    pytest.importorskip("boto3")
+def test_cloud_access_init():
+    cloud.HAS_BOTO3 = False
+    with pytest.raises(ImportError, match='Please install the `boto3` and `botocore` packages'):
+        CloudAccess()
 
+    # Restore the original state for other tests
+    cloud.HAS_BOTO3 = True
+
+
+def test_download_file_from_cloud(patch_boto3):
+    mock_client, mock_resource = patch_boto3
     cloud = CloudAccess()
 
-    mock_client.return_value.head_object.return_value = {'ContentLength': 123}
-    mock_resource.return_value.Bucket.return_value.download_file.return_value = None
+    mock_client.head_object.return_value = {'ContentLength': 123}
+    mock_resource.Bucket.return_value.download_file.return_value = None
 
     cloud.download_file_from_cloud(
         "s3://stpubdata/hst/public/u9o4/u9o40504m/u9o40504m_c3m.fits",
         "local.fits",
         verbose=False
     )
-    mock_resource.return_value.Bucket.return_value.download_file.assert_called_once()
+    mock_resource.Bucket.return_value.download_file.assert_called_once()
 
 
-@patch("boto3.resource")
-@patch("boto3.client")
-def test_download_file_from_cloud_not_found(mock_client, mock_resource, patch_post):
-    pytest.importorskip("boto3")
-
+def test_download_file_from_cloud_not_found(patch_boto3):
     cloud = CloudAccess()
 
     # Force get_cloud_uri_list to return [None]
     cloud.get_cloud_uri_list = lambda *a, **k: [None]
 
     with pytest.raises(RemoteServiceError, match='was not found in the cloud'):
-        cloud.download_file_from_cloud(
-            "mast:HST/product/missing.fits",
-            "local.fits",
-        )
+        cloud.download_file_from_cloud("mast:HST/product/missing.fits", "local.fits")
 
 
 @patch('os.path.exists', return_value=True)
 @patch('os.path.getsize', return_value=123)
-@patch('boto3.resource')
-@patch('boto3.client')
-def test_download_file_from_cloud_existing(mock_client, mock_resource, mock_getsize, mock_exists, patch_post):
-    pytest.importorskip("boto3")
-
-    mock_client.return_value.head_object.return_value = {'ContentLength': 123}
+def test_download_file_from_cloud_existing(mock_getsize, mock_exists, patch_boto3):
+    mock_client, mock_resource = patch_boto3
+    mock_client.head_object.return_value = {'ContentLength': 123}
     cloud = CloudAccess()
 
     # File exists locally with same size
@@ -1920,7 +1915,7 @@ def test_download_file_from_cloud_existing(mock_client, mock_resource, mock_gets
         verbose=False
     )
     # No download should be attempted
-    mock_resource.return_value.Bucket.return_value.download_file.assert_not_called()
+    mock_resource.Bucket.return_value.download_file.assert_not_called()
 
     # File exists locally with different size
     mock_getsize.return_value = 456
@@ -1930,17 +1925,15 @@ def test_download_file_from_cloud_existing(mock_client, mock_resource, mock_gets
         verbose=False
     )
     # Download should be attempted
-    mock_resource.return_value.Bucket.return_value.download_file.assert_called_once()
+    mock_resource.Bucket.return_value.download_file.assert_called_once()
 
 
-@patch("boto3.resource")
-@patch("boto3.client")
-def test_download_file_from_cloud_verbose(mock_client, mock_resource, patch_post):
-    pytest.importorskip("boto3")
+def test_download_file_from_cloud_verbose(patch_boto3):
+    mock_client, mock_resource = patch_boto3
     cloud = CloudAccess()
 
-    mock_client.return_value.head_object.return_value = {'ContentLength': 123}
-    mock_resource.return_value.Bucket.return_value.download_file.return_value = None
+    mock_client.head_object.return_value = {'ContentLength': 123}
+    mock_resource.Bucket.return_value.download_file.return_value = None
 
     cloud.download_file_from_cloud(
         "s3://stpubdata/hst/public/u9o4/u9o40504m/u9o40504m_c3m.fits",
@@ -1948,5 +1941,5 @@ def test_download_file_from_cloud_verbose(mock_client, mock_resource, patch_post
         verbose=True
     )
     # Ensure callback was supplied
-    _, kwargs = mock_resource.return_value.Bucket.return_value.download_file.call_args
+    _, kwargs = mock_resource.Bucket.return_value.download_file.call_args
     assert "Callback" in kwargs

--- a/astroquery/mast/tests/test_mast_remote.py
+++ b/astroquery/mast/tests/test_mast_remote.py
@@ -39,6 +39,17 @@ def msa_product_table():
     return products
 
 
+@pytest.fixture()
+def reset_cloud_state():
+    pytest.importorskip('boto3')
+    # Reset cloud dataset state before and after each test
+    Observations._cloud_enabled_explicitly = None
+    Observations._cloud_connection = None
+    yield
+    Observations._cloud_enabled_explicitly = None
+    Observations._cloud_connection = None
+
+
 @pytest.mark.remote_data
 class TestMast:
 
@@ -785,9 +796,8 @@ class TestMast:
         with caplog.at_level("INFO", logger="astroquery"):
             assert "products were duplicates" in caplog.text
 
-    def test_observations_download_products_cloud(self, tmp_path, msa_product_table):
-        pytest.importorskip('boto3')
-
+    def test_observations_download_products_cloud(self, tmp_path, msa_product_table, reset_cloud_state):
+        # Explicity enable cloud dataset
         Observations.enable_cloud_dataset()
 
         # Adding a product that's not in the cloud to test mixed downloads
@@ -821,8 +831,6 @@ class TestMast:
         assert result['Status'][1] == 'COMPLETE'
         assert Path(result['Local Path'][0]).exists()
         assert Path(result['Local Path'][1]).exists()
-
-        Observations.disable_cloud_dataset()
 
     def test_observations_download_file(self, tmp_path):
 
@@ -865,22 +873,16 @@ class TestMast:
         'MISDR1_18916_0459-fd-flagstar.fits.gz',
         'mast:HST/product/u24r0102t_c3m.fits'
     ])
-    def test_observations_download_file_cloud(self, tmp_path, in_uri):
-        pytest.importorskip("boto3")
-
-        Observations.enable_cloud_dataset()
-
+    def test_observations_download_file_cloud(self, tmp_path, in_uri, reset_cloud_state):
         filename = Path(in_uri).name
         result = Observations.download_file(uri=in_uri, cloud_only=True, local_path=tmp_path)
         assert result == ('COMPLETE', None, None)
         assert Path(tmp_path, filename).exists()
 
-        Observations.disable_cloud_dataset()
-
-    def test_observations_download_file_cloud_not_found(self, tmp_path):
-        pytest.importorskip("boto3")
+    def test_observations_download_file_cloud_not_found(self, tmp_path, reset_cloud_state):
         in_uri = 'mast:IUE/url/pub/vospectra/iue2/swp18830mxlo_vo.fits'
 
+        # Explicity enable cloud dataset
         Observations.enable_cloud_dataset()
 
         # Warn and fallback
@@ -895,8 +897,6 @@ class TestMast:
             result = Observations.download_file(uri=in_uri, cloud_only=True, local_path=tmp_path)
             assert result == ('SKIPPED', None, None)
             assert not Path(tmp_path, Path(in_uri).name).exists()
-
-        Observations.disable_cloud_dataset()
 
     def test_observations_download_file_escaped(self, tmp_path):
         # test that `download_file` correctly escapes a URI
@@ -928,15 +928,13 @@ class TestMast:
         assert result == ("COMPLETE", None, None)
         assert Path(tmp_path, filename).exists()
 
-    def test_observations_list_cloud_missions(self):
-        pytest.importorskip('boto3')
-        Observations.enable_cloud_dataset()
+    def test_observations_list_cloud_missions(self, reset_cloud_state):
+        # Test that the function to list missions with cloud datasets returns expected missions
         missions = Observations.list_cloud_datasets()
         assert isinstance(missions, list)
         assert len(missions) > 0
         for m in ['hst', 'jwst', 'panstarrs', 'galex', 'tess']:
             assert m in missions
-        Observations.disable_cloud_dataset()
 
     @pytest.mark.parametrize("test_data_uri, expected_cloud_uri", [
         ("mast:HST/product/u24r0102t_c1f.fits",
@@ -945,13 +943,10 @@ class TestMast:
          "s3://stpubdata/panstarrs/ps1/public/rings.v3.skycell/1334/061/"
          "rings.v3.skycell.1334.061.stk.r.unconv.exp.fits")
     ])
-    def test_observations_get_cloud_uri(self, test_data_uri, expected_cloud_uri):
-        pytest.importorskip("boto3")
+    def test_observations_get_cloud_uri(self, test_data_uri, expected_cloud_uri, reset_cloud_state):
         # get a product list
         product = Table()
         product['dataURI'] = [test_data_uri]
-        # enable access to public AWS S3 bucket
-        Observations.enable_cloud_dataset()
 
         # get uri
         uri = Observations.get_cloud_uri(product[0])
@@ -963,21 +958,14 @@ class TestMast:
         uri = Observations.get_cloud_uri(test_data_uri)
         assert uri == expected_cloud_uri, f'Cloud URI does not match expected. ({uri} != {expected_cloud_uri})'
 
-        Observations.disable_cloud_dataset()
-
     @pytest.mark.parametrize("test_obs_id", ["25568122", "31411", "107604081"])
-    def test_observations_get_cloud_uris(self, test_obs_id):
-        pytest.importorskip("boto3")
-
+    def test_observations_get_cloud_uris(self, test_obs_id, reset_cloud_state):
         # get a product list
         index = 24 if test_obs_id == '25568122' else 0
         products = Observations.get_product_list(test_obs_id)[index:index + 2]
 
         assert len(products) > 0, (f'No products found for OBSID {test_obs_id}. '
                                    'Unable to move forward with getting URIs from the cloud.')
-
-        # enable access to public AWS S3 bucket
-        Observations.enable_cloud_dataset()
 
         # get uris
         uris = Observations.get_cloud_uris(products)
@@ -989,18 +977,12 @@ class TestMast:
             Observations.get_cloud_uris(products,
                                         extension='png')
 
-        Observations.disable_cloud_dataset()
-
-    def test_observations_get_cloud_uris_list_input(self):
-        pytest.importorskip("boto3")
+    def test_observations_get_cloud_uris_list_input(self, reset_cloud_state):
         uri_list = ['mast:HST/product/u24r0102t_c1f.fits',
                     'mast:PS1/product/rings.v3.skycell.1334.061.stk.r.unconv.exp.fits']
         expected = ['s3://stpubdata/hst/public/u24r/u24r0102t/u24r0102t_c1f.fits',
                     's3://stpubdata/panstarrs/ps1/public/rings.v3.skycell/1334/061/rings.v3.skycell.1334.'
                     '061.stk.r.unconv.exp.fits']
-
-        # enable access to public AWS S3 bucket
-        Observations.enable_cloud_dataset()
 
         # list of URI strings as input
         uris = Observations.get_cloud_uris(uri_list)
@@ -1023,14 +1005,7 @@ class TestMast:
         with pytest.warns(NoResultsWarning, match='Failed to retrieve cloud path'):
             Observations.get_cloud_uris(['mast:HST/product/does_not_exist.fits'])
 
-        Observations.disable_cloud_dataset()
-
-    def test_observations_get_cloud_uris_query(self):
-        pytest.importorskip("boto3")
-
-        # enable access to public AWS S3 bucket
-        Observations.enable_cloud_dataset()
-
+    def test_observations_get_cloud_uris_query(self, reset_cloud_state):
         # get uris with other functions
         obs = Observations.query_criteria(target_name=234295610)
         prod = Observations.get_product_list(obs)
@@ -1050,24 +1025,15 @@ class TestMast:
         with pytest.warns(NoResultsWarning):
             Observations.get_cloud_uris(target_name=234295611)
 
-        Observations.disable_cloud_dataset()
-
-    def test_observations_get_cloud_uris_no_duplicates(self, msa_product_table):
-        pytest.importorskip("boto3")
-
+    def test_observations_get_cloud_uris_no_duplicates(self, msa_product_table, reset_cloud_state):
         # Get a product list with 6 duplicate JWST MSA config files
         products = msa_product_table
 
         assert len(products) == 6
 
-        # enable access to public AWS S3 bucket
-        Observations.enable_cloud_dataset(provider='AWS')
-
         # Check that only one URI is returned
         uris = Observations.get_cloud_uris(products)
         assert len(uris) == 1
-
-        Observations.disable_cloud_dataset()
 
     ######################
     # CatalogClass tests #


### PR DESCRIPTION
## Current Behavior
- Access to cloud dataset is not enabled by default.
- Users have to explicitly run the `enable_cloud_dataset`  function before they use any cloud-related functions.

## Proposed Behavior
- The cloud dataset is enabled by default, so users do not have to explicitly call `enable_cloud_dataset`.
- To disable the cloud dataset, users can alter a config value or call the `disable_cloud_dataset` function.

## Advantages
- Faster downloads (in some cases)
- Removes a hidden step that users may not even know is available to them.
- More in line with the direction that MAST is heading re. Roman and other large datasets
- More convenient for users in cloud platforms
- Fewer download failures
- Reduce operational load on MAST servers

## What Changes for Users?
- No longer have to call `enable_cloud_dataset` explicitly
- Cloud downloads will be preferred automatically.
- Files in the cloud will be pulled from there instead of MAST servers.
- This is just default behavior and can be changed.
- Cloud dataset will NOT be enabled if the user does not have the prerequisite packages (`boto3`, `botocore`)
- Users can change whether the cloud dataset is automatically enabled with a configuration variable 

## Other Things to Note
- Cloud access is instantiated lazily only when a relevant method is called (`download_file`, `download_products`, `get_cloud_uri(s)`)
- Fixes a bug introduced in #3488 where `botocore`, an optional package, is imported without a guard. Now, both `boto3` and `botocore` are imported with try blocks and `ImportError` is properly handled.
- `Observations` internally keeps track of whether the cloud dataset is explicitly enabled or disabled. If not explicitly enabled by the user (they call `enable_cloud_dataset`), warning messages are not logged when a product cannot be found in the cloud and the download falls back to on-prem. This is to avoid clogging up the console and introducing warning messages where there were none before.

Close #3546