### PR TITLE
EUCLID: update output filename for downloads in the method get_product for multiple values in  `file_name` or `product_id`

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -25,7 +25,11 @@ esa.euclid
   ``dec_column_name`` independently [#3496]
 - Method ``get_product`` now supports the input file_name as a Python list (e.g. ["file1.fits", "file2.fits"]) while
   still accepting the original comma separated string format. [#3541]
-- update the output filename for downloads in the methods get_product and get_cutout [#3550]
+- Method ``get_product`` now supports the input product_id as a Python list while still accepting the original comma
+  separated string format. [#3564]
+- Update the output filename for downloads in the methods ``get_product`` and ``get_cutout`` [#3550]
+- The output file returned by the method ``get_product`` is never uncompressed and has the default name
+  get_product_ouput.zip in case the ``output_file`` is not defined. [#3564]
 - The method ``get_spectrum`` accepts the new parameter ``linking_parameter`` to retrieve the spectra by source_id and
   sourcepatch_id. [#3543]
 -  The ``source_id`` kwarg in the ``get_spectrum`` method has been renamed to ``ids``. [#3543]
@@ -33,6 +37,7 @@ esa.euclid
   The method now only supports retrieval of MER (background‑subtracted) image cutouts. [#3559]
 - The ``get_product_list`` method now also returns file_name_list column when the product type belongs to 
   BASIC_DOWNLOAD_DATA_PRODUCTS. [#3562]
+
 
 vizier
 ^^^^^^

--- a/astroquery/esa/euclid/core.py
+++ b/astroquery/esa/euclid/core.py
@@ -792,23 +792,39 @@ class EuclidClass(TapPlus):
             now = datetime.now()
             output_dir = os.path.join(os.getcwd(), "temp_" + now.strftime("%Y%m%d_%H%M%S"))
             output_file_full_path = os.path.join(output_dir, str(observation_id))
+
+            try:
+                if output_dir:
+                    os.makedirs(output_dir, exist_ok=True)
+            except OSError as err:
+                raise OSError("Creation of the directory %s failed: %s"
+                              % (output_dir, err.strerror))
         else:
-            output_file_full_path = output_file
-            output_dir = os.path.dirname(output_file_full_path)
-        try:
-            if output_dir:
-                os.makedirs(output_dir, exist_ok=True)
-        except OSError as err:
-            raise OSError("Creation of the directory %s failed: %s"
-                          % (output_dir, err.strerror))
+            if '' == os.path.dirname(output_file):
+                output_file_full_path = os.path.join(os.getcwd(), output_file)
+                output_dir = os.path.dirname(output_file_full_path)
+            else:
+                output_file_full_path = output_file
+                output_dir = os.path.dirname(output_file_full_path)
+
         return output_file_full_path, output_dir
 
     @staticmethod
     def __check_file_number(output_dir, output_file_name, output_file_full_path, files):
+
+        if tarfile.is_tarfile(output_file_full_path):
+            with tarfile.open(output_file_full_path) as tar_ref:
+                files.extend([os.path.join(output_dir, file) for file in tar_ref.namelist()])
+            return
+        elif zipfile.is_zipfile(output_file_full_path):
+            with zipfile.ZipFile(output_file_full_path, 'r') as zip_ref:
+                files.extend([os.path.join(output_dir, file) for file in zip_ref.namelist()])
+            return
+
         num_files_in_dir = len(os.listdir(output_dir))
         if num_files_in_dir == 1:
             output_f = output_file_name
-            output_full_path = output_dir + os.sep + output_f
+            output_full_path = os.path.join(output_dir, output_f)
 
             os.rename(output_file_full_path, output_full_path)
             files.append(output_full_path)
@@ -824,13 +840,16 @@ class EuclidClass(TapPlus):
         if tarfile.is_tarfile(output_file_full_path):
             with tarfile.open(output_file_full_path) as tar_ref:
                 tar_ref.extractall(path=output_dir)
+                files.extend([os.path.join(output_dir, file) for file in tar_ref.namelist()])
         elif zipfile.is_zipfile(output_file_full_path):
             with zipfile.ZipFile(output_file_full_path, 'r') as zip_ref:
                 zip_ref.extractall(output_dir)
+                files.extend([os.path.join(output_dir, file) for file in zip_ref.namelist()])
         elif not EuclidClass.is_gz_file(output_file_full_path):
             # single file: return it
             files.append(output_file_full_path)
             return files
+        return None
 
     def get_observation_products(self, *, id=None, schema="sedm", product_type=None, product_subtype="STK",
                                  filter="VIS", dsr_part1=None, dsr_part2=None, dsr_part3=None, output_file=None,
@@ -1318,25 +1337,28 @@ class EuclidClass(TapPlus):
 
         Parameters
         ----------
-        file_name : str, optional, default None
+        file_name : str or list of str, mandatory, default None
             file name for the product. Can be a single string, including multiple file names separated
             by commas, or a list of file name strings. Either file_name or product_id is mandatory.
-        product_id : str, optional, default None
-            product id. More than one can be specified between comma. Either file_name or product_id is mandatory
+            Downloading multiple files at once is less efficient than downloading them individually.
+        product_id : str or list of str, mandatory, default None
+            product id. More than one can be specified between comma or a list of product id strings.
+            Either file_name or product_id is mandatory.  Downloading multiple products at once is less efficient than
+            downloading them individually.
         schema : str, optional, default 'sedm'
             the data release name in which the product should be searched
         output_file : str, optional
-            output file, use zip extension when downloading multiple files
-            if no value is provided, a temporary one is created
+            output file path, use zip extension when downloading multiple files.
+            If no value is provided, a temporary one is created: "<working directory>/temp_<%Y%m%d_%H%M%S>/<file_name>".
         dsr_part1: str, optional, default None
             the data set release part 1: for OTF environment, the activity code; for REG and IDR, the target
-            environment. Not applicable if product_id is None
+            environment. Only applicable for product_id
         dsr_part2: str, optional, default None
             the data set release part 2: for OTF environment, the patch id (a positive integer); for REG and IDR,
-            the activity code. Not applicable if product_id is None
+            the activity code. Only applicable for product_id
         dsr_part3: int, optional, default None
             the data set release part 3: for OTF, REG and IDR environment, the version (an integer greater than 1).
-            Not applicable if product_id is None
+            Only applicable for product_id
         verbose : bool, optional, default 'False'
             flag to display information about the process
 
@@ -1348,15 +1370,27 @@ class EuclidClass(TapPlus):
         if file_name is None and product_id is None:
             raise ValueError("'file_name' and 'product_id' are both None")
 
-        if isinstance(file_name, (list, tuple)):
-            file_name = ",".join(file_name)
-
         params_dict = {'TAPCLIENT': 'ASTROQUERY', 'RELEASE': schema}
 
+        multiple_values = False
+
         if file_name is not None:
+
+            multiple_values = self.__is_multiple(file_name)
+
+            if isinstance(file_name, (list, tuple)):
+                file_name = ",".join(file_name)
+
             params_dict['FILE_NAME'] = file_name
             params_dict['RETRIEVAL_TYPE'] = 'FILE'
+
         if product_id is not None:
+
+            multiple_values = self.__is_multiple(product_id)
+
+            if isinstance(product_id, (list, tuple)):
+                product_id = ",".join(product_id)
+
             params_dict['PRODUCT_ID'] = product_id
             params_dict['RETRIEVAL_TYPE'] = 'PRODUCT_ID'
 
@@ -1369,10 +1403,13 @@ class EuclidClass(TapPlus):
             if dsr_part3 is not None:
                 params_dict['DSP3'] = dsr_part3
 
-        if file_name is not None:
-            observation_id = file_name
+        if multiple_values:
+            observation_id = 'get_product_output.zip'
         else:
-            observation_id = product_id + '.fits'
+            if file_name is not None:
+                observation_id = file_name
+            else:
+                observation_id = product_id + '.fits'
 
         output_file_full_path, output_dir = self.__set_dirs(output_file=output_file, observation_id=observation_id)
 
@@ -1390,18 +1427,21 @@ class EuclidClass(TapPlus):
             return None
 
         files = []
-        self.__extract_file(output_file_full_path=output_file_full_path, output_dir=output_dir, files=files)
-        if files:
-            return files
-
-        self.__check_file_number(output_dir=output_dir, output_file_name=os.path.basename(output_file_full_path),
-                                 output_file_full_path=output_file_full_path, files=files)
+        if multiple_values:
+            self.__check_file_number(output_dir=output_dir, output_file_name=os.path.basename(output_file_full_path),
+                                     output_file_full_path=output_file_full_path, files=files)
+        else:
+            files.append(output_file_full_path)
 
         return files
 
+    def __is_multiple(self, value):
+
+        return (isinstance(value, (list, tuple)) and len(value) > 1) or ',' in value
+
     @deprecated_renamed_argument(('instrument', 'id'), (None, None), since='0.4.12')
-    def get_cutout(self, *, file_path=None, coordinate, radius, output_file=None,
-                   verbose=False, instrument=None, id=None):
+    def get_cutout(self, *, file_path=None, coordinate, radius, output_file=None, verbose=False, instrument=None,
+                   id=None):
         """
         Downloads a cutout from a MER mosaic (background-subtracted image) for a given
         fits file path, centered on a coordinate and with a specified radius.
@@ -1446,7 +1486,8 @@ class EuclidClass(TapPlus):
             print("Cutout output file: " + output_file_full_path)
 
         try:
-            self.__euclidcutout.load_data(params_dict=params_dict, output_file=output_file_full_path, verbose=verbose)
+            self.__euclidcutout.load_data(params_dict=params_dict, output_file=output_file_full_path,
+                                          verbose=verbose)
         except HTTPError as err:
             log.error(
                 f"Cannot retrieve the product for file_path {file_path}. "

--- a/astroquery/esa/euclid/core.py
+++ b/astroquery/esa/euclid/core.py
@@ -1337,7 +1337,7 @@ class EuclidClass(TapPlus):
 
         Parameters
         ----------
-        file_name : str or list of str, mandatory, default None
+        file_name : str or list of str, default None
             file name for the product. Can be a single string, including multiple file names separated
             by commas, or a list of file name strings. Either file_name or product_id is mandatory.
             Downloading multiple files at once is less efficient than downloading them individually.

--- a/astroquery/esa/euclid/tests/test_euclidtap.py
+++ b/astroquery/esa/euclid/tests/test_euclidtap.py
@@ -803,6 +803,35 @@ def test_get_product_by_product_id(tmp_path_factory, capsys):
 
     remove_temp_dir()
 
+    # Multiple product ids
+    result = tap.get_product(product_id='123456789,987654321', output_file=None)
+
+    assert result is not None
+
+    now = datetime.now()
+    dirs = glob.glob(os.path.join(os.getcwd(), "temp_" + now.strftime("%Y%m%d") + '_*'))
+
+    assert len(dirs) == 1
+    assert dirs[0] is not None
+
+    assert os.path.exists(os.path.join(dirs[0], 'get_product_output.zip'))
+
+    remove_temp_dir()
+
+    result = tap.get_product(product_id=['123456789', '987654321'], output_file=None)
+
+    assert result is not None
+
+    now = datetime.now()
+    dirs = glob.glob(os.path.join(os.getcwd(), "temp_" + now.strftime("%Y%m%d") + '_*'))
+
+    assert len(dirs) == 1
+    assert dirs[0] is not None
+
+    assert os.path.exists(os.path.join(dirs[0], 'get_product_output.zip'))
+
+    remove_temp_dir()
+
 
 def test_get_product_by_product_id_data_set_release(tmp_path_factory):
     conn_handler = DummyConnHandler()
@@ -868,6 +897,35 @@ def test_get_product(capsys):
 
     remove_temp_dir()
 
+    # Multiple product ids
+    result = tap.get_product(file_name='uno.fits,dos.fits', output_file=None)
+
+    assert result is not None
+
+    now = datetime.now()
+    dirs = glob.glob(os.path.join(os.getcwd(), "temp_" + now.strftime("%Y%m%d") + '_*'))
+
+    assert len(dirs) == 1
+    assert dirs[0] is not None
+
+    assert os.path.exists(os.path.join(dirs[0], 'get_product_output.zip'))
+
+    remove_temp_dir()
+
+    result = tap.get_product(file_name=['uno.fits', 'dos.fits'], output_file=None)
+
+    assert result is not None
+
+    now = datetime.now()
+    dirs = glob.glob(os.path.join(os.getcwd(), "temp_" + now.strftime("%Y%m%d") + '_*'))
+
+    assert len(dirs) == 1
+    assert dirs[0] is not None
+
+    assert os.path.exists(os.path.join(dirs[0], 'get_product_output.zip'))
+
+    remove_temp_dir()
+
 
 @patch.object(TapPlus, 'load_data')
 def test_get_product_with_list_of_filenames(mock_load_data, tmp_path_factory):
@@ -919,6 +977,20 @@ def test_get_product_with_list_of_filenames(mock_load_data, tmp_path_factory):
     params_dict = kwargs.get("params_dict")
     assert params_dict["FILE_NAME"] == "file1.fits,file2.fits,file3.fits,file4.fits"
     assert params_dict["RETRIEVAL_TYPE"] == "FILE"
+
+    result = tap.get_product(file_name=filenames)
+
+    assert result is not None
+
+    now = datetime.now()
+    dirs = glob.glob(os.path.join(os.getcwd(), "temp_" + now.strftime("%Y%m%d") + '_*'))
+
+    assert len(dirs) == 1
+    assert dirs[0] is not None
+
+    assert os.path.exists(os.path.join(dirs[0], 'get_product_output.zip'))
+
+    remove_temp_dir()
 
 
 def test_get_product_exceptions():


### PR DESCRIPTION
Dear Astroquery team,

in the PR #3550 the method `get_product` was updated so that the output file name is directly related to the input `file_name` or `product_id`. We have realized that that implementation does not work as we would expect in the case multiple values for `file_name`or `product_id` are used.

In this PR we have implemented the following changes:

1. The parameter `product_id` now accepts a list/tuple (similar to the changes in PR #3541)

2. For multiple values, in case the parameter `output_file` is not defined, the downloaded zip file is automatically created with the name get_product_output.zip and it is not uncompressed. The present implementation downloads the zip file (with wrong name and extension) and uncompresses it. So the user always have both files, the compressed and the uncompressed. Since the downloaded fits files can be pretty large (tens of GB), we think that this change is pretty convenient.
3. A similar behaviour is obtained in case  multiple values are used and the parameter `output_file `is defined by the user.


cc @esdc-esac-esa-int 
jira: EUCLIDSWRQ-283