### PR TITLE
Allow multiple search positions in MastMissions

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -98,6 +98,10 @@ mast
 - Added a new ``Observations.list_cloud_datasets()`` method for querying cloud-supported MAST datasets, alongside 
   improvements to cloud download handling. [#3488]
 
+- ``MastMissions`` query functions now support single or multiple targets via ``coordinates`` and
+  ``object_names`` (including combined use in ``query_criteria``). The legacy ``objectname`` keyword
+  is deprecated in favor of ``object_names``. [#3540]
+
 jplspec
 ^^^^^^^
 

--- a/astroquery/mast/missions.py
+++ b/astroquery/mast/missions.py
@@ -333,7 +333,7 @@ class MastMissionsClass(MastQueryWithLogin):
 
     @class_or_instance
     @deprecated_renamed_argument('objectname', 'object_names', since='0.4.11')
-    def query_criteria_async(self, *, coordinates=None, object_names=None, objectname=None, radius=3*u.arcmin,
+    def query_criteria_async(self, *, coordinates=None, object_names=None, radius=3*u.arcmin,
                              limit=5000, offset=0, select_cols=None, resolver=None, **criteria):
         """
         Given a set of search criteria, returns a list of mission metadata.
@@ -350,9 +350,7 @@ class MastMissionsClass(MastQueryWithLogin):
             - A single object name string
             - A comma-separated string of object names (e.g., "M31, M51, NGC 1234")
             - An iterable of object name strings
-            If both `coordinates` and `object_names` are provided, they are combined.
-        objectname : str, deprecated
-            Deprecated alias for `object_names`.
+            If both ``coordinates`` and ``object_names`` are provided, they are combined.
         radius : str or `~astropy.units.Quantity` object
             Default is 3 arcminutes. The radius around the coordinates to search within.
             The string must be parsable by `~astropy.coordinates.Angle`. The
@@ -476,7 +474,7 @@ class MastMissionsClass(MastQueryWithLogin):
 
     @class_or_instance
     @deprecated_renamed_argument('objectname', 'object_names', since='0.4.11')
-    def query_object_async(self, object_names, *, objectname=None, radius=3*u.arcmin, limit=5000, offset=0,
+    def query_object_async(self, object_names, *, radius=3*u.arcmin, limit=5000, offset=0,
                            select_cols=None, resolver=None, **criteria):
         """
         Given an object name (or names), returns a list of matching rows.
@@ -488,9 +486,7 @@ class MastMissionsClass(MastQueryWithLogin):
             - A single object name string
             - A comma-separated string of object names (e.g., "M31, M51, NGC 1234")
             - An iterable of object name strings
-            If both `coordinates` and `object_names` are provided, they are combined.
-        objectname : str, deprecated
-            Deprecated alias for `object_names`.
+            If both ``coordinates`` and ``object_names`` are provided, they are combined.
         radius : str or `~astropy.units.Quantity` object, optional
             Default is 3 arcminutes. The radius around the coordinates to search within.
             The string must be parsable by `~astropy.coordinates.Angle`. The

--- a/astroquery/mast/missions.py
+++ b/astroquery/mast/missions.py
@@ -277,7 +277,8 @@ class MastMissionsClass(MastQueryWithLogin):
         ----------
         coordinates : str, iterable of str, or `~astropy.coordinates` object, optional
             Coordinate target(s). Can be a single coordinate string/object, a comma-separated
-            coordinate string, or an iterable of coordinate strings/objects.
+            coordinate string, an iterable of coordinate strings/objects, or a vector
+            `~astropy.coordinates.SkyCoord`.
         object_names : str or iterable of str, optional
             Object-name target(s). Can be a single object name string, a comma-separated
             object-name string, or an iterable of object-name strings.
@@ -319,7 +320,12 @@ class MastMissionsClass(MastQueryWithLogin):
         # Parse coordinate targets
         for coord in coordinate_items:
             sc = commons.parse_coordinates(coord, return_frame='icrs')
-            targets.append(f"{sc.ra.deg} {sc.dec.deg}")
+            # If input is a vector SkyCoord, iterate through each coordinate
+            if isinstance(sc, SkyCoord) and sc.isscalar is False:
+                for ra, dec in zip(sc.ra.deg, sc.dec.deg):
+                    targets.append(f"{ra} {dec}")
+            else:
+                targets.append(f"{sc.ra.deg} {sc.dec.deg}")
 
         # Parse object name targets
         if object_names:

--- a/astroquery/mast/tests/test_mast.py
+++ b/astroquery/mast/tests/test_mast.py
@@ -363,6 +363,11 @@ def test_missions_parse_multiple_targets(patch_post):
     result = MastMissions._parse_multiple_targets(coordinates=coords_str)
     assert result == ['10.684 41.269', '83.6331 22.0145']
 
+    # Vector SkyCoord input
+    vector_coords = SkyCoord([10.684, 83.6324], [41.269, 22.0174], frame='icrs', unit='deg')
+    result = MastMissions._parse_multiple_targets(coordinates=vector_coords)
+    assert result == ['10.684 41.269', '83.6324 22.0174']
+
     # Single object name
     result = MastMissions._parse_multiple_targets(object_names="M101")
     assert result == ['210.802429 54.34875']

--- a/astroquery/mast/tests/test_mast_remote.py
+++ b/astroquery/mast/tests/test_mast_remote.py
@@ -151,7 +151,7 @@ class TestMast:
         assert (result['sci_aec'] == 'S').all()
 
         # Positional criteria search
-        result = MastMissions.query_criteria(objectname='NGC6121',
+        result = MastMissions.query_criteria(object_names='NGC6121',
                                              radius=0.1,
                                              sci_start_time='<2012',
                                              sci_actual_duration='0..200',
@@ -162,10 +162,12 @@ class TestMast:
         assert (result['sci_start_time'] < '2012').all()
         assert ((result['sci_actual_duration'] >= 0) & (result['sci_actual_duration'] <= 200)).all()
 
-        # Raise error if a non-positional criterion is not supplied
-        with pytest.raises(InvalidQueryError):
-            MastMissions.query_criteria(coordinates="245.89675 -26.52575",
-                                        radius=1)
+        # Search with multiple positional inputs
+        coord = SkyCoord(245.89675, -26.52575, unit='deg')
+        result = MastMissions.query_criteria(coordinates=[coord, "205.54842 28.37728"],
+                                             object_names=["M2", "M9"],
+                                             radius=0.1)
+        assert len(set(result['search_pos'])) == 4  # Should have four different search positions
 
         # Raise error if invalid input is given
         with pytest.raises(InvalidQueryError):

--- a/astroquery/utils/commons.py
+++ b/astroquery/utils/commons.py
@@ -40,7 +40,7 @@ ASTROPY_LT_6_0 = not minversion('astropy', '6.0')
 ASTROPY_LT_7_1_1 = not minversion('astropy', '7.1.1')
 
 
-def parse_coordinates(coordinates, *, return_frame=None):
+def parse_coordinates(coordinates, *, return_frame=None, resolve_names=True):
     """
     Takes a string or astropy.coordinates object. Checks if the
     string is parsable as an `astropy.coordinates`
@@ -55,6 +55,9 @@ def parse_coordinates(coordinates, *, return_frame=None):
         The frame to return the coordinates in. If None and ``coordinates`` is
         a string, the frame will be ICRS. If ``coordinates`` is an `astropy.coordinates` object, the
         frame will be the same as the input object.
+    resolve_names : bool
+        If `coordinates` is a string, whether to attempt to resolve it as an astronomical object name if
+        it cannot be parsed as a coordinate string. Default is `True`.
 
     Returns
     -------
@@ -85,8 +88,14 @@ def parse_coordinates(coordinates, *, return_frame=None):
                                   "ICRS coordinate provided in degrees.", InputWarning)
 
                 except ValueError:
+                    if not resolve_names:
+                        raise ValueError(f"Could not parse coordinate string '{coordinates}' "
+                                         "and name resolution is disabled.")
                     c = SkyCoord.from_name(coordinates, frame="icrs")
             else:
+                if not resolve_names:
+                    raise ValueError(f"Could not parse coordinate string '{coordinates}' "
+                                     "and name resolution is disabled.")
                 c = SkyCoord.from_name(coordinates, frame="icrs")
 
     elif isinstance(coordinates, CoordClasses):

--- a/astroquery/utils/commons.py
+++ b/astroquery/utils/commons.py
@@ -40,7 +40,7 @@ ASTROPY_LT_6_0 = not minversion('astropy', '6.0')
 ASTROPY_LT_7_1_1 = not minversion('astropy', '7.1.1')
 
 
-def parse_coordinates(coordinates, *, return_frame=None, resolve_names=True):
+def parse_coordinates(coordinates, *, return_frame=None):
     """
     Takes a string or astropy.coordinates object. Checks if the
     string is parsable as an `astropy.coordinates`
@@ -55,9 +55,6 @@ def parse_coordinates(coordinates, *, return_frame=None, resolve_names=True):
         The frame to return the coordinates in. If None and ``coordinates`` is
         a string, the frame will be ICRS. If ``coordinates`` is an `astropy.coordinates` object, the
         frame will be the same as the input object.
-    resolve_names : bool
-        If `coordinates` is a string, whether to attempt to resolve it as an astronomical object name if
-        it cannot be parsed as a coordinate string. Default is `True`.
 
     Returns
     -------
@@ -88,14 +85,8 @@ def parse_coordinates(coordinates, *, return_frame=None, resolve_names=True):
                                   "ICRS coordinate provided in degrees.", InputWarning)
 
                 except ValueError:
-                    if not resolve_names:
-                        raise ValueError(f"Could not parse coordinate string '{coordinates}' "
-                                         "and name resolution is disabled.")
                     c = SkyCoord.from_name(coordinates, frame="icrs")
             else:
-                if not resolve_names:
-                    raise ValueError(f"Could not parse coordinate string '{coordinates}' "
-                                     "and name resolution is disabled.")
                 c = SkyCoord.from_name(coordinates, frame="icrs")
 
     elif isinstance(coordinates, CoordClasses):

--- a/docs/mast/mast_missions.rst
+++ b/docs/mast/mast_missions.rst
@@ -45,10 +45,30 @@ To search for JWST metadata, the ``mission`` attribute is reassigned to ``'JWST'
    >>> print(m.mission)
    jwst
 
-The ``missions`` object can be used to search metadata by sky position, object name, or other criteria.
-When writing queries, keyword arguments can be used to specify output characteristics and filter on 
-values like instrument, exposure type, and principal investigator. The available column names for a 
-mission are returned by the `~astroquery.mast.MastMissionsClass.get_column_list` function.
+
+Querying Missions
+==================
+
+The MastMissions interface provides three closely related query methods. All three methods return results as an `~astropy.table.Table` 
+and all three support column-based filtering, sorting, and result limiting. The primary difference between them is how positional 
+constraints are specified.
+
+At a high level:
+  - `~astroquery.mast.MastMissionsClass.query_criteria` is the most flexible method. It supports purely column-based queries, 
+    purely positional queries, or a combination of both.
+
+  - `~astroquery.mast.MastMissionsClass.query_region` is a convenience wrapper for positional queries using coordinates.
+
+  - `~astroquery.mast.MastMissionsClass.query_object` is a convenience wrapper for positional queries using object names.
+
+Query Parameters
+----------------
+
+The ``missions`` object can be used to search mission metadata by sky position,
+object name, or other criteria. Keyword arguments may be used to specify output
+characteristics and filter on values such as instrument, exposure type, and
+principal investigator. The available column names for a mission can be retrieved
+using the `~astroquery.mast.MastMissionsClass.get_column_list` method.
 
 .. doctest-remote-data::
 
@@ -63,116 +83,90 @@ Keyword arguments can also be used to refine results further. The following para
 
 - ``limit``: The maximum number of results to return. Default is 5000.
 
-- ``offset``: Skip the first ***n*** results. Useful for paging through results.
+- ``offset``: Skip the first *n* results. Useful for paging through results.
 
 - ``sort_by``: A string or list of field names to sort by.
 
-- ``sort_desc``: A boolean or list of booleans (one for each field specified in ``sort_by``),
-  describing if each field should be sorted in descending order (``True``) or ascending order (``False``).
+- ``sort_desc``: A boolean or list of booleans (one for each field specified in
+  ``sort_by``) indicating whether each field should be sorted in descending
+  (``True``) or ascending (``False``) order.
 
 - ``select_cols``: Columns to include in the result table. If not specified, a default set of columns
   is returned. This parameter may be given as an iterable of column names, a comma-separated string, or the special
   values ``'all'`` or ``'*'`` to return all available columns.
 
+Writing Queries
+----------------
 
-Mission Positional Queries
-===========================
+The `~astroquery.mast.MastMissionsClass.query_criteria` method supports both positional parameters and column-based filters.
+Positional constraints are optional. 
 
-Metadata queries can be performed on a particular region in the sky. Passing in a set of coordinates to the 
-`~astroquery.mast.MastMissionsClass.query_region` function returns datasets that fall within a
-certain radius value of that point. This type of search is also known as a cone search.
+Supported positional parameters include:
+
+  - ``coordinates`` : Sky coordinates around which to perform a cone search.
+  - ``objectname`` : Name(s) of the object(s) around which to perform a cone search.
+  - ``resolver`` : Resolver service to use for object name resolution.
+  - ``radius`` : Radius of the cone searches around the specified coordinates or object names. Can be defined as an `~astropy.units.Quantity`, 
+    a string with units (e.g., ``"10 arcsec"``), or a numeric value interpreted as degrees.
+
+Multiple coordinates or objects may be queried in a single request. The ``coordinates`` and ``object_names`` parameters 
+accept a single value, an iterable of values, or a comma-separated string. When multiple values are provided for either parameter,
+results matching *any* of the supplied positions are returned.
 
 .. doctest-remote-data::
 
-   >>> from astroquery.mast import MastMissions
    >>> from astropy.coordinates import SkyCoord
-   >>> missions = MastMissions(mission='hst')
-   >>> regionCoords = SkyCoord(210.80227, 54.34895, unit=('deg', 'deg'))
-   >>> results = missions.query_region(regionCoords, 
-   ...                                 radius=3,
-   ...                                 sci_pep_id=12556,
-   ...                                 select_cols=["sci_stop_time", "sci_targname", "sci_start_time", "sci_status"],
-   ...                                 sort_by='sci_targname')
-   >>> results[:5]   # doctest: +IGNORE_OUTPUT
-   <Table masked=True length=5>
-    search_pos     sci_data_set_name   sci_targname         sci_start_time             sci_stop_time              ang_sep        sci_status
-   ------------------ ----------------- ---------------- -------------------------- -------------------------- -------------------- ----------
-   210.80227 54.34895         OBQU01050 NUCLEUS+HODGE602 2012-05-24T07:51:40.553000 2012-05-24T07:54:46.553000 0.017460048037303017     PUBLIC
-   210.80227 54.34895         OBQU010H0 NUCLEUS+HODGE602 2012-05-24T09:17:38.570000 2012-05-24T09:20:44.570000 0.017460048037303017     PUBLIC
-   210.80227 54.34895         OBQU01030 NUCLEUS+HODGE602 2012-05-24T07:43:20.553000 2012-05-24T07:46:26.553000 0.022143836477276503     PUBLIC
-   210.80227 54.34895         OBQU010F0 NUCLEUS+HODGE602 2012-05-24T09:09:18.570000 2012-05-24T09:12:24.570000 0.022143836477276503     PUBLIC
-   210.80227 54.34895         OBQU01070 NUCLEUS+HODGE602 2012-05-24T08:00:00.553000 2012-05-24T08:03:06.553000  0.04381046755938432     PUBLIC
+   >>> select_cols = ["sci_targname", "sci_pep_id", "sci_status"]
+   >>> results = missions.query_criteria(coordinates=[SkyCoord(245.89675, -26.52575, unit='deg'), "205.54842 28.37728"], 
+   ...                                   object_names=["M2", "M9"],
+   ...                                   radius=0.1,
+   ...                                   select_cols=select_cols,
+   ...                                   sort_by='search_pos')
+   >>> results.pprint(max_width=-1)  +IGNORE_OUTPUT
+        search_pos     sci_data_set_name  sci_targname sci_pep_id       ang_sep        sci_status
+   ------------------- ----------------- ------------- ---------- -------------------- ----------
+   205.54842 28.37728          O5GX13010 NGC5272-BSSV6       8226  0.09983625899279894     PUBLIC
+   205.54842 28.37728          O5GX13020 NGC5272-BSSV6       8226  0.09983625899279894     PUBLIC
+   205.54842 28.37728          O5GX13030 NGC5272-BSSV6       8226  0.09983625899279894     PUBLIC
+   245.89675 -26.52575         W0FX0301T       NGC6121       3111  0.04464557414882169     PUBLIC
+   245.89675 -26.52575         W0FX0302T       NGC6121       3111  0.04464557414882169     PUBLIC
+   245.89675 -26.52575         OC4U5RFMQ          DARK      13131  0.06347519519464637     PUBLIC
+   245.89675 -26.52575         JC5GE5011          BIAS      13154  0.06347519583709554     PUBLIC
+   245.89675 -26.52575         IBKH03020       NGC6121      12193   0.0687421385505865     PUBLIC
+   245.89675 -26.52575         IBKH03030       NGC6121      12193   0.0687421385505865     PUBLIC
+   245.89675 -26.52575         IBKH03040       NGC6121      12193   0.0687421385505865     PUBLIC
+   259.79908 -18.51625         J9D613011   MESSIER-009      10573 0.009682839438074332     PUBLIC
+   259.79908 -18.51625         J9D613I1Q   MESSIER-009      10573 0.009682839438074332     PUBLIC
+   259.79908 -18.51625         J9D613I3Q   MESSIER-009      10573 0.009682839438074332     PUBLIC
+   323.36258 -0.82325          ICAU46020  NGC-7089-M-2      13297  0.07051422608168086     PUBLIC
+   323.36258 -0.82325          ICAU45020  NGC-7089-M-2      13297  0.07087801874163793     PUBLIC
 
 You may notice that the above query returned more columns than were specified in the ``select_cols``
 argument. For each mission, certain columns are automatically returned.
 
-- *HST*: For positional searches, the columns ``sci_data_set_name``, ``search_pos``, and ``ang_sep``
-  are always included in the query results. For non-positional searches, ``sci_data_set_name`` is always 
-  present.
+To filter results based on column values, users may specify criteria as keyword arguments,
+where the keyword is the column name and the value is the desired filter. Multiple criteria are combined
+using logical **AND**.
 
-- *JWST*: For every query, the ``ArchiveFileID`` column is always returned.
+Criteria syntax supports several operations:
 
-- *CLASSY*: For positional searches, the columns ``search_pos``, ``Target``, and ``ang_sep`` are always included.
-  For non-positional searches, ``Target`` is always returned.
+- Exact matches by specifying a single value for a column (e.g., ``sci_instrume='ACS'``).
 
-- *ULLYSES*: For positional searches, the columns ``search_pos``, ``target_id``, ``names_search``, ``target_name_hlsp``,
-  ``simbad_link``, ``ang_sep``, and ``plot_preview`` are always included. For non-positional searches, ``target_id``, 
-  ``target_name_hlsp``, ``simbad_link``, and ``observation_id`` are always returned.
+- To filter by multiple values for a single column, provide a list of values or a comma-separated string.
+  This performs an **OR** operation between the values.
 
-Searches can also be run on target names with the `~astroquery.mast.MastMissionsClass.query_object` 
-function.
+- A filter value can be negated by prefixing it with ``!``, excluding rows that
+  match that value. When negated values appear in a list, positive values are
+  combined using **OR**, while negated values are applied using **AND** logic.
 
-.. doctest-remote-data::
-
-   >>> results = missions.query_object('M101', 
-   ...                                 radius=3, 
-   ...                                 select_cols=["sci_stop_time", "sci_targname", "sci_start_time", "sci_status"],
-   ...                                 sort_by='sci_targname')
-   >>> results[:5]  # doctest: +IGNORE_OUTPUT
-   <Table masked=True length=5>
-    search_pos     sci_data_set_name sci_targname       sci_start_time             sci_stop_time             ang_sep       sci_status
-   ------------------ ----------------- ------------ -------------------------- -------------------------- ------------------ ----------
-   210.80243 54.34875         LDJI01010   +164.6+9.9 2019-02-19T00:49:58.010000 2019-02-19T05:52:40.020000 2.7469653000840397     PUBLIC
-   210.80243 54.34875         J8OB02011          ANY 2003-08-27T07:44:47.417000 2003-08-27T08:27:34.513000 0.8111299061221189     PUBLIC
-   210.80243 54.34875         J8D711J1Q          ANY 2003-01-17T00:42:06.993000 2003-01-17T00:50:22.250000 1.1297984178946574     PUBLIC
-   210.80243 54.34875         JD6V01012          ANY 2017-06-15T18:10:12.037000 2017-06-15T18:33:25.983000 1.1541053362381077     PUBLIC
-   210.80243 54.34875         JD6V01013          ANY 2017-06-15T19:45:30.023000 2017-06-15T20:08:44.063000   1.15442580192948     PUBLIC
-
-
-Mission Criteria Queries
-=========================
-
-For non-positional metadata queries, use the `~astroquery.mast.MastMissionsClass.query_criteria` 
-function.
-
-.. doctest-remote-data::
-
-   >>> results = missions.query_criteria(sci_start_time=">=2021-01-01 00:00:00",
-   ...                                   select_cols=["sci_stop_time", "sci_targname", "sci_start_time", "sci_status", "sci_pep_id"],
-   ...                                   sort_by='sci_pep_id',
-   ...                                   limit=1000,
-   ...                                   offset=1000)  # doctest: +IGNORE_WARNINGS
-   ... # MaxResultsWarning('Maximum results returned, may not include all sources within radius.')
-   >>> len(results)
-   1000
-
-Here are some tips and tricks for writing more advanced queries:
-
-- To exclude and filter out a certain value from the results, prepend the value with ``!``.
-
-- To filter by multiple values for a single column, use a list of values or a string of values delimited by commas.
-
-- For columns with numeric or date data types, filter using comparison values (``<``, ``>``, ``<=``, ``>=``).
+- For numeric or data columns, filter using comparison values (``<``, ``>``, ``<=``, ``>=``).
 
   - ``<``: Return values less than or before the given number/date
-
   - ``>``: Return values greater than or after the given number/date
-
   - ``<=``: Return values less than or equal to the given number/date
-
   - ``>=``: Return values greater than or equal to the given number/date
 
-- For columns with numeric or date data types, select a range with the syntax ``'#..#'``.
+- For numeric or date columns, select an inclusive range with the syntax ``'#..#'``.
 
 - Wildcards are special characters used in search patterns to represent one or more unknown characters, 
   allowing for flexible matching of strings. The wildcard character is ``*`` and it replaces any number
@@ -187,7 +181,7 @@ Here are some tips and tricks for writing more advanced queries:
    ...                                   sci_actual_duration="1000..2000",
    ...                                   sci_targname="*GAL*",
    ...                                   select_cols=["sci_obs_type", "sci_spec_1234"])
-   >>> results[:5]  # doctest: +IGNORE_OUTPUT
+   >>> results[:5].pprint(max_width=-1)  # doctest: +IGNORE_OUTPUT
    <Table masked=True length=5>
    sci_data_set_name       sci_targname      sci_spec_1234 sci_obs_type
    ----------------- ----------------------- ------------- ------------
@@ -196,6 +190,51 @@ Here are some tips and tricks for writing more advanced queries:
         N4A704010 GAL-CLUS-0026+1653-ARCA         F110W        IMAGE
         N4A702010 GAL-CLUS-0026+1653-ARCC         F110W        IMAGE
         N4A705010 GAL-CLUS-0026+1653-ARCC         F110W        IMAGE
+
+The `~astroquery.mast.MastMissionsClass.query_region` and `~astroquery.mast.MastMissionsClass.query_object` methods are 
+convenience wrappers around `~astroquery.mast.MastMissionsClass.query_criteria`:
+
+  - `~astroquery.mast.MastMissionsClass.query_region` requires ``coordinates``.
+
+  - `~astroquery.mast.MastMissionsClass.query_object` requires ``object_names`` and an optional ``resolver``.
+
+Both methods also accept column-based criteria, which are applied in the same way as in `~astroquery.mast.MastMissionsClass.query_criteria`.
+
+.. doctest-remote-data::
+
+   >>> regionCoords = SkyCoord(210.80227, 54.34895, unit=('deg', 'deg'))
+   >>> select_cols = ["sci_stop_time", "sci_targname", "sci_start_time", "sci_status"]
+   >>> results = missions.query_region(regionCoords, 
+   ...                                 radius=3,
+   ...                                 sci_pep_id=12556,
+   ...                                 select_cols=select_cols,
+   ...                                 sort_by='sci_targname')
+   >>> results[:5].pprint(max_width=-1)   # doctest: +IGNORE_OUTPUT
+   <Table masked=True length=5>
+    search_pos     sci_data_set_name   sci_targname         sci_start_time             sci_stop_time              ang_sep        sci_status
+   ------------------ ----------------- ---------------- -------------------------- -------------------------- -------------------- ----------
+   210.80227 54.34895         OBQU01050 NUCLEUS+HODGE602 2012-05-24T07:51:40.553000 2012-05-24T07:54:46.553000 0.017460048037303017     PUBLIC
+   210.80227 54.34895         OBQU010H0 NUCLEUS+HODGE602 2012-05-24T09:17:38.570000 2012-05-24T09:20:44.570000 0.017460048037303017     PUBLIC
+   210.80227 54.34895         OBQU01030 NUCLEUS+HODGE602 2012-05-24T07:43:20.553000 2012-05-24T07:46:26.553000 0.022143836477276503     PUBLIC
+   210.80227 54.34895         OBQU010F0 NUCLEUS+HODGE602 2012-05-24T09:09:18.570000 2012-05-24T09:12:24.570000 0.022143836477276503     PUBLIC
+   210.80227 54.34895         OBQU01070 NUCLEUS+HODGE602 2012-05-24T08:00:00.553000 2012-05-24T08:03:06.553000  0.04381046755938432     PUBLIC
+
+.. doctest-remote-data::
+
+   >>> results = missions.query_object('M101', 
+   ...                                 radius=3, 
+   ...                                 select_cols=select_cols,
+   ...                                 sort_by='sci_targname')
+   >>> results[:5]  # doctest: +IGNORE_OUTPUT
+   <Table masked=True length=5>
+    search_pos     sci_data_set_name sci_targname       sci_start_time             sci_stop_time             ang_sep       sci_status
+   ------------------ ----------------- ------------ -------------------------- -------------------------- ------------------ ----------
+   210.80243 54.34875         LDJI01010   +164.6+9.9 2019-02-19T00:49:58.010000 2019-02-19T05:52:40.020000 2.7469653000840397     PUBLIC
+   210.80243 54.34875         J8OB02011          ANY 2003-08-27T07:44:47.417000 2003-08-27T08:27:34.513000 0.8111299061221189     PUBLIC
+   210.80243 54.34875         J8D711J1Q          ANY 2003-01-17T00:42:06.993000 2003-01-17T00:50:22.250000 1.1297984178946574     PUBLIC
+   210.80243 54.34875         JD6V01012          ANY 2017-06-15T18:10:12.037000 2017-06-15T18:33:25.983000 1.1541053362381077     PUBLIC
+   210.80243 54.34875         JD6V01013          ANY 2017-06-15T19:45:30.023000 2017-06-15T20:08:44.063000   1.15442580192948     PUBLIC
+
 
 Retrieving Data Products
 ========================

--- a/docs/mast/mast_missions.rst
+++ b/docs/mast/mast_missions.rst
@@ -122,7 +122,7 @@ results matching *any* of the supplied positions are returned.
    ...                                   radius=0.1,
    ...                                   select_cols=select_cols,
    ...                                   sort_by='search_pos')
-   >>> results.pprint(max_width=-1)  +IGNORE_OUTPUT
+   >>> results.pprint(max_width=-1)  # doctest: +IGNORE_OUTPUT
         search_pos     sci_data_set_name  sci_targname sci_pep_id       ang_sep        sci_status
    ------------------- ----------------- ------------- ---------- -------------------- ----------
    205.54842 28.37728          O5GX13010 NGC5272-BSSV6       8226  0.09983625899279894     PUBLIC


### PR DESCRIPTION
`MastMissions` query functions now support single or multiple targets via `coordinates` and
 `object_names` (including combined use in `query_criteria`).

Notes:
- Multiple coordinates/object names can be provided as an iterable or a comma-separated string.
- The legacy `objectname` keyword is deprecated in favor of `object_names`.
- `query_criteria` no longer requires that a non-positional criterion be provided.
- Refactored so that `query_region` and `query_object` call `query_criteria`. Docs now emphasize that `query_region` and `query_object` are convenience wrappers.