### PR TITLE
MPC: Fix column parsing in get_ephemeris

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -167,6 +167,7 @@ mpc
 ^^^
 
 - Fix bug in queries for interstellar objects with ``MPC.get_observations`` and enable queries for "dead" comets [#3474]
+- Fix ``MPC.get_observations`` column parsing for very close objects, very high proper motions, and objects in the Earth's shadow [#3594]
 
 linelists
 ^^^^^^^^^

--- a/astroquery/mpc/core.py
+++ b/astroquery/mpc/core.py
@@ -1088,9 +1088,35 @@ class MPCClass(BaseQuery):
             if SKY:
                 names = ('Date', 'RA', 'Dec', 'Delta',
                          'r', 'Elongation', 'Phase', 'V')
-                col_starts = (0, 18, 29, 39, 47, 56, 62, 69)
-                col_ends = (17, 28, 38, 46, 55, 61, 68, 72)
+                col_starts = [0, 18, 29, 39, 47, 56, 62, 69]
+                col_ends = [17, 28, 38, 46, 55, 61, 68, 73]
                 units = (None, None, None, 'au', 'au', 'deg', 'deg', 'mag')
+
+                # The column division between Delta and r is variable: the enn
+                # column of a very small delta is greater than the start column
+                # of a very large r.
+                #
+                # Also note that high rates of motion will collide with the V mag.
+                #
+                # For examples, compare 2008 TC3 with 2018 AG37:
+                #
+                #      K08T03C       [H=30.72]
+                # Date       UT      R.A. (J2000) Decl.    Delta     r     El.    Ph.   V      Sky Motion   ...
+                #             h m s                                                            "/min    P.A....
+                # 2008 10 07 025000 08 00 22.2 +12 14 07   0.00004 0.999   74.6 105.4  12.426720.01    110.1...
+                #
+                #      K18A37G       [H= 4.22]
+                # Date       UT      R.A. (J2000) Decl.    Delta     r     El.    Ph.   V      Sky Motion   ...
+                #             h m s                                                            "/min    P.A....
+                # 2008 10 07 000000 08 21 45.7 +34 31 18 131.948 131.692   74.9   0.4  25.5    0.0074  063.7...
+                #
+                # It seems that there may always be a space between the Delta
+                # and r columns, so identify the split based on that assumption.
+
+                delta_rh = first_row[col_starts[3]:col_ends[4]]
+                delta_string = delta_rh.strip().split()[0]
+                col_ends[3] = col_starts[3] + delta_rh.index(delta_string) + len(delta_string)
+                col_starts[4] = col_ends[3] + 1
 
                 if 's=t' in result.request.body:    # total motion
                     names += ('Proper motion', 'Direction')
@@ -1102,7 +1128,7 @@ class MPCClass(BaseQuery):
                     names += ('dRA cos(Dec)', 'dDec')
                     units += ('arcsec/h', 'arcsec/h')
                 col_starts += (73, 82)
-                col_ends += (81, 91)
+                col_ends += (81, 90)
 
                 if 'Moon' in columns:
                     # table includes Alt, Az, Sun and Moon geometry
@@ -1143,7 +1169,8 @@ class MPCClass(BaseQuery):
             tab = ascii.read(text_table, format='fixed_width_no_header',
                              names=names, col_starts=col_starts,
                              col_ends=col_ends, data_start=data_start,
-                             fill_values=(('N/A', np.nan),), fast_reader=False)
+                             fill_values=(('N/A', np.nan), ("********", np.nan)),
+                             fast_reader=False)
 
             for col, unit in zip(names, units):
                 tab[col].unit = unit

--- a/astroquery/mpc/core.py
+++ b/astroquery/mpc/core.py
@@ -1089,7 +1089,7 @@ class MPCClass(BaseQuery):
                 names = ('Date', 'RA', 'Dec', 'Delta',
                          'r', 'Elongation', 'Phase', 'V')
                 col_starts = [0, 18, 29, 39, 47, 56, 62, 69]
-                col_ends = [17, 28, 38, 46, 55, 61, 68, 73]
+                col_ends = [17, 28, 38, 46, 55, 61, 68, 72]
                 units = (None, None, None, 'au', 'au', 'deg', 'deg', 'mag')
 
                 # The column division between Delta and r is variable: the enn

