### PR TITLE
Fix NAIF ID typos in Most: nafid -> naifid

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -128,6 +128,14 @@ imcce
 - Change the URL for SkyBot and Miriade Web Services [#3595]
 - Adapted the ``Miriade`` Class to the new outputs of the Web Service [#3595]
 
+ipac.irsa
+^^^^^^^^^
+
+- Fix NAIF ID input mode in ``Most``: the parameter and value ``nafid``
+  were typos; the API expects ``naifid``. Old ``obj_nafid`` keyword and
+  ``"nafid_input"`` ``input_mode`` still work but emit
+  ``AstropyDeprecationWarning``. [#3607]
+
 
 mast
 ^^^^

--- a/astroquery/ipac/irsa/most.py
+++ b/astroquery/ipac/irsa/most.py
@@ -274,8 +274,6 @@ class MostClass(BaseQuery):
         obj_naifid : str or None
             Object NAIF ID.
             Required when input mode is ``"naifid_input"``.
-        obj_nafid : str or None
-            Deprecated name for ``obj_naifid``.
         obj_type : str or None
             Object type, ``"Asteroid"`` or ``Comet``.
             Required when input mode is ``"mpc_input"`` or ``"manual_input"``.
@@ -454,8 +452,6 @@ class MostClass(BaseQuery):
         obj_naifid : str or None
             Object NAIF ID.
             Required when input mode is ``"naifid_input"``.
-        obj_nafid : str or None
-            Deprecated name for ``obj_naifid``.
         obj_type : str or None
             Object type, ``"Asteroid"`` or ``Comet``
             Required when input mode is ``"mpc_input"`` or ``"manual_input"``.

--- a/astroquery/ipac/irsa/most.py
+++ b/astroquery/ipac/irsa/most.py
@@ -388,8 +388,8 @@ class MostClass(BaseQuery):
 
         return images
 
-    @deprecated_renamed_argument('obj_nafid', 'obj_naifid', since='0.4.12')
     @class_or_instance
+    @deprecated_renamed_argument('obj_nafid', 'obj_naifid', since='0.4.12')
     def query_object(self, catalog="wise_merge", input_mode="name_input", output_mode="Regular",
                      ephem_step=0.25, with_tarballs=False, obs_begin=None, obs_end=None,
                      obj_name=None, obj_naifid=None, obj_type=None, mpc_data=None,

--- a/astroquery/ipac/irsa/most.py
+++ b/astroquery/ipac/irsa/most.py
@@ -7,6 +7,7 @@ from bs4 import BeautifulSoup
 
 from astropy.io import votable, fits
 from astropy.table import Table
+from astropy.utils.decorators import deprecated_renamed_argument
 from astropy.utils.exceptions import AstropyDeprecationWarning
 
 from astroquery.query import BaseQuery
@@ -230,8 +231,9 @@ class MostClass(BaseQuery):
             catalogs.remove("--- Internal use only:")
         return catalogs
 
+    @deprecated_renamed_argument('obj_nafid', 'obj_naifid', since='0.4.12')
     def get_images(self, catalog="wise_merge", input_mode="name_input", ephem_step=0.25,
-                   obs_begin=None, obs_end=None, obj_name=None, obj_nafid=None, obj_naifid=None, obj_type=None,
+                   obs_begin=None, obs_end=None, obj_name=None, obj_naifid=None, obj_type=None,
                    mpc_data=None, body_designation=None, epoch=None, eccentricity=None,
                    inclination=None, arg_perihelion=None, ascend_node=None, semimajor_axis=None,
                    mean_anomaly=None, perih_dist=None, perih_time=None, get_query_payload=False,
@@ -269,9 +271,11 @@ class MostClass(BaseQuery):
         obj_name : str or None
             Object name.
             Required when input mode is ``"name_input"``.
-        obj_nafid : str or None
-            Object NAIFD.
+        obj_naifid : str or None
+            Object NAIF ID.
             Required when input mode is ``"naifid_input"``.
+        obj_nafid : str or None
+            Deprecated name for ``obj_naifid``.
         obj_type : str or None
             Object type, ``"Asteroid"`` or ``Comet``.
             Required when input mode is ``"mpc_input"`` or ``"manual_input"``.
@@ -329,14 +333,6 @@ class MostClass(BaseQuery):
         images : list
             A list of `~astropy.io.fits.HDUList` objects.
         """
-        # Handle deprecated parameters
-        if obj_nafid is not None and obj_naifid is None:
-            warnings.warn(
-                "'obj_nafid' is deprecated; use 'obj_naifid' instead (the API parameter is 'obj_naifid').",
-                AstropyDeprecationWarning,
-                stacklevel=2,
-            )
-            obj_naifid = obj_nafid
         if input_mode == "nafid_input":
             warnings.warn(
                 "'nafid_input' is deprecated; use 'naifid_input' instead (the API value is 'naifid_input').",
@@ -392,10 +388,11 @@ class MostClass(BaseQuery):
 
         return images
 
+    @deprecated_renamed_argument('obj_nafid', 'obj_naifid', since='0.4.12')
     @class_or_instance
     def query_object(self, catalog="wise_merge", input_mode="name_input", output_mode="Regular",
                      ephem_step=0.25, with_tarballs=False, obs_begin=None, obs_end=None,
-                     obj_name=None, obj_nafid=None, obj_naifid=None, obj_type=None, mpc_data=None,
+                     obj_name=None, obj_naifid=None, obj_type=None, mpc_data=None,
                      body_designation=None, epoch=None, eccentricity=None, inclination=None,
                      arg_perihelion=None, ascend_node=None, semimajor_axis=None, mean_anomaly=None,
                      perih_dist=None, perih_time=None, get_query_payload=False):
@@ -454,9 +451,11 @@ class MostClass(BaseQuery):
         obj_name : str or None
             Object name.
             Required when input mode is ``"name_input"``.
-        obj_nafid : str or None
-            Object NAIFD
+        obj_naifid : str or None
+            Object NAIF ID.
             Required when input mode is ``"naifid_input"``.
+        obj_nafid : str or None
+            Deprecated name for ``obj_naifid``.
         obj_type : str or None
             Object type, ``"Asteroid"`` or ``Comet``
             Required when input mode is ``"mpc_input"`` or ``"manual_input"``.
@@ -515,14 +514,6 @@ class MostClass(BaseQuery):
             in ``"VOTable"`` an `~astropy.io.votable.tree.VOTableFile`. See
             module help for more details on the content of these tables.
         """
-        # Handle deprecated parameters
-        if obj_nafid is not None and obj_naifid is None:
-            warnings.warn(
-                "'obj_nafid' is deprecated; use 'obj_naifid' instead (the API parameter is 'obj_naifid').",
-                AstropyDeprecationWarning,
-                stacklevel=2,
-            )
-            obj_naifid = obj_nafid
         if input_mode == "nafid_input":
             warnings.warn(
                 "'nafid_input' is deprecated; use 'naifid_input' instead (the API value is 'naifid_input').",

--- a/astroquery/ipac/irsa/most.py
+++ b/astroquery/ipac/irsa/most.py
@@ -7,6 +7,7 @@ from bs4 import BeautifulSoup
 
 from astropy.io import votable, fits
 from astropy.table import Table
+from astropy.utils.exceptions import AstropyDeprecationWarning
 
 from astroquery.query import BaseQuery
 from astroquery.utils import class_or_instance
@@ -56,8 +57,8 @@ class MostClass(BaseQuery):
             If the input does not have the minimum required parameters set to
             an at least truthy value.
         """
-        if not params.get("obj_nafid", False):
-            raise ValueError("When input type is 'nafid_input' key 'obj_nafid' is required.")
+        if not params.get("obj_naifid", False):
+            raise ValueError("When input type is 'naifid_input' key 'obj_naifid' is required.")
 
     def _validate_mpc_input_type(self, params):
         """
@@ -148,7 +149,7 @@ class MostClass(BaseQuery):
 
         if input_type == "name_input":
             self._validate_name_input_type(params)
-        elif input_type == "nafid_input":
+        elif input_type == "naifid_input":
             self._validate_nafid_input_type(params)
         elif input_type == "mpc_input":
             self._validate_mpc_input_type(params)
@@ -156,7 +157,7 @@ class MostClass(BaseQuery):
             self._validate_manual_input_type(params)
         else:
             raise ValueError(
-                "Unrecognized 'input_type'. Expected `name_input`, `nafid_input` "
+                "Unrecognized 'input_type'. Expected `name_input`, `naifid_input` "
                 f"`mpc_input` or `manual_input`, got {input_type} instead."
             )
 
@@ -230,7 +231,7 @@ class MostClass(BaseQuery):
         return catalogs
 
     def get_images(self, catalog="wise_merge", input_mode="name_input", ephem_step=0.25,
-                   obs_begin=None, obs_end=None, obj_name=None, obj_nafid=None, obj_type=None,
+                   obs_begin=None, obs_end=None, obj_name=None, obj_nafid=None, obj_naifid=None, obj_type=None,
                    mpc_data=None, body_designation=None, epoch=None, eccentricity=None,
                    inclination=None, arg_perihelion=None, ascend_node=None, semimajor_axis=None,
                    mean_anomaly=None, perih_dist=None, perih_time=None, get_query_payload=False,
@@ -328,6 +329,22 @@ class MostClass(BaseQuery):
         images : list
             A list of `~astropy.io.fits.HDUList` objects.
         """
+        # Handle deprecated parameters
+        if obj_nafid is not None and obj_naifid is None:
+            warnings.warn(
+                "'obj_nafid' is deprecated; use 'obj_naifid' instead (the API parameter is 'obj_naifid').",
+                AstropyDeprecationWarning,
+                stacklevel=2,
+            )
+            obj_naifid = obj_nafid
+        if input_mode == "nafid_input":
+            warnings.warn(
+                "'nafid_input' is deprecated; use 'naifid_input' instead (the API value is 'naifid_input').",
+                AstropyDeprecationWarning,
+                stacklevel=2,
+            )
+            input_mode = "naifid_input"
+
         # We insist on output_mode being regular so that it executes quicker,
         # and we insist on tarballs so the download is quicker. We ignore
         # whatever else user provides, but leave the parameters as arguments to
@@ -339,7 +356,7 @@ class MostClass(BaseQuery):
             obs_end=obs_end,
             ephem_step=ephem_step,
             obj_name=obj_name,
-            obj_nafid=obj_nafid,
+            obj_naifid=obj_naifid,
             obj_type=obj_type,
             mpc_data=mpc_data,
             body_designation=body_designation,
@@ -378,7 +395,7 @@ class MostClass(BaseQuery):
     @class_or_instance
     def query_object(self, catalog="wise_merge", input_mode="name_input", output_mode="Regular",
                      ephem_step=0.25, with_tarballs=False, obs_begin=None, obs_end=None,
-                     obj_name=None, obj_nafid=None, obj_type=None, mpc_data=None,
+                     obj_name=None, obj_nafid=None, obj_naifid=None, obj_type=None, mpc_data=None,
                      body_designation=None, epoch=None, eccentricity=None, inclination=None,
                      arg_perihelion=None, ascend_node=None, semimajor_axis=None, mean_anomaly=None,
                      perih_dist=None, perih_time=None, get_query_payload=False):
@@ -498,6 +515,22 @@ class MostClass(BaseQuery):
             in ``"VOTable"`` an `~astropy.io.votable.tree.VOTableFile`. See
             module help for more details on the content of these tables.
         """
+        # Handle deprecated parameters
+        if obj_nafid is not None and obj_naifid is None:
+            warnings.warn(
+                "'obj_nafid' is deprecated; use 'obj_naifid' instead (the API parameter is 'obj_naifid').",
+                AstropyDeprecationWarning,
+                stacklevel=2,
+            )
+            obj_naifid = obj_nafid
+        if input_mode == "nafid_input":
+            warnings.warn(
+                "'nafid_input' is deprecated; use 'naifid_input' instead (the API value is 'naifid_input').",
+                AstropyDeprecationWarning,
+                stacklevel=2,
+            )
+            input_mode = "naifid_input"
+
         # This is a map between the keyword names used by the MOST cgi-bin
         # service and their more user-friendly names. For example,
         # input_type -> input_mode or fits_region_files --> with tarballs
@@ -510,7 +543,7 @@ class MostClass(BaseQuery):
             "ephem_step": ephem_step,
             "fits_region_files": "on" if with_tarballs else "",
             "obj_name": obj_name,
-            "obj_nafid": obj_nafid,
+            "obj_naifid": obj_naifid,
             "obj_type": obj_type,
             "mpc_data": mpc_data,
             "body_designation": body_designation,

--- a/astroquery/ipac/irsa/tests/test_most.py
+++ b/astroquery/ipac/irsa/tests/test_most.py
@@ -263,7 +263,7 @@ def test_naifid_input(patch_requests):
 
 def test_nafid_deprecation(patch_requests):
     """Deprecated 'obj_nafid' and 'nafid_input' emit AstropyDeprecationWarning."""
-    with pytest.warns(AstropyDeprecationWarning, match="obj_naifid"):
+    with pytest.warns(AstropyDeprecationWarning, match="obj_nafid"):
         Most.query_object(
             obj_nafid="606",
             input_mode="naifid_input",

--- a/astroquery/ipac/irsa/tests/test_most.py
+++ b/astroquery/ipac/irsa/tests/test_most.py
@@ -6,9 +6,10 @@ import pytest
 
 from astropy.io import votable
 from astropy.table import Table
+from astropy.utils.diff import report_diff_values
+from astropy.utils.exceptions import AstropyDeprecationWarning
 from astroquery.utils.mocks import MockResponse
 from astroquery.ipac.irsa import Most
-from astropy.utils.diff import report_diff_values
 
 
 # each MOST query is given a PID and a temporary directory availible publicly
@@ -248,3 +249,30 @@ def test_gator(patch_requests):
     tbl = Table.read(data_path("most_gator.tbl"), format="ipac")
     silent_stream = io.StringIO()
     assert report_diff_values(tbl, response, silent_stream)
+
+
+def test_naifid_input(patch_requests):
+    """NAIF ID input mode works with the correct 'naifid_input' spelling."""
+    response = Most.query_object(
+        obj_naifid="606",
+        input_mode="naifid_input",
+        output_mode="Brief",
+    )
+    assert len(response) > 0
+
+
+def test_nafid_deprecation(patch_requests):
+    """Deprecated 'obj_nafid' and 'nafid_input' emit AstropyDeprecationWarning."""
+    with pytest.warns(AstropyDeprecationWarning, match="obj_naifid"):
+        Most.query_object(
+            obj_nafid="606",
+            input_mode="naifid_input",
+            output_mode="Brief",
+        )
+
+    with pytest.warns(AstropyDeprecationWarning, match="naifid_input"):
+        Most.query_object(
+            obj_naifid="606",
+            input_mode="nafid_input",
+            output_mode="Brief",
+        )


### PR DESCRIPTION
Fixes #3605.

The MOST cgi-bin API expects `naifid` but the astroquery code had `nafid` (missing the 'i') in multiple places, so NAIF ID queries were silently broken. Confirmed against the IRSA MOST API docs (`MOSTProgramInterface.html`).

Changes:
- `_validate_nafid_input_type`: fix the dict key and error message
- `_validate_input`: fix the dispatch key and the unrecognized-input error message
- `get_images` and `query_object` signatures: add `obj_naifid` parameter
- `get_images` and `query_object` bodies: handle the deprecated `obj_nafid` keyword and `"nafid_input"` `input_mode`, remapping to the correct names with `AstropyDeprecationWarning`
- `qparams` dict in `query_object`: fix the POST key from `obj_nafid` to `obj_naifid`

Tests:
- `test_naifid_input`: verifies the corrected spelling actually works against the mock
- `test_nafid_deprecation`: verifies the deprecated spellings emit `AstropyDeprecationWarning`

8/8 most tests pass. CHANGES.rst entry under `ipac.irsa` in 'Service fixes and enhancements'.