### PR TITLE
MAST: Deprecate objectname

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -43,6 +43,9 @@ mast
 - When cloud access is enabled, ``Observations.download_file`` and ``Observations.download_products``
   now check all requested products against cloud storage. As a result, setting ``cloud_only=True`` will skip
   any products that are not available in the cloud, rather than falling back to on-prem downloads.
+- The ``objectname`` keyword is deprecated in ``MastMissions`` in favor of ``object_names``. [#3540]
+- The ``objectname`` parameter in ``Catalogs``, ``Observations``, ``Tesscut``, and ``utils`` is deprecated 
+  in favor of ``object_name``. [#3567]
 
 vo_conesearch
 ^^^^^^^^^^^^^
@@ -90,39 +93,26 @@ mast
 ^^^^
 
 - Raise an error if non-string values are passed to ``utils.resolve_object``. [#3435]
-
 - Filtering by file extension or by a string column is now case-insensitive in ``MastMissions.filter_products``
   and ``Observations.filter_products``. [#3427]
-
 - Switch to use HTTP continuation for partial downloads. [#3448]
-
 - Expand the supported data types for filter values in ``Mast.mast_query``. Previously, users had to input
   filter values enclosed in lists, even when specifying a single value or dictionary. [#3422]
-
 - Raise informative error if ``MastMissions`` query radius is too large. [#3447]
-
 - Add ``batch_size`` parameter to ``MastMissions.get_product_list``, ``Observations.get_product_list``,
   and ``utils.resolve_object`` to allow controlling the number of items sent in each batch request to the server.
   This can help avoid timeouts or connection errors for large requests. [#3454]
-
 - Separate requests for moving target cutouts in ``Tesscut`` to one per sector. [#3467]
-
 - Improved robustness of PanSTARRS column metadata parsing. This prevents metadata-related query errors. [#3485]
-
 - The ``select_cols`` parameter in ``MastMissions`` query functions now accepts an iterable of column names, a comma-delimited
   string of column names, or the special values 'all' or '*' to return all available columns. [#3492]
-
 - Improved robustness of product downloads for ``MastMissions``, including support for subscription-service JSON inputs and
   clearer validation of MAST URIs and product metadata. [#3517]
-
 - Added full support for the International Ultraviolet Explorer (IUE) mission in ``MastMissions``. [#3517]
-
 - Added a new ``Observations.list_cloud_datasets()`` method for querying cloud-supported MAST datasets, alongside
   improvements to cloud download handling. [#3488]
-
 - ``MastMissions`` query functions now support single or multiple targets via ``coordinates`` and
-  ``object_names`` (including combined use in ``query_criteria``). The legacy ``objectname`` keyword
-  is deprecated in favor of ``object_names``. [#3540]
+  ``object_names`` (including combined use in ``query_criteria``). [#3540]
 
 jplspec
 ^^^^^^^

--- a/astroquery/mast/collections.py
+++ b/astroquery/mast/collections.py
@@ -16,8 +16,8 @@ from requests import HTTPError, RequestException
 
 import astropy.units as u
 import astropy.coordinates as coord
-
 from astropy.table import Table, Row
+from astropy.utils.decorators import deprecated_renamed_argument
 
 from ..utils import commons, async_to_sync
 from ..utils.class_or_instance import class_or_instance
@@ -298,7 +298,8 @@ class CatalogsClass(MastQueryWithLogin):
                                                               use_json=use_json)
 
     @class_or_instance
-    def query_object_async(self, objectname, *, radius=0.2*u.deg, catalog="Hsc",
+    @deprecated_renamed_argument('objectname', 'object_name', since='0.4.12')
+    def query_object_async(self, object_name, *, radius=0.2*u.deg, catalog="Hsc",
                            pagesize=None, page=None, version=None, resolver=None, **criteria):
         """
         Given an object name, returns a list of catalog entries.
@@ -306,7 +307,7 @@ class CatalogsClass(MastQueryWithLogin):
 
         Parameters
         ----------
-        objectname : str
+        object_name : str
             The name of the target around which to search.
         radius : str or `~astropy.units.Quantity` object, optional
             Default 0.2 degrees.
@@ -349,7 +350,7 @@ class CatalogsClass(MastQueryWithLogin):
         response : list of `~requests.Response`
         """
 
-        coordinates = utils.resolve_object(objectname, resolver=resolver)
+        coordinates = utils.resolve_object(object_name, resolver=resolver)
 
         return self.query_region_async(coordinates,
                                        radius=radius,
@@ -382,7 +383,7 @@ class CatalogsClass(MastQueryWithLogin):
             for more information. Default is None.
         **criteria
             Criteria to apply. At least one non-positional criteria must be supplied.
-            Valid criteria are coordinates, objectname, radius (as in `query_region` and `query_object`),
+            Valid criteria are coordinates, object_name, radius (as in `query_region` and `query_object`),
             and all fields listed in the column documentation for the catalog being queried.
             The Column Name is the keyword, with the argument being one or more acceptable values for that parameter,
             except for fields with a float datatype where the argument should be in the form [minVal, maxVal].
@@ -406,12 +407,12 @@ class CatalogsClass(MastQueryWithLogin):
 
         # Separating any position info from the rest of the filters
         coordinates = criteria.pop('coordinates', None)
-        objectname = criteria.pop('objectname', None)
+        object_name = criteria.pop('object_name', None)
         radius = criteria.pop('radius', 0.2*u.deg)
 
-        if objectname or coordinates:
+        if object_name or coordinates:
             coordinates = utils.parse_input_location(coordinates=coordinates,
-                                                     objectname=objectname,
+                                                     object_name=object_name,
                                                      resolver=resolver)
 
         # if radius is just a number we assume degrees
@@ -444,21 +445,21 @@ class CatalogsClass(MastQueryWithLogin):
 
             if catalog.lower() == "tic":
                 service = "Mast.Catalogs.Filtered.Tic"
-                if coordinates or objectname:
+                if coordinates or object_name:
                     service += ".Position"
                 service += ".Rows"  # Using the rowstore version of the query for speed
                 column_config_name = "Mast.Catalogs.Tess.Cone"
                 params["columns"] = "*"
             elif catalog.lower() == "ctl":
                 service = "Mast.Catalogs.Filtered.Ctl"
-                if coordinates or objectname:
+                if coordinates or object_name:
                     service += ".Position"
                 service += ".Rows"  # Using the rowstore version of the query for speed
                 column_config_name = "Mast.Catalogs.Tess.Cone"
                 params["columns"] = "*"
             elif catalog.lower() == "diskdetective":
                 service = "Mast.Catalogs.Filtered.DiskDetective"
-                if coordinates or objectname:
+                if coordinates or object_name:
                     service += ".Position"
                 column_config_name = "Mast.Catalogs.Dd.Cone"
             else:

--- a/astroquery/mast/core.py
+++ b/astroquery/mast/core.py
@@ -6,6 +6,7 @@ MAST Core
 This the base class for MAST queries.
 """
 from astropy.utils import deprecated
+from astropy.utils.decorators import deprecated_renamed_argument
 from ..query import QueryWithLogin
 from . import utils
 from .auth import MastAuth
@@ -110,13 +111,14 @@ class MastQueryWithLogin(QueryWithLogin):
         """
         pass
 
-    def resolve_object(self, objectname, *, resolver=None, resolve_all=False):
+    @deprecated_renamed_argument('objectname', 'object_name', since='0.4.12')
+    def resolve_object(self, object_name, *, resolver=None, resolve_all=False):
         """
         Resolves an object name to a position on the sky.
 
         Parameters
         ----------
-        objectname : str
+        object_name : str
             Name of astronomical object to resolve.
         resolver : str, optional
             The resolver to use when resolving a named target into coordinates. Valid options are "SIMBAD" and "NED".
@@ -135,6 +137,6 @@ class MastQueryWithLogin(QueryWithLogin):
             If ``resolve_all`` is True, returns a dictionary where the keys are the resolver names and the values are
             `~astropy.coordinates.SkyCoord` objects with the resolved coordinates.
         """
-        return utils.resolve_object(objectname,
+        return utils.resolve_object(object_name,
                                     resolver=resolver,
                                     resolve_all=resolve_all)

--- a/astroquery/mast/cutouts.py
+++ b/astroquery/mast/cutouts.py
@@ -100,7 +100,7 @@ class TesscutClass(MastQueryWithLogin):
                     }
         self._service_api_connection.set_service_params(services, "tesscut")
 
-    def _validate_target_input(self, coordinates, objectname, moving_target):
+    def _validate_target_input(self, coordinates, object_name, moving_target):
         """
         Validate the input parameters for target selection.
 
@@ -109,9 +109,9 @@ class TesscutClass(MastQueryWithLogin):
         coordinates : str or `astropy.coordinates` object, optional
             The target around which to search. It may be specified as a
             string or as the appropriate `astropy.coordinates` object.
-        objectname : str, optional
-            The target around which to search, by name (objectname="M104")
-            or TIC ID (objectname="TIC 141914082"). If moving_target is True, input must be the name or ID
+        object_name : str, optional
+            The target around which to search, by name (object_name="M104")
+            or TIC ID (object_name="TIC 141914082"). If moving_target is True, input must be the name or ID
             (as understood by the `JPL ephemerides service <https://ssd.jpl.nasa.gov/horizons/app.html>`__)
             of a moving target such as an asteroid or comet.
         moving_target : bool, optional
@@ -122,22 +122,22 @@ class TesscutClass(MastQueryWithLogin):
         -------
         InvalidQueryError
             If ``moving_target`` is True and ``coordinates`` is provided.
-            If ``moving_target`` is True and ``objectname`` is not provided.
-            If both ``coordinates`` and ``objectname`` are provided.
+            If ``moving_target`` is True and ``object_name`` is not provided.
+            If both ``coordinates`` and ``object_name`` are provided.
         """
         if moving_target:
             if coordinates:
                 raise InvalidQueryError("Only one of moving_target and coordinates may be specified. "
-                                        "Please remove coordinates if using moving_target and objectname.")
+                                        "Please remove coordinates if using moving_target and object_name.")
 
-            if not objectname:
+            if not object_name:
                 raise InvalidQueryError("Please specify the object name or ID (as understood by the "
                                         "`JPL ephemerides service <https://ssd.jpl.nasa.gov/horizons/app.html>`__) "
                                         "of a moving target such as an asteroid or comet.")
         else:
-            if coordinates and objectname:
-                raise InvalidQueryError("Only one of objectname and coordinates may be specified. "
-                                        "Please remove objectname if using coordinates.")
+            if coordinates and object_name:
+                raise InvalidQueryError("Only one of object_name and coordinates may be specified. "
+                                        "Please remove object_name if using coordinates.")
 
     def _validate_product(self, product):
         """
@@ -156,13 +156,13 @@ class TesscutClass(MastQueryWithLogin):
         if product.upper() != "SPOC":
             raise InvalidQueryError("Input product must be SPOC.")
 
-    def _get_moving_target_sectors(self, objectname, mt_type=None):
+    def _get_moving_target_sectors(self, object_name, mt_type=None):
         """
         Helper method to fetch unique sectors for a moving target
 
         Parameters
         ----------
-        objectname : str
+        object_name : str
             The name or ID of the moving target.
         mt_type : str, optional
             The moving target type (majorbody or smallbody).
@@ -174,7 +174,7 @@ class TesscutClass(MastQueryWithLogin):
         """
         with warnings.catch_warnings():
             warnings.filterwarnings("ignore", category=NoResultsWarning)
-            sector_table = self.get_sectors(objectname=objectname, moving_target=True, mt_type=mt_type)
+            sector_table = self.get_sectors(object_name=object_name, moving_target=True, mt_type=mt_type)
 
         if len(sector_table) == 0:
             warnings.warn("Coordinates are not in any TESS sector.", NoResultsWarning)
@@ -185,7 +185,8 @@ class TesscutClass(MastQueryWithLogin):
     @deprecated_renamed_argument('product', None, since='0.4.11', message='Tesscut no longer supports operations on '
                                  'TESS Image Calibrator (TICA) products. '
                                  'The `product` argument is deprecated and will be removed in a future version.')
-    def get_sectors(self, *, coordinates=None, radius=0*u.deg, product='SPOC', objectname=None,
+    @deprecated_renamed_argument('objectname', 'object_name', since='0.4.12')
+    def get_sectors(self, *, coordinates=None, radius=0*u.deg, product='SPOC', object_name=None,
                     moving_target=False, mt_type=None, resolver=None):
         """
         Get a list of the TESS data sectors whose footprints intersect
@@ -197,7 +198,7 @@ class TesscutClass(MastQueryWithLogin):
             The target around which to search. It may be specified as a
             string or as the appropriate `astropy.coordinates` object.
 
-            NOTE: If moving_target or objectname is supplied, this argument cannot be used.
+            NOTE: If moving_target or object_name is supplied, this argument cannot be used.
         radius : str, float, or `~astropy.units.Quantity` object, optional
             Default 0 degrees.
             If supplied as a float degrees is the assumed unit.
@@ -210,9 +211,9 @@ class TesscutClass(MastQueryWithLogin):
             Deprecated. Default is 'SPOC'.
             The product that the cutouts will be made out of. The only valid value for this parameter is 'SPOC', for the
             Science Processing Operations Center (SPOC) products.
-        objectname : str, optional
-            The target around which to search, by name (objectname="M104")
-            or TIC ID (objectname="TIC 141914082"). If moving_target is True, input must be the name or ID
+        object_name : str, optional
+            The target around which to search, by name (object_name="M104")
+            or TIC ID (object_name="TIC 141914082"). If moving_target is True, input must be the name or ID
             (as understood by the `JPL ephemerides service <https://ssd.jpl.nasa.gov/horizons/app.html>`__)
             of a moving target such as an asteroid or comet.
 
@@ -236,20 +237,20 @@ class TesscutClass(MastQueryWithLogin):
         Returns
         -------
         response : `~astropy.table.Table`
-            Sector/camera/chip information for given coordinates/objectname/moving_target.
+            Sector/camera/chip information for given coordinates/object_name/moving_target.
         """
         self._validate_product(product)
-        self._validate_target_input(coordinates, objectname, moving_target)
+        self._validate_target_input(coordinates, object_name, moving_target)
 
         if moving_target:
-            params = {"obj_id": objectname}
+            params = {"obj_id": object_name}
             if mt_type:  # Add optional parameter if present
                 params["obj_type"] = mt_type
             service = "mt_sector"
         else:
             # Get Skycoord object for coordinates/object
             coordinates = parse_input_location(coordinates=coordinates,
-                                               objectname=objectname,
+                                               object_name=object_name,
                                                resolver=resolver)
             # If radius is just a number we assume degrees
             radius = Angle(radius, u.deg)
@@ -273,8 +274,9 @@ class TesscutClass(MastQueryWithLogin):
     @deprecated_renamed_argument('product', None, since='0.4.11', message='Tesscut no longer supports operations on '
                                  'TESS Image Calibrator (TICA) products. '
                                  'The `product` argument is deprecated and will be removed in a future version.')
+    @deprecated_renamed_argument('objectname', 'object_name', since='0.4.12')
     def download_cutouts(self, *, coordinates=None, size=5, sector=None, product='SPOC', path=".",
-                         inflate=True, objectname=None, moving_target=False, mt_type=None, resolver=None,
+                         inflate=True, object_name=None, moving_target=False, mt_type=None, resolver=None,
                          verbose=False):
         """
         Download cutout target pixel file(s) around the given coordinates with indicated size.
@@ -285,7 +287,7 @@ class TesscutClass(MastQueryWithLogin):
             The target around which to search. It may be specified as a
             string or as the appropriate `astropy.coordinates` object.
 
-            NOTE: If moving_target or objectname is supplied, this argument cannot be used.
+            NOTE: If moving_target or object_name is supplied, this argument cannot be used.
         size : int, array-like, `~astropy.units.Quantity`
             Optional, default 5 pixels.
             The size of the cutout array. If ``size`` is a scalar number or
@@ -314,9 +316,9 @@ class TesscutClass(MastQueryWithLogin):
             Cutout target pixel files are returned from the server in a zip file,
             by default they will be inflated and the zip will be removed.
             Set inflate to false to stop before the inflate step.
-        objectname : str, optional
-            The target around which to search, by name (objectname="M104")
-            or TIC ID (objectname="TIC 141914082"). If moving_target is True, input must be the name or ID
+        object_name : str, optional
+            The target around which to search, by name (object_name="M104")
+            or TIC ID (object_name="TIC 141914082"). If moving_target is True, input must be the name or ID
             (as understood by the `JPL ephemerides service <https://ssd.jpl.nasa.gov/horizons/app.html>`__)
             of a moving target such as an asteroid or comet.
 
@@ -342,13 +344,13 @@ class TesscutClass(MastQueryWithLogin):
         response : `~astropy.table.Table`
         """
         self._validate_product(product)
-        self._validate_target_input(coordinates, objectname, moving_target)
+        self._validate_target_input(coordinates, object_name, moving_target)
 
         # For moving targets without a sector specified, fetch sectors first and make
         # individual requests per sector to reduce memory pressure on the service
         if moving_target and sector is None:
             localpath_table = Table(names=["Local Path"], dtype=[str])
-            unique_sectors = self._get_moving_target_sectors(objectname, mt_type)
+            unique_sectors = self._get_moving_target_sectors(object_name, mt_type)
 
             if unique_sectors is None:
                 return localpath_table
@@ -361,7 +363,7 @@ class TesscutClass(MastQueryWithLogin):
                     sector=sect,
                     path=path,
                     inflate=inflate,
-                    objectname=objectname,
+                    object_name=object_name,
                     moving_target=True,
                     mt_type=mt_type,
                     verbose=verbose,
@@ -377,13 +379,13 @@ class TesscutClass(MastQueryWithLogin):
             params["sector"] = sector
 
         if moving_target:
-            params["obj_id"] = objectname
+            params["obj_id"] = object_name
             if mt_type:  # Add optional parameter if present
                 params["obj_type"] = mt_type
             request_path = "moving_target/astrocut"
         else:
             coordinates = parse_input_location(coordinates=coordinates,
-                                               objectname=objectname,
+                                               object_name=object_name,
                                                resolver=resolver)
             params.update({"ra": coordinates.ra.deg, "dec": coordinates.dec.deg})
             request_path = "astrocut"
@@ -423,8 +425,9 @@ class TesscutClass(MastQueryWithLogin):
     @deprecated_renamed_argument('product', None, since='0.4.11', message='Tesscut no longer supports operations on '
                                  'TESS Image Calibrator (TICA) products. '
                                  'The `product` argument is deprecated and will be removed in a future version.')
+    @deprecated_renamed_argument('objectname', 'object_name', since='0.4.12')
     def get_cutouts(self, *, coordinates=None, size=5, product='SPOC', sector=None,
-                    objectname=None, moving_target=False, mt_type=None, resolver=None):
+                    object_name=None, moving_target=False, mt_type=None, resolver=None):
         """
         Get cutout target pixel file(s) around the given coordinates with indicated size,
         and return them as a list of  `~astropy.io.fits.HDUList` objects.
@@ -435,7 +438,7 @@ class TesscutClass(MastQueryWithLogin):
             The target around which to search. It may be specified as a
             string or as the appropriate `astropy.coordinates` object.
 
-            NOTE: If moving_target or objectname is supplied, this argument cannot be used.
+            NOTE: If moving_target or object_name is supplied, this argument cannot be used.
         size : int, array-like, `~astropy.units.Quantity`
             Optional, default 5 pixels.
             The size of the cutout array. If ``size`` is a scalar number or
@@ -455,9 +458,9 @@ class TesscutClass(MastQueryWithLogin):
 
             NOTE: For moving targets, if sector is not specified, the method will automatically
             fetch all available sectors and make individual requests per sector.
-        objectname : str, optional
-            The target around which to search, by name (objectname="M104")
-            or TIC ID (objectname="TIC 141914082"). If moving_target is True, input must be the name or ID
+        object_name : str, optional
+            The target around which to search, by name (object_name="M104")
+            or TIC ID (object_name="TIC 141914082"). If moving_target is True, input must be the name or ID
             (as understood by the `JPL ephemerides service <https://ssd.jpl.nasa.gov/horizons/app.html>`__)
             of a moving target such as an asteroid or comet.
 
@@ -483,12 +486,12 @@ class TesscutClass(MastQueryWithLogin):
         response : A list of `~astropy.io.fits.HDUList` objects.
         """
         self._validate_product(product)
-        self._validate_target_input(coordinates, objectname, moving_target)
+        self._validate_target_input(coordinates, object_name, moving_target)
 
         # For moving targets without a sector specified, fetch sectors first and make
         # individual requests per sector to reduce memory pressure on the service
         if moving_target and sector is None:
-            unique_sectors = self._get_moving_target_sectors(objectname, mt_type)
+            unique_sectors = self._get_moving_target_sectors(object_name, mt_type)
 
             if unique_sectors is None:
                 return []
@@ -497,7 +500,7 @@ class TesscutClass(MastQueryWithLogin):
             all_cutouts = []
             for sect in unique_sectors:
                 cutouts = self.get_cutouts(
-                    size=size, sector=sect, objectname=objectname, moving_target=True, mt_type=mt_type
+                    size=size, sector=sect, object_name=object_name, moving_target=True, mt_type=mt_type
                 )
                 all_cutouts.extend(cutouts)
             return all_cutouts
@@ -507,14 +510,14 @@ class TesscutClass(MastQueryWithLogin):
             params["sector"] = sector
 
         if moving_target:
-            params["obj_id"] = objectname
+            params["obj_id"] = object_name
             if mt_type:  # Add optional parameter if present
                 params["obj_type"] = mt_type
             service = "mt_astrocut"
         else:
             # Get Skycoord object for coordinates/object
             coordinates = parse_input_location(coordinates=coordinates,
-                                               objectname=objectname,
+                                               object_name=object_name,
                                                resolver=resolver)
             params.update({"ra": coordinates.ra.deg, "dec": coordinates.dec.deg})
             service = "astrocut"
@@ -707,7 +710,6 @@ class ZcutClass(MastQueryWithLogin):
         coordinates : str or `astropy.coordinates` object
             The target around which to search. It may be specified as a
             string or as the appropriate `astropy.coordinates` object.
-            One and only one of coordinates and objectname must be supplied.
         size : int, array-like, `~astropy.units.Quantity`
             Optional, default 5 pixels.
             The size of the cutout array. If ``size`` is a scalar number or

--- a/astroquery/mast/discovery_portal.py
+++ b/astroquery/mast/discovery_portal.py
@@ -378,7 +378,7 @@ class PortalAPI(BaseQuery):
             The service that will use the columns config, default is to be the same as column_config_name.
         **filters :
             Filters to apply. At least one filter must be supplied.
-            Valid criteria are coordinates, objectname, radius (as in `query_region` and `query_object`),
+            Valid criteria are coordinates, object_name, radius (as in `query_region` and `query_object`),
             and all observation fields listed `here <https://mast.stsci.edu/api/v0/_c_a_o_mfields.html>`__.
             The Column Name is the keyword, with the argument being one or more acceptable values for that parameter,
             except for fields with a float datatype where the argument should be in the form [minVal, maxVal].

--- a/astroquery/mast/missions.py
+++ b/astroquery/mast/missions.py
@@ -290,7 +290,8 @@ class MastMissionsClass(MastQueryWithLogin):
         list of str
             A list of target strings in "ra dec" format for the API.
         """
-        def _normalize_inputs(values):
+        def _as_list(values):
+            """Normalize the input values into a list of strings or coordinate objects."""
             if values is None:
                 items = []
             elif isinstance(values, str):
@@ -302,8 +303,26 @@ class MastMissionsClass(MastQueryWithLogin):
 
             return [item.strip() if isinstance(item, str) else item for item in items]
 
-        coordinate_items = _normalize_inputs(coordinates)
-        object_name_items = _normalize_inputs(object_names)
+        def _is_legacy_ra_dec_pair(items):
+            """Detect ['ra', 'dec'] passed as one coordinate split on comma."""
+            if len(items) != 2 or not all(isinstance(item, str) for item in items):
+                return False
+
+            try:
+                float(items[0])
+                float(items[1])
+                return True
+            except ValueError:
+                return False
+
+        coordinate_items = _as_list(coordinates)
+        object_name_items = _as_list(object_names)
+
+        # Backward compatibility for historical single-coordinate input like:
+        # coordinates="10.5, -20.1"
+        if _is_legacy_ra_dec_pair(coordinate_items):
+            coordinate_items = [f"{coordinate_items[0]} {coordinate_items[1]}"]
+
         total_targets = len(coordinate_items) + len(object_name_items)
 
         if total_targets == 0:
@@ -338,7 +357,7 @@ class MastMissionsClass(MastQueryWithLogin):
         return targets
 
     @class_or_instance
-    @deprecated_renamed_argument('objectname', 'object_names', since='0.4.11')
+    @deprecated_renamed_argument('objectname', 'object_names', since='0.4.12')
     def query_criteria_async(self, *, coordinates=None, object_names=None, radius=3*u.arcmin,
                              limit=5000, offset=0, select_cols=None, resolver=None, **criteria):
         """
@@ -479,7 +498,7 @@ class MastMissionsClass(MastQueryWithLogin):
                                          **criteria)
 
     @class_or_instance
-    @deprecated_renamed_argument('objectname', 'object_names', since='0.4.11')
+    @deprecated_renamed_argument('objectname', 'object_names', since='0.4.12')
     def query_object_async(self, object_names, *, radius=3*u.arcmin, limit=5000, offset=0,
                            select_cols=None, resolver=None, **criteria):
         """

--- a/astroquery/mast/observations.py
+++ b/astroquery/mast/observations.py
@@ -13,14 +13,13 @@ import os
 from urllib.parse import quote
 
 import numpy as np
-
-from requests import HTTPError
-
 import astropy.units as u
 import astropy.coordinates as coord
+from requests import HTTPError
 from botocore.exceptions import ClientError, BotoCoreError
-
 from astropy.table import Table, Row, vstack
+from astropy.utils.decorators import deprecated_renamed_argument
+
 from astroquery import log
 from astroquery.mast.cloud import CloudAccess
 from astroquery.utils import commons
@@ -134,7 +133,7 @@ class ObservationsClass(MastQueryWithLogin):
             for more information. Default is None.
         **criteria
             Criteria to apply.
-            Valid criteria are coordinates, objectname, radius (as in `query_region` and `query_object`),
+            Valid criteria are coordinates, object_name, radius (as in `query_region` and `query_object`),
             and all observation fields returned by the ``get_metadata("observations")``.
             The Column Name is the keyword, with the argument being one or more acceptable values for that parameter,
             except for fields with a float datatype where the argument should be in the form [minVal, maxVal].
@@ -146,22 +145,22 @@ class ObservationsClass(MastQueryWithLogin):
         Returns
         -------
         response : tuple
-            Tuple of the form (position, filter_set), where position is either None (coordinates and objectname
+            Tuple of the form (position, filter_set), where position is either None (coordinates and object_name
             not given) or a string, and filter_set is list of filters dictionaries.
         """
 
         # Separating any position info from the rest of the filters
         coordinates = criteria.pop('coordinates', None)
-        objectname = criteria.pop('objectname', None)
+        object_name = criteria.pop('object_name', None)
         radius = criteria.pop('radius', 0.2*u.deg)
 
         # Build the mashup filter object and store it in the correct service_name entry
-        if coordinates or objectname:
+        if coordinates or object_name:
             mashup_filters = self._portal_api_connection.build_filter_set(self._caom_cone,
                                                                           self._caom_filtered_position,
                                                                           **criteria)
             coordinates = utils.parse_input_location(coordinates=coordinates,
-                                                     objectname=objectname,
+                                                     object_name=object_name,
                                                      resolver=resolver)
         else:
             mashup_filters = self._portal_api_connection.build_filter_set(self._caom_cone,
@@ -248,14 +247,15 @@ class ObservationsClass(MastQueryWithLogin):
         return self._portal_api_connection.service_request_async(service, params, pagesize=pagesize, page=page)
 
     @class_or_instance
-    def query_object_async(self, objectname, *, radius=0.2*u.deg, pagesize=None, page=None, resolver=None):
+    @deprecated_renamed_argument('objectname', 'object_name', since='0.4.12')
+    def query_object_async(self, object_name, *, radius=0.2*u.deg, pagesize=None, page=None, resolver=None):
         """
         Given an object name, returns a list of MAST observations.
         See column documentation `here <https://mast.stsci.edu/api/v0/_c_a_o_mfields.html>`__.
 
         Parameters
         ----------
-        objectname : str
+        object_name : str
             The name of the target around which to search.
         radius : str or `~astropy.units.Quantity` object, optional
             Default 0.2 degrees.
@@ -281,7 +281,7 @@ class ObservationsClass(MastQueryWithLogin):
         response : list of `~requests.Response`
         """
 
-        coordinates = utils.resolve_object(objectname, resolver=resolver)
+        coordinates = utils.resolve_object(object_name, resolver=resolver)
 
         return self.query_region_async(coordinates, radius=radius, pagesize=pagesize, page=page)
 
@@ -306,7 +306,7 @@ class ObservationsClass(MastQueryWithLogin):
             for more information. Default is None.
         **criteria
             Criteria to apply. At least one non-positional criteria must be supplied.
-            Valid criteria are coordinates, objectname, radius (as in `query_region` and `query_object`),
+            Valid criteria are coordinates, object_name, radius (as in `query_region` and `query_object`),
             and all observation fields returned by the ``get_metadata("observations")``.
             The Column Name is the keyword, with the argument being one or more acceptable values for that parameter,
             except for fields with a float datatype where the argument should be in the form [minVal, maxVal].
@@ -379,13 +379,14 @@ class ObservationsClass(MastQueryWithLogin):
 
         return int(self._portal_api_connection.service_request(service, params, pagesize, page)[0][0])
 
-    def query_object_count(self, objectname, *, radius=0.2*u.deg, pagesize=None, page=None, resolver=None):
+    @deprecated_renamed_argument('objectname', 'object_name', since='0.4.12')
+    def query_object_count(self, object_name, *, radius=0.2*u.deg, pagesize=None, page=None, resolver=None):
         """
         Given an object name, returns the number of MAST observations.
 
         Parameters
         ----------
-        objectname : str
+        object_name : str
             The name of the target around which to search.
         radius : str or `~astropy.units.Quantity` object, optional
             The string must be parsable by `~astropy.coordinates.Angle`. The
@@ -408,7 +409,7 @@ class ObservationsClass(MastQueryWithLogin):
         response : int
         """
 
-        coordinates = utils.resolve_object(objectname, resolver=resolver)
+        coordinates = utils.resolve_object(object_name, resolver=resolver)
 
         return self.query_region_count(coordinates, radius=radius, pagesize=pagesize, page=page)
 
@@ -431,7 +432,7 @@ class ObservationsClass(MastQueryWithLogin):
             for more information. Default is None.
         **criteria
             Criteria to apply. At least one non-positional criterion must be supplied.
-            Valid criteria are coordinates, objectname, radius (as in `query_region` and `query_object`),
+            Valid criteria are coordinates, object_name, radius (as in `query_region` and `query_object`),
             and all observation fields listed `here <https://mast.stsci.edu/api/v0/_c_a_o_mfields.html>`__.
             The Column Name is the keyword, with the argument being one or more acceptable values for that parameter,
             except for fields with a float datatype where the argument should be in the form [minVal, maxVal].
@@ -1012,7 +1013,7 @@ class ObservationsClass(MastQueryWithLogin):
             Default True. Whether to issue warnings if a product cannot be found in the cloud.
         **criteria
             Criteria to apply. At least one non-positional criteria must be supplied.
-            Valid criteria are coordinates, objectname, radius (as in `query_region` and `query_object`),
+            Valid criteria are coordinates, object_name, radius (as in `query_region` and `query_object`),
             and all observation fields returned by the ``get_metadata("observations")``.
             The Column Name is the keyword, with the argument being one or more acceptable values for that parameter,
             except for fields with a float datatype where the argument should be in the form [minVal, maxVal].

--- a/astroquery/mast/tests/test_mast.py
+++ b/astroquery/mast/tests/test_mast.py
@@ -363,6 +363,11 @@ def test_missions_parse_multiple_targets(patch_post):
     result = MastMissions._parse_multiple_targets(coordinates=coords_str)
     assert result == ['10.684 41.269', '83.6331 22.0145']
 
+    # Special case: one string coordinate with elements separated by a comma instead of space
+    coords_str_comma = "10.684, 41.269"
+    result = MastMissions._parse_multiple_targets(coordinates=coords_str_comma)
+    assert result == ['10.684 41.269']
+
     # Vector SkyCoord input
     vector_coords = SkyCoord([10.684, 83.6324], [41.269, 22.0174], frame='icrs', unit='deg')
     result = MastMissions._parse_multiple_targets(coordinates=vector_coords)
@@ -895,7 +900,7 @@ def test_query_observations_criteria_async(patch_post):
 
     # with position
     responses = Observations.query_criteria_async(filters=["NUV", "FUV"],
-                                                  objectname="M101")
+                                                  object_name="M101")
     assert isinstance(responses, list)
 
 
@@ -908,16 +913,16 @@ def test_observations_query_criteria(patch_post):
 
     # with position
     result = Observations.query_criteria(filters=["NUV", "FUV"],
-                                         objectname="M101")
+                                         object_name="M101")
     assert isinstance(result, Table)
 
     with pytest.raises(InvalidQueryError) as invalid_query:
-        Observations.query_criteria(objectname="M101")
+        Observations.query_criteria(object_name="M101")
     assert "least one non-positional criterion" in str(invalid_query.value)
 
     with pytest.raises(InvalidQueryError) as invalid_query:
-        Observations.query_criteria(objectname="M101", coordinates=regionCoords, intentType="science")
-    assert "one of objectname and coordinates" in str(invalid_query.value)
+        Observations.query_criteria(object_name="M101", coordinates=regionCoords, intentType="science")
+    assert "one of object_name and coordinates" in str(invalid_query.value)
 
 
 # count functions
@@ -943,8 +948,8 @@ def test_observations_query_criteria_count(patch_post):
     assert result == 599
 
     with pytest.raises(InvalidQueryError) as invalid_query:
-        Observations.query_criteria_count(coordinates=regionCoords, objectname="M101", proposal_pi="Ost*")
-    assert "one of objectname and coordinates" in str(invalid_query.value)
+        Observations.query_criteria_count(coordinates=regionCoords, object_name="M101", proposal_pi="Ost*")
+    assert "one of object_name and coordinates" in str(invalid_query.value)
 
 
 # product functions
@@ -1427,16 +1432,16 @@ def test_catalogs_query_criteria_async(patch_post):
                                               Bmag=[30, 50], objType="STAR")
     assert isinstance(responses, list)
 
-    responses = Catalogs.query_criteria_async(catalog="Tic", objectname="M10",
+    responses = Catalogs.query_criteria_async(catalog="Tic", object_name="M10",
                                               Bmag=[30, 50], objType="STAR")
     assert isinstance(responses, list)
 
     responses = Catalogs.query_criteria_async(catalog="DiskDetective",
-                                              objectname="M10", radius=2,
+                                              object_name="M10", radius=2,
                                               state="complete")
     assert isinstance(responses, list)
 
-    responses = Catalogs.query_criteria_async(catalog="panstarrs", objectname="M10", radius=2,
+    responses = Catalogs.query_criteria_async(catalog="panstarrs", object_name="M10", radius=2,
                                               table="mean", qualityFlag=48)
     assert isinstance(responses, MockResponse)
 
@@ -1449,9 +1454,9 @@ def test_catalogs_query_criteria_async(patch_post):
     assert "query not available" in str(invalid_query.value)
 
     with pytest.raises(InvalidQueryError) as invalid_query:
-        Catalogs.query_criteria_async(catalog="panstarrs", objectname="M10", coordinates=regionCoords,
+        Catalogs.query_criteria_async(catalog="panstarrs", object_name="M10", coordinates=regionCoords,
                                       objType="STAR")
-    assert "one of objectname and coordinates" in str(invalid_query.value)
+    assert "one of object_name and coordinates" in str(invalid_query.value)
 
 
 def test_catalogs_query_criteria(patch_post):
@@ -1468,12 +1473,12 @@ def test_catalogs_query_criteria(patch_post):
 
     # with position
     result = Catalogs.query_criteria(catalog="DiskDetective",
-                                     objectname="M10", radius=2,
+                                     object_name="M10", radius=2,
                                      state="complete")
     assert isinstance(result, Table)
 
     with pytest.raises(InvalidQueryError) as invalid_query:
-        Catalogs.query_criteria(catalog="Tic", objectname="M10")
+        Catalogs.query_criteria(catalog="Tic", object_name="M10")
     assert "non-positional" in str(invalid_query.value)
 
 
@@ -1540,7 +1545,7 @@ def test_tesscut_get_sector(patch_post):
     assert sector_table['ccd'][0] == 3
 
     # Exercising the search by object name
-    sector_table = Tesscut.get_sectors(objectname="M103")
+    sector_table = Tesscut.get_sectors(object_name="M103")
     assert isinstance(sector_table, Table)
     assert len(sector_table) == 1
     assert sector_table['sectorName'][0] == "tess-s0001-1-3"
@@ -1549,7 +1554,7 @@ def test_tesscut_get_sector(patch_post):
     assert sector_table['ccd'][0] == 3
 
     # Exercising the search by moving target
-    sector_table = Tesscut.get_sectors(objectname="Ceres",
+    sector_table = Tesscut.get_sectors(object_name="Ceres",
                                        moving_target=True,
                                        mt_type='small_body')
     assert isinstance(sector_table, Table)
@@ -1562,9 +1567,9 @@ def test_tesscut_get_sector(patch_post):
     # Invalid queries
     # Testing catch for multiple designators'
     error_str = ("Only one of moving_target and coordinates may be specified. "
-                 "Please remove coordinates if using moving_target and objectname.")
+                 "Please remove coordinates if using moving_target and object_name.")
     with pytest.raises(InvalidQueryError) as invalid_query:
-        Tesscut.get_sectors(objectname='Ceres', moving_target=True, coordinates=coord)
+        Tesscut.get_sectors(object_name='Ceres', moving_target=True, coordinates=coord)
     assert error_str in str(invalid_query.value)
 
     # Error when no object name with moving target
@@ -1572,14 +1577,14 @@ def test_tesscut_get_sector(patch_post):
         Tesscut.get_sectors(moving_target=True)
 
     # Error when both object name and coordinates are specified
-    with pytest.raises(InvalidQueryError, match='Please remove objectname if using coordinates'):
-        Tesscut.get_sectors(objectname='Ceres', coordinates=coord)
+    with pytest.raises(InvalidQueryError, match='Please remove object_name if using coordinates'):
+        Tesscut.get_sectors(object_name='Ceres', coordinates=coord)
 
     # Testing invalid queries
     # Invalid product type
     with pytest.raises(InvalidQueryError) as invalid_query:
         with pytest.warns(AstropyDeprecationWarning, match="Tesscut no longer supports"):
-            Tesscut.get_sectors(objectname="M101", product="spooc")
+            Tesscut.get_sectors(object_name="M101", product="spooc")
     assert "Input product must be SPOC." in str(invalid_query.value)
 
 
@@ -1602,14 +1607,14 @@ def test_tesscut_download_cutouts(patch_post, tmpdir):
     assert os.path.isfile(manifest[0]['Local Path'])
 
     # Exercising the search by object name
-    manifest = Tesscut.download_cutouts(objectname="M103", size=5, path=str(tmpdir))
+    manifest = Tesscut.download_cutouts(object_name="M103", size=5, path=str(tmpdir))
     assert isinstance(manifest, Table)
     assert len(manifest) == 1
     assert manifest["Local Path"][0][-4:] == "fits"
     assert os.path.isfile(manifest[0]['Local Path'])
 
     # Exercising the search by moving target
-    manifest = Tesscut.download_cutouts(objectname="Eleonora",
+    manifest = Tesscut.download_cutouts(object_name="Eleonora",
                                         moving_target=True,
                                         mt_type='small_body',
                                         sector=1,
@@ -1622,10 +1627,10 @@ def test_tesscut_download_cutouts(patch_post, tmpdir):
 
     # Testing catch for multiple designators'
     error_str = ("Only one of moving_target and coordinates may be specified. "
-                 "Please remove coordinates if using moving_target and objectname.")
+                 "Please remove coordinates if using moving_target and object_name.")
 
     with pytest.raises(InvalidQueryError) as invalid_query:
-        Tesscut.download_cutouts(objectname="Eleonora",
+        Tesscut.download_cutouts(object_name="Eleonora",
                                  moving_target=True,
                                  coordinates=coord,
                                  size=5,
@@ -1635,7 +1640,7 @@ def test_tesscut_download_cutouts(patch_post, tmpdir):
     # Testing invalid queries
     with pytest.raises(InvalidQueryError) as invalid_query:
         with pytest.warns(AstropyDeprecationWarning, match="Tesscut no longer supports"):
-            Tesscut.download_cutouts(objectname="M101", product="spooc")
+            Tesscut.download_cutouts(object_name="M101", product="spooc")
     assert "Input product must be SPOC." in str(invalid_query.value)
 
 
@@ -1647,13 +1652,13 @@ def test_tesscut_get_cutouts(patch_post, tmpdir):
     assert isinstance(cutout_hdus_list[0], fits.HDUList)
 
     # Exercising the search by object name
-    cutout_hdus_list = Tesscut.get_cutouts(objectname="M103", size=5)
+    cutout_hdus_list = Tesscut.get_cutouts(object_name="M103", size=5)
     assert isinstance(cutout_hdus_list, list)
     assert len(cutout_hdus_list) == 1
     assert isinstance(cutout_hdus_list[0], fits.HDUList)
 
     # Exercising the search by object name
-    cutout_hdus_list = Tesscut.get_cutouts(objectname='Eleonora',
+    cutout_hdus_list = Tesscut.get_cutouts(object_name='Eleonora',
                                            moving_target=True,
                                            mt_type='small_body',
                                            sector=1,
@@ -1664,10 +1669,10 @@ def test_tesscut_get_cutouts(patch_post, tmpdir):
 
     # Testing catch for multiple designators'
     error_str = ("Only one of moving_target and coordinates may be specified. "
-                 "Please remove coordinates if using moving_target and objectname.")
+                 "Please remove coordinates if using moving_target and object_name.")
 
     with pytest.raises(InvalidQueryError) as invalid_query:
-        Tesscut.get_cutouts(objectname="Eleonora",
+        Tesscut.get_cutouts(object_name="Eleonora",
                             moving_target=True,
                             coordinates=coord,
                             size=5)
@@ -1676,7 +1681,7 @@ def test_tesscut_get_cutouts(patch_post, tmpdir):
     # Testing invalid queries
     with pytest.raises(InvalidQueryError) as invalid_query:
         with pytest.warns(AstropyDeprecationWarning, match="Tesscut no longer supports"):
-            Tesscut.get_cutouts(objectname="M101", product="spooc")
+            Tesscut.get_cutouts(object_name="M101", product="spooc")
     assert "Input product must be SPOC." in str(invalid_query.value)
 
 
@@ -1687,7 +1692,7 @@ def test_tesscut_get_cutouts_mt_no_sector(patch_post):
     automatically fetch available sectors and make individual requests per sector.
     """
     # Moving target without specifying sector - should automatically fetch sectors
-    cutout_hdus_list = Tesscut.get_cutouts(objectname="Eleonora", moving_target=True, mt_type="small_body", size=5)
+    cutout_hdus_list = Tesscut.get_cutouts(object_name="Eleonora", moving_target=True, mt_type="small_body", size=5)
     assert isinstance(cutout_hdus_list, list)
     # Mock returns 1 sector, so we expect 1 cutout
     assert len(cutout_hdus_list) == 1
@@ -1702,7 +1707,7 @@ def test_tesscut_download_cutouts_mt_no_sector(patch_post, tmpdir):
     """
     # Moving target without specifying sector - should automatically fetch sectors
     manifest = Tesscut.download_cutouts(
-        objectname="Eleonora", moving_target=True, mt_type="small_body", size=5, path=str(tmpdir)
+        object_name="Eleonora", moving_target=True, mt_type="small_body", size=5, path=str(tmpdir)
     )
     assert isinstance(manifest, Table)
     # Mock returns 1 sector, so we expect 1 file
@@ -1721,7 +1726,7 @@ def test_tesscut_get_cutouts_mt_no_sector_empty_results(patch_post, monkeypatch)
     monkeypatch.setattr(Tesscut, "get_sectors", lambda *args, **kwargs: empty_sector_table)
 
     with pytest.warns(NoResultsWarning, match="Coordinates are not in any TESS sector"):
-        cutout_hdus_list = Tesscut.get_cutouts(objectname="NonExistentObject", moving_target=True, size=5)
+        cutout_hdus_list = Tesscut.get_cutouts(object_name="NonExistentObject", moving_target=True, size=5)
     assert isinstance(cutout_hdus_list, list)
     assert len(cutout_hdus_list) == 0
 
@@ -1737,7 +1742,7 @@ def test_tesscut_download_cutouts_mt_no_sector_empty_results(patch_post, tmpdir,
 
     with pytest.warns(NoResultsWarning, match="Coordinates are not in any TESS sector"):
         manifest = Tesscut.download_cutouts(
-            objectname="NonExistentObject", moving_target=True, size=5, path=str(tmpdir)
+            object_name="NonExistentObject", moving_target=True, size=5, path=str(tmpdir)
         )
     assert isinstance(manifest, Table)
     assert len(manifest) == 0
@@ -1818,17 +1823,17 @@ def test_parse_input_location(patch_post):
 
     # Test with object name
     obj_coord = SkyCoord(124.531756290083, -68.3129998725044, unit="deg")
-    loc = utils.parse_input_location(objectname="TIC 307210830")
+    loc = utils.parse_input_location(object_name="TIC 307210830")
     assert isinstance(loc, SkyCoord)
     assert loc.ra == obj_coord.ra
     assert loc.dec == obj_coord.dec
 
     # Error if both coordinates and object name are provided
-    with pytest.raises(InvalidQueryError, match="Only one of objectname and coordinates may be specified"):
-        utils.parse_input_location(coordinates=coord, objectname="M101")
+    with pytest.raises(InvalidQueryError, match="Only one of object_name and coordinates may be specified"):
+        utils.parse_input_location(coordinates=coord, object_name="M101")
 
     # Error if neither coordinates nor object name is provided
-    with pytest.raises(InvalidQueryError, match="One of objectname and coordinates must be specified"):
+    with pytest.raises(InvalidQueryError, match="One of object_name and coordinates must be specified"):
         utils.parse_input_location()
 
     # Warn if resolver is specified without an object name

--- a/astroquery/mast/tests/test_mast_remote.py
+++ b/astroquery/mast/tests/test_mast_remote.py
@@ -531,7 +531,7 @@ class TestMast:
 
         # with position
         responses = Observations.query_criteria_async(filters=["NUV", "FUV"],
-                                                      objectname="M10")
+                                                      object_name="M10")
         assert isinstance(responses, list)
 
     def test_observations_query_criteria(self):
@@ -545,7 +545,7 @@ class TestMast:
         assert ((result['obs_collection'] == 'HST') | (result['obs_collection'] == 'HLA')).all()
 
         # with position
-        result = Observations.query_criteria(objectname="M10",
+        result = Observations.query_criteria(object_name="M10",
                                              filters=["NUV", "FUV"],
                                              obs_collection="GALEX")
         assert isinstance(result, Table)
@@ -553,7 +553,7 @@ class TestMast:
         assert (result['obs_collection'] == 'GALEX').all()
         assert sum(result['filters'] == 'NUV') == 4
 
-        result = Observations.query_criteria(objectname="M10",
+        result = Observations.query_criteria(object_name="M10",
                                              dataproduct_type="IMAGE",
                                              intentType="calibration")
         assert (result["intentType"] == "calibration").all()
@@ -602,7 +602,7 @@ class TestMast:
     # product functions
     def test_observations_get_product_list_async(self):
 
-        test_obs = Observations.query_criteria(filters=["NUV", "FUV"], objectname="M10")
+        test_obs = Observations.query_criteria(filters=["NUV", "FUV"], object_name="M10")
 
         responses = Observations.get_product_list_async(test_obs[0]["obsid"])
         assert isinstance(responses, list)
@@ -610,7 +610,7 @@ class TestMast:
         responses = Observations.get_product_list_async(test_obs[2:3])
         assert isinstance(responses, list)
 
-        observations = Observations.query_criteria(objectname="M8", obs_collection=["K2", "IUE"])
+        observations = Observations.query_criteria(object_name="M8", obs_collection=["K2", "IUE"])
         responses = Observations.get_product_list_async(observations[0])
         assert isinstance(responses, list)
 
@@ -622,7 +622,7 @@ class TestMast:
         assert isinstance(responses, list)
 
     def test_observations_get_product_list(self, capsys):
-        observations = Observations.query_criteria(objectname='M8', obs_collection=['K2', 'IUE'])
+        observations = Observations.query_criteria(object_name='M8', obs_collection=['K2', 'IUE'])
         test_obs_id = str(observations[0]['obsid'])
         mult_obs_ids = str(observations[0]['obsid']) + ',' + str(observations[1]['obsid'])
 
@@ -831,7 +831,7 @@ class TestMast:
             assert os.path.exists(path)
 
         # get observations from GALEX instrument with query_criteria
-        observations = Observations.query_criteria(objectname='M10',
+        observations = Observations.query_criteria(object_name='M10',
                                                    radius=0.001,
                                                    instrument_name='GALEX')
 
@@ -1267,24 +1267,24 @@ class TestMast:
 
         # with position
         responses = Catalogs.query_criteria_async(catalog="Tic",
-                                                  objectname="M10",
+                                                  object_name="M10",
                                                   objType="EXTENDED")
         assert isinstance(responses, list)
 
         responses = Catalogs.query_criteria_async(catalog="CTL",
-                                                  objectname="M10",
+                                                  object_name="M10",
                                                   objType="EXTENDED")
         assert isinstance(responses, list)
 
         responses = Catalogs.query_criteria_async(catalog="DiskDetective",
-                                                  objectname="M10",
+                                                  object_name="M10",
                                                   radius=2,
                                                   state="complete")
         assert isinstance(responses, list)
 
         responses = Catalogs.query_criteria_async(catalog="panstarrs",
                                                   table="mean",
-                                                  objectname="M10",
+                                                  object_name="M10",
                                                   radius=.02,
                                                   qualityFlag=48)
         assert isinstance(responses, Response)
@@ -1324,23 +1324,23 @@ class TestMast:
 
         # with position
         result = Catalogs.query_criteria(catalog="Tic",
-                                         objectname="M10", objType="EXTENDED")
+                                         object_name="M10", objType="EXTENDED")
         check_result(result, {'ID': '10000732589'})
 
-        result = Catalogs.query_criteria(objectname='TIC 291067184',
+        result = Catalogs.query_criteria(object_name='TIC 291067184',
                                          catalog="ctl",
                                          Tmag=[10.5, 11],
                                          POSflag="2mass")
         check_result(result, {'Tmag': 10.893})
 
         result = Catalogs.query_criteria(catalog="DiskDetective",
-                                         objectname="M10",
+                                         object_name="M10",
                                          radius=2,
                                          state="complete")
         check_result(result, {'designation': 'J165628.40-054630.8'})
 
         result = Catalogs.query_criteria(catalog="panstarrs",
-                                         objectname="M10",
+                                         object_name="M10",
                                          radius=.01,
                                          qualityFlag=32,
                                          zoneID=10306,
@@ -1473,13 +1473,13 @@ class TestMast:
         sector_table = Tesscut.get_sectors(coordinates=coord)
         check_sector_table(sector_table)
 
-        sector_table = Tesscut.get_sectors(objectname="M104")
+        sector_table = Tesscut.get_sectors(object_name="M104")
         check_sector_table(sector_table)
 
     def test_tesscut_get_sectors_mt(self):
         # Moving target functionality testing
         moving_target_name = 'Eleonora'
-        sector_table = Tesscut.get_sectors(objectname=moving_target_name,
+        sector_table = Tesscut.get_sectors(object_name=moving_target_name,
                                            moving_target=True)
         assert isinstance(sector_table, Table)
         assert len(sector_table) >= 1
@@ -1490,7 +1490,7 @@ class TestMast:
 
         error_nameresolve = f"Could not resolve \"{moving_target_name}\" to a sky position."
         with pytest.raises(ResolverError) as error_msg:
-            Tesscut.get_sectors(objectname=moving_target_name)
+            Tesscut.get_sectors(object_name=moving_target_name)
         assert error_nameresolve in str(error_msg.value)
 
     def test_tesscut_download_cutouts(self, tmpdir):
@@ -1518,14 +1518,14 @@ class TestMast:
                                             path=str(tmpdir), inflate=False)
         check_manifest(manifest, ".zip")
 
-        manifest = Tesscut.download_cutouts(objectname="TIC 32449963", size=1, path=str(tmpdir))
+        manifest = Tesscut.download_cutouts(object_name="TIC 32449963", size=1, path=str(tmpdir))
         check_manifest(manifest, "fits")
 
     def test_tesscut_download_cutouts_mt(self, tmpdir):
         # Moving target functionality testing
         moving_target_name = 'Eleonora'
 
-        manifest = Tesscut.download_cutouts(objectname=moving_target_name,
+        manifest = Tesscut.download_cutouts(object_name=moving_target_name,
                                             moving_target=True,
                                             sector=6,
                                             size=1,
@@ -1538,7 +1538,7 @@ class TestMast:
 
         error_nameresolve = f"Could not resolve \"{moving_target_name}\" to a sky position."
         with pytest.raises(ResolverError) as error_msg:
-            Tesscut.download_cutouts(objectname=moving_target_name)
+            Tesscut.download_cutouts(object_name=moving_target_name)
         assert error_nameresolve in str(error_msg.value)
 
     def test_tesscut_get_cutouts(self):
@@ -1559,7 +1559,7 @@ class TestMast:
                                                sector=[28, 68])
         check_cutout_hdu(cutout_hdus_list)
 
-        cutout_hdus_list = Tesscut.get_cutouts(objectname="TIC 32449963",
+        cutout_hdus_list = Tesscut.get_cutouts(object_name="TIC 32449963",
                                                size=1,
                                                sector=37)
         check_cutout_hdu(cutout_hdus_list)
@@ -1567,7 +1567,7 @@ class TestMast:
     def test_tesscut_get_cutouts_mt(self):
         # Moving target functionality testing
         moving_target_name = 'Eleonora'
-        cutout_hdus_list = Tesscut.get_cutouts(objectname=moving_target_name,
+        cutout_hdus_list = Tesscut.get_cutouts(object_name=moving_target_name,
                                                moving_target=True,
                                                sector=6,
                                                size=1)
@@ -1577,7 +1577,7 @@ class TestMast:
 
         error_nameresolve = f"Could not resolve \"{moving_target_name}\" to a sky position."
         with pytest.raises(ResolverError) as error_msg:
-            Tesscut.get_cutouts(objectname=moving_target_name)
+            Tesscut.get_cutouts(object_name=moving_target_name)
         assert error_nameresolve in str(error_msg.value)
 
     def test_tesscut_get_cutouts_mt_no_sector(self):
@@ -1588,7 +1588,7 @@ class TestMast:
         """
         moving_target_name = "Eleonora"
         # Moving target without specifying sector - should automatically fetch sectors
-        cutout_hdus_list = Tesscut.get_cutouts(objectname=moving_target_name, moving_target=True, size=1)
+        cutout_hdus_list = Tesscut.get_cutouts(object_name=moving_target_name, moving_target=True, size=1)
         assert isinstance(cutout_hdus_list, list)
         # Should return cutouts for all available sectors
         assert len(cutout_hdus_list) >= 1
@@ -1602,7 +1602,8 @@ class TestMast:
         """
         moving_target_name = "Eleonora"
         # Moving target without specifying sector - should automatically fetch sectors
-        manifest = Tesscut.download_cutouts(objectname=moving_target_name, moving_target=True, size=1, path=str(tmpdir))
+        manifest = Tesscut.download_cutouts(object_name=moving_target_name,
+                                            moving_target=True, size=1, path=str(tmpdir))
         assert isinstance(manifest, Table)
         # Should return files for all available sectors
         assert len(manifest) >= 1

--- a/astroquery/mast/utils.py
+++ b/astroquery/mast/utils.py
@@ -16,6 +16,7 @@ from astropy.coordinates import SkyCoord
 from astropy.table import Table
 from astropy.utils import deprecated
 from astropy.utils.console import ProgressBarOrSpinner
+from astropy.utils.decorators import deprecated_renamed_argument
 from astropy import units as u
 
 from .. import log
@@ -149,13 +150,14 @@ def _batched_request(
         return extract_func(resp)
 
 
-def resolve_object(objectname, *, resolver=None, resolve_all=False, batch_size=30):
+@deprecated_renamed_argument('objectname', 'object_name', since='0.4.12')
+def resolve_object(object_name, *, resolver=None, resolve_all=False, batch_size=30):
     """
     Resolves one or more object names to a position on the sky.
 
     Parameters
     ----------
-    objectname : str, or iterable of str
+    object_name : str, or iterable of str
         Name(s) of astronomical object(s) to resolve.
     resolver : str, optional
         The resolver to use when resolving a named target into coordinates. Valid options are "SIMBAD" and "NED".
@@ -185,11 +187,11 @@ def resolve_object(objectname, *, resolver=None, resolve_all=False, batch_size=3
     # Normalize input
     try:
         # Strings are iterable, so check explicitly
-        if isinstance(objectname, str):
+        if isinstance(object_name, str):
             raise TypeError
-        object_names = list(objectname)
+        object_names = list(object_name)
     except TypeError:
-        object_names = [objectname]
+        object_names = [object_name]
 
     # If any items are not strings, raise an error
     if not all(isinstance(name, str) for name in object_names):
@@ -304,20 +306,21 @@ def resolve_object(objectname, *, resolver=None, resolve_all=False, batch_size=3
     return list(resolved_coords.values())[0] if single else resolved_coords
 
 
-def parse_input_location(*, coordinates=None, objectname=None, resolver=None):
+@deprecated_renamed_argument('objectname', 'object_name', since='0.4.12')
+def parse_input_location(*, coordinates=None, object_name=None, resolver=None):
     """
-    Convenience function to parse user input of coordinates and objectname.
+    Convenience function to parse user input of coordinates and object_name.
 
     Parameters
     ----------
     coordinates : str or `astropy.coordinates` object, optional
         The target around which to search. It may be specified as a
         string or as the appropriate `astropy.coordinates` object.
-        One and only one of coordinates and objectname must be supplied.
-    objectname : str, optional
-        The target around which to search, by name (objectname="M104")
-        or TIC ID (objectname="TIC 141914082").
-        One and only one of coordinates and objectname must be supplied.
+        One and only one of coordinates and object_name must be supplied.
+    object_name : str, optional
+        The target around which to search, by name (object_name="M104")
+        or TIC ID (object_name="TIC 141914082").
+        One and only one of coordinates and object_name must be supplied.
     resolver : str, optional
         The resolver to use when resolving a named target into coordinates. Valid options are "SIMBAD" and "NED".
         If not specified, the default resolver order will be used. Please see the
@@ -332,17 +335,17 @@ def parse_input_location(*, coordinates=None, objectname=None, resolver=None):
     """
 
     # Checking for valid input
-    if objectname and coordinates:
-        raise InvalidQueryError("Only one of objectname and coordinates may be specified.")
+    if object_name and coordinates:
+        raise InvalidQueryError("Only one of object_name and coordinates may be specified.")
 
-    if not (objectname or coordinates):
-        raise InvalidQueryError("One of objectname and coordinates must be specified.")
+    if not (object_name or coordinates):
+        raise InvalidQueryError("One of object_name and coordinates must be specified.")
 
-    if not objectname and resolver:
+    if not object_name and resolver:
         warnings.warn("Resolver is only used when resolving object names and will be ignored.", InputWarning)
 
-    if objectname:
-        obj_coord = resolve_object(objectname, resolver=resolver)
+    if object_name:
+        obj_coord = resolve_object(object_name, resolver=resolver)
 
     # Parse coordinates, if given
     if coordinates:

--- a/docs/mast/mast_catalog.rst
+++ b/docs/mast/mast_catalog.rst
@@ -166,7 +166,7 @@ The TESS Input Catalog (TIC), Disk Detective Catalog, and PanSTARRS Catalog can 
    >>> from astroquery.mast import Catalogs
    ...
    >>> catalog_data = Catalogs.query_criteria(catalog="Ctl",
-   ...                                        objectname='M101', 
+   ...                                        object_name='M101', 
    ...                                        radius=1, 
    ...                                        Tmag=[10.75,11])
    >>> print(catalog_data)
@@ -187,7 +187,7 @@ The TESS Input Catalog (TIC), Disk Detective Catalog, and PanSTARRS Catalog can 
    >>> from astroquery.mast import Catalogs
    ...
    >>> catalog_data = Catalogs.query_criteria(catalog="DiskDetective",
-   ...                                        objectname="M10",
+   ...                                        object_name="M10",
    ...                                        radius=2,
    ...                                        state="complete")
    >>> print(catalog_data)      # doctest: +IGNORE_OUTPUT
@@ -204,7 +204,7 @@ The TESS Input Catalog (TIC), Disk Detective Catalog, and PanSTARRS Catalog can 
 
 The `~astroquery.mast.CatalogsClass.query_criteria` function requires at least one non-positional parameter.
 These parameters are the column names listed in the `field descriptions <https://mast.stsci.edu/api/v0/pages.html>`__
-of the catalog being queried. They do not include objectname, coordinates, or radius. Running a query with only positional
+of the catalog being queried. They do not include object_name, coordinates, or radius. Running a query with only positional
 parameters will result in an error.
 
 .. doctest-remote-data::
@@ -212,7 +212,7 @@ parameters will result in an error.
    >>> from astroquery.mast import Catalogs
    ...
    >>> catalog_data = Catalogs.query_criteria(catalog="Tic",
-   ...                                        objectname='M101', radius=1)
+   ...                                        object_name='M101', radius=1)
    Traceback (most recent call last):
    ...
    astroquery.exceptions.InvalidQueryError: At least one non-positional criterion must be supplied.

--- a/docs/mast/mast_cut.rst
+++ b/docs/mast/mast_cut.rst
@@ -97,11 +97,11 @@ The following example demonstrates how to use the `~astroquery.mast.TesscutClass
    tess-s0061-1-2     61      1   2
    tess-s0088-1-2     88      1   2
 
-You can also use the ``objectname`` parameter to specify a target by name or TIC ID.
+You can also use the ``object_name`` parameter to specify a target by name or TIC ID.
 
 .. doctest-remote-data::
 
-   >>> sector_table = Tesscut.get_sectors(objectname="TIC 32449963")
+   >>> sector_table = Tesscut.get_sectors(object_name="TIC 32449963")
    >>> print(sector_table)     # doctest: +IGNORE_OUTPUT
      sectorName   sector camera ccd
    -------------- ------ ------ ---
@@ -111,7 +111,7 @@ To find sectors for a moving target, set the ``moving_target`` parameter to ``Tr
 
 .. doctest-remote-data::
 
-   >>> sector_table = Tesscut.get_sectors(objectname="Ceres", moving_target=True)
+   >>> sector_table = Tesscut.get_sectors(object_name="Ceres", moving_target=True)
    >>> print(sector_table)
      sectorName   sector camera ccd
    -------------- ------ ------ ---
@@ -161,12 +161,12 @@ The following example demonstrates how to request a TESS cutout using sky coordi
    1  PIXELS        1 BinTableHDU    281   3495R x 12C   [D, E, J, 25J, 25E, 25E, 25E, 25E, J, E, E, 38A]
    2  APERTURE      1 ImageHDU        82   (5, 5)   int32
 
-You may also request cutouts of a moving target by inputting a valid moving target as the ``objectname`` and setting 
+You may also request cutouts of a moving target by inputting a valid moving target as the ``object_name`` and setting 
 the ``moving_target`` parameter to ``True``.
 
 .. doctest-remote-data::
 
-   >>> hdulist = Tesscut.get_cutouts(objectname="Eleonora",
+   >>> hdulist = Tesscut.get_cutouts(object_name="Eleonora",
    ...                               moving_target=True,
    ...                               sector=6)
    >>> hdulist[0].info()  # doctest: +IGNORE_OUTPUT

--- a/docs/mast/mast_missions.rst
+++ b/docs/mast/mast_missions.rst
@@ -104,7 +104,7 @@ Positional constraints are optional.
 Supported positional parameters include:
 
   - ``coordinates`` : Sky coordinates around which to perform a cone search.
-  - ``objectname`` : Name(s) of the object(s) around which to perform a cone search.
+  - ``object_name`` : Name(s) of the object(s) around which to perform a cone search.
   - ``resolver`` : Resolver service to use for object name resolution.
   - ``radius`` : Radius of the cone searches around the specified coordinates or object names. Can be defined as an `~astropy.units.Quantity`, 
     a string with units (e.g., ``"10 arcsec"``), or a numeric value interpreted as degrees.

--- a/docs/mast/mast_obsquery.rst
+++ b/docs/mast/mast_obsquery.rst
@@ -187,14 +187,14 @@ for JWST science instruments, which you can read more about on the MAST page for
    >>> set(obs_table['instrument_name'])  # doctest: +IGNORE_OUTPUT
    {'NIRISS', 'NIRISS/IMAGE', 'NIRISS/SOSS'}
 
-You can also perform positional queries with additional criteria by passing in ``objectname``, ``coordinates``,
+You can also perform positional queries with additional criteria by passing in ``object_name``, ``coordinates``,
 and/or ``radius`` as keyword arguments.
 
 .. doctest-remote-data::
 
    >>> from astroquery.mast import Observations
    ...
-   >>> obs_table = Observations.query_criteria(objectname="M10",
+   >>> obs_table = Observations.query_criteria(object_name="M10",
    ...                                         radius="0.1 deg",
    ...                                         filters=["*UV","Kepler"],
    ...                                         obs_collection="GALEX")
@@ -273,7 +273,7 @@ If not provided, batch_size defaults to 500.
 
    >>> from astroquery.mast import Observations
    ...
-   >>> obs_table = Observations.query_criteria(objectname="M8", obs_collection=["K2", "IUE"])
+   >>> obs_table = Observations.query_criteria(object_name="M8", obs_collection=["K2", "IUE"])
    >>> data_products_by_obs = Observations.get_product_list(obs_table[0:2], batch_size=500)
    >>> print(data_products_by_obs)  # doctest: +IGNORE_OUTPUT
    obsID  obs_collection dataproduct_type ... dataRights calib_level filters


### PR DESCRIPTION
The `objectname` parameter in `Catalogs`, `Observations`, `Tesscut`, and `utils` is deprecated in favor of `object_name`.

I also used this PR to fix an unintentional backwards compatibility issue that was introduced in #3540. Previously, users could input a single coordinate string with a comma separating the RA and declination (`"20, -30"`). The code introduced in that PR splits the string on commas, assuming that coordinates are only separated by a space, which breaks this workflow. I implemented a corner case that detects this historical single-coordinate input and works around it to still return results.