### PR TITLE
Fix bug caching requests with pyvo request_hooks

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -201,6 +201,8 @@ Infrastructure, Utility and Other Changes and Additions
 
 - Fix no expiration case for ``cache_timeout`` config option. [#3579]
 
+- Workaround upstream bug when caching a response using pyvo. [#3586]
+
 utils.tap
 ^^^^^^^^^
 

--- a/astroquery/query.py
+++ b/astroquery/query.py
@@ -30,15 +30,22 @@ from astroquery.utils import system_tools
 __all__ = ['BaseVOQuery', 'BaseQuery', 'QueryWithLogin']
 
 
-def to_cache(response, cache_file):
+def to_cache(original_response, cache_file):
     log.debug("Caching data to {0}".format(cache_file))
 
-    response = copy.deepcopy(response)
-    if hasattr(response, 'request'):
-        for key in tuple(response.request.hooks.keys()):
-            del response.request.hooks[key]
+    hooks = None
+    if hasattr(original_response, 'request'):
+        hooks = original_response.request.hooks
+        del original_response.request.hooks
+    if hasattr(original_response, 'history'):
+        for r in original_response.history:
+            if hasattr(r, 'request'):
+                del r.request.hooks
+    response_copy = copy.deepcopy(original_response)
+    if hooks:
+        original_response.request.hooks = hooks
     with open(cache_file, "wb") as f:
-        pickle.dump(response, f, protocol=4)
+        pickle.dump(response_copy, f, protocol=4)
 
 
 def _replace_none_iterable(iterable):

--- a/astroquery/query.py
+++ b/astroquery/query.py
@@ -33,6 +33,10 @@ __all__ = ['BaseVOQuery', 'BaseQuery', 'QueryWithLogin']
 def to_cache(original_response, cache_file):
     log.debug("Caching data to {0}".format(cache_file))
 
+    # Copying a TAPService instance with an auth session produces some warnings
+    # as a side affect. The hooks are not needed in the cache, so we remove
+    # them before caching and restore them afterwards.
+    # Related pyvo issue: https://github.com/astropy/pyvo/issues/755
     hooks = None
     if hasattr(original_response, 'request'):
         hooks = original_response.request.hooks


### PR DESCRIPTION
When we migrated the ESASky module to use EsaTap/PyVO we noticed some weird errors for some of our requests that we didn't have before. When downloading images through the ESASky module we got Pyvo errors saying that we didn't conform to the TAP spec. It turns out that when we do a deep copy on the response (which contains the request hooks) during caching, it triggers something within Pyvo to do that validation.

I guess this is more of a workaround around something that is broken within pyvo rather than an actual bug fix. Let me know if you find this acceptable, or if you would rather see a proper fix within pyvo.
