### PR TITLE
EUCLID: update output filename for downloads in the methods get_product  and get_cutout

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -21,13 +21,11 @@ esa.euclid
   ``datalabs_path``, ``file_name`` and ``hdu_index``. [#3438]
 - The default value of the parameter ``output_format`` in the the methods ``launch_job``, ``launch_job_async`` and
   ``cone_search`` is changed to "votable_gzip". [#3497]
-
-
 - Methods ``cone_search`` and ``cross_match_basic`` now define the  parameters ``table_name`` and ``ra_column_name`` and
   ``dec_column_name`` independently [#3496]
-
 - Method ``get_product`` now supports the input file_name as a Python list (e.g. ["file1.fits", "file2.fits"]) while
   still accepting the original comma separated string format. [#3541]
+- update the output filename for downloads in the methods get_product and get_cutout [#3550]
 
 vizier
 ^^^^^^

--- a/astroquery/esa/euclid/core.py
+++ b/astroquery/esa/euclid/core.py
@@ -787,8 +787,8 @@ class EuclidClass(TapPlus):
     def __set_dirs(output_file, observation_id):
         if output_file is None:
             now = datetime.now()
-            output_dir = os.getcwd() + os.sep + "temp_" + now.strftime("%Y%m%d_%H%M%S")
-            output_file_full_path = output_dir + os.sep + str(observation_id)
+            output_dir = os.path.join(os.getcwd(), "temp_" + now.strftime("%Y%m%d_%H%M%S"))
+            output_file_full_path = os.path.join(output_dir, str(observation_id))
         else:
             output_file_full_path = output_file
             output_dir = os.path.dirname(output_file_full_path)
@@ -801,8 +801,7 @@ class EuclidClass(TapPlus):
         return output_file_full_path, output_dir
 
     @staticmethod
-    def __check_file_number(output_dir, output_file_name,
-                            output_file_full_path, files):
+    def __check_file_number(output_dir, output_file_name, output_file_full_path, files):
         num_files_in_dir = len(os.listdir(output_dir))
         if num_files_in_dir == 1:
             output_f = output_file_name
@@ -1366,7 +1365,15 @@ class EuclidClass(TapPlus):
             if dsr_part3 is not None:
                 params_dict['DSP3'] = dsr_part3
 
-        output_file_full_path, output_dir = self.__set_dirs(output_file=output_file, observation_id='temp')
+        observation_id = product_id + '.fits'
+        if file_name is not None:
+            observation_id = file_name
+
+        output_file_full_path, output_dir = self.__set_dirs(output_file=output_file, observation_id=observation_id)
+
+        if verbose:
+            print(f"Product output file: {output_file_full_path}")
+
         try:
             self.__eucliddata.load_data(params_dict=params_dict, output_file=output_file_full_path, verbose=verbose)
         except HTTPError as err:
@@ -1429,7 +1436,12 @@ class EuclidClass(TapPlus):
         params_dict = {'TAPCLIENT': 'ASTROQUERY', 'FILEPATH': file_path, 'COLLECTION': instrument, 'OBSID': id,
                        'POS': pos}
 
-        output_file_full_path, output_dir = self.__set_dirs(output_file=output_file, observation_id='temp')
+        output_file_full_path, output_dir = self.__set_dirs(output_file=output_file,
+                                                            observation_id=os.path.basename(file_path).replace('.fits',
+                                                                                                               '_cutout.fits'))
+        if verbose:
+            print("Cutout output file: " + output_file_full_path)
+
         try:
             self.__euclidcutout.load_data(params_dict=params_dict, output_file=output_file_full_path, verbose=verbose)
         except HTTPError as err:
@@ -1513,9 +1525,12 @@ class EuclidClass(TapPlus):
                 output_file = os.path.join(os.getcwd(), output_file)
 
             if verbose:
-                print(f"output file: {output_file}")
+                print(f"Spectra output file: {output_file}")
 
         output_file_full_path, output_dir = self.__set_dirs(output_file=output_file, observation_id=fits_file)
+
+        if verbose:
+            print("Spectra output file: " + output_file_full_path)
 
         if os.listdir(output_dir):
             raise IOError(f'The directory is not empty: {output_dir}')

--- a/astroquery/esa/euclid/core.py
+++ b/astroquery/esa/euclid/core.py
@@ -1365,9 +1365,10 @@ class EuclidClass(TapPlus):
             if dsr_part3 is not None:
                 params_dict['DSP3'] = dsr_part3
 
-        observation_id = product_id + '.fits'
         if file_name is not None:
             observation_id = file_name
+        else:
+            observation_id = product_id + '.fits'
 
         output_file_full_path, output_dir = self.__set_dirs(output_file=output_file, observation_id=observation_id)
 
@@ -1436,9 +1437,8 @@ class EuclidClass(TapPlus):
         params_dict = {'TAPCLIENT': 'ASTROQUERY', 'FILEPATH': file_path, 'COLLECTION': instrument, 'OBSID': id,
                        'POS': pos}
 
-        output_file_full_path, output_dir = self.__set_dirs(output_file=output_file,
-                                                            observation_id=os.path.basename(file_path).replace('.fits',
-                                                                                                               '_cutout.fits'))
+        replace = os.path.basename(file_path).replace('.fits', '_cutout.fits')
+        output_file_full_path, output_dir = self.__set_dirs(output_file=output_file, observation_id=replace)
         if verbose:
             print("Cutout output file: " + output_file_full_path)
 

--- a/astroquery/esa/euclid/tests/test_euclidtap.py
+++ b/astroquery/esa/euclid/tests/test_euclidtap.py
@@ -749,7 +749,7 @@ def test_get_product_list_errors():
         tap.get_product_list(observation_id='13', product_type='DpdMerBksMosaic')
 
 
-def test_get_product_by_product_id(tmp_path_factory):
+def test_get_product_by_product_id(tmp_path_factory, capsys):
     conn_handler = DummyConnHandler()
     tap_plus = TapPlus(url="http://test:1111/tap", data_context='data', client_id='ASTROQUERY',
                        connhandler=conn_handler)
@@ -775,9 +775,32 @@ def test_get_product_by_product_id(tmp_path_factory):
 
     fits_file = os.path.join(tmp_path_factory.mktemp("euclid_tmp"), 'my_fits_file.fits')
 
-    result = tap.get_product(product_id='123456789', output_file=fits_file)
+    captured = capsys.readouterr()
+
+    result = tap.get_product(product_id='123456789', output_file=fits_file, verbose=True)
 
     assert result is not None
+
+    captured = capsys.readouterr()
+
+    file_path = captured.out.splitlines()[0].replace('Product output file: ', '')
+    assert os.path.exists(file_path)
+
+    remove_temp_dir()
+
+    result = tap.get_product(product_id='123456789', output_file=None, verbose=True)
+
+    assert result is not None
+
+    captured = capsys.readouterr()
+
+    file_path = captured.out.splitlines()[0].replace('Product output file: ', '')
+    assert os.path.exists(file_path)
+    assert '123456789' in file_path
+
+    remove_temp_dir()
+
+
 
 
 def test_get_product_by_product_id_data_set_release(tmp_path_factory):
@@ -813,7 +836,7 @@ def test_get_product_by_product_id_data_set_release(tmp_path_factory):
     assert result is not None
 
 
-def test_get_product():
+def test_get_product(capsys):
     conn_handler = DummyConnHandler()
     tap_plus = TapPlus(url="http://test:1111/tap", data_context='data', client_id='ASTROQUERY',
                        connhandler=conn_handler)
@@ -826,15 +849,21 @@ def test_get_product():
     tap = EuclidClass(tap_plus_conn_handler=conn_handler, datalink_handler=tap_plus, show_server_messages=False)
 
     result = tap.get_product(file_name='EUC_SIM_NISRGS180-8-1_20220722T094150.427Z_PV023_NISP-S_8_18_0.fits',
-                             output_file=None)
+                             output_file=None, verbose=True)
 
     assert result is not None
+
+    captured = capsys.readouterr()
 
     now = datetime.now()
     dirs = glob.glob(os.path.join(os.getcwd(), "temp_" + now.strftime("%Y%m%d") + '_*'))
 
     assert len(dirs) == 1
     assert dirs[0] is not None
+
+    file_path = captured.out.splitlines()[0].replace('Product output file: ', '')
+    assert os.path.exists(file_path)
+    assert 'EUC_SIM_NISRGS180-8-1_20220722T094150.427Z_PV023_NISP-S_8_18_0' in file_path
 
     remove_temp_dir()
 
@@ -1068,7 +1097,7 @@ def test_get_observation_products_exceptions_2(mock_load_data, caplog):
     remove_temp_dir()
 
 
-def test_get_cutout():
+def test_get_cutout(capsys):
     conn_handler = DummyConnHandler()
     tap_plus = TapPlus(url="http://test:1111/tap", data_context='cutout', client_id='ASTROQUERY',
                        connhandler=conn_handler)
@@ -1090,9 +1119,14 @@ def test_get_cutout():
 
     result = tap.get_cutout(
         file_path='/data/repository/NIR/19704/EUC_NIR_W-STACK_NIR-J-19704_20190718T001858.5Z_00.00.fits',
-        instrument='NISP', id='19704', coordinate=c, radius=r, output_file=None)
+        instrument='NISP', id='19704', coordinate=c, radius=r, output_file=None, verbose=True)
 
     assert result is not None
+
+    captured = capsys.readouterr()
+
+    file_path = captured.out.splitlines()[0].replace('Cutout output file: ', '')
+    assert os.path.exists(file_path)
 
     remove_temp_dir()
 
@@ -1175,7 +1209,7 @@ def test_get_cutout_exceptions_2(mock_load_data, caplog):
     assert caplog.records[1].msg == mssg
 
 
-def test_get_spectrum(tmp_path_factory):
+def test_get_spectrum(tmp_path_factory, capsys):
     conn_handler = DummyConnHandler()
     tap_plus = TapPlus(url="http://test:1111/tap", data_context='data', client_id='ASTROQUERY',
                        connhandler=conn_handler)
@@ -1202,8 +1236,22 @@ def test_get_spectrum(tmp_path_factory):
     fits_file = os.path.join(tmp_path_factory.mktemp("euclid_tmp"), 'my_fits_file.fits')
 
     result = tap.get_spectrum(source_id='2417660845403252054', schema='sedm_sc8', output_file=fits_file)
+    assert os.path.exists(fits_file + '.zip')
 
     assert result is not None
+
+    remove_temp_dir()
+
+    result = tap.get_spectrum(source_id='2417660845403252054', schema='sedm_sc8', output_file=None, verbose=True)
+
+    assert result is not None
+
+    captured = capsys.readouterr()
+
+    file_path = captured.out.splitlines()[0].replace('Spectra output file: ', '')
+    assert os.path.exists(file_path)
+
+    remove_temp_dir()
 
 
 @patch.object(TapPlus, 'load_data')

--- a/astroquery/esa/euclid/tests/test_euclidtap.py
+++ b/astroquery/esa/euclid/tests/test_euclidtap.py
@@ -801,8 +801,6 @@ def test_get_product_by_product_id(tmp_path_factory, capsys):
     remove_temp_dir()
 
 
-
-
 def test_get_product_by_product_id_data_set_release(tmp_path_factory):
     conn_handler = DummyConnHandler()
     tap_plus = TapPlus(url="http://test:1111/tap", data_context='data', client_id='ASTROQUERY',


### PR DESCRIPTION
Dear Astroquery team,

The Astroquery Euclid get_product method (https://astroquery.readthedocs.io/en/latest/api/astroquery.esa.euclid.EuclidClass.html#astroquery.esa.euclid.EuclidClass.get_product) allows one to retrieve one or multiple Euclid products (FITS files) provided that the user knows the file_name or product_id of the product to be retrieved. The method is certainly useful, but its implementation could be improved to make the life of the users easier:

out_path = Euclid.get_product(file_name = 'EUC_VIS_SWL-DET-002704-01-1-0000000__20241017T042805.678587Z.fits')

By default, the code writes the downloaded file into a file named "temp_YYYYMMDD_HHMMDD/temp", where "temp_YYYYMMDD_HHMMDD" is automatically created by the method. The name of the file is at the very least misleading (especially since it does not even include the .fits extension). We suggest changing "temp" to the actual name of the file downloaded. That is, in the example above, the downloaded file should be stored as: "temp_YYYYMMDD_HHMMDD/EUC_VIS_SWL-DET-002704-01-1-0000000__20241017T042805.678587Z.fits"

The same scenario is present in the method get_cutout.


cc @esdc-esac-esa-int 
Jira: EUCLIDSWRQ-283