### PR TITLE
API: Deprecate vo_conesearch

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -26,7 +26,7 @@ esa.euclid
 - Methods ``cone_search`` and ``cross_match_basic`` now define the  parameters ``table_name`` and ``ra_column_name`` and
   ``dec_column_name`` independently [#3496]
 
-- Method ``get_product`` now supports the input file_name as a Python list (e.g. ["file1.fits", "file2.fits"]) while 
+- Method ``get_product`` now supports the input file_name as a Python list (e.g. ["file1.fits", "file2.fits"]) while
   still accepting the original comma separated string format. [#3541]
 
 vizier
@@ -37,9 +37,15 @@ vizier
 mast
 ^^^^
 - ``utils.mast_relative_path`` is now deprecated in favor of ``utils.get_cloud_paths``. [#3488]
-- When cloud access is enabled, ``Observations.download_file`` and ``Observations.download_products`` 
-  now check all requested products against cloud storage. As a result, setting ``cloud_only=True`` will skip 
+- When cloud access is enabled, ``Observations.download_file`` and ``Observations.download_products``
+  now check all requested products against cloud storage. As a result, setting ``cloud_only=True`` will skip
   any products that are not available in the cloud, rather than falling back to on-prem downloads.
+
+vo_conesearch
+^^^^^^^^^^^^^
+- The whole ``vo_conesearch`` module is deprecated. Queries can be made using
+  PyVO Simple Cone Search interface instead. There is no direct replacement
+  for server validation. [#3548]
 
 Service fixes and enhancements
 ------------------------------
@@ -98,7 +104,7 @@ mast
 
 - Added full support for the International Ultraviolet Explorer (IUE) mission in ``MastMissions``. [#3517]
 
-- Added a new ``Observations.list_cloud_datasets()`` method for querying cloud-supported MAST datasets, alongside 
+- Added a new ``Observations.list_cloud_datasets()`` method for querying cloud-supported MAST datasets, alongside
   improvements to cloud download handling. [#3488]
 
 jplspec

--- a/astroquery/vo_conesearch/__init__.py
+++ b/astroquery/vo_conesearch/__init__.py
@@ -1,6 +1,15 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 
+import warnings
+
 from astropy import config as _config
+from astropy.utils.exceptions import AstropyDeprecationWarning
+
+warnings.warn(
+    "astroquery.vo_conesearch was deprecated in version 0.4.12 "
+    "and will be removed in a future version; "
+    "where possible, use PyVO SCS instead.",
+    AstropyDeprecationWarning)
 
 
 class Conf(_config.ConfigNamespace):

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -294,10 +294,8 @@ The following modules have been completed using a common API:
   ukidss/ukidss.rst
   vamdc/vamdc.rst
   vizier/vizier.rst
-  vo_conesearch/vo_conesearch.rst
   vsa/vsa.rst
   xmatch/xmatch.rst
-
 
 These others are functional, but do not follow a common & consistent API:
 
@@ -323,6 +321,13 @@ There are also subpackages that serve as the basis of others.
   :maxdepth: 1
 
   wfau/wfau.rst
+
+This module is deprecated in favor of :ref:`PyVO Simple Cone Search (SCS) <pyvo:pyvo-scs>`:
+
+.. toctree::
+  :maxdepth: 1
+
+  vo_conesearch/vo_conesearch.rst
 
 Catalog, Archive, and Other
 ===========================
@@ -355,7 +360,6 @@ for each source)
   simbad/simbad.rst
   ukidss/ukidss.rst
   vizier/vizier.rst
-  vo_conesearch/vo_conesearch.rst
   vsa/vsa.rst
   xmatch/xmatch.rst
 

--- a/docs/vo_conesearch/vo_conesearch.rst
+++ b/docs/vo_conesearch/vo_conesearch.rst
@@ -6,6 +6,14 @@
 VO Simple Cone Search (``astroquery.vo_conesearch``)
 ****************************************************
 
+.. warning::
+
+   As of version 0.4.12, this module has been deprecated. Client-side queries can be made using
+   :ref:`PyVO Simple Cone Search (SCS) <pyvo:pyvo-scs>` interface instead.
+   However, there is no direct replacement for server validation functionality.
+   If you need help transitioning away from the deprecated
+   functionality here, please reach out to Astroquery or PyVO communities.
+
 Astroquery offers Simple Cone Search Version 1.03 as defined in IVOA
 Recommendation (February 22, 2008). Cone Search queries an
 area encompassed by a given radius centered on a given RA and Dec and returns

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -123,6 +123,7 @@ filterwarnings = [
   "error",
 # Ignore astroquery's own module reorganization deprecation warnings during testing
   "ignore:Importing from 'astroquery.jplspec' is deprecated:DeprecationWarning",
+  "ignore:astroquery\\.vo_conesearch was deprecated:astropy.utils.exceptions.AstropyDeprecationWarning",
 #   These are temporary measures, all of these should be fixed:
 #   -----------------------------------------------------------
   "ignore:distutils Version classes are deprecated:DeprecationWarning",


### PR DESCRIPTION
Close https://github.com/astropy/astroquery/issues/2027

After merge:

* ~Open follow-up issue to remove `vo_conesearch` completely after deprecation period has elapsed.~ -- no need; we don't normally open such follow-up issues.
* Open follow-up issue to write up a transition guide, if there is a need for it.  -- edit by Brigitta: I would also just open this issue if the need arises, not before.