### PR TITLE
ESA-HST: Improve get_datalabs_path for eHST

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -118,6 +118,8 @@ esa.hubble
 
 - Update ``get_datalabs_path`` method so an alternative path is checked if the
   file is not in Datalabs yet [#3437]
+- Update ``get_datalabs_path`` method to check for files for new collections (HLSP and HSLA) [#3578]
+
 
 mast
 ^^^^

--- a/astroquery/esa/hubble/core.py
+++ b/astroquery/esa/hubble/core.py
@@ -940,7 +940,7 @@ class ESAHubbleClass(EsaTap):
         """
 
         # FITS files are always compressed
-        if filename.endswith('.fits') and not 'hlsp' in filename:
+        if filename.endswith('.fits') and 'hlsp' not in filename:
             filename = f"{filename}.gz"
 
         query = f"select file_path from ehst.artifact where file_name = '{filename}'"

--- a/astroquery/esa/hubble/core.py
+++ b/astroquery/esa/hubble/core.py
@@ -940,7 +940,7 @@ class ESAHubbleClass(EsaTap):
         """
 
         # FITS files are always compressed
-        if filename.endswith('.fits'):
+        if filename.endswith('.fits') and not 'hlsp' in filename:
             filename = f"{filename}.gz"
 
         query = f"select file_path from ehst.artifact where file_name = '{filename}'"
@@ -968,7 +968,7 @@ class ESAHubbleClass(EsaTap):
         for datalabs_path in ["/data/user/", "/data/"]:
             # Automatic fill: convert /hstdata/hstdata_i/i/b4x/04 to <datalabs_path>/hub_hstdata_i/i/b4x/04
             if default_volume is None:
-                full_path = datalabs_path + "hub_" + path_parsed + "/" + filename
+                full_path = self.__get_default_datalabs_path(datalabs_path, path_parsed, filename)
 
             # Use the path provided by the user: convert /hstdata/hstdata_i/i/b4x/04 to <datalabs_path>/myPath/i/b4x/04
             else:
@@ -980,9 +980,38 @@ class ESAHubbleClass(EsaTap):
             if file_exists:
                 return full_path
 
-        warnings.warn(f"File {filename} is not accessible. Please ensure the {instrument_name} "
+        warnings.warn(f"File {filename} is not accessible. Please ensure the {instrument_name} / {path_parsed} "
                       "volume is mounted in your ESA Datalabs instance.")
         return full_path
+
+    def __get_default_datalabs_path(self, datalabs_path, path_parsed, filename):
+        """Get the default path based on the type of the collection
+
+        Parameters
+        ----------
+        datalabs_path : string, mandatory
+            Default datalabs path where volumes can be mounted
+        path_parsed : string, mandatory
+            Folder in the volumes where data is stored
+        filename : string, mandatory
+            Name of the file to be retrieved
+
+        Returns
+        -------
+        The complete path of the file name in Datalabs
+        """
+        if 'hap' in path_parsed:
+            instrument_folder = path_parsed.split('_')[2]
+            return f"{datalabs_path}hst_data_hap_{instrument_folder}{filename}"
+
+        if 'hlsp' in path_parsed:
+            subfolders = path_parsed.split('hlsp/')[1]
+            return f"{datalabs_path}hst_hstdata_hlsp/{subfolders}{filename}"
+        if 'hsla' in path_parsed:
+            target_folder = path_parsed.split('hsla/')[1]
+            return f"{datalabs_path}hub_hstdata_hsla/{target_folder}{filename}"
+        # Default value
+        return f"{datalabs_path}hub_{path_parsed}/{filename}"
 
 
 # Need to be False in order to avoid reaching out to the remote server at import time

--- a/astroquery/esa/hubble/tests/test_esa_hubble.py
+++ b/astroquery/esa/hubble/tests/test_esa_hubble.py
@@ -831,4 +831,3 @@ class TestESAHubble:
             full_path = ehst.get_datalabs_path(filename=filename, default_volume=default_volume)
             assert full_path == ("/data/user/hst_hstdata_hlsp/rocky-worlds/HST/"
                                  "GJ3929/visit8/hlsp_rocky-worlds_hst_stis_gj3929_g140m_v1.0_lc.fits")
-

--- a/astroquery/esa/hubble/tests/test_esa_hubble.py
+++ b/astroquery/esa/hubble/tests/test_esa_hubble.py
@@ -789,3 +789,46 @@ class TestESAHubble:
 
             full_path = ehst.get_datalabs_path(filename=filename, default_volume=default_volume)
             assert full_path == "/data/user/myPath/i/b4x/04/ib4x04ivq_flt.jpg"
+
+    @patch('astroquery.esa.utils.utils.pyvo.dal.TAPService.capabilities', [])
+    @patch.object(ESAHubbleClass, 'query_tap')
+    @patch.object(ESAHubbleClass, '_get_decoded_string')
+    def test_get_datalabs_path_hsla(self, mock_get_decoded_string, mock_query_tap):
+        ehst = ESAHubbleClass(show_messages=False)
+
+        with patch('os.path.exists') as mock_exists:
+            mock_get_decoded_string.return_value = "/hstdata/hsla/hst_g249-36--7063/"
+            mock_exists.side_effect = [True]
+            filename = "hst_g249-36--7063_aspec_thumb.png"
+            default_volume = None
+            full_path = ehst.get_datalabs_path(filename=filename, default_volume=default_volume)
+            assert full_path == "/data/user/hub_hstdata_hsla/hst_g249-36--7063/hst_g249-36--7063_aspec_thumb.png"
+
+    @patch('astroquery.esa.utils.utils.pyvo.dal.TAPService.capabilities', [])
+    @patch.object(ESAHubbleClass, 'query_tap')
+    @patch.object(ESAHubbleClass, '_get_decoded_string')
+    def test_get_datalabs_path_hap(self, mock_get_decoded_string, mock_query_tap):
+        ehst = ESAHubbleClass(show_messages=False)
+        with patch('os.path.exists') as mock_exists:
+            mock_get_decoded_string.return_value = "/hstdata/hstdata_hap_i/11926/23/wfc3/"
+            mock_exists.side_effect = [True]
+            filename = "hst_11926_23_wfc3_ir_f098m_ibcf23_drz.fits.gz"
+            default_volume = None
+            full_path = ehst.get_datalabs_path(filename=filename, default_volume=default_volume)
+            assert full_path == "/data/user/hst_data_hap_i/11926/23/wfc3/hst_11926_23_wfc3_ir_f098m_ibcf23_drz.fits.gz"
+
+    @patch('astroquery.esa.utils.utils.pyvo.dal.TAPService.capabilities', [])
+    @patch.object(ESAHubbleClass, 'query_tap')
+    @patch.object(ESAHubbleClass, '_get_decoded_string')
+    def test_get_datalabs_path_hlsp(self, mock_get_decoded_string, mock_query_tap):
+        ehst = ESAHubbleClass(show_messages=False)
+
+        with patch('os.path.exists') as mock_exists:
+            mock_get_decoded_string.return_value = "/hstdata/hlsp/rocky-worlds/HST/GJ3929/visit8/"
+            mock_exists.side_effect = [True]
+            filename = "hlsp_rocky-worlds_hst_stis_gj3929_g140m_v1.0_lc.fits"
+            default_volume = None
+            full_path = ehst.get_datalabs_path(filename=filename, default_volume=default_volume)
+            assert full_path == "/data/user/hst_hstdata_hlsp/rocky-worlds/HST/GJ3929/visit8/hlsp_rocky-worlds_hst_stis_gj3929_g140m_v1.0_lc.fits"
+
+

--- a/astroquery/esa/hubble/tests/test_esa_hubble.py
+++ b/astroquery/esa/hubble/tests/test_esa_hubble.py
@@ -829,6 +829,6 @@ class TestESAHubble:
             filename = "hlsp_rocky-worlds_hst_stis_gj3929_g140m_v1.0_lc.fits"
             default_volume = None
             full_path = ehst.get_datalabs_path(filename=filename, default_volume=default_volume)
-            assert full_path == "/data/user/hst_hstdata_hlsp/rocky-worlds/HST/GJ3929/visit8/hlsp_rocky-worlds_hst_stis_gj3929_g140m_v1.0_lc.fits"
-
+            assert full_path == ("/data/user/hst_hstdata_hlsp/rocky-worlds/HST/"
+                                 "GJ3929/visit8/hlsp_rocky-worlds_hst_stis_gj3929_g140m_v1.0_lc.fits")
 


### PR DESCRIPTION
Dear Astroquery team,

As the number of collections available in ESA HST Module has grown, we had to extend the get_datalabs_path method to consider different paths depending on the type of the product we want to retrieve.

As always, we are open to your feedback.

Many thanks!
@jespinosaar 

cc @esdc-esac-esa-int 