--- a/astroquery/mpc/tests/data/2008TC3_ephemeris_500-a-t.html
+++ b/astroquery/mpc/tests/data/2008TC3_ephemeris_500-a-t.html
@@ -1,0 +1,83 @@
+ <!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN">
+ <html>
+ <head>
+ <META HTTP-EQUIV="Content-Type" CONTENT="text/html; charset=ISO-8859-1">
+ <title>Minor Planet Ephemeris Service: Query Results</title>
+ </head>
+ <body>
+ <h1>Minor Planet Ephemeris Service: Query Results</h1>
+ Below are the results of your request from the Minor Planet Center's
+ Minor Planet Ephemeris Service.
+ <p>
+   Newly designated objects may take up to 1 day to show up in this service.
+ </p>
+ <p>
+   Orbits and ephemerides of unnumbered NEOs are up-to-date. Other orbits are in
+  the process of being refreshed.
+ </p>
+ <p>
+   The current system is not completely reliable in the case of objects
+   with very-close approaches with the Earth.
+   <br></br> We are working on a completely new system,
+   but for the time being we encourage the users to double check
+   the results with other ephemeris generators when the object is very close to 
+ Earth.
+ </p>
+ Ephemerides are for
+ the geocenter.
+ <p><hr><p>
+ <p>
+ <b>2008 TC3</b>
+
+ <p>Perturbed ephemeris below is based on
+   1-day-arc
+ unperturbed elements from 
+ <i>MPO</i> 689019.
+ Last observed on  2008 Oct. 7.
+ <p><pre>
+     K08T03C       [H=30.72]
+Date       UT      R.A. (J2000) Decl.    Delta     r     El.    Ph.   V      Sky Motion
+            h m s                                                            "/hr     P.A.
+2008 10 07 000000 23 43 34.9 +10 39 12   0.00054 1.000  162.4  17.6  15.3 8954.03    069.0
+2008 10 07 001000 23 45 14.8 +10 48 35   0.00051 1.000  162.8  17.2  15.2 9975.70    069.1
+2008 10 07 002000 23 47 06.5 +10 59 02   0.00048 1.000  163.2  16.8  15.011188.96    069.2
+2008 10 07 003000 23 49 12.4 +11 10 44   0.00045 1.000  163.6  16.4  14.912646.03    069.3
+2008 10 07 004000 23 51 35.6 +11 23 58   0.00042 1.000  164.1  15.9  14.714418.52    069.4
+2008 10 07 005000 23 54 19.9 +11 39 02   0.00039 1.000  164.6  15.4  14.516606.91    069.5
+2008 10 07 010000 23 57 30.6 +11 56 22   0.00037 1.000  165.2  14.8  14.419357.90    069.7
+2008 10 07 011000 00 01 15.1 +12 16 33   0.00034 1.000  165.9  14.1  14.222880.51    069.9
+2008 10 07 012000 00 05 43.4 +12 40 21   0.00031 1.000  166.6  13.4  13.927513.52    070.1
+2008 10 07 013000 00 11 10.5 +13 08 53   0.00028 1.000  167.4  12.6  13.733779.40    070.5
+2008 10 07 014000 00 17 59.2 +13 43 47   0.00025 1.000  168.3  11.7  13.442585.98    070.8
+2008 10 07 015000 00 26 46.2 +14 27 30   0.00022 1.000  169.2  10.8  13.155566.08    071.4 In Earth's umbra
+2008 10 07 020000 00 38 34.9 +15 23 55   0.00018 1.000  169.6  10.4  12.775929.21    072.1 In Earth's umbra
+2008 10 07 021000 00 55 25.2 +16 39 27   0.00015 1.000  168.9  11.1  12.3110806.2    073.3 In Earth's umbra
+2008 10 07 022000 01 21 29.7 +18 24 28   0.00012 1.000  165.2  14.8  11.9178296.2    075.3 In Earth's umbra
+2008 10 07 023000 02 08 52.4 +20 56 09   0.00009 0.999  155.8  24.2  11.6338153.7    079.3 In Earth's umbra
+2008 10 07 024000 03 57 18.0 +23 24 40   0.00006 0.999  132.0  48.0  11.3871966.5    089.7
+2008 10 07 025000 08 00 22.2 +12 14 07   0.00004 0.999   74.6 105.4  12.4********    110.1
+2008 10 07 030000 12 08 52.4 -12 56 59   0.00005 0.999   12.9 167.1  23.5325022.4    289.7
+2008 10 07 031000 11 18 54.0 -08 15 25   0.00009 0.999   23.2 156.8  20.5********    112.0
+2008 10 07 032000 16 39 04.8 -23 07 11   0.00022 0.999   57.3 122.6  17.5176735.9    086.2
+2008 10 07 033000 07 09 08.7 +16 24 41   0.00011 0.999   87.5  92.5  14.370147.88    106.9
+2008 10 07 034000 15 40 59.1 -23 20 16   0.00037 0.999   44.4 135.6  19.9438347.4    091.9
+2008 10 07 035000 17 23 33.2 -22 02 47   0.00010 0.999   67.4 112.6  15.1********    081.9
+2008 10 07 040000 14 46 09.3 -22 18 48   0.00012 0.999   32.2 147.8  19.2325242.4    097.3
+2008 10 07 041000 15 23 27.2 -23 08 24   0.00050 0.999   40.5 139.5  21.0235710.5    093.7
+2008 10 07 042000 15 25 11.6 -23 09 55   0.00030 0.999   40.8 139.2  19.8********    273.5
+2008 10 07 043000 14 17 45.4 -21 18 52   0.0011  0.998   26.0 153.9  25.2173972.6    099.9
+2008 10 07 044000 21 43 24.3 -01 51 29   0.00028 1.000  132.3  47.7  14.8802044.4    246.7
+2008 10 07 045000 14 02 46.6 -20 39 36   0.0016  0.998   22.8 157.2  26.867906.20    281.3
+</pre>
+ <p><hr><p>
+ These calculations have been performed on the
+ <a href="http://www.minorplanetcenter.net/iau/Ack/TamkinFoundation.html">Tamkin
+ Foundation Computing Network</a>.
+ <p><hr>
+ <p>
+       <a href="http://validator.w3.org/check?uri=referer"><img border="0"
+           src="http://www.w3.org/Icons/valid-html401"
+           alt="Valid HTML 4.01!" height="31" width="88"></a>
+ </p>
+ </body>
+ </html>

