### PR TITLE
Disable cache expiration if timeout is -1 instead of None

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -54,9 +54,9 @@ esa.euclid
 - The method ``get_spectrum`` accepts the new parameter ``linking_parameter`` to retrieve the spectra by source_id and
   sourcepatch_id. [#3543]
 -  The ``source_id`` kwarg in the ``get_spectrum`` method has been renamed to ``ids``. [#3543]
-- Method ``get_cutout`` has deprecated the 'instrument' and 'id' parameters, providing them has no effect any more. 
+- Method ``get_cutout`` has deprecated the 'instrument' and 'id' parameters, providing them has no effect any more.
   The method now only supports retrieval of MER (background‑subtracted) image cutouts. [#3559]
-- The ``get_product_list`` method now also returns file_name_list column when the product type belongs to 
+- The ``get_product_list`` method now also returns file_name_list column when the product type belongs to
   BASIC_DOWNLOAD_DATA_PRODUCTS. [#3562]
 - The method ``get_spectrum`` accepts a single source_id or designation or multiple values separated by commas or a
    list. [#3570]
@@ -74,7 +74,7 @@ mast
   now check all requested products against cloud storage. As a result, setting ``cloud_only=True`` will skip
   any products that are not available in the cloud, rather than falling back to on-prem downloads.
 - The ``objectname`` keyword is deprecated in ``MastMissions`` in favor of ``object_names``. [#3540]
-- The ``objectname`` parameter in ``Catalogs``, ``Observations``, ``Tesscut``, and ``utils`` is deprecated 
+- The ``objectname`` parameter in ``Catalogs``, ``Observations``, ``Tesscut``, and ``utils`` is deprecated
   in favor of ``object_name``. [#3567]
 
 vo_conesearch
@@ -199,6 +199,7 @@ Infrastructure, Utility and Other Changes and Additions
 - ``BaseVOQuery`` now accepts a ``extra_user_agents`` parameter to allow the addition
   of user agents on top of astroquery's ones [#3526]
 
+- Fix no experation case for ``cache_timeout`` config option. [#3579]
 
 utils.tap
 ^^^^^^^^^

--- a/astroquery/__init__.py
+++ b/astroquery/__init__.py
@@ -49,7 +49,7 @@ class Cache_Conf(_config.ConfigNamespace):
     cache_timeout = _config.ConfigItem(
         604800,
         ('Astroquery-wide cache timeout (seconds). Default is 1 week (604800). '
-         'Setting to None prevents the cache from expiring (not recommended).'),
+         'Setting to -1 prevents the cache from expiring (not recommended).'),
         cfgtype='integer'
     )
 

--- a/astroquery/query.py
+++ b/astroquery/query.py
@@ -116,7 +116,7 @@ class AstroQuery:
     def from_cache(self, cache_location, cache_timeout):
         request_file = self.request_file(cache_location)
         try:
-            if cache_timeout is None:
+            if cache_timeout == -1:
                 expired = False
             else:
                 current_time = datetime.now(timezone.utc)

--- a/astroquery/tests/test_cache.py
+++ b/astroquery/tests/test_cache.py
@@ -167,8 +167,8 @@ def test_timeout(changing_mocked_response, monkeypatch):
     resp = mytest.test_func(URL1)
     assert resp.content == TEXT2  # now see the new response
 
-    # Testing a cache timeout of "none"
-    cache_conf.cache_timeout = None
+    # Testing a cache timeout of -1
+    cache_conf.cache_timeout = -1
     # Ensure response can only come from cache.
     monkeypatch.delattr(requests.Session, "request")
 


### PR DESCRIPTION
There does not appear to be a way to set the value of `cache_timeout` to `None` in a .ini file because there is no value that will be decoded to None and will also validate as an integer.