### PR TITLE
Minor update to include "E" for float conversion in get_headers

### DIFF
--- a/astroquery/eso/core.py
+++ b/astroquery/eso/core.py
@@ -727,7 +727,7 @@ class EsoClass(QueryWithLogin):
                         # Convert to string, removing quotation marks
                         elif value[0] == "'":
                             value = value[1:-1]
-                        elif "." in value:  # Convert to float
+                        elif "." in value or "E" in value:  # Convert to float
                             value = float(value)
                         else:  # Convert to integer
                             value = int(value)


### PR DESCRIPTION
Very minor update to allow conversion of string to floats which include "E" in get_headers() . 

That is to avoid error:

`invalid literal for int() with base 10: '5E-05'`