### PR TITLE
Added a method to HeasarcClass that returns the number of rows in a named catalog

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -54,6 +54,7 @@ heasarc
 - Add ``query_constraints`` to allow querying of different catalog columns. [#3403]
 - Add support for uploading tables when using TAP directly through ``query_tap``. [#3403]
 - Add automatic guessing for the data host in ``download_data``. [#3403]
+- Include method to count the number of rows in a specified table. [#3549]
 
 gaia
 ^^^^

--- a/astroquery/heasarc/core.py
+++ b/astroquery/heasarc/core.py
@@ -976,7 +976,7 @@ class HeasarcClass(BaseVOQuery, BaseQuery):
             The total number of rows in the specified catalog.
         """
         # Send a query requesting a count of the number of rows in the
-        #  specified catalog.
+        #  specified catalog. Return is a one-row TAPResults object.
         count_return = self.query_tap(f"SELECT COUNT(*) FROM {catalog}")
 
         # Extract an integer number of rows from the returned table.

--- a/astroquery/heasarc/core.py
+++ b/astroquery/heasarc/core.py
@@ -961,7 +961,7 @@ class HeasarcClass(BaseVOQuery, BaseQuery):
     def count_rows(self, catalog):
         """
         Returns the number of rows in the HEASARC-hosted catalog specified by
-        the `catalog` argument.
+        the ``catalog`` argument.
 
         Parameters
         ----------

--- a/astroquery/heasarc/core.py
+++ b/astroquery/heasarc/core.py
@@ -958,5 +958,27 @@ class HeasarcClass(BaseVOQuery, BaseQuery):
             path = key.replace(f's3://{self.S3_BUCKET}/', '')
             _s3_tree_download(self.s3_client, self.S3_BUCKET, path, location)
 
+    def count_rows(self, catalog: str) -> int:
+        """
+        Returns the number of rows in the HEASARC-hosted catalog specified by
+        the `catalog` argument.
+
+        Parameters
+        ----------
+        catalog : `str`
+            The name of the catalog to query for a total number of rows. To list
+            the available catalogs, use
+            :meth:`~astroquery.heasarc.HeasarcClass.list_catalogs`.
+
+        Returns
+        -------
+        num_rows : `int`
+            The total number of rows in the specified catalog.
+        """
+        count_return = self.query_tap(f"SELECT COUNT(*) FROM {catalog}")
+
+        num_rows = count_return["count"][0]
+        return num_rows
+
 
 Heasarc = HeasarcClass()

--- a/astroquery/heasarc/core.py
+++ b/astroquery/heasarc/core.py
@@ -958,7 +958,7 @@ class HeasarcClass(BaseVOQuery, BaseQuery):
             path = key.replace(f's3://{self.S3_BUCKET}/', '')
             _s3_tree_download(self.s3_client, self.S3_BUCKET, path, location)
 
-    def count_rows(self, catalog: str) -> int:
+    def count_rows(self, catalog: str) -> np.int64:
         """
         Returns the number of rows in the HEASARC-hosted catalog specified by
         the `catalog` argument.
@@ -972,11 +972,14 @@ class HeasarcClass(BaseVOQuery, BaseQuery):
 
         Returns
         -------
-        num_rows : `int`
+        num_rows : `np.int64`
             The total number of rows in the specified catalog.
         """
+        # Send a query requesting a count of the number of rows in the
+        #  specified catalog.
         count_return = self.query_tap(f"SELECT COUNT(*) FROM {catalog}")
 
+        # Extract an integer number of rows from the returned table.
         num_rows = count_return["count"][0]
         return num_rows
 

--- a/astroquery/heasarc/core.py
+++ b/astroquery/heasarc/core.py
@@ -958,21 +958,21 @@ class HeasarcClass(BaseVOQuery, BaseQuery):
             path = key.replace(f's3://{self.S3_BUCKET}/', '')
             _s3_tree_download(self.s3_client, self.S3_BUCKET, path, location)
 
-    def count_rows(self, catalog: str) -> np.int64:
+    def count_rows(self, catalog):
         """
         Returns the number of rows in the HEASARC-hosted catalog specified by
         the `catalog` argument.
 
         Parameters
         ----------
-        catalog : `str`
+        catalog : str
             The name of the catalog to query for a total number of rows. To list
             the available catalogs, use
             :meth:`~astroquery.heasarc.HeasarcClass.list_catalogs`.
 
         Returns
         -------
-        num_rows : `np.int64`
+        num_rows : np.int64
             The total number of rows in the specified catalog.
         """
         # Send a query requesting a count of the number of rows in the

--- a/astroquery/heasarc/tests/test_heasarc.py
+++ b/astroquery/heasarc/tests/test_heasarc.py
@@ -6,6 +6,8 @@ import tempfile
 from unittest.mock import patch, PropertyMock
 from astropy.coordinates import SkyCoord
 from astropy.table import Table
+from astropy.io import votable
+from pyvo.dal import TAPResults
 import astropy.units as u
 
 from astroquery.heasarc import Heasarc, HeasarcClass
@@ -55,7 +57,11 @@ class MockTap:
     }
 
     def search(self, query, language='ADQL', maxrec=1000, uploads=None):
-        return MockResult()
+        if "SELECT COUNT(*) FROM" in query:
+            return TAPResults(votable.from_table(Table([[3055]], names=['count'],
+                                                       dtype=['int64'])))
+        else:
+            return MockResult()
 
 
 class MockResult:
@@ -719,3 +725,13 @@ def test_s3_mock_directory(s3_mock):
         assert os.path.exists(f"{tmpdir}/location/file1.txt")
         assert os.path.exists(f"{tmpdir}/location/sub/file2.txt")
         assert os.path.exists(f"{tmpdir}/location/sub/sub2/file3.txt")
+
+
+# def test__list_columns(mock_tap, mock_default_cols):
+#     cols = Heasarc.list_columns(catalog_name='name-1')
+#     assert list(cols['name']) == ['col-2', 'col-3']
+#     assert list(cols['description']) == ['desc-2', 'desc-3']
+
+def test_row_count(mock_tap, mock_default_cols):
+    cat = "name-1"
+    assert Heasarc.count_rows(cat) == 3055

--- a/astroquery/heasarc/tests/test_heasarc.py
+++ b/astroquery/heasarc/tests/test_heasarc.py
@@ -727,11 +727,6 @@ def test_s3_mock_directory(s3_mock):
         assert os.path.exists(f"{tmpdir}/location/sub/sub2/file3.txt")
 
 
-# def test__list_columns(mock_tap, mock_default_cols):
-#     cols = Heasarc.list_columns(catalog_name='name-1')
-#     assert list(cols['name']) == ['col-2', 'col-3']
-#     assert list(cols['description']) == ['desc-2', 'desc-3']
-
 def test_row_count(mock_tap, mock_default_cols):
     cat = "name-1"
     assert Heasarc.count_rows(cat) == 3055

--- a/astroquery/heasarc/tests/test_heasarc_remote.py
+++ b/astroquery/heasarc/tests/test_heasarc_remote.py
@@ -273,6 +273,13 @@ class TestHeasarc:
                 Heasarc.query_region(pos, mission="xmmmaster",
                                      **{keyword: value})
 
+    def test_row_count(self):
+        """Test the convenience method that uses ADQL's COUNT function to
+        return the number of rows in a catalog.
+        """
+        cat = "suzamaster"
+        assert Heasarc.count_rows(cat) == 3055
+
 
 @pytest.mark.remote_data
 class TestHeasarcBrowse:

--- a/docs/heasarc/heasarc.rst
+++ b/docs/heasarc/heasarc.rst
@@ -422,6 +422,16 @@ in the XMM master catalog ``xmmmaster``:
     public_date     Public Date                              mjd
     ra              Right Ascension (Pointing Position)      degree
 
+Get Length Of Catalog
+---------------------
+To easily find out the number of rows in a catalog, use the `~astroquery.heasarc.HeasarcClass.count_rows`
+method. Here, for instance, we fetch the number of rows in the Suzaku 'master' observation table (``suzamaster``):
+
+.. doctest-remote-data::
+
+    >>> from astroquery.heasarc import Heasarc
+    >>> Heasarc.count_rows('suzamaster')
+
 Reference/API
 =============
 

--- a/docs/heasarc/heasarc.rst
+++ b/docs/heasarc/heasarc.rst
@@ -431,6 +431,7 @@ method. Here, for instance, we fetch the number of rows in the Suzaku 'master' o
 
     >>> from astroquery.heasarc import Heasarc
     >>> Heasarc.count_rows('suzamaster')
+    np.int64(3055)
 
 Reference/API
 =============


### PR DESCRIPTION
A small convenience method has been included in the HeasarcClass class which takes the name of a catalog as an argument and passes it to a simple ADQL query that uses COUNT(*) to fetch the number of rows it contains.

The integer number of rows is then extracted from that return, and passed back to the user.

This abstracts another use of ADQL away from the user.

A simple test was added, and an example in the Heasarc sub-module docs.