### PR TITLE
MAINT: some TLC for old versions

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -62,22 +62,12 @@ dependencies required to build the documentation or run the tests):
     $ python -m pip install -U --pre astroquery[all]
 
 
-To install the 'bleeding edge' version:
+To install the 'bleeding edge' version from GitHub:
 
 .. code-block:: bash
 
    $ python -m pip install git+https://github.com/astropy/astroquery.git
 
-or cloned and installed from source:
-
-.. code-block:: bash
-
-    $ # If you have a github account:
-    $ git clone git@github.com:astropy/astroquery.git
-    $ # If you do not:
-    $ git clone https://github.com/astropy/astroquery.git
-    $ cd astroquery
-    $ python -m pip install .
 
 Using astroquery
 ----------------
@@ -114,7 +104,7 @@ looked up at the following `Zenodo page <https://doi.org/10.5281/zenodo.591669>`
 Additional Links
 ----------------
 
-Maintained by `Adam Ginsburg`_ and `Brigitta Sipocz <https://github.com/bsipocz>`_
+Maintained by `Adam Ginsburg`_ and `Brigitta Sipőcz <https://github.com/bsipocz>`_
 
 
 .. _Download Development ZIP: https://github.com/astropy/astroquery/zipball/main

--- a/README.rst
+++ b/README.rst
@@ -43,7 +43,7 @@ website <https://simbad.cds.unistra.fr/simbad/>`_, use the ``simbad`` sub-packag
 Installation and Requirements
 -----------------------------
 
-Astroquery works with Python 3.9 or later.
+Astroquery works with Python 3.10 or later.
 As an `astropy`_ affiliate, astroquery requires `astropy`_ version 5.0 or later.
 
 The latest version of astroquery can be pip installed (note the ``--pre`` for

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -12,9 +12,13 @@
 # See astropy.sphinx.conf for which values are set there.
 
 import datetime
-import os
 import sys
-import tomllib
+
+if sys.version_info < (3, 11):
+    import tomli as tomllib
+else:
+    import tomllib
+
 from pathlib import Path
 
 # Load all of the global Astropy configuration


### PR DESCRIPTION
We run into a couple of easy to fix issues while investigating #3584 

I still have issues directly running `sphinx-build` in some old python env, but all those python versions do work for me™️ with `tox -e build_docs`, so I stopped investigating further. 

(typical flavour of the failure I see is automodapi related with something like this:

```Extension error (sphinx_automodapi.automodsumm):
Handler <function process_automodsumm_generation at 0x123f96f80> for event 'builder-inited' threw an exception (exception: No module named 'astroquery.esa.integral')
```

I would say it probably wouldn't hurt to find and declare minimum sphinx and sphinx extension versions, too. 