### PR TITLE
RTD: Fetch all tags for accurate version reporting

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -6,6 +6,9 @@ build:
     python: "3.11"
   apt_packages:
     - graphviz
+  jobs:
+    post_checkout:
+      - git fetch --unshallow || true
 
 sphinx:
   builder: html


### PR DESCRIPTION
Fix https://github.com/astropy/astroquery/issues/3565

No need for CI, just need RTD.

Before: https://astroquery.readthedocs.io/en/latest/ (`astroquery v0.1.dev329+g1ad1025d5`)

After: https://astroquery--3602.org.readthedocs.build/en/3602/ (`astroquery v0.4.12.dev532+g998ead2a5`)