### PR TITLE
NXSAPCR-1220: get the current version of RMF matrices from server

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -50,8 +50,8 @@ vo_conesearch
 Service fixes and enhancements
 ------------------------------
 
-esa.xmm-newton
-^^^^^^^^^^
+esa.xmm_newton
+^^^^^^^^^^^^^^
 
 - Update ``get_epic_spectra`` method to get the latest version of PN RMF files from the SAS server
   instead of having it hardcoded [#3544]

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -54,7 +54,7 @@ esa.xmm_newton
 ^^^^^^^^^^^^^^
 
 - Update ``get_epic_spectra`` method to get the latest version of PN RMF files from the SAS server
-  instead of having it hardcoded [#3544]
+  instead of having it hardcoded [#3563]
 
 svo_fps
 ^^^^^^^

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -50,6 +50,12 @@ vo_conesearch
 Service fixes and enhancements
 ------------------------------
 
+esa.xmm-newton
+^^^^^^^^^^
+
+- Update ``get_epic_spectra`` method to get the latest version of PN RMF files from the SAS server
+  instead of having it hardcoded [#3544]
+
 svo_fps
 ^^^^^^^
 

--- a/astroquery/esa/xmm_newton/core.py
+++ b/astroquery/esa/xmm_newton/core.py
@@ -402,11 +402,11 @@ class XMMNewtonClass(BaseQuery):
         (https://xmm-tools.cosmos.esa.int/external/xmm_obs_info/odf/data/docs/XMM-SOC-GEN-ICD-0024.pdf).
 
         The RMF to be used for the spectral analysis should be generated with the same PPS version as the spectrum,
-        background and ARF. The PPS version can be found in SASVERS keyword in the SPECTRUM file, characters [-6:-3].
+        background and ARF.
         Once the sas version is determined, the code should look for the proper version of RMF in the FTP tree.
-        However, for the current PPS versions available in the archive, i.e v18.0, v19.0, v20.0 and v21.0,
+        However, for the current PPS versions available in the archive, i.e v18.x, v19.x, v20.x and v21.x,
         all RMF matrices are equal among the versions and for all instruments, so it is possible to download the last
-        one, v21.0, available in the root FTP stored in 'rmf_ftp'. In the future, the FTP tree and/or PPS keywords will
+        one available in the root FTP stored in 'rmf_ftp'. In the future, the FTP tree and/or PPS keywords will
         be modified to make it easier to download the appropriate RMF file for each spectrum.
         """
         _instrument = ["M1", "M2", "PN", "EP"]
@@ -458,8 +458,10 @@ class XMMNewtonClass(BaseQuery):
                                 elif fname_info["I"] == "PN":
                                     inst = "PN/"
                                     file_name, file_ext = os.path.splitext(rmf_fname)
-                                    rmf_fname = file_name + "_v21.0" + file_ext
-
+                                    # Fetch the current RMF version string from the FTP Version.txt file
+                                    response = self._request('GET', self._rmf_ftp + inst + "Version.txt")
+                                    version_str = response.text.strip()
+                                    rmf_fname = file_name + version_str + file_ext
                                 link = self._rmf_ftp + inst + rmf_fname
 
                                 if verbose:

--- a/astroquery/esa/xmm_newton/tests/test_xmm_newton.py
+++ b/astroquery/esa/xmm_newton/tests/test_xmm_newton.py
@@ -17,6 +17,7 @@ from unittest.mock import patch, MagicMock
 
 import pytest
 from astropy.io import fits
+from astropy.coordinates import SkyCoord
 
 from astroquery.exceptions import LoginError
 from astroquery.esa.xmm_newton.core import XMMNewtonClass
@@ -643,17 +644,3 @@ class TestXMMNewton:
         assert "PN" in res
         assert "PN_rmf" in res
         assert os.path.exists(res["PN_rmf"])
-
-    def test_get_epic_metadata(self):
-        xsa = XMMNewtonClass(self.get_dummy_tap_handler())
-        xsa.query_xsa_tap = MagicMock(return_value=None)
-
-        # Test with target_name
-        xsa.get_epic_metadata(target_name="m31")
-        assert xsa.query_xsa_tap.called
-
-        # Test with coordinates
-        from astropy.coordinates import SkyCoord
-        c = SkyCoord(ra=10.6847, dec=41.2687, unit="deg")
-        xsa.get_epic_metadata(coordinates=c, radius=0.1)
-        assert xsa.query_xsa_tap.called

--- a/astroquery/esa/xmm_newton/tests/test_xmm_newton.py
+++ b/astroquery/esa/xmm_newton/tests/test_xmm_newton.py
@@ -17,7 +17,6 @@ from unittest.mock import patch, MagicMock
 
 import pytest
 from astropy.io import fits
-from astropy.coordinates import SkyCoord
 
 from astroquery.exceptions import LoginError
 from astroquery.esa.xmm_newton.core import XMMNewtonClass

--- a/astroquery/esa/xmm_newton/tests/test_xmm_newton.py
+++ b/astroquery/esa/xmm_newton/tests/test_xmm_newton.py
@@ -13,7 +13,7 @@ import os
 import shutil
 import tarfile
 from pathlib import Path
-from unittest.mock import patch
+from unittest.mock import patch, MagicMock
 
 import pytest
 from astropy.io import fits
@@ -30,15 +30,18 @@ def data_path(filename):
 
 
 class mockResponse:
-    headers = {'Date': 'Wed, 24 Nov 2021 13:43:50 GMT',
-               'Server': 'Apache/2.4.6 (Red Hat Enterprise Linux) OpenSSL/1.0.2k-fips',
-               'Content-Disposition': 'inline; filename="0560181401.tar.gz"',
-               'Content-Type': 'application/x-gzip',
-               'Content-Length': '6590874', 'Connection': 'close'}
-    status_code = 400
+    def __init__(self, content=None, text=None, status_code=200, headers=None):
+        self.content = content
+        self.text = text
+        self.status_code = status_code
+        self.headers = headers if headers is not None else {
+            'Date': 'Wed, 24 Nov 2021 13:43:50 GMT',
+            'Server': 'Apache/2.4.6 (Red Hat Enterprise Linux) OpenSSL/1.0.2k-fips',
+            'Content-Disposition': 'inline; filename="0560181401.tar.gz"',
+            'Content-Type': 'application/x-gzip',
+            'Content-Length': '6590874', 'Connection': 'close'}
 
-    @staticmethod
-    def raise_for_status():
+    def raise_for_status(self):
         pass
 
 
@@ -527,7 +530,7 @@ class TestXMMNewton:
     @patch('astroquery.query.BaseQuery._request')
     def test_request_link(self, mock_request):
         xsa = XMMNewtonClass(self.get_dummy_tap_handler())
-        mock_request.return_value = mockResponse
+        mock_request.return_value = mockResponse()
         params = xsa._request_link("https://nxsa.esac.esa.int/nxsa-sl/servlet/data-action-aio?obsno=0560181401", None)
         assert params == {'filename': '0560181401.tar.gz'}
 
@@ -535,29 +538,21 @@ class TestXMMNewton:
     def test_request_link_protected(self, mock_request):
         with pytest.raises(LoginError):
             xsa = XMMNewtonClass(self.get_dummy_tap_handler())
-            dummyclass = mockResponse
-            dummyclass.headers = {}
-            mock_request.return_value = dummyclass
+            mock_request.return_value = mockResponse(headers={})
             xsa._request_link("https://nxsa.esac.esa.int/nxsa-sl/servlet/data-action-aio?obsno=0560181401", None)
 
     @patch('astroquery.query.BaseQuery._request')
     def test_request_link_incorrect_credentials(self, mock_request):
         with pytest.raises(LoginError):
             xsa = XMMNewtonClass(self.get_dummy_tap_handler())
-            dummyclass = mockResponse
-            dummyclass.headers = {}
-            dummyclass.status_code = 10
-            mock_request.return_value = dummyclass
+            mock_request.return_value = mockResponse(headers={}, status_code=10)
             xsa._request_link("https://nxsa.esac.esa.int/nxsa-sl/servlet/data-action-aio?obsno=0560181401", None)
 
     @patch('astroquery.query.BaseQuery._request')
     def test_request_link_with_statuscode_401(self, mock_request):
         with pytest.raises(LoginError):
             xsa = XMMNewtonClass(self.get_dummy_tap_handler())
-            dummyclass = mockResponse
-            dummyclass.headers = {}
-            dummyclass.status_code = 401
-            mock_request.return_value = dummyclass
+            mock_request.return_value = mockResponse(headers={}, status_code=401)
             xsa._request_link("https://nxsa.esac.esa.int/nxsa-sl/servlet/data-action-aio?obsno=0560181401", None)
 
     def test_get_username_and_password(self):
@@ -576,3 +571,89 @@ class TestXMMNewton:
         xsa = XMMNewtonClass(self.get_dummy_tap_handler())
         filename = xsa._create_filename("Test", "0560181401", ['.tar', '.gz'])
         assert filename == "Test.tar.gz"
+
+    def test_download_data_verbose(self, tmp_path):
+        xsa = XMMNewtonClass(self.get_dummy_tap_handler())
+        xsa._create_link = MagicMock(return_value="http://dummy")
+        xsa._get_username_and_password = MagicMock(return_value=("user", "pass"))
+        xsa._request_link = MagicMock(return_value={"filename": "obs.tar.gz"})
+        # Mock _download_file
+        xsa._download_file = MagicMock()
+
+        with patch('astroquery.esa.xmm_newton.core.log') as mock_log:
+            xsa.download_data("0405320501", verbose=True, prop=True)
+            # Verify verbose logs
+            assert mock_log.info.called
+            assert xsa._download_file.called
+
+    def test_get_postcard_verbose(self, tmp_path):
+        xsa = XMMNewtonClass(self.get_dummy_tap_handler())
+        # Mock _request to return a local path for the postcard
+        dummy_png = Path(tmp_path, "dummy.png")
+        dummy_png.touch()
+        xsa._request = MagicMock(side_effect=[
+            str(dummy_png),  # For GET (save=True)
+            mockResponse(headers={'Content-Disposition': 'inline; filename="0405320501.png"'})  # For HEAD
+        ])
+        cwd = os.getcwd()
+        os.chdir(tmp_path)
+        try:
+            with patch('astroquery.esa.xmm_newton.core.log') as mock_log:
+                res = xsa.get_postcard("0405320501", verbose=True)
+                assert res == "0405320501.png"
+                assert mock_log.info.called
+                assert os.path.exists("0405320501.png")
+        finally:
+            os.chdir(cwd)
+
+    def test_get_epic_spectra_rmf(self, tmp_path):
+        # This test aims to cover the RMF fetching logic in get_epic_spectra
+        tar_path = Path(tmp_path, "test_spectra.tar")
+        obs_id = "0405320501"
+        # The member name in tar must have 3 levels: something/pps/filename
+        pps_dir = Path(tmp_path, "obs", "pps")
+        pps_dir.mkdir(parents=True)
+
+        # Create a dummy spectrum file with the expected header
+        source_number_hex = "%03x" % 83
+        spec_file_name = f"P{obs_id}PNS001SRSPEC0{source_number_hex}.FTZ"
+        spec_path = pps_dir / spec_file_name
+        hdr = fits.Header()
+        hdr["RESPFILE"] = "dummy.rmf"
+        hdu = fits.PrimaryHDU(header=hdr)
+        hdu.name = "SPECTRUM"
+        hdu.writeto(spec_path)
+
+        with tarfile.open(tar_path, "w") as tar:
+            tar.add(spec_path, arcname=os.path.join("obs", "pps", spec_file_name))
+
+        xsa = XMMNewtonClass(self.get_dummy_tap_handler())
+
+        # Mock _request for Version.txt and RMF file
+        def mock_request(method, url, *args, **kwargs):
+            if "Version.txt" in url:
+                return mockResponse(text="_v1")
+            else:
+                return mockResponse(content=b"rmf_content")
+
+        xsa._request = MagicMock(side_effect=mock_request)
+
+        res = xsa.get_epic_spectra(str(tar_path), 83, instrument=['PN'], path=str(tmp_path))
+
+        assert "PN" in res
+        assert "PN_rmf" in res
+        assert os.path.exists(res["PN_rmf"])
+
+    def test_get_epic_metadata(self):
+        xsa = XMMNewtonClass(self.get_dummy_tap_handler())
+        xsa.query_xsa_tap = MagicMock(return_value=None)
+
+        # Test with target_name
+        xsa.get_epic_metadata(target_name="m31")
+        assert xsa.query_xsa_tap.called
+
+        # Test with coordinates
+        from astropy.coordinates import SkyCoord
+        c = SkyCoord(ra=10.6847, dec=41.2687, unit="deg")
+        xsa.get_epic_metadata(coordinates=c, radius=0.1)
+        assert xsa.query_xsa_tap.called

--- a/astroquery/esa/xmm_newton/tests/test_xmm_newton_remote.py
+++ b/astroquery/esa/xmm_newton/tests/test_xmm_newton_remote.py
@@ -198,7 +198,7 @@ class TestXMMNewtonRemote:
         assert report_diff_values(slew_source, table)
 
     def test_download_proprietary_data_incorrect_credentials(self, tmp_cwd):
-        parameters = {'observation_id': "0861270201",
+        parameters = {'observation_id': "0984300101",
                       'prop': 'True',
                       'credentials_file': data_path("dummy_config.ini"),
                       'level': "PPS",
@@ -212,7 +212,7 @@ class TestXMMNewtonRemote:
             xsa.download_data(**parameters)
 
     def test_download_proprietary_data_without_credentials(self, tmp_cwd):
-        parameters = {'observation_id': "0861270201",
+        parameters = {'observation_id': "0984300101",
                       'level': "PPS",
                       'name': 'OBSMLI',
                       'filename': 'single',


### PR DESCRIPTION
Dear Astroquery team,

To fix the issue [#3544 (XMM-Newton RMF version is outdated)](https://github.com/astropy/astroquery/issues/3544) of having a hardcoded version string which then is used to fetch a file from a URL, but files get removed when new versions are deployed, we have implemented a dynamic fetch of the version from the server.

Happy to receive your feedback and implement any change you require!

Kind regards,
@toniorte

cc @esdc-esac-esa-int 
