### PR TITLE
Add get_zeropoint and more flexible metadata querying to SVO FPS

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -96,6 +96,7 @@ svo_fps
 ^^^^^^^
 
 - Add ``get_filter_metadata`` to allow retrieval of filter metadata. [#3528]
+- Add ``get_zeropoint`` to allow retrieval of filter zeropoints and allow kwarg passing to ``get_filter_metadata``. [#3545]
 
 heasarc
 ^^^^^^^

--- a/astroquery/svo_fps/core.py
+++ b/astroquery/svo_fps/core.py
@@ -23,6 +23,11 @@ for suffix in ("_min", "_max"):
 QUERY_PARAMETERS.update(("Instrument", "Facility", "PhotSystem", "ID", "PhotCalID",
                          "FORMAT", "VERB"))
 
+ALLOWED_QUERY_PARAMETERS = {
+    "VERB": {0, 1, 2},
+    "FORMAT": {"metadata", None}
+}
+
 
 class SvoFpsClass(BaseQuery):
     """
@@ -31,21 +36,88 @@ class SvoFpsClass(BaseQuery):
     SVO_MAIN_URL = conf.base_url
     TIMEOUT = conf.timeout
 
-    def data_from_svo(self, query, *, cache=True, timeout=None,
-                      error_msg='No data found for requested query'):
+    def data_from_svo(self,
+                      *,
+                      WavelengthRef_min=None,
+                      WavelengthRef_max=None,
+                      WavelengthMean_min=None,
+                      WavelengthMean_max=None,
+                      WavelengthEff_min=None,
+                      WavelengthEff_max=None,
+                      WavelengthMin_min=None,
+                      WavelengthMin_max=None,
+                      WavelengthMax_min=None,
+                      WavelengthMax_max=None,
+                      WidthEff_min=None,
+                      WidthEff_max=None,
+                      FWHM_min=None,
+                      FWHM_max=None,
+                      Instrument=None,
+                      Facility=None,
+                      PhotSystem=None,
+                      ID=None,
+                      PhotCalID=None,
+                      FORMAT=None,
+                      VERB=2,
+                      cache=True, timeout=None,
+                      error_msg='No data found for requested query',
+                      ):
         """Get data in response to the query send to SVO FPS.
         This method is not generally intended for users, but it can be helpful
         if you want something very specific from the SVO FPS service.
         If you don't know what you're doing, try `get_filter_index`,
         `get_filter_list`, and `get_transmission_data` instead.
 
+        Description of search parameters can be found at
+        https://svo2.cab.inta-csic.es/theory/fps/index.php?mode=voservice
+
+
         Parameters
         ----------
-        query : dict
-            Used to create a HTTP query string i.e. send to SVO FPS to get data.
-            In dictionary, specify keys as search parameters (str) and
-            values as required. Description of search parameters can be found at
-            https://svo2.cab.inta-csic.es/theory/fps/index.php?mode=voservice
+        WavelengthRef_min : float, optional
+            Min value for WavelengthRef parameter
+        WavelengthRef_max : float, optional
+            Max value for WavelengthRef parameter
+        WavelengthMean_min : float, optional
+            Min value for WavelengthMean parameter
+        WavelengthMean_max : float, optional
+            Max value for WavelengthMean parameter
+        WavelengthEff_min : float, optional
+            Min value for WavelengthEff parameter
+        WavelengthEff_max : float, optional
+            Max value for WavelengthEff parameter
+        WavelengthMin_min : float, optional
+            Min value for WavelengthMin parameter
+        WavelengthMin_max : float, optional
+            Max value for WavelengthMin parameter
+        WavelengthMax_min : float, optional
+            Min value for WavelengthMax parameter
+        WavelengthMax_max : float, optional
+            Max value for WavelengthMax parameter
+        WidthEff_min : float, optional
+            Min value for WidthEff parameter
+        WidthEff_max : float, optional
+            Max value for WidthEff parameter
+        FWHM_min : float, optional
+            Min value for FWHM parameter
+        FWHM_max : float, optional
+            Max value for FWHM parameter
+        Instrument : str, optional
+            Instrument for filters (default is None). Leave empty if there are no instruments for specified facility
+        Facility : str, optional
+            Facility for filters (default is None)
+        PhotSystem : str, optional
+            Photometric system for filters (default is None)
+        ID : str, optional
+            Filter ID (default is None)
+        PhotCalID : str, optional
+            Photometric calibration ID (default is None)
+        FORMAT : str, optional
+            Format of the output.  Default includes all data, ``metadata`` includes only metadata.
+        VERB : 0, 1, or 2
+            0: The resulting VOTable won't include the transmission curve or PARAM descriptions.
+            1: The resulting VOTable won't include the transmission curve but it will include PARAM descriptions.
+            2: The resulting VOTable will include the transmission curve and PARAM descriptions.
         error_msg : str, optional
             Error message to be shown in case no table element found in the
             responded VOTable. Use this to make error message verbose in context
@@ -59,14 +131,39 @@ class SvoFpsClass(BaseQuery):
         astropy.table.table.Table object
             Table containing data fetched from SVO (in response to query)
         """
-        bad_params = [param for param in query if param not in QUERY_PARAMETERS]
-        if bad_params:
-            raise InvalidQueryError(
-                f"parameter{'s' if len(bad_params) > 1 else ''} "
-                f"{', '.join(bad_params)} {'are' if len(bad_params) > 1 else 'is'} "
-                f"invalid. For a description of valid query parameters see "
-                "https://svo2.cab.inta-csic.es/theory/fps/index.php?mode=voservice"
-            )
+
+        query = {
+            'WavelengthRef_min': WavelengthRef_min,
+            'WavelengthRef_max': WavelengthRef_max,
+            'WavelengthMean_min': WavelengthMean_min,
+            'WavelengthMean_max': WavelengthMean_max,
+            'WavelengthEff_min': WavelengthEff_min,
+            'WavelengthEff_max': WavelengthEff_max,
+            'WavelengthMin_min': WavelengthMin_min,
+            'WavelengthMin_max': WavelengthMin_max,
+            'WavelengthMax_min': WavelengthMax_min,
+            'WavelengthMax_max': WavelengthMax_max,
+            'WidthEff_min': WidthEff_min,
+            'WidthEff_max': WidthEff_max,
+            'FWHM_min': FWHM_min,
+            'FWHM_max': FWHM_max,
+            'Instrument': Instrument,
+            'Facility': Facility,
+            'PhotSystem': PhotSystem,
+            'ID': ID,
+            'PhotCalID': PhotCalID,
+            'FORMAT': FORMAT,
+            'VERB': VERB
+        }
+
+        # check validity of query parameters with limited allowed values
+        for key in ALLOWED_QUERY_PARAMETERS:
+            if key in query and query[key] not in ALLOWED_QUERY_PARAMETERS[key]:
+                raise InvalidQueryError(
+                    f"Invalid value for parameter {key}. Allowed values are "
+                    f"{ALLOWED_QUERY_PARAMETERS[key]}"
+                )
+
         response = self._request("GET", self.SVO_MAIN_URL, params=query,
                                  timeout=timeout or self.TIMEOUT,
                                  cache=cache)
@@ -97,11 +194,14 @@ class SvoFpsClass(BaseQuery):
         astropy.table.table.Table object
             Table containing data fetched from SVO (in response to query)
         """
-        query = {'WavelengthEff_min': wavelength_eff_min.to_value(u.angstrom),
-                 'WavelengthEff_max': wavelength_eff_max.to_value(u.angstrom)}
         error_msg = 'No filter found for requested Wavelength Effective range'
         try:
-            return self.data_from_svo(query=query, error_msg=error_msg, **kwargs)
+            return self.data_from_svo(
+                WavelengthEff_min=wavelength_eff_min.to_value(u.angstrom),
+                WavelengthEff_max=wavelength_eff_max.to_value(u.angstrom),
+                error_msg=error_msg,
+                **kwargs
+            )
         except requests.ReadTimeout:
             raise TimeoutError(
                 "Query did not finish fast enough. A smaller wavelength range might "
@@ -123,9 +223,7 @@ class SvoFpsClass(BaseQuery):
         timeout : int
             Timeout in seconds. If not specified, defaults to ``conf.timeout``.
         kwargs : dict
-            Appended to the ``query`` dictionary sent to SVO.
-        kwargs : dict
-            Appended to the ``query`` dictionary sent to SVO.
+            Appended to the ``query`` dictionary sent to SVO. See the API documentation of `data_from_svo` for the valid parameter names.
 
         Returns
         -------
@@ -186,7 +284,7 @@ class SvoFpsClass(BaseQuery):
         mag_system : str
             The magnitude system for which to return the zero point.
         kwargs : dict
-            Appended to the ``query`` dictionary sent to SVO.
+            Appended to the ``query`` dictionary sent to SVO. See the API documentation of `data_from_svo` for the valid parameter names.
 
         Examples
         --------
@@ -233,9 +331,8 @@ class SvoFpsClass(BaseQuery):
         astropy.table.table.Table object
             Table containing data fetched from SVO (in response to query)
         """
-        query = {'ID': filter_id}
         error_msg = 'No filter found for requested Filter ID'
-        return self.data_from_svo(query=query, error_msg=error_msg, **kwargs)
+        return self.data_from_svo(ID=filter_id, error_msg=error_msg, **kwargs)
 
     def get_filter_list(self, facility, *, instrument=None, **kwargs):
         """Get filters data for requested facilty and instrument from SVO
@@ -255,10 +352,13 @@ class SvoFpsClass(BaseQuery):
         astropy.table.table.Table object
             Table containing data fetched from SVO (in response to query)
         """
-        query = {'Facility': facility,
-                 'Instrument': instrument}
         error_msg = 'No filter found for requested Facilty (and Instrument)'
-        return self.data_from_svo(query=query, error_msg=error_msg, **kwargs)
+        return self.data_from_svo(
+            Facility=facility,
+            Instrument=instrument,
+            error_msg=error_msg,
+            **kwargs
+        )
 
 
 SvoFps = SvoFpsClass()

--- a/astroquery/svo_fps/core.py
+++ b/astroquery/svo_fps/core.py
@@ -239,8 +239,7 @@ class SvoFpsClass(BaseQuery):
             raise InvalidQueryError(
                 f"parameter{'s' if len(bad_params) > 1 else ''} "
                 f"{', '.join(bad_params)} {'are' if len(bad_params) > 1 else 'is'} "
-                f"invalid. For a description of valid query parameters see "
-                "https://svo2.cab.inta-csic.es/theory/fps/index.php?mode=voservice"
+                f"invalid. For a description of valid query parameters see the docstring for SvoFps.data_from_svo"
             )
 
         query.update(kwargs)
@@ -282,7 +281,7 @@ class SvoFpsClass(BaseQuery):
             Filter ID in the format SVO specifies it: 'facilty/instrument.filter'.
             This is returned by `get_filter_list` and `get_filter_index` as the
             ``filterID`` column.
-        mag_system : str
+        mag_system : 'Vega' (default), 'AB', or 'ST'
             The magnitude system for which to return the zero point.
         kwargs : dict
             Appended to the ``query`` dictionary sent to SVO. See the API
@@ -307,6 +306,9 @@ class SvoFpsClass(BaseQuery):
          'ZeroPointType': 'Pogson'}
 
         """
+        if mag_system not in ['Vega', 'AB', 'ST']:
+            raise InvalidQueryError("Invalid magnitude system. Allowed values are 'Vega', 'AB', and 'ST'.")
+
         metadata = self.get_filter_metadata(filter_id=filter_id,
                                             PhotCalID=f'{filter_id}/{mag_system}', **kwargs)
 

--- a/astroquery/svo_fps/core.py
+++ b/astroquery/svo_fps/core.py
@@ -256,7 +256,7 @@ class SvoFpsClass(BaseQuery):
                 params[param.name] = param.value
         return params
 
-    def get_zeropoint(self, filter_id, mag_system='Vega', **kwargs):
+    def get_zeropoint(self, filter_id, *, mag_system='Vega', **kwargs):
         """
         Get the zero point for a specififed filter in a specified system.
 

--- a/astroquery/svo_fps/core.py
+++ b/astroquery/svo_fps/core.py
@@ -108,7 +108,7 @@ class SvoFpsClass(BaseQuery):
                 "succeed. Try increasing the timeout limit if a large range is needed."
             )
 
-    def get_filter_metadata(self, filter_id, *, cache=True, timeout=None):
+    def get_filter_metadata(self, filter_id, *, cache=True, timeout=None, **kwargs):
         """Get metadata/parameters for the requested Filter ID from SVO
 
         Parameters
@@ -122,6 +122,10 @@ class SvoFpsClass(BaseQuery):
             See :ref:`caching documentation <astroquery_cache>`.
         timeout : int
             Timeout in seconds. If not specified, defaults to ``conf.timeout``.
+        kwargs : dict
+            Appended to the ``query`` dictionary sent to SVO.
+        kwargs : dict
+            Appended to the ``query`` dictionary sent to SVO.
 
         Returns
         -------
@@ -129,6 +133,28 @@ class SvoFpsClass(BaseQuery):
             Dictionary of VOTable PARAM names and values.
         """
         query = {'ID': filter_id, 'VERB': 0}
+        query.update(kwargs)
+
+        bad_params = [param for param in query if param not in QUERY_PARAMETERS]
+        if bad_params:
+            raise InvalidQueryError(
+                f"parameter{'s' if len(bad_params) > 1 else ''} "
+                f"{', '.join(bad_params)} {'are' if len(bad_params) > 1 else 'is'} "
+                f"invalid. For a description of valid query parameters see "
+                "https://svo2.cab.inta-csic.es/theory/fps/index.php?mode=voservice"
+            )
+
+        query.update(kwargs)
+
+        bad_params = [param for param in query if param not in QUERY_PARAMETERS]
+        if bad_params:
+            raise InvalidQueryError(
+                f"parameter{'s' if len(bad_params) > 1 else ''} "
+                f"{', '.join(bad_params)} {'are' if len(bad_params) > 1 else 'is'} "
+                f"invalid. For a description of valid query parameters see "
+                "https://svo2.cab.inta-csic.es/theory/fps/index.php?mode=voservice"
+            )
+
         response = self._request("GET", self.SVO_MAIN_URL, params=query,
                                  timeout=timeout or self.TIMEOUT,
                                  cache=cache)
@@ -142,6 +168,53 @@ class SvoFpsClass(BaseQuery):
             else:
                 params[param.name] = param.value
         return params
+
+    def get_zeropoint(self, filter_id, mag_system='Vega', **kwargs):
+        """
+        Get the zero point for a specififed filter in a specified system.
+
+        This is a highly-specific downselection of the metadata returned by
+        `get_filter_metadata`; the full metadata includes the zero point with
+        ``Vega`` as the default system.
+
+        Parameters
+        ----------
+        filter_id : str
+            Filter ID in the format SVO specifies it: 'facilty/instrument.filter'.
+            This is returned by `get_filter_list` and `get_filter_index` as the
+            ``filterID`` column.
+        mag_system : str
+            The magnitude system for which to return the zero point.
+        kwargs : dict
+            Appended to the ``query`` dictionary sent to SVO.
+
+        Examples
+        --------
+        >>> from astroquery.svo_fps import SvoFps  # doctest: +REMOTE_DATA
+        >>> SvoFps.get_zeropoint(filter_id='2MASS/2MASS.J', mag_system='AB')  # doctest: +REMOTE_DATA
+        {'MagSys': 'AB',
+         'ZeroPoint': <Quantity 3631. Jy>,
+         'ZeroPointUnit': 'Jy',
+         'ZeroPointType': 'Pogson'}
+        >>> SvoFps.get_filter_metadata(filter_id='2MASS/2MASS.J', PhotCalID='2MASS/2MASS.J/AB')  # doctest: +REMOTE_DATA
+        {'FilterProfileService': 'ivo://svo/fps',
+         'filterID': '2MASS/2MASS.J',
+         ...
+         'PhotCalID': '2MASS/2MASS.J/AB',
+         'MagSys': 'AB',
+         'ZeroPoint': <Quantity 3631. Jy>,
+         'ZeroPointUnit': 'Jy',
+         'ZeroPointType': 'Pogson'}
+
+        """
+        metadata = self.get_filter_metadata(filter_id=filter_id,
+                                            PhotCalID=f'{filter_id}/{mag_system}', **kwargs)
+
+        zeropoint_keys = ['MagSys', 'ZeroPoint', 'ZeroPointUnit', 'ZeroPointType']
+
+        zp = {key: metadata[key] for key in zeropoint_keys if key in metadata}
+
+        return zp
 
     def get_transmission_data(self, filter_id, **kwargs):
         """Get transmission data for the requested Filter ID from SVO

--- a/astroquery/svo_fps/core.py
+++ b/astroquery/svo_fps/core.py
@@ -225,7 +225,7 @@ class SvoFpsClass(BaseQuery):
         kwargs : dict
             Appended to the ``query`` dictionary sent to SVO. See the API
             documentation of `data_from_svo` for the valid parameter names.
-            
+
         Returns
         -------
         params : dict
@@ -287,7 +287,7 @@ class SvoFpsClass(BaseQuery):
         kwargs : dict
             Appended to the ``query`` dictionary sent to SVO. See the API
             documentation of `data_from_svo` for the valid parameter names.
-            
+
         Examples
         --------
         >>> from astroquery.svo_fps import SvoFps  # doctest: +REMOTE_DATA

--- a/astroquery/svo_fps/core.py
+++ b/astroquery/svo_fps/core.py
@@ -242,17 +242,6 @@ class SvoFpsClass(BaseQuery):
                 f"invalid. For a description of valid query parameters see the docstring for SvoFps.data_from_svo"
             )
 
-        query.update(kwargs)
-
-        bad_params = [param for param in query if param not in QUERY_PARAMETERS]
-        if bad_params:
-            raise InvalidQueryError(
-                f"parameter{'s' if len(bad_params) > 1 else ''} "
-                f"{', '.join(bad_params)} {'are' if len(bad_params) > 1 else 'is'} "
-                f"invalid. For a description of valid query parameters see "
-                "https://svo2.cab.inta-csic.es/theory/fps/index.php?mode=voservice"
-            )
-
         response = self._request("GET", self.SVO_MAIN_URL, params=query,
                                  timeout=timeout or self.TIMEOUT,
                                  cache=cache)

--- a/astroquery/svo_fps/core.py
+++ b/astroquery/svo_fps/core.py
@@ -223,8 +223,9 @@ class SvoFpsClass(BaseQuery):
         timeout : int
             Timeout in seconds. If not specified, defaults to ``conf.timeout``.
         kwargs : dict
-            Appended to the ``query`` dictionary sent to SVO. See the API documentation of `data_from_svo` for the valid parameter names.
-
+            Appended to the ``query`` dictionary sent to SVO. See the API
+            documentation of `data_from_svo` for the valid parameter names.
+            
         Returns
         -------
         params : dict
@@ -284,8 +285,9 @@ class SvoFpsClass(BaseQuery):
         mag_system : str
             The magnitude system for which to return the zero point.
         kwargs : dict
-            Appended to the ``query`` dictionary sent to SVO. See the API documentation of `data_from_svo` for the valid parameter names.
-
+            Appended to the ``query`` dictionary sent to SVO. See the API
+            documentation of `data_from_svo` for the valid parameter names.
+            
         Examples
         --------
         >>> from astroquery.svo_fps import SvoFps  # doctest: +REMOTE_DATA

--- a/astroquery/svo_fps/core.py
+++ b/astroquery/svo_fps/core.py
@@ -327,16 +327,6 @@ class SvoFpsClass(BaseQuery):
          'ZeroPoint': <Quantity 3631. Jy>,
          'ZeroPointUnit': 'Jy',
          'ZeroPointType': 'Pogson'}
-        >>> SvoFps.get_filter_metadata(filter_id='2MASS/2MASS.J', phot_cal_id='2MASS/2MASS.J/AB')  # doctest: +REMOTE_DATA
-        {'FilterProfileService': 'ivo://svo/fps',
-         'filterID': '2MASS/2MASS.J',
-         ...
-         'PhotCalID': '2MASS/2MASS.J/AB',
-         'MagSys': 'AB',
-         'ZeroPoint': <Quantity 3631. Jy>,
-         'ZeroPointUnit': 'Jy',
-         'ZeroPointType': 'Pogson'}
-
         """
         if mag_system not in ['Vega', 'AB', 'ST']:
             raise InvalidQueryError("Invalid magnitude system. Allowed values are 'Vega', 'AB', and 'ST'.")

--- a/astroquery/svo_fps/core.py
+++ b/astroquery/svo_fps/core.py
@@ -13,20 +13,61 @@ from astroquery.exceptions import InvalidQueryError, TimeoutError
 
 __all__ = ['SvoFpsClass', 'SvoFps']
 
-# Valid query parameters taken from
+
+# Parameters the SVO service accepts as either ``Name`` (base) or as a
+# range pair ``Name_min``/``Name_max``.
+RANGE_BASES = {"wavelength_ref", "wavelength_mean", "wavelength_eff",
+               "wavelength_min", "wavelength_max", "width_eff", "fwhm"}
+
+# Base mapping from public (snake_case, lowercase) keyword names to the
+# CamelCase parameter names the SVO FPS server actually accepts.  The SVO
+# service is case-sensitive: lowercase parameters silently fall through
+# (the server returns the full unfiltered response), so every value sent
+# in a query must come from this mapping.  See
 # https://svo2.cab.inta-csic.es/theory/fps/index.php?mode=voservice
-_params_with_range = {"WavelengthRef", "WavelengthMean", "WavelengthEff",
-                      "WavelengthMin", "WavelengthMax", "WidthEff", "FWHM"}
-QUERY_PARAMETERS = _params_with_range.copy()
-for suffix in ("_min", "_max"):
-    QUERY_PARAMETERS.update(param + suffix for param in _params_with_range)
-QUERY_PARAMETERS.update(("Instrument", "Facility", "PhotSystem", "ID", "PhotCalID",
-                         "FORMAT", "VERB"))
+BASE_PARAM_NAMES = {
+    "wavelength_ref": "WavelengthRef",
+    "wavelength_mean": "WavelengthMean",
+    "wavelength_eff": "WavelengthEff",
+    "wavelength_min": "WavelengthMin",
+    "wavelength_max": "WavelengthMax",
+    "width_eff": "WidthEff",
+    "fwhm": "FWHM",
+    "instrument": "Instrument",
+    "facility": "Facility",
+    "phot_system": "PhotSystem",
+    "id": "ID",
+    "phot_cal_id": "PhotCalID",
+    "format": "FORMAT",
+    "verb": "VERB",
+}
+
+# Full mapping including the range variants, so a single dict lookup
+# resolves any user-facing kwarg.
+SVO_PARAM_NAMES = {
+    **BASE_PARAM_NAMES,
+    **{f"{k}_min": f"{v}_min"
+       for k, v in BASE_PARAM_NAMES.items() if k in RANGE_BASES},
+    **{f"{k}_max": f"{v}_max"
+       for k, v in BASE_PARAM_NAMES.items() if k in RANGE_BASES},
+}
+
+# Set of every valid public keyword name (used to validate **kwargs
+# passed to ``get_filter_metadata``).
+QUERY_PARAMETERS = set(SVO_PARAM_NAMES)
 
 ALLOWED_QUERY_PARAMETERS = {
-    "VERB": {0, 1, 2},
-    "FORMAT": {"metadata", None}
+    "verb": {0, 1, 2},
+    "format": {"metadata", None}
 }
+
+
+def to_svo_query(local_params):
+    """Translate a dict of public (snake_case) kwargs to the SVO native
+    parameter names the server expects.  ``None`` values are dropped so
+    they aren't sent over the wire."""
+    return {SVO_PARAM_NAMES[k]: v for k, v in local_params.items()
+            if v is not None}
 
 
 class SvoFpsClass(BaseQuery):
@@ -38,27 +79,27 @@ class SvoFpsClass(BaseQuery):
 
     def data_from_svo(self,
                       *,
-                      WavelengthRef_min=None,
-                      WavelengthRef_max=None,
-                      WavelengthMean_min=None,
-                      WavelengthMean_max=None,
-                      WavelengthEff_min=None,
-                      WavelengthEff_max=None,
-                      WavelengthMin_min=None,
-                      WavelengthMin_max=None,
-                      WavelengthMax_min=None,
-                      WavelengthMax_max=None,
-                      WidthEff_min=None,
-                      WidthEff_max=None,
-                      FWHM_min=None,
-                      FWHM_max=None,
-                      Instrument=None,
-                      Facility=None,
-                      PhotSystem=None,
-                      ID=None,
-                      PhotCalID=None,
-                      FORMAT=None,
-                      VERB=2,
+                      wavelength_ref_min=None,
+                      wavelength_ref_max=None,
+                      wavelength_mean_min=None,
+                      wavelength_mean_max=None,
+                      wavelength_eff_min=None,
+                      wavelength_eff_max=None,
+                      wavelength_min_min=None,
+                      wavelength_min_max=None,
+                      wavelength_max_min=None,
+                      wavelength_max_max=None,
+                      width_eff_min=None,
+                      width_eff_max=None,
+                      fwhm_min=None,
+                      fwhm_max=None,
+                      instrument=None,
+                      facility=None,
+                      phot_system=None,
+                      id=None,
+                      phot_cal_id=None,
+                      format=None,
+                      verb=2,
                       cache=True, timeout=None,
                       error_msg='No data found for requested query',
                       ):
@@ -74,47 +115,47 @@ class SvoFpsClass(BaseQuery):
 
         Parameters
         ----------
-        WavelengthRef_min : float, optional
+        wavelength_ref_min : float, optional
             Min value for WavelengthRef parameter
-        WavelengthRef_max : float, optional
+        wavelength_ref_max : float, optional
             Max value for WavelengthRef parameter
-        WavelengthMean_min : float, optional
+        wavelength_mean_min : float, optional
             Min value for WavelengthMean parameter
-        WavelengthMean_max : float, optional
+        wavelength_mean_max : float, optional
             Max value for WavelengthMean parameter
-        WavelengthEff_min : float, optional
+        wavelength_eff_min : float, optional
             Min value for WavelengthEff parameter
-        WavelengthEff_max : float, optional
+        wavelength_eff_max : float, optional
             Max value for WavelengthEff parameter
-        WavelengthMin_min : float, optional
+        wavelength_min_min : float, optional
             Min value for WavelengthMin parameter
-        WavelengthMin_max : float, optional
+        wavelength_min_max : float, optional
             Max value for WavelengthMin parameter
-        WavelengthMax_min : float, optional
+        wavelength_max_min : float, optional
             Min value for WavelengthMax parameter
-        WavelengthMax_max : float, optional
+        wavelength_max_max : float, optional
             Max value for WavelengthMax parameter
-        WidthEff_min : float, optional
+        width_eff_min : float, optional
             Min value for WidthEff parameter
-        WidthEff_max : float, optional
+        width_eff_max : float, optional
             Max value for WidthEff parameter
-        FWHM_min : float, optional
+        fwhm_min : float, optional
             Min value for FWHM parameter
-        FWHM_max : float, optional
+        fwhm_max : float, optional
             Max value for FWHM parameter
-        Instrument : str, optional
+        instrument : str, optional
             Instrument for filters (default is None). Leave empty if there are no instruments for specified facility
-        Facility : str, optional
+        facility : str, optional
             Facility for filters (default is None)
-        PhotSystem : str, optional
+        phot_system : str, optional
             Photometric system for filters (default is None)
-        ID : str, optional
+        id : str, optional
             Filter ID (default is None)
-        PhotCalID : str, optional
+        phot_cal_id : str, optional
             Photometric calibration ID (default is None)
-        FORMAT : str, optional
+        format : str, optional
             Format of the output.  Default includes all data, ``metadata`` includes only metadata.
-        VERB : 0, 1, or 2
+        verb : 0, 1, or 2
             0: The resulting VOTable won't include the transmission curve or PARAM descriptions.
             1: The resulting VOTable won't include the transmission curve but it will include PARAM descriptions.
             2: The resulting VOTable will include the transmission curve and PARAM descriptions.
@@ -132,38 +173,39 @@ class SvoFpsClass(BaseQuery):
             Table containing data fetched from SVO (in response to query)
         """
 
-        query = {
-            'WavelengthRef_min': WavelengthRef_min,
-            'WavelengthRef_max': WavelengthRef_max,
-            'WavelengthMean_min': WavelengthMean_min,
-            'WavelengthMean_max': WavelengthMean_max,
-            'WavelengthEff_min': WavelengthEff_min,
-            'WavelengthEff_max': WavelengthEff_max,
-            'WavelengthMin_min': WavelengthMin_min,
-            'WavelengthMin_max': WavelengthMin_max,
-            'WavelengthMax_min': WavelengthMax_min,
-            'WavelengthMax_max': WavelengthMax_max,
-            'WidthEff_min': WidthEff_min,
-            'WidthEff_max': WidthEff_max,
-            'FWHM_min': FWHM_min,
-            'FWHM_max': FWHM_max,
-            'Instrument': Instrument,
-            'Facility': Facility,
-            'PhotSystem': PhotSystem,
-            'ID': ID,
-            'PhotCalID': PhotCalID,
-            'FORMAT': FORMAT,
-            'VERB': VERB
+        local_params = {
+            'wavelength_ref_min': wavelength_ref_min,
+            'wavelength_ref_max': wavelength_ref_max,
+            'wavelength_mean_min': wavelength_mean_min,
+            'wavelength_mean_max': wavelength_mean_max,
+            'wavelength_eff_min': wavelength_eff_min,
+            'wavelength_eff_max': wavelength_eff_max,
+            'wavelength_min_min': wavelength_min_min,
+            'wavelength_min_max': wavelength_min_max,
+            'wavelength_max_min': wavelength_max_min,
+            'wavelength_max_max': wavelength_max_max,
+            'width_eff_min': width_eff_min,
+            'width_eff_max': width_eff_max,
+            'fwhm_min': fwhm_min,
+            'fwhm_max': fwhm_max,
+            'instrument': instrument,
+            'facility': facility,
+            'phot_system': phot_system,
+            'id': id,
+            'phot_cal_id': phot_cal_id,
+            'format': format,
+            'verb': verb,
         }
 
         # check validity of query parameters with limited allowed values
         for key in ALLOWED_QUERY_PARAMETERS:
-            if key in query and query[key] not in ALLOWED_QUERY_PARAMETERS[key]:
+            if key in local_params and local_params[key] not in ALLOWED_QUERY_PARAMETERS[key]:
                 raise InvalidQueryError(
                     f"Invalid value for parameter {key}. Allowed values are "
                     f"{ALLOWED_QUERY_PARAMETERS[key]}"
                 )
 
+        query = to_svo_query(local_params)
         response = self._request("GET", self.SVO_MAIN_URL, params=query,
                                  timeout=timeout or self.TIMEOUT,
                                  cache=cache)
@@ -197,8 +239,8 @@ class SvoFpsClass(BaseQuery):
         error_msg = 'No filter found for requested Wavelength Effective range'
         try:
             return self.data_from_svo(
-                WavelengthEff_min=wavelength_eff_min.to_value(u.angstrom),
-                WavelengthEff_max=wavelength_eff_max.to_value(u.angstrom),
+                wavelength_eff_min=wavelength_eff_min.to_value(u.angstrom),
+                wavelength_eff_max=wavelength_eff_max.to_value(u.angstrom),
                 error_msg=error_msg,
                 **kwargs
             )
@@ -231,10 +273,10 @@ class SvoFpsClass(BaseQuery):
         params : dict
             Dictionary of VOTable PARAM names and values.
         """
-        query = {'ID': filter_id, 'VERB': 0}
-        query.update(kwargs)
+        local_params = {'id': filter_id, 'verb': 0}
+        local_params.update(kwargs)
 
-        bad_params = [param for param in query if param not in QUERY_PARAMETERS]
+        bad_params = [param for param in local_params if param not in QUERY_PARAMETERS]
         if bad_params:
             raise InvalidQueryError(
                 f"parameter{'s' if len(bad_params) > 1 else ''} "
@@ -242,6 +284,7 @@ class SvoFpsClass(BaseQuery):
                 f"invalid. For a description of valid query parameters see the docstring for SvoFps.data_from_svo"
             )
 
+        query = to_svo_query(local_params)
         response = self._request("GET", self.SVO_MAIN_URL, params=query,
                                  timeout=timeout or self.TIMEOUT,
                                  cache=cache)
@@ -284,7 +327,7 @@ class SvoFpsClass(BaseQuery):
          'ZeroPoint': <Quantity 3631. Jy>,
          'ZeroPointUnit': 'Jy',
          'ZeroPointType': 'Pogson'}