--- a/astroquery/mpc/tests/data/2018AG37_ephemeris_500-a-t.html
+++ b/astroquery/mpc/tests/data/2018AG37_ephemeris_500-a-t.html
@@ -1,0 +1,75 @@
+ <!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN">
+ <html>
+ <head>
+ <META HTTP-EQUIV="Content-Type" CONTENT="text/html; charset=ISO-8859-1">
+ <title>Minor Planet Ephemeris Service: Query Results</title>
+ </head>
+ <body>
+ <h1>Minor Planet Ephemeris Service: Query Results</h1>
+ Below are the results of your request from the Minor Planet Center's
+ Minor Planet Ephemeris Service.
+ <p>
+   Newly designated objects may take up to 1 day to show up in this service.
+ </p>
+ <p>
+   Orbits and ephemerides of unnumbered NEOs are up-to-date. Other orbits are in
+  the process of being refreshed.
+ </p>
+ <p>
+   The current system is not completely reliable in the case of objects
+   with very-close approaches with the Earth.
+   <br></br> We are working on a completely new system,
+   but for the time being we encourage the users to double check
+   the results with other ephemeris generators when the object is very close to 
+ Earth.
+ </p>
+ Ephemerides are for
+ the geocenter.
+ <p><hr><p>
+ <p>
+ <b>2018 AG37</b>
+<p> Number of variant orbits available:     11</p>
+ <p>Perturbed ephemeris below is based on
+    3-opp
+ unperturbed elements from 
+ <i>MPO</i> 641000.
+ Last observed on  2020 Jan. 25.
+<p><a href="https://www.minorplanetcenter.net/iau/info/FurtherObs.html">Further observations?</a>  Useful for orbit improvement.
+ <p><pre>
+     K18A37G       [H= 4.22]
+Date       UT      R.A. (J2000) Decl.    Delta     r     El.    Ph.   V      Sky Motion       Uncertainty info
+            h m s                                                            "/hr     P.A.    3-sig/" P.A.
+2026 05 18 170657 08 29 51.0 +34 34 26 133.443 133.016   64.8   0.4  25.6    0.58    129.6    182686 058.7 / <a href="https://cgi.minorplanetcenter.net/cgi-bin/uncertaintymap.cgi?Obj=K18A37G&JD=2461179.21316&Ext=VAR2">Map</a> / <a href="https://cgi.minorplanetcenter.net/cgi-bin/uncertaintymap.cgi?Obj=K18A37G&JD=2461179.21316&Ext=VAR2&Form=Y&OC=500">Offsets</a>
+2026 05 19 170657 08 29 51.8 +34 34 17 133.458 133.016   63.9   0.4  25.6    0.60    128.7    182670 058.7 / <a href="https://cgi.minorplanetcenter.net/cgi-bin/uncertaintymap.cgi?Obj=K18A37G&JD=2461180.21316&Ext=VAR2">Map</a> / <a href="https://cgi.minorplanetcenter.net/cgi-bin/uncertaintymap.cgi?Obj=K18A37G&JD=2461180.21316&Ext=VAR2&Form=Y&OC=500">Offsets</a>
+2026 05 20 170657 08 29 52.8 +34 34 08 133.473 133.016   63.0   0.4  25.6    0.61    127.9    182654 058.7 / <a href="https://cgi.minorplanetcenter.net/cgi-bin/uncertaintymap.cgi?Obj=K18A37G&JD=2461181.21316&Ext=VAR2">Map</a> / <a href="https://cgi.minorplanetcenter.net/cgi-bin/uncertaintymap.cgi?Obj=K18A37G&JD=2461181.21316&Ext=VAR2&Form=Y&OC=500">Offsets</a>
+2026 05 21 170657 08 29 53.7 +34 33 59 133.488 133.016   62.1   0.4  25.6    0.62    127.1    182637 058.7 / <a href="https://cgi.minorplanetcenter.net/cgi-bin/uncertaintymap.cgi?Obj=K18A37G&JD=2461182.21316&Ext=VAR2">Map</a> / <a href="https://cgi.minorplanetcenter.net/cgi-bin/uncertaintymap.cgi?Obj=K18A37G&JD=2461182.21316&Ext=VAR2&Form=Y&OC=500">Offsets</a>
+2026 05 22 170657 08 29 54.7 +34 33 50 133.502 133.016   61.1   0.4  25.6    0.64    126.4    182619 058.7 / <a href="https://cgi.minorplanetcenter.net/cgi-bin/uncertaintymap.cgi?Obj=K18A37G&JD=2461183.21316&Ext=VAR2">Map</a> / <a href="https://cgi.minorplanetcenter.net/cgi-bin/uncertaintymap.cgi?Obj=K18A37G&JD=2461183.21316&Ext=VAR2&Form=Y&OC=500">Offsets</a>
+2026 05 23 170657 08 29 55.7 +34 33 41 133.516 133.017   60.2   0.4  25.6    0.65    125.6    182600 058.7 / <a href="https://cgi.minorplanetcenter.net/cgi-bin/uncertaintymap.cgi?Obj=K18A37G&JD=2461184.21316&Ext=VAR2">Map</a> / <a href="https://cgi.minorplanetcenter.net/cgi-bin/uncertaintymap.cgi?Obj=K18A37G&JD=2461184.21316&Ext=VAR2&Form=Y&OC=500">Offsets</a>
+2026 05 24 170657 08 29 56.8 +34 33 32 133.531 133.017   59.3   0.4  25.6    0.67    125.0    182581 058.7 / <a href="https://cgi.minorplanetcenter.net/cgi-bin/uncertaintymap.cgi?Obj=K18A37G&JD=2461185.21316&Ext=VAR2">Map</a> / <a href="https://cgi.minorplanetcenter.net/cgi-bin/uncertaintymap.cgi?Obj=K18A37G&JD=2461185.21316&Ext=VAR2&Form=Y&OC=500">Offsets</a>
+2026 05 25 170657 08 29 57.8 +34 33 23 133.545 133.017   58.4   0.4  25.6    0.68    124.3    182561 058.7 / <a href="https://cgi.minorplanetcenter.net/cgi-bin/uncertaintymap.cgi?Obj=K18A37G&JD=2461186.21316&Ext=VAR2">Map</a> / <a href="https://cgi.minorplanetcenter.net/cgi-bin/uncertaintymap.cgi?Obj=K18A37G&JD=2461186.21316&Ext=VAR2&Form=Y&OC=500">Offsets</a>
+2026 05 26 170657 08 29 58.9 +34 33 13 133.559 133.017   57.5   0.4  25.6    0.69    123.7    182540 058.7 / <a href="https://cgi.minorplanetcenter.net/cgi-bin/uncertaintymap.cgi?Obj=K18A37G&JD=2461187.21316&Ext=VAR2">Map</a> / <a href="https://cgi.minorplanetcenter.net/cgi-bin/uncertaintymap.cgi?Obj=K18A37G&JD=2461187.21316&Ext=VAR2&Form=Y&OC=500">Offsets</a>
+2026 05 27 170657 08 30 00.1 +34 33 04 133.573 133.017   56.6   0.4  25.5    0.71    123.0    182519 058.7 / <a href="https://cgi.minorplanetcenter.net/cgi-bin/uncertaintymap.cgi?Obj=K18A37G&JD=2461188.21316&Ext=VAR2">Map</a> / <a href="https://cgi.minorplanetcenter.net/cgi-bin/uncertaintymap.cgi?Obj=K18A37G&JD=2461188.21316&Ext=VAR2&Form=Y&OC=500">Offsets</a>
+2026 05 28 170657 08 30 01.2 +34 32 55 133.586 133.017   55.7   0.4  25.5    0.72    122.5    182497 058.7 / <a href="https://cgi.minorplanetcenter.net/cgi-bin/uncertaintymap.cgi?Obj=K18A37G&JD=2461189.21316&Ext=VAR2">Map</a> / <a href="https://cgi.minorplanetcenter.net/cgi-bin/uncertaintymap.cgi?Obj=K18A37G&JD=2461189.21316&Ext=VAR2&Form=Y&OC=500">Offsets</a>
+2026 05 29 170657 08 30 02.4 +34 32 46 133.600 133.018   54.8   0.4  25.5    0.73    121.9    182474 058.7 / <a href="https://cgi.minorplanetcenter.net/cgi-bin/uncertaintymap.cgi?Obj=K18A37G&JD=2461190.21316&Ext=VAR2">Map</a> / <a href="https://cgi.minorplanetcenter.net/cgi-bin/uncertaintymap.cgi?Obj=K18A37G&JD=2461190.21316&Ext=VAR2&Form=Y&OC=500">Offsets</a>
+2026 05 30 170657 08 30 03.7 +34 32 36 133.613 133.018   53.9   0.4  25.5    0.75    121.3    182451 058.7 / <a href="https://cgi.minorplanetcenter.net/cgi-bin/uncertaintymap.cgi?Obj=K18A37G&JD=2461191.21316&Ext=VAR2">Map</a> / <a href="https://cgi.minorplanetcenter.net/cgi-bin/uncertaintymap.cgi?Obj=K18A37G&JD=2461191.21316&Ext=VAR2&Form=Y&OC=500">Offsets</a>
+2026 05 31 170657 08 30 04.9 +34 32 27 133.626 133.018   53.0   0.3  25.5    0.76    120.8    182426 058.7 / <a href="https://cgi.minorplanetcenter.net/cgi-bin/uncertaintymap.cgi?Obj=K18A37G&JD=2461192.21316&Ext=VAR2">Map</a> / <a href="https://cgi.minorplanetcenter.net/cgi-bin/uncertaintymap.cgi?Obj=K18A37G&JD=2461192.21316&Ext=VAR2&Form=Y&OC=500">Offsets</a>
+2026 06 01 170657 08 30 06.2 +34 32 18 133.639 133.018   52.1   0.3  25.5    0.77    120.3    182402 058.7 / <a href="https://cgi.minorplanetcenter.net/cgi-bin/uncertaintymap.cgi?Obj=K18A37G&JD=2461193.21316&Ext=VAR2">Map</a> / <a href="https://cgi.minorplanetcenter.net/cgi-bin/uncertaintymap.cgi?Obj=K18A37G&JD=2461193.21316&Ext=VAR2&Form=Y&OC=500">Offsets</a>
+2026 06 02 170657 08 30 07.5 +34 32 08 133.652 133.018   51.2   0.3  25.5    0.78    119.8    182376 058.7 / <a href="https://cgi.minorplanetcenter.net/cgi-bin/uncertaintymap.cgi?Obj=K18A37G&JD=2461194.21316&Ext=VAR2">Map</a> / <a href="https://cgi.minorplanetcenter.net/cgi-bin/uncertaintymap.cgi?Obj=K18A37G&JD=2461194.21316&Ext=VAR2&Form=Y&OC=500">Offsets</a>
+2026 06 03 170657 08 30 08.8 +34 31 59 133.664 133.018   50.3   0.3  25.5    0.80    119.3    182350 058.7 / <a href="https://cgi.minorplanetcenter.net/cgi-bin/uncertaintymap.cgi?Obj=K18A37G&JD=2461195.21316&Ext=VAR2">Map</a> / <a href="https://cgi.minorplanetcenter.net/cgi-bin/uncertaintymap.cgi?Obj=K18A37G&JD=2461195.21316&Ext=VAR2&Form=Y&OC=500">Offsets</a>
+2026 06 04 170657 08 30 10.2 +34 31 50 133.677 133.019   49.4   0.3  25.5    0.81    118.9    182324 058.7 / <a href="https://cgi.minorplanetcenter.net/cgi-bin/uncertaintymap.cgi?Obj=K18A37G&JD=2461196.21316&Ext=VAR2">Map</a> / <a href="https://cgi.minorplanetcenter.net/cgi-bin/uncertaintymap.cgi?Obj=K18A37G&JD=2461196.21316&Ext=VAR2&Form=Y&OC=500">Offsets</a>
+2026 06 05 170657 08 30 11.6 +34 31 40 133.689 133.019   48.5   0.3  25.5    0.82    118.4    182296 058.7 / <a href="https://cgi.minorplanetcenter.net/cgi-bin/uncertaintymap.cgi?Obj=K18A37G&JD=2461197.21316&Ext=VAR2">Map</a> / <a href="https://cgi.minorplanetcenter.net/cgi-bin/uncertaintymap.cgi?Obj=K18A37G&JD=2461197.21316&Ext=VAR2&Form=Y&OC=500">Offsets</a>
+2026 06 06 170657 08 30 13.0 +34 31 31 133.701 133.019   47.6   0.3  25.5    0.83    118.0    182268 058.7 / <a href="https://cgi.minorplanetcenter.net/cgi-bin/uncertaintymap.cgi?Obj=K18A37G&JD=2461198.21316&Ext=VAR2">Map</a> / <a href="https://cgi.minorplanetcenter.net/cgi-bin/uncertaintymap.cgi?Obj=K18A37G&JD=2461198.21316&Ext=VAR2&Form=Y&OC=500">Offsets</a>
+2026 06 07 170657 08 30 14.4 +34 31 21 133.713 133.019   46.7   0.3  25.5    0.85    117.6    182240 058.7 / <a href="https://cgi.minorplanetcenter.net/cgi-bin/uncertaintymap.cgi?Obj=K18A37G&JD=2461199.21316&Ext=VAR2">Map</a> / <a href="https://cgi.minorplanetcenter.net/cgi-bin/uncertaintymap.cgi?Obj=K18A37G&JD=2461199.21316&Ext=VAR2&Form=Y&OC=500">Offsets</a>
+</pre>
+ <p><hr><p>
+ These calculations have been performed on the
+ <a href="http://www.minorplanetcenter.net/iau/Ack/TamkinFoundation.html">Tamkin
+ Foundation Computing Network</a>.
+ <p><hr>
+ <p>
+       <a href="http://validator.w3.org/check?uri=referer"><img border="0"
+           src="http://www.w3.org/Icons/valid-html401"
+           alt="Valid HTML 4.01!" height="31" width="88"></a>
+ </p>
+ </body>
+ </html>

