### PR TITLE
Esa gaia issue1325 cone search and query object

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -57,6 +57,7 @@ gaia
 
 - New datalink DR4 retrieval type RESIDUAL_IMAGE. [#3489]
 - The method ``load_data`` parses ecsv files [#3500].
+- Fixed decimal precision for query_object and cone_search to use 14 decimal places [#3539].
 
 esa.hubble
 ^^^^^^^^^^

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -58,6 +58,8 @@ gaia
 - New datalink DR4 retrieval type RESIDUAL_IMAGE. [#3489]
 - The method ``load_data`` parses ecsv files [#3500].
 - Fixed decimal precision for query_object and cone_search to use 14 decimal places [#3539].
+- Added ``get_query_payload`` kwarg to return the ADQL query string. [#3539]
+
 
 esa.hubble
 ^^^^^^^^^^

--- a/astroquery/gaia/core.py
+++ b/astroquery/gaia/core.py
@@ -518,7 +518,7 @@ class GaiaClass(TapPlus):
                       {row_limit}
                       DISTANCE(
                         POINT('ICRS', {ra_column}, {dec_column}),
-                        POINT('ICRS', {ra}, {dec})
+                        POINT('ICRS', {ra:.14f}, {dec:.14f})
                       ) as dist,
                       {columns}
                     FROM
@@ -528,10 +528,10 @@ class GaiaClass(TapPlus):
                         POINT('ICRS', {ra_column}, {dec_column}),
                         BOX(
                           'ICRS',
-                          {ra},
-                          {dec},
-                          {width},
-                          {height}
+                          {ra:.14f},
+                          {dec:.14f},
+                          {width:.14f},
+                          {height:.14f}
                         )
                       )
                     ORDER BY
@@ -664,14 +664,14 @@ class GaiaClass(TapPlus):
                   {columns},
                   DISTANCE(
                     POINT('ICRS', {ra_column}, {dec_column}),
-                    POINT('ICRS', {ra}, {dec})
+                    POINT('ICRS', {ra:.14f}, {dec:.14f})
                   ) AS dist
                 FROM
                   {table_name}
                 WHERE
                   1 = CONTAINS(
                     POINT('ICRS', {ra_column}, {dec_column}),
-                    CIRCLE('ICRS', {ra}, {dec}, {radius})
+                    CIRCLE('ICRS', {ra:.14f}, {dec:.14f}, {radius:.14f})
                   )
                 ORDER BY
                   dist ASC

--- a/astroquery/gaia/core.py
+++ b/astroquery/gaia/core.py
@@ -470,7 +470,7 @@ class GaiaClass(TapPlus):
         return self.__gaiadata.get_datalinks(ids=ids, linking_parameter=final_linking_parameter, verbose=verbose)
 
     def __query_object(self, coordinate, *, radius=None, width=None, height=None,
-                       async_job=False, verbose=False, columns=()):
+                       async_job=False, verbose=False, columns=(), get_query_payload=False):
         """Launches a job
         TAP & TAP+
 
@@ -491,6 +491,9 @@ class GaiaClass(TapPlus):
             flag to display information about the process
         columns: list, optional, default ()
             if empty, all columns will be selected
+        get_query_payload : bool, optional
+            If True, return the SQL query string that would be sent to the server,
+            instead of executing the query. This is useful for debugging and testing.
 
         Returns
         -------
@@ -541,13 +544,18 @@ class GaiaClass(TapPlus):
                                   'columns': columns, 'table_name': self.MAIN_GAIA_TABLE or conf.MAIN_GAIA_TABLE,
                                   'ra': ra, 'dec': dec,
                                   'width': widthDeg.value, 'height': heightDeg.value})
+
+            if get_query_payload:
+                return query
+
             if async_job:
                 job = self.launch_job_async(query, verbose=verbose)
             else:
                 job = self.launch_job(query, verbose=verbose)
         return job.get_results()
 
-    def query_object(self, coordinate, *, radius=None, width=None, height=None, verbose=False, columns=()):
+    def query_object(self, coordinate, *, radius=None, width=None, height=None, verbose=False, columns=(),
+                     get_query_payload=False):
         """Launches a synchronous cone search for the input search radius or the box on the sky, sorted by angular
         separation
         TAP & TAP+
@@ -566,13 +574,16 @@ class GaiaClass(TapPlus):
             flag to display information about the process
         columns: list, optional, default ()
             if empty, all columns will be selected
+        get_query_payload : bool, optional
+            If True, return the SQL query string that would be sent to the server,
+            instead of executing the query. This is useful for debugging and testing.
 
         Returns
         -------
         The job results (astropy.table).
         """
         return self.__query_object(coordinate, radius=radius, width=width, height=height, async_job=False,
-                                   verbose=verbose, columns=columns)
+                                   verbose=verbose, columns=columns, get_query_payload=get_query_payload)
 
     def query_object_async(self, coordinate, *, radius=None, width=None, height=None, verbose=False, columns=()):
         """Launches an asynchronous cone search for the input search radius or the box on the sky, sorted by angular
@@ -608,7 +619,8 @@ class GaiaClass(TapPlus):
                       background=False,
                       output_file=None, output_format="votable_gzip", verbose=False,
                       dump_to_file=False,
-                      columns=()):
+                      columns=(),
+                      get_query_payload=False):
         """Cone search sorted by distance
         TAP & TAP+
 
@@ -641,6 +653,9 @@ class GaiaClass(TapPlus):
             if True, the results are saved in a file instead of using memory
         columns: list, optional, default ()
             if empty, all columns will be selected
+        get_query_payload : bool, optional
+            If True, return the SQL query string that would be sent to the server,
+            instead of executing it. This is useful for debugging and testing.
 
         Returns
         -------
@@ -681,6 +696,9 @@ class GaiaClass(TapPlus):
                               'radius': radiusDeg,
                               'table_name': table_name or self.MAIN_GAIA_TABLE or conf.MAIN_GAIA_TABLE})
 
+        if get_query_payload:
+            return query
+
         if async_job:
             return self.launch_job_async(query=query, output_file=output_file, output_format=output_format,
                                          verbose=verbose, dump_to_file=dump_to_file, background=background)
@@ -695,7 +713,8 @@ class GaiaClass(TapPlus):
                     output_file=None,
                     output_format="votable_gzip", verbose=False,
                     dump_to_file=False,
-                    columns=()):
+                    columns=(),
+                    get_query_payload=False):
         """Cone search sorted by distance (sync.)
         TAP & TAP+
 
@@ -722,6 +741,9 @@ class GaiaClass(TapPlus):
             if True, the results are saved in a file instead of using memory
         columns: list, optional, default ()
             if empty, all columns will be selected
+        get_query_payload : bool, optional
+            If True, return the SQL query string that would be sent to the server,
+            instead of executing the query. This is useful for debugging and testing.
 
         Returns
         -------
@@ -737,7 +759,8 @@ class GaiaClass(TapPlus):
                                   output_file=output_file,
                                   output_format=output_format,
                                   verbose=verbose,
-                                  dump_to_file=dump_to_file, columns=columns)
+                                  dump_to_file=dump_to_file, columns=columns,
+                                  get_query_payload=get_query_payload)
 
     def cone_search_async(self, coordinate, *, radius=None,
                           table_name=None,

--- a/astroquery/gaia/core.py
+++ b/astroquery/gaia/core.py
@@ -492,7 +492,7 @@ class GaiaClass(TapPlus):
         columns: list, optional, default ()
             if empty, all columns will be selected
         get_query_payload : bool, optional
-            If True, return the SQL query string that would be sent to the server,
+            If True, return the ADQL query string that would be sent to the server,
             instead of executing the query. This is useful for debugging and testing.
 
         Returns
@@ -575,7 +575,7 @@ class GaiaClass(TapPlus):
         columns: list, optional, default ()
             if empty, all columns will be selected
         get_query_payload : bool, optional
-            If True, return the SQL query string that would be sent to the server,
+            If True, return the ADQL query string that would be sent to the server,
             instead of executing the query. This is useful for debugging and testing.
 
         Returns
@@ -654,7 +654,7 @@ class GaiaClass(TapPlus):
         columns: list, optional, default ()
             if empty, all columns will be selected
         get_query_payload : bool, optional
-            If True, return the SQL query string that would be sent to the server,
+            If True, return the ADQL query string that would be sent to the server,
             instead of executing it. This is useful for debugging and testing.
 
         Returns
@@ -742,7 +742,7 @@ class GaiaClass(TapPlus):
         columns: list, optional, default ()
             if empty, all columns will be selected
         get_query_payload : bool, optional
-            If True, return the SQL query string that would be sent to the server,
+            If True, return the ADQL query string that would be sent to the server,
             instead of executing the query. This is useful for debugging and testing.
 
         Returns

--- a/astroquery/gaia/tests/test_gaiatap.py
+++ b/astroquery/gaia/tests/test_gaiatap.py
@@ -517,6 +517,7 @@ def test_query_object_async(column_attrs, mock_querier_async, kwargs):
     for colname, attrs in column_attrs.items():
         assert table[colname].attrs_equal(attrs)
 
+
 def test_query_object_precision_debug(monkeypatch, mock_querier):
     captured_query = {}
 
@@ -527,8 +528,10 @@ def test_query_object_precision_debug(monkeypatch, mock_querier):
         class FakeJob:
             async_ = False
             failed = False
+
             def get_phase(self):
                 return "COMPLETED"
+
             def get_results(self):
                 return Table({"x": [1]})
         return FakeJob()
@@ -566,6 +569,7 @@ def test_query_object_precision_debug(monkeypatch, mock_querier):
         f"found {len(matches)}. Query:\n{query}"
     )
 
+
 def test_cone_search_precision_debug(monkeypatch, mock_querier):
     """
     Test that cone_search() builds a query containing RA, DEC and radius
@@ -583,8 +587,10 @@ def test_cone_search_precision_debug(monkeypatch, mock_querier):
         class FakeJob:
             async_ = False
             failed = False
+
             def get_phase(self):
                 return "COMPLETED"
+
             def get_results(self):
                 return Table({"x": [1]})
         return FakeJob()
@@ -621,6 +627,7 @@ def test_cone_search_precision_debug(monkeypatch, mock_querier):
         f"Expected 5 float values with 14 decimals, "
         f"but found {len(matches)}. Query:\n{query}"
     )
+
 
 def test_cone_search_sync(column_attrs, mock_querier):
     assert mock_querier.USE_NAMES_OVER_IDS is True
@@ -1713,4 +1720,3 @@ def test_logout(mock_logout):
     mock_logout.side_effect = HTTPError("Login error")
     tap.logout()
     assert (mock_logout.call_count == 3)
-

--- a/astroquery/gaia/tests/test_gaiatap.py
+++ b/astroquery/gaia/tests/test_gaiatap.py
@@ -518,114 +518,49 @@ def test_query_object_async(column_attrs, mock_querier_async, kwargs):
         assert table[colname].attrs_equal(attrs)
 
 
-def test_query_object_precision_debug(monkeypatch, mock_querier):
-    captured_query = {}
-
-    # Intercept call to launch_job so we can capture the generated query
-    def fake_launch_job(self, query, verbose=False):
-        captured_query["query"] = query
-
-        class FakeJob:
-            async_ = False
-            failed = False
-
-            def get_phase(self):
-                return "COMPLETED"
-
-            def get_results(self):
-                return Table({"x": [1]})
-        return FakeJob()
-
-    monkeypatch.setattr(GaiaClass, "launch_job", fake_launch_job)
-
-    # Use coordinates that produce predictable float values
+def test_query_object_precision(mock_querier):
+    """
+    Verifies that query_object() produces a query where RA, DEC, width and height
+    are formatted with exactly 14 decimal places when using get_query_payload=True.
+    """
     coord = SkyCoord(ra=19 * u.deg, dec=20 * u.deg)
     width = 12 * u.deg
     height = 10 * u.deg
 
-    # Execute the query
-    mock_querier.query_object(coord, width=width, height=height)
+    query = mock_querier.query_object(
+        coord,
+        width=width,
+        height=height,
+        get_query_payload=True
+    )
 
-    query = captured_query.get("query")
-    assert query is not None
-
-    # Regex to detect floats with exactly 14 decimal digits
     float14 = r"[0-9]+\.[0-9]{14}"
     matches = re.findall(float14, query)
 
-    # -----------------------------
-    # Debug: print out everything
-    # -----------------------------
-    print("\n==== DEBUG: Generated query ====")
-    print(query)
-    print("==== DEBUG: Detected 14-decimal floats ====")
-    for m in matches:
-        print(m)
-    print("================================\n")
-
-    # At least RA, DEC, width and height should be formatted with 14 decimals
     assert len(matches) == 6, (
-        f"Expected 6 float values with 14 decimals, "
-        f"found {len(matches)}. Query:\n{query}"
+        f"Expected 6 float values with 14 decimals, found {len(matches)}.\n{query}"
     )
 
 
-def test_cone_search_precision_debug(monkeypatch, mock_querier):
+def test_cone_search_precision(mock_querier):
     """
-    Test that cone_search() builds a query containing RA, DEC and radius
-    formatted with 14 decimal places. This test also prints the captured
-    numbers for debugging purposes.
+    Verifies that cone_search() produces a query where RA, DEC and radius
+    appear formatted with exactly 14 decimal places when using get_query_payload=True.
     """
+    coord = SkyCoord(ra=19*u.deg, dec=20*u.deg)
+    radius = 1*u.deg
 
-    captured_query = {}
+    query = mock_querier.cone_search(
+        coord,
+        radius=radius,
+        get_query_payload=True,
+    )
 
-    # Intercept launch_job to capture the generated SQL query
-    def fake_launch_job(self, query, output_file=None, output_format="votable_gzip",
-                        verbose=False, dump_to_file=False):
-        captured_query["query"] = query
-
-        class FakeJob:
-            async_ = False
-            failed = False
-
-            def get_phase(self):
-                return "COMPLETED"
-
-            def get_results(self):
-                return Table({"x": [1]})
-        return FakeJob()
-
-    monkeypatch.setattr(GaiaClass, "launch_job", fake_launch_job)
-
-    # Coordinates chosen to generate predictable floats
-    coord = SkyCoord(ra=19 * u.deg, dec=20 * u.deg)
-    radius = 1 * u.deg
-
-    # Run the cone search
-    job = mock_querier.cone_search(coord, radius=radius)
-    job.get_results()
-
-    query = captured_query.get("query")
-    assert query is not None
-
-    # Regex to detect floats with exactly 14 decimal digits
     float14 = r"[0-9]+\.[0-9]{14}"
     matches = re.findall(float14, query)
 
-    # -----------------------------
-    # Debug: output for inspection
-    # -----------------------------
-    print("\n==== DEBUG: Generated cone-search query ====")
-    print(query)
-    print("==== DEBUG: Detected 14-decimal floats ====")
-    for m in matches:
-        print(m)
-    print("============================================\n")
-
-    # We expect at least RA, DEC and radius in .14f format
     assert len(matches) == 5, (
-        f"Expected 5 float values with 14 decimals, "
-        f"but found {len(matches)}. Query:\n{query}"
+        f"Expected 5 float values with 14 decimals, found {len(matches)}.\n{query}"
     )
 
 


### PR DESCRIPTION
Hi, this is my first contribution to this repository. My name is Enrique Ruiz, and I work at Starion for ESA (SCO-08), at ESAC, mainly involved in development and maintenance of the Survey Data Archives.

This PR updates the Gaia package to enforce .14f formatting for RA/DEC/radius in cone_search and query_object, ensuring consistent ADQL queries across Python versions.

CC: @esdc-esac-esa-int
Jira: GAIAPCR-1325