-        >>> SvoFps.get_filter_metadata(filter_id='2MASS/2MASS.J', PhotCalID='2MASS/2MASS.J/AB')  # doctest: +REMOTE_DATA
+        >>> SvoFps.get_filter_metadata(filter_id='2MASS/2MASS.J', phot_cal_id='2MASS/2MASS.J/AB')  # doctest: +REMOTE_DATA
         {'FilterProfileService': 'ivo://svo/fps',
          'filterID': '2MASS/2MASS.J',
          ...
@@ -299,7 +342,7 @@ class SvoFpsClass(BaseQuery):
             raise InvalidQueryError("Invalid magnitude system. Allowed values are 'Vega', 'AB', and 'ST'.")
 
         metadata = self.get_filter_metadata(filter_id=filter_id,
-                                            PhotCalID=f'{filter_id}/{mag_system}', **kwargs)
+                                            phot_cal_id=f'{filter_id}/{mag_system}', **kwargs)
 
         zeropoint_keys = ['MagSys', 'ZeroPoint', 'ZeroPointUnit', 'ZeroPointType']
 
@@ -325,7 +368,7 @@ class SvoFpsClass(BaseQuery):
             Table containing data fetched from SVO (in response to query)
         """
         error_msg = 'No filter found for requested Filter ID'
-        return self.data_from_svo(ID=filter_id, error_msg=error_msg, **kwargs)
+        return self.data_from_svo(id=filter_id, error_msg=error_msg, **kwargs)
 
     def get_filter_list(self, facility, *, instrument=None, **kwargs):
         """Get filters data for requested facilty and instrument from SVO