--- a/astroquery/mpc/tests/test_mpc.py
+++ b/astroquery/mpc/tests/test_mpc.py
@@ -32,6 +32,8 @@ parameters = {
   '2024AA_ephemeris_G37-a-t': ('2024 AA', {'location': 'G37'}),
   'testfail_ephemeris_500-a-t': ('test fail', {}),
   '2008JG_ephemeris_500-a-t': ('2008 JG', {}),
+  '2008TC3_ephemeris_500-a-t': ('2008 TC3', {'start': '2008-10-07', 'step': u.Quantity('10 min'), 'number': 30}),
+  '2018AG37_ephemeris_500-a-t': ('2018 AG37', {}),
 }
 for prefix, (name, kwargs) in parameters.items():
     with open(prefix + '.html', 'w') as outf:
@@ -387,6 +389,36 @@ def test_get_ephemeris_unc_links(unc_links, patch_post):
     assert np.all(result['Uncertainty 3sig'].quantity > 0 * u.arcsec)
     assert ('Unc. map' in result.colnames) == unc_links
     assert ('Unc. offsets' in result.colnames) == unc_links
+
+
+def test_get_ephemeris_earth_close_approach(patch_post):
+    """Low Delta and high rate of motion tests.
+
+    Tests the column splitting between Delta and r for low Delta values.
+
+    Tests the column splitting between V and Sky Motion for high rates of
+    motion.
+
+    Tests the masking of data values for extreme rates of motion.
+
+    """
+
+    result = mpc.core.MPC.get_ephemeris("2008 TC3", start="2008-10-07", step=u.Quantity("10 min"), number=30)
+    assert np.isclose(np.min(result["Delta"]), 0.00004)
+    assert np.allclose(result["r"], 1, rtol=0.002)
+    assert result["Proper motion"].mask.sum() == 4
+    assert np.isclose(result["Proper motion"].max(), 871966.5)
+
+def test_get_ephemeris_distant_object(patch_post):
+    """Distant object / large heliocentric distance test.
+
+    Tests the column splitting between Delta and r for high r values.
+
+    """
+
+    result = mpc.core.MPC.get_ephemeris("2018 AG37")
+    assert np.isclose(np.min(result["r"]), 133.016)
+    assert np.isclose(np.min(result["Delta"]), 133.443)
 
 
 def test_get_observatory_codes(patch_get):

