### PR TITLE
Update Zcut request parameter

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -157,8 +157,9 @@ mast
   default can be overridden by setting the ``enable_cloud_dataset`` configuration option to False. [#3534]
 - Results returned from ``MastMissions`` metadata query functions now include search parameters in the metadata of the ``astropy.table.Table`` object
   and column descriptions in the column metadata. [#3588]
-- Added ``pass_id`` as an alias for the ``pass`` column in query functions for the Roman mission to avoid conflicts with 
+- Added ``pass_id`` as an alias for the ``pass`` column in query functions for the Roman mission to avoid conflicts with
   the reserved Python keyword. [#3588]
+- Update the cutout format request parameter in ``Zcut.download_cutouts`` to reflect a recent service change. [#3608]
 
 
 jplspec

--- a/astroquery/mast/cutouts.py
+++ b/astroquery/mast/cutouts.py
@@ -8,24 +8,23 @@ Cutout queries on TESS FFIs.
 
 """
 
-import warnings
-import time
 import json
-import zipfile
 import os
+import time
+import warnings
+import zipfile
 from io import BytesIO
 
-import numpy as np
 import astropy.units as u
+import numpy as np
 from astropy.coordinates import Angle
-from astropy.table import Table
 from astropy.io import fits
+from astropy.table import Table
 from astropy.utils.decorators import deprecated_renamed_argument
 
-from ..exceptions import InputWarning, NoResultsWarning, InvalidQueryError
-from .utils import parse_input_location
+from ..exceptions import InputWarning, InvalidQueryError, NoResultsWarning
 from .core import MastQueryWithLogin
-
+from .utils import parse_input_location
 
 __all__ = ["TesscutClass", "Tesscut", "ZcutClass", "Zcut"]
 
@@ -665,7 +664,7 @@ class ZcutClass(MastQueryWithLogin):
         if survey:
             astrocut_request += "&survey={}".format(survey)
 
-        astrocut_request += "&format={}".format(cutout_format)
+        astrocut_request += "&cutout_format={}".format(cutout_format)
 
         for key in img_params:
             if key in self.accepted_img_params:


### PR DESCRIPTION
One of the request parameters in our Zcut service was recently changed, making Astroquery return unexpected results. This is a quick fix.