### PR TITLE
MAINT: Pin `pytest-rerunfailures` in oldest deps

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -48,6 +48,7 @@ deps =
     oldestdeps: keyring==23.0
     oldestdeps: pytest==7.4
     oldestdeps: beautifulsoup4==4.10
+    # Newer versions would bump the pytest version, revise the pin when we revise pytest
     oldestdeps: pytest-rerunfailures==16.1
     oldestdeps-alldeps: mocpy==0.12
     oldestdeps-alldeps: regions==0.5

--- a/tox.ini
+++ b/tox.ini
@@ -48,6 +48,7 @@ deps =
     oldestdeps: keyring==23.0
     oldestdeps: pytest==7.4
     oldestdeps: beautifulsoup4==4.10
+    oldestdeps: pytest-rerunfailures==16.1
     oldestdeps-alldeps: mocpy==0.12
     oldestdeps-alldeps: regions==0.5
     oldestdeps-alldeps: astropy-healpix==0.7


### PR DESCRIPTION
The "oldest version for all dependencies" CI job has been failing since May 13th. I tracked this down to a release of `pytest-rerunfailures` that requires a newer version of pytest. Pinning the version to 16.1 for `oldestdeps` makes the job pass again.  