@@ -347,8 +390,8 @@ class SvoFpsClass(BaseQuery):
         """
         error_msg = 'No filter found for requested Facilty (and Instrument)'
         return self.data_from_svo(
-            Facility=facility,
-            Instrument=instrument,
+            facility=facility,
+            instrument=instrument,
             error_msg=error_msg,
             **kwargs
         )

--- a/astroquery/svo_fps/tests/data/svo_fps_PhotCalID=2MASS.2MASS.H.Vega.xml
+++ b/astroquery/svo_fps/tests/data/svo_fps_PhotCalID=2MASS.2MASS.H.Vega.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0"?>
+<VOTABLE version="1.1" xsi:schemaLocation="http://www.ivoa.net/xml/VOTable/v1.1" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+  <INFO name="QUERY_STATUS" value="OK"/>
+  <RESOURCE type="results">
+    <TABLE utype="photdm:PhotometryFilter.transmissionCurve.spectrum">
+    <PARAM name="FilterProfileService" value="ivo://svo/fps" ucd="meta.ref.ivorn" utype="PhotometryFilter.fpsIdentifier" datatype="char" arraysize="*"/>
+    <PARAM name="filterID" value="2MASS/2MASS.H" ucd="meta.id" utype="photdm:PhotometryFilter.identifier" datatype="char" arraysize="*"/>
+    <PARAM name="WavelengthUnit" value="Angstrom" ucd="meta.unit" utype="PhotometryFilter.SpectralAxis.unit" datatype="char" arraysize="*"/>
+    <PARAM name="Description" value="2MASS H" ucd="meta.note" utype="photdm:PhotometryFilter.description" datatype="char" arraysize="*"/>
+    <PARAM name="WavelengthEff" value="16620" unit="Angstrom" ucd="em.wl.effective" datatype="float" >
+       <DESCRIPTION>Manually specified. See reference</DESCRIPTION>
+    </PARAM>
+    <PARAM name="ZeroPoint" value="1024" unit="Jy" ucd="phot.flux.density" utype="photdm:PhotCal.ZeroPoint.Flux.value" datatype="float" />
+    <PARAM name="PhotCalID" value="2MASS/2MASS.H/Vega" ucd="meta.id" utype="photdm:PhotCal.identifier" datatype="char" arraysize="*"/>
+    <PARAM name="MagSys" value="Vega" ucd="meta.code" utype="photdm:PhotCal.MagnitudeSystem.type" datatype="char" arraysize="*"/>
+    <PARAM name="ZeroPointUnit" value="Jy" ucd="meta.unit" utype="photdm:PhotCal.ZeroPoint.Flux.unit" datatype="char" arraysize="*"/>
+    <PARAM name="ZeroPointType" value="Pogson" ucd="meta.code" utype="photdm:PhotCal.ZeroPoint.type" datatype="char" arraysize="*"/>
+      <DATA>
+        <TABLEDATA>
+        </TABLEDATA>
+      </DATA>
+    </TABLE>
+  </RESOURCE>
+</VOTABLE>

--- a/astroquery/svo_fps/tests/test_svo_fps.py
+++ b/astroquery/svo_fps/tests/test_svo_fps.py
@@ -3,7 +3,7 @@ import os
 from astropy import units as u
 from requests import ReadTimeout
 
-from astroquery.exceptions import TimeoutError
+from astroquery.exceptions import TimeoutError, InvalidQueryError
 from astroquery.utils.mocks import MockResponse
 from ..core import SvoFps
 
@@ -102,6 +102,15 @@ def test_get_zeropoint(patch_get):
 
 
 def test_invalid_query(patch_get):
-    msg = r"^SvoFpsClass.data_from_svo\(\) got an unexpected keyword argument 'bad_param'"
-    with pytest.raises(TypeError, match=msg):
-        SvoFps.data_from_svo(bad_param=0, FWHM_min=20)
+    msg = 'Invalid value for parameter VERB. Allowed values are {0, 1, 2}'
+    with pytest.raises(InvalidQueryError, match=msg):
+        SvoFps.data_from_svo(VERB=5)
+    # need this wonky regex b/c {'metadata', None} is a set and the order flips every time
+    msg = r"Invalid value for parameter FORMAT\. Allowed values are \{(?=.*'metadata')(?=.*None).*\}"
+    with pytest.raises(InvalidQueryError, match=msg):
+        SvoFps.data_from_svo(FORMAT='silly_format')
+
+def test_invalid_get_filter_metadata(patch_get):
+    msg = 'parameter flag_system is invalid. For a description of valid query parameters see the docstring for SvoFps.data_from_svo'
+    with pytest.raises(InvalidQueryError, match=msg):
+        SvoFps.get_filter_metadata(TEST_FILTER_ID, flag_system='no such kwd')

--- a/astroquery/svo_fps/tests/test_svo_fps.py
+++ b/astroquery/svo_fps/tests/test_svo_fps.py
@@ -3,7 +3,7 @@ import os
 from astropy import units as u
 from requests import ReadTimeout
 
-from astroquery.exceptions import InvalidQueryError, TimeoutError
+from astroquery.exceptions import TimeoutError
 from astroquery.utils.mocks import MockResponse
 from ..core import SvoFps
 
@@ -102,9 +102,6 @@ def test_get_zeropoint(patch_get):
 
 
 def test_invalid_query(patch_get):
-    msg = r"^parameter bad_param is invalid\. For a description of valid query "
-    with pytest.raises(InvalidQueryError, match=msg):
-        SvoFps.data_from_svo(query={"bad_param": 0, "FWHM": 20})
-    msg = r"^parameters invalid_param, bad_param are invalid\. For a description of "
-    with pytest.raises(InvalidQueryError, match=msg):
-        SvoFps.data_from_svo(query={"invalid_param": 0, 'bad_param': -1})
+    msg = r"^SvoFpsClass.data_from_svo\(\) got an unexpected keyword argument 'bad_param'"
+    with pytest.raises(TypeError, match=msg):
+        SvoFps.data_from_svo(bad_param=0, FWHM_min=20)

--- a/astroquery/svo_fps/tests/test_svo_fps.py
+++ b/astroquery/svo_fps/tests/test_svo_fps.py
@@ -9,12 +9,14 @@ from ..core import SvoFps
 
 DATA_FILES = {'filter_index': 'svo_fps_WavelengthEff_min=12000_WavelengthEff_max=12100.xml',
               'transmission_data': 'svo_fps_ID=2MASS.2MASS.H.xml',
-              'filter_list': 'svo_fps_Facility=Keck_Instrument=NIRC2.xml'
+              'filter_list': 'svo_fps_Facility=Keck_Instrument=NIRC2.xml',
+              'zeropoint': 'svo_fps_PhotCalID=2MASS.2MASS.H.Vega.xml',
               }
 TEST_LAMBDA = 12000
 TEST_FILTER_ID = '2MASS/2MASS.H'
 TEST_FACILITY = 'Keck'
 TEST_INSTRUMENT = 'NIRC2'
+TEST_MAG_SYSTEM = 'Vega'
 
 
 def data_path(filename):
@@ -35,6 +37,10 @@ def get_mockreturn(method, url, params=None, timeout=10, cache=None, **kwargs):
         and (params['WavelengthEff_min'] == TEST_LAMBDA
              and params['WavelengthEff_max'] == TEST_LAMBDA+100)):
         filename = data_path(DATA_FILES['filter_index'])
+    elif ('PhotCalID' in params
+          and params.get('ID') == TEST_FILTER_ID
+          and params['PhotCalID'] == f'{TEST_FILTER_ID}/{TEST_MAG_SYSTEM}'):
+        filename = data_path(DATA_FILES['zeropoint'])
     elif 'ID' in params and params['ID'] == TEST_FILTER_ID:
         filename = data_path(DATA_FILES['filter_index'])
     elif 'Facility' in params and (params['Facility'] == TEST_FACILITY
@@ -82,6 +88,17 @@ def test_get_filter_list(patch_get):
     table = SvoFps.get_filter_list(TEST_FACILITY, instrument=TEST_INSTRUMENT)
     # Check if column for Filter ID (named 'filterID') exists in table
     assert 'filterID' in table.colnames
+
+
+def test_get_zeropoint(patch_get):
+    zp = SvoFps.get_zeropoint(TEST_FILTER_ID, mag_system=TEST_MAG_SYSTEM)
+    assert 'ZeroPoint' in zp
+    assert 'MagSys' in zp
+    assert zp['MagSys'] == TEST_MAG_SYSTEM
+    assert 'ZeroPointType' in zp
+    assert zp['ZeroPointType'] == 'Pogson'
+    assert 'ZeroPointUnit' in zp
+    assert zp['ZeroPoint'].unit == u.Jy
 
 
 def test_invalid_query(patch_get):

--- a/astroquery/svo_fps/tests/test_svo_fps.py
+++ b/astroquery/svo_fps/tests/test_svo_fps.py
@@ -110,7 +110,9 @@ def test_invalid_query(patch_get):
     with pytest.raises(InvalidQueryError, match=msg):
         SvoFps.data_from_svo(FORMAT='silly_format')
 
+
 def test_invalid_get_filter_metadata(patch_get):
-    msg = 'parameter flag_system is invalid. For a description of valid query parameters see the docstring for SvoFps.data_from_svo'
+    msg = ('parameter flag_system is invalid. '
+           'For a description of valid query parameters see the docstring for SvoFps.data_from_svo')
     with pytest.raises(InvalidQueryError, match=msg):
         SvoFps.get_filter_metadata(TEST_FILTER_ID, flag_system='no such kwd')

--- a/astroquery/svo_fps/tests/test_svo_fps.py
+++ b/astroquery/svo_fps/tests/test_svo_fps.py
@@ -102,13 +102,13 @@ def test_get_zeropoint(patch_get):
 
 
 def test_invalid_query(patch_get):
-    msg = 'Invalid value for parameter VERB. Allowed values are {0, 1, 2}'
+    msg = 'Invalid value for parameter verb. Allowed values are {0, 1, 2}'
     with pytest.raises(InvalidQueryError, match=msg):
-        SvoFps.data_from_svo(VERB=5)
+        SvoFps.data_from_svo(verb=5)
     # need this wonky regex b/c {'metadata', None} is a set and the order flips every time
-    msg = r"Invalid value for parameter FORMAT\. Allowed values are \{(?=.*'metadata')(?=.*None).*\}"
+    msg = r"Invalid value for parameter format\. Allowed values are \{(?=.*'metadata')(?=.*None).*\}"
     with pytest.raises(InvalidQueryError, match=msg):
-        SvoFps.data_from_svo(FORMAT='silly_format')
+        SvoFps.data_from_svo(format='silly_format')
 
 
 def test_invalid_get_filter_metadata(patch_get):

--- a/astroquery/svo_fps/tests/test_svo_fps_remote.py
+++ b/astroquery/svo_fps/tests/test_svo_fps_remote.py
@@ -40,6 +40,23 @@ class TestSvoFpsClass:
         # Check if column for Filter ID (named 'filterID') exists in table
         assert 'filterID' in table.colnames
 
+    @pytest.mark.parametrize('test_filter_id, mag_system, expected_zp_jy', [
+        ('2MASS/2MASS.J', 'Vega', 1594.0),
+        ('2MASS/2MASS.J', 'AB', 3631.0),
+    ])
+    def test_get_zeropoint(self, test_filter_id, mag_system, expected_zp_jy):
+        zp = SvoFps.get_zeropoint(test_filter_id, mag_system=mag_system)
+        # Check all expected keys are present
+        assert 'ZeroPoint' in zp
+        assert 'MagSys' in zp
+        assert 'ZeroPointType' in zp
+        assert 'ZeroPointUnit' in zp
+        # Check the magnitude system matches what was requested
+        assert zp['MagSys'] == mag_system
+        # Check zero point has the right unit and an approximately correct value
+        assert zp['ZeroPoint'].unit == u.Jy
+        assert abs(zp['ZeroPoint'].value - expected_zp_jy) < 10.0
+
     def test_query_parameter_names(self):
         # Checks if `QUERY_PARAMETERS` is up to date.
         query = {"FORMAT": "metadata"}

--- a/astroquery/svo_fps/tests/test_svo_fps_remote.py
+++ b/astroquery/svo_fps/tests/test_svo_fps_remote.py
@@ -5,7 +5,7 @@ from astropy import units as u
 from astropy.io.votable import parse
 
 from astroquery.svo_fps import conf, SvoFps
-from astroquery.svo_fps.core import QUERY_PARAMETERS
+from astroquery.svo_fps.core import QUERY_PARAMETERS, SVO_PARAM_NAMES
 
 
 @pytest.mark.remote_data
@@ -58,20 +58,31 @@ class TestSvoFpsClass:
         assert abs(zp['ZeroPoint'].value - expected_zp_jy) < 10.0
 
     def test_query_parameter_names(self):
-        # Checks if `QUERY_PARAMETERS` is up to date.
+        # Checks if `QUERY_PARAMETERS` (snake_case, lowercase) is up to date
+        # against the SVO server's native (CamelCase) parameter names.
         query = {"FORMAT": "metadata"}
         response = BytesIO(
             SvoFps._request(
                 "GET", conf.base_url, params=query, timeout=conf.timeout, cache=False
             ).content
         )
-        params = {p.name.split(":")[1] for p in parse(response).resources[0].params}
-        # All valid parameters should be present in `QUERY_PARAMETERS`.
-        assert not params.difference(QUERY_PARAMETERS)
-        # Some valid parameter names are not in `params`.
-        for p in QUERY_PARAMETERS.difference(params):
-            # `QUERY_PARAMETERS` also contains names without "_min" or "_max" ending
-            # because "Param_min=a&Param_max=b" can be replaced with "Param=a/b".
-            if p + "_min" not in params:
-                # There's a few extra parameters we didn't get from the server.
-                assert p in {"VERB", "FORMAT", "PhotCalID", "ID"}
+        server_params = {p.name.split(":")[1]
+                         for p in parse(response).resources[0].params}
+        # Inverse mapping so we can compare server's CamelCase against our
+        # snake_case `QUERY_PARAMETERS`.
+        svo_to_snake = {v: k for k, v in SVO_PARAM_NAMES.items()}
+        # All server-returned parameters should map to something we know about.
+        unknown = server_params - set(svo_to_snake)
+        assert not unknown, f"server returned unknown params: {unknown}"
+        # Translate server-returned names to snake_case.
+        server_params_snake = {svo_to_snake[p] for p in server_params}
+        # All names we know about should appear on the server (modulo a few
+        # we keep in `QUERY_PARAMETERS` but the metadata endpoint doesn't
+        # report).
+        for p in QUERY_PARAMETERS.difference(server_params_snake):
+            # `QUERY_PARAMETERS` also contains base names without "_min" or
+            # "_max" ending because "Param_min=a&Param_max=b" can be
+            # replaced with "Param=a/b".
+            if p + "_min" not in server_params_snake:
+                # Server doesn't echo these back in the metadata response.
+                assert p in {"verb", "format", "phot_cal_id", "id"}


### PR DESCRIPTION
There is metadata on SVO FPS that is inaccessible but should be.

https://github.com/astropy/astroquery/pull/3528 showed the right mechanism to retrieve metadata, but it didn't allow querying on PhotCalID - while `data_from_svo` allowed specification of this parameter, the mechanism we are using to parse the votable drops the relevant data.

This PR adds a new `get_zeropoint` mechanism to very explicitly and cleanly retrieve zeropoints and also generalizes `get_filter_metadata`.

Note that I have made some serious mistakes in recent publications because I failed to realize the default zeropoint was vega, so it's high importance for me to expose the `get_zeropoint` method with an explicit `mag_sys` keyword to users.