### PR TITLE
Updated get_product to accept file_name as a python list

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -26,6 +26,9 @@ esa.euclid
 - Methods ``cone_search`` and ``cross_match_basic`` now define the  parameters ``table_name`` and ``ra_column_name`` and
   ``dec_column_name`` independently [#3496]
 
+- Method ``get_product`` now supports the input file_name as a Python list (e.g. ["file1.fits", "file2.fits"]) while 
+  still accepting the original comma separated string format. [#3541]
+
 vizier
 ^^^^^^
 

--- a/astroquery/esa/euclid/core.py
+++ b/astroquery/esa/euclid/core.py
@@ -1316,8 +1316,8 @@ class EuclidClass(TapPlus):
         Parameters
         ----------
         file_name : str, optional, default None
-            file name for the product. More than one can be specified between comma. Either file_name or product_id
-            is mandatory
+            file name for the product. Can be a single string, o or a single string with multiple file names separated
+            by commas, or a list of file name strings. Either file_name or product_id is mandatory
         product_id : str, optional, default None
             product id. More than one can be specified between comma. Either file_name or product_id is mandatory
         schema : str, optional, default 'sedm'
@@ -1344,6 +1344,9 @@ class EuclidClass(TapPlus):
 
         if file_name is None and product_id is None:
             raise ValueError("'file_name' and 'product_id' are both None")
+
+        if isinstance(file_name, (list, tuple)):
+            file_name = ",".join(file_name)
 
         params_dict = {'TAPCLIENT': 'ASTROQUERY', 'RELEASE': schema}
 

--- a/astroquery/esa/euclid/core.py
+++ b/astroquery/esa/euclid/core.py
@@ -1316,8 +1316,8 @@ class EuclidClass(TapPlus):
         Parameters
         ----------
         file_name : str, optional, default None
-            file name for the product. Can be a single string, o or a single string with multiple file names separated
-            by commas, or a list of file name strings. Either file_name or product_id is mandatory
+            file name for the product. Can be a single string, including multiple file names separated
+            by commas, or a list of file name strings. Either file_name or product_id is mandatory.
         product_id : str, optional, default None
             product id. More than one can be specified between comma. Either file_name or product_id is mandatory
         schema : str, optional, default 'sedm'

--- a/astroquery/esa/euclid/tests/test_euclidtap.py
+++ b/astroquery/esa/euclid/tests/test_euclidtap.py
@@ -839,6 +839,59 @@ def test_get_product():
     remove_temp_dir()
 
 
+@patch.object(TapPlus, 'load_data')
+def test_get_product_with_list_of_filenames(mock_load_data, tmp_path_factory):
+    """
+    Test that get_product accepts a list for file_name and converts it into
+    a comma-separated string, while ensuring a real output file exists so
+    __extract_file doesn't fail.
+    """
+
+    # Preparación del entorno simulado
+    conn_handler = DummyConnHandler()
+    tap_plus = TapPlus(url="http://test:1111/tap", data_context='data', client_id='ASTROQUERY',
+                       connhandler=conn_handler)
+
+    responseLaunchJob = DummyResponse(200)
+    responseLaunchJob.set_data(method='POST', context=None, body='', headers=None)
+    conn_handler.set_default_response(responseLaunchJob)
+
+    tap = EuclidClass(tap_plus_conn_handler=conn_handler, datalink_handler=tap_plus, show_server_messages=False)
+
+    # Mock: crear el fichero de salida que la función usará después
+    def _fake_load_data(*args, **kwargs):
+        output_file = kwargs.get("output_file")
+        # Crear el directorio y un FITS "dummy"
+        of = Path(output_file)
+        of.parent.mkdir(parents=True, exist_ok=True)
+        # Contenido mínimo; no se va a parsear, sólo se comprueba su existencia/extensión
+        of.write_bytes(b"SIMPLE  =                    T\nEND\n")
+        return None
+
+    mock_load_data.side_effect = _fake_load_data
+
+    # Entrada como lista para file_name
+    filenames = ["file1.fits", "file2.fits", "file3.fits", "file4.fits"]
+
+    # Forzar un nombre de salida con .fits para que el extractor lo trate como 1 fichero
+    out_dir = tmp_path_factory.mktemp("euclid_tmp")
+    output_file = str(out_dir / "dummy.fits")
+
+    result = tap.get_product(file_name=filenames, output_file=output_file)
+
+    # Debe devolver lista de ficheros (al menos el que hemos creado)
+    assert result is not None
+    assert isinstance(result, list)
+    assert len(result) >= 1
+    assert result[0].endswith(".fits")
+
+    # Verificar que FILE_NAME fue convertido a CSV correctamente
+    kwargs = mock_load_data.call_args.kwargs
+    params_dict = kwargs.get("params_dict")
+    assert params_dict["FILE_NAME"] == "file1.fits,file2.fits,file3.fits,file4.fits"
+    assert params_dict["RETRIEVAL_TYPE"] == "FILE"
+
+
 def test_get_product_exceptions():
     conn_handler = DummyConnHandler()
     tap_plus = TapPlus(url="http://test:1111/tap", data_context='data', client_id='ASTROQUERY',


### PR DESCRIPTION
Method get_product now supports providing file_name as a Python list (e.g. ["file1.fits", "file2.fits"]) while still accepting the original comma‑separated string format. Also added new one test to check this new functionality.

CC: @esdc-esac-esa-int 
Jira: EUCLIDSWRQ-284