--- a/astroquery/mpc/tests/test_mpc.py
+++ b/astroquery/mpc/tests/test_mpc.py
@@ -409,6 +409,7 @@ def test_get_ephemeris_earth_close_approach(patch_post):
     assert result["Proper motion"].mask.sum() == 4
     assert np.isclose(result["Proper motion"].max(), 871966.5)
 
+
 def test_get_ephemeris_distant_object(patch_post):
     """Distant object / large heliocentric distance test.
 


### PR DESCRIPTION
This PR aims to improve the column parsing for the MPC.get_ephemeris results.  Specifically:
1. The Delta column definition for very close objects depends on the absolute value of the distance.
2. The "direction" column definition is too wide.
3. Very high proper motions can start immediately after the V mag column (without a space between) or even be replaced with a masked constant ******.

First, MPC.get_ephemeris incorrectly parses the query results for very close objects:
```python
>>> from astroquery.mpc import MPC
>>> MPC.get_ephemeris("2008 TC3", start="2008-10-07")
<Table length=21>
          Date                  RA                 Dec          Delta     r    Elongation  Phase   V   Proper motion Direction
                               deg                 deg            AU      AU      deg       deg   mag    arcsec / h     deg   
          Time               float64             float64       float64   str7   float64   float64 str4    float64     float64 
----------------------- ------------------ ------------------- ------- ------- ---------- ------- ---- ------------- ---------
2008-10-07 00:00:00.000  355.8954166666666  10.653333333333334  0.0005 4 1.000      162.4    17.6 15.3       8954.03      69.0
2008-10-08 00:00:00.000 214.61041666666665  -21.34111111111111   0.014   0.987       25.4   154.2 30.7         65.83     280.2
2008-10-09 00:00:00.000             214.39 -21.301111111111112    0.03   0.971       24.3   155.0 32.6         15.75     283.0
2008-10-10 00:00:00.000 214.31124999999997 -21.280833333333334   0.047   0.956       23.3   155.6 33.6          8.83     288.5
2008-10-11 00:00:00.000 214.25916666666663 -21.261944444444445   0.063   0.940       22.3   156.3 34.4          7.24     294.3
2008-10-12 00:00:00.000          214.21375 -21.240555555555556    0.08   0.924       21.3   156.9               7.09     298.8
2008-10-13 00:00:00.000 214.16916666666665  -21.21611111111111   0.097   0.908       20.3   157.6               7.46     302.0
2008-10-14 00:00:00.000 214.12291666666667  -21.18777777777778   0.113   0.891       19.3   158.2               8.07     304.4
2008-10-15 00:00:00.000          214.07375 -21.155277777777776    0.13   0.875       18.4   158.9               8.78     306.3
2008-10-16 00:00:00.000 214.02166666666668  -21.11861111111111   0.147   0.858       17.4   159.7               9.53     307.9
2008-10-17 00:00:00.000 213.96624999999997 -21.077222222222222   0.164   0.841       16.4   160.4              10.31     309.4
2008-10-18 00:00:00.000 213.90749999999997 -21.031388888888888   0.181   0.824       15.5   161.2              11.08     310.8
2008-10-19 00:00:00.000 213.84624999999997 -20.980555555555554   0.198   0.806       14.5   161.9              11.84     312.2
2008-10-20 00:00:00.000           213.7825  -20.92527777777778   0.215   0.788       13.6   162.7              12.59     313.7
2008-10-21 00:00:00.000 213.71666666666664 -20.864722222222223   0.232   0.770       12.7   163.6              13.32     315.3
2008-10-22 00:00:00.000 213.64916666666664  -20.79888888888889    0.25   0.752       11.8   164.4              14.02     316.9
2008-10-23 00:00:00.000 213.58041666666662 -20.728055555555553   0.268   0.734       10.9   165.2              14.69     318.7
2008-10-24 00:00:00.000  213.5108333333333 -20.651944444444442   0.286   0.715       10.0   166.0              15.31     320.6
2008-10-25 00:00:00.000  213.4420833333333  -20.57027777777778   0.304   0.696        9.2   166.8               15.9     322.8
2008-10-26 00:00:00.000 213.37416666666664 -20.483055555555556   0.323   0.676        8.5   167.5              16.43     325.2
2008-10-27 00:00:00.000 213.30874999999997 -20.390277777777776   0.342   0.657        7.8   168.2              16.92     327.9
```

Notice that the r column is a string (should be a float), and the first value is nonsense: "4 1.000".

The issue is that the fixed width column positions vary, depending on distance.  Here is a very distant TNO showing that the r column may need all 7 characters currently allotted to it:

```python
>>> MPC.get_ephemeris("9530", number=2)
<Table length=2>
          Date                  RA                Dec          Delta     r    Elongation  Phase     V    Proper motion Direction Uncertainty 3sig Unc. P.A.
                               deg                deg            AU      AU      deg       deg     mag     arcsec / h     deg         arcsec         deg   
          Time               float64            float64       float64 float64  float64   float64 float64    float64     float64      float64       float64 
----------------------- ----------------- ------------------- ------- ------- ---------- ------- ------- ------------- --------- ---------------- ---------
2026-05-18 19:58:45.000 266.4595833333333 -24.128611111111113    2.09   3.014      150.7     9.4    18.9         21.32     271.8               --        --
2026-05-19 19:58:45.000 266.3016666666666 -24.124166666666667   2.083   3.014      151.9     9.1    18.9         22.01     271.9               --        --

>>> MPC.get_ephemeris("2018 AG37", number=2)
<Table length=2>
          Date                  RA                Dec          Delta     r    Elongation  Phase     V    Proper motion Direction Uncertainty 3sig Unc. P.A.
                               deg                deg            AU      AU      deg       deg     mag     arcsec / h     deg         arcsec         deg   
          Time               float64            float64       float64 float64  float64   float64 float64    float64     float64       int64        float64 
----------------------- ------------------ ------------------ ------- ------- ---------- ------- ------- ------------- --------- ---------------- ---------
2026-05-18 19:58:52.000 127.46291666666663  34.57361111111111 133.445 133.016       64.7     0.4    25.6          0.58     129.5           182684      58.7
2026-05-19 19:58:52.000 127.46624999999999 34.571111111111115  133.46 133.016       63.8     0.4    25.6           0.6     128.6           182668      58.7
```

In my tests, I've concluded that there will always be a space between the two columns.  The fix is to inspect the Delta-r portion of the returned table and identify the column split based on the presence of a delimiting space.

At the same time, I noticed that the proper motion column is two characters too long.  When 2008 TC3 is "In Earth's umbra" the "I" from "I" is appended to the direction column:
```python
>>> MPC.get_ephemeris("2008 TC3", start="2008-10-07", step="10 min", number=15)
<Table length=15>
          Date                  RA                Dec          Delta     r    Elongation  Phase     V    Proper motion Direction
                               deg                deg            AU      AU      deg       deg     mag     arcsec / h     deg   
          Time               float64            float64       float64   str7   float64   float64 float64    float64       str7  
----------------------- ------------------ ------------------ ------- ------- ---------- ------- ------- ------------- ---------
2008-10-07 00:00:00.000  355.8954166666666 10.653333333333334  0.0005 4 1.000      162.4    17.6    15.3       8954.03     069.0
2008-10-07 00:10:00.000  356.3116666666666 10.809722222222224  0.0005 1 1.000      162.8    17.2    15.2        9975.7     069.1
2008-10-07 00:20:00.000 356.77708333333334 10.983888888888888  0.0004 8 1.000      163.2    16.8    15.0      11188.96     069.2
2008-10-07 00:30:00.000  357.3016666666666 11.178888888888888  0.0004 5 1.000      163.6    16.4    14.9      12646.03     069.3
2008-10-07 00:40:00.000  357.8983333333333 11.399444444444445  0.0004 2 1.000      164.1    15.9    14.7      14418.52     069.4
2008-10-07 00:50:00.000  358.5829166666666 11.650555555555556  0.0003 9 1.000      164.6    15.4    14.5      16606.91     069.5
2008-10-07 01:00:00.000           359.3775 11.939444444444444  0.0003 7 1.000      165.2    14.8    14.4       19357.9     069.7
2008-10-07 01:10:00.000 0.3129166666666666 12.275833333333335  0.0003 4 1.000      165.9    14.1    14.2      22880.51     069.9
2008-10-07 01:20:00.000 1.4308333333333332            12.6725  0.0003 1 1.000      166.6    13.4    13.9      27513.52     070.1
2008-10-07 01:30:00.000 2.7937499999999997 13.148055555555555  0.0002 8 1.000      167.4    12.6    13.7       33779.4     070.5
2008-10-07 01:40:00.000  4.496666666666666 13.729722222222222  0.0002 5 1.000      168.3    11.7    13.4      42585.98     070.8
2008-10-07 01:50:00.000  6.692499999999999 14.458333333333332  0.0002 2 1.000      169.2    10.8    13.1      55566.08   071.4 I
2008-10-07 02:00:00.000  9.645416666666666  15.39861111111111  0.0001 8 1.000      169.6    10.4    12.7      75929.21   072.1 I
2008-10-07 02:10:00.000 13.854999999999999            16.6575  0.0001 5 1.000      168.9    11.1    12.3      110806.2   073.3 I
2008-10-07 02:20:00.000           20.37375 18.407777777777778  0.0001 2 1.000      165.2    14.8    11.9      178296.2   075.3 I
```

Finally, when the proper motion is very high, the ephemeris service returns ****** and astroquery crashes:
```python
>>>  MPC.get_ephemeris("2008 TC3", start="2008-10-07", step="10 min", number=30)
---------------------------------------------------------------------------
UFuncTypeError                            Traceback (most recent call last)
Cell In[14], line 1
----> 1 MPC.get_ephemeris("2008 TC3", start="2008-10-07", step="10 min", number=30)

File ~/Projects/astroquery/astroquery/utils/class_or_instance.py:25, in class_or_instance.__get__.<locals>.f(*args, **kwds)
     23 def f(*args, **kwds):
     24     if obj is not None:
---> 25         return self.fn(obj, *args, **kwds)
     26     else:
     27         return self.fn(cls, *args, **kwds)

File ~/Projects/astroquery/astroquery/utils/process_asyncs.py:35, in async_to_sync.<locals>.create_method.<locals>.newmethod(self, *args, **kwargs)
     33 if isinstance(response, Response):
     34     response.raise_for_status()
---> 35 result = self._parse_result(response, verbose=verbose)
     36 self.table = result
     37 return result

File ~/Projects/astroquery/astroquery/mpc/core.py:1183, in MPCClass._parse_result(self, result, **kwargs)
   1181     for col in ('Proper motion', 'dRA', 'dRA cos(Dec)', 'dDec'):
   1182         if col in tab.colnames:
-> 1183             tab[col].convert_unit_to(self._proper_motion_unit)
   1184 else:
   1185     # convert from MPES string to Time
   1186     tab['JD'] = Time(tab['JD'], format='jd', scale='tt')

File ~/.venv/lib/python3.12/site-packages/astropy/table/column.py:1035, in BaseColumn.convert_unit_to(self, new_unit, equivalencies)
   1033 if self.unit is None:
   1034     raise ValueError("No unit set on column")
-> 1035 self.data[:] = self.unit.to(new_unit, self.data, equivalencies=equivalencies)
   1036 self.unit = new_unit

File ~/.venv/lib/python3.12/site-packages/astropy/units/core.py:660, in UnitBase.to(self, other, value, equivalencies)
    658     return UNITY
    659 else:
--> 660     return self.get_converter(Unit(other), equivalencies)(value)

File ~/.venv/lib/python3.12/site-packages/astropy/units/core.py:2749, in unit_scale_converter(val)
   2743 def unit_scale_converter(val):
   2744     """Function that just multiplies the value by unity.
   2745 
   2746     This is a separate function so it can be recognized and
   2747     discarded in unit conversion.
   2748     """
-> 2749     return 1.0 * _condition_arg(val)

UFuncTypeError: ufunc 'multiply' did not contain a loop with signature matching types (dtype('float64'), dtype('<U8')) -> None
```