### PR TITLE
GAIA: Update allowed values for data_structure in method load_data

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -66,6 +66,11 @@ esa.euclid
    ``latest``. [#3601]
 - The methods ``get_product_list`` and ``get_scientific_product_list`` accept the new parameter ``schema``. [#3611]
 
+gaia
+^^^^
+
+- The values that the ``data_structure parameter`` can accept have been changed from RAW to DATAMODEL_GAIA, and from
+INDIVIDUAL to DATAMODEL_STANDARD. [#3629]
 
 vizier
 ^^^^^^

--- a/astroquery/gaia/core.py
+++ b/astroquery/gaia/core.py
@@ -165,7 +165,7 @@ class GaiaClass(TapPlus):
             log.error("Error logging out data server")
 
     @deprecated_renamed_argument(("output_file", "band"), (None, None), since=("0.4.8", "0.4.11"))
-    def load_data(self, ids, *, data_release=None, data_structure='INDIVIDUAL', retrieval_type="ALL",
+    def load_data(self, ids, *, data_release=None, data_structure='DATAMODEL_STANDARD', retrieval_type="ALL",
                   linking_parameter='SOURCE_ID', valid_data=False, band=None, avoid_datatype_check=False,
                   format="votable", dump_to_file=False, overwrite_output_file=False, verbose=False,
                   output_file=None):
@@ -178,10 +178,10 @@ class GaiaClass(TapPlus):
             List of identifiers
         data_release: str, optional, default None
             Data release from which data should be taken. E.g. 'Gaia DR3'. By default, it takes the current default one.
-        data_structure: str, optional, default 'INDIVIDUAL'
-            It can be 'INDIVIDUAL' or 'RAW':
-            'INDIVIDUAL' means products are provided in separate files for each sourceId. All files are zipped
-            in a single bundle, even if only one source/file is considered 'RAW' means products are provided
+        data_structure: str, optional, default 'DATAMODEL_STANDARD'
+            It can be 'DATAMODEL_STANDARD' or 'DATAMODEL_GAIA':
+            'DATAMODEL_STANDARD' means products are provided in separate files for each sourceId. All files are zipped
+            in a single bundle, even if only one source/file is considered 'DATAMODEL_GAIA' means products are provided
             following a Data Model similar to that used in the MDB, meaning in particular that parameters stored as
             arrays will remain as such. A single file is provided for the data of all sourceIds together, but in this
             case there will be always be one row per sourceId.

--- a/astroquery/gaia/tests/test_gaiatap.py
+++ b/astroquery/gaia/tests/test_gaiatap.py
@@ -209,7 +209,7 @@ def mock_datalink_querier(patch_datetime_now):
     # The query contains decimals: default response is more robust.
     conn_handler.set_default_response(launch_response)
     conn_handler.set_response(
-        '?DATA_STRUCTURE=INDIVIDUAL&FORMAT=votable&ID=5937083312263887616&RELEASE=Gaia+DR3&RETRIEVAL_TYPE=ALL'
+        '?DATA_STRUCTURE=DATAMODEL_STANDARD&FORMAT=votable&ID=5937083312263887616&RELEASE=Gaia+DR3&RETRIEVAL_TYPE=ALL'
         '&USE_ZIP_ALWAYS=true&VALID_DATA=false',
         launch_response)
 
@@ -226,7 +226,7 @@ def mock_datalink_querier_ecsv():
     # The query contains decimals: default response is more robust.
     conn_handler.set_default_response(launch_response)
     conn_handler.set_response(
-        '?DATA_STRUCTURE=INDIVIDUAL&FORMAT=ecsv&ID=5937083312263887616&RELEASE=Gaia+DR3&RETRIEVAL_TYPE=ALL'
+        '?DATA_STRUCTURE=DATAMODEL_STANDARD&FORMAT=ecsv&ID=5937083312263887616&RELEASE=Gaia+DR3&RETRIEVAL_TYPE=ALL'
         '&USE_ZIP_ALWAYS=true&VALID_DATA=false',
         launch_response)
 
@@ -243,7 +243,7 @@ def mock_datalink_querier_csv():
     # The query contains decimals: default response is more robust.
     conn_handler.set_default_response(launch_response)
     conn_handler.set_response(
-        '?DATA_STRUCTURE=INDIVIDUAL&FORMAT=csv&ID=5937083312263887616&RELEASE=Gaia+DR3&RETRIEVAL_TYPE=ALL'
+        '?DATA_STRUCTURE=DATAMODEL_STANDARD&FORMAT=csv&ID=5937083312263887616&RELEASE=Gaia+DR3&RETRIEVAL_TYPE=ALL'
         '&USE_ZIP_ALWAYS=true&VALID_DATA=false',
         launch_response)
 
@@ -260,7 +260,7 @@ def mock_datalink_querier_fits():
     # The query contains decimals: default response is more robust.
     conn_handler.set_default_response(launch_response)
     conn_handler.set_response(
-        '?DATA_STRUCTURE=INDIVIDUAL&FORMAT=fits&ID=5937083312263887616&RELEASE=Gaia+DR3&RETRIEVAL_TYPE=ALL'
+        '?DATA_STRUCTURE=DATAMODEL_STANDARD&FORMAT=fits&ID=5937083312263887616&RELEASE=Gaia+DR3&RETRIEVAL_TYPE=ALL'
         '&USE_ZIP_ALWAYS=true&VALID_DATA=false',
         launch_response)
 
@@ -898,7 +898,7 @@ def test_datalink_querier_load_data_vot_exception(mock_datalink_querier, overwri
 
         with pytest.raises(ValueError) as excinfo:
             mock_datalink_querier.load_data(ids=[5937083312263887616], data_release='Gaia DR3',
-                                            data_structure='INDIVIDUAL',
+                                            data_structure='DATAMODEL_STANDARD',
                                             retrieval_type="ALL",
                                             linking_parameter='SOURCE_ID', valid_data=False,
                                             avoid_datatype_check=False,
@@ -911,7 +911,7 @@ def test_datalink_querier_load_data_vot_exception(mock_datalink_querier, overwri
 
     else:
         mock_datalink_querier.load_data(ids=[5937083312263887616], data_release='Gaia DR3',
-                                        data_structure='INDIVIDUAL',
+                                        data_structure='DATAMODEL_STANDARD',
                                         retrieval_type="ALL",
                                         linking_parameter='SOURCE_ID', valid_data=False,
                                         avoid_datatype_check=False,
@@ -926,7 +926,7 @@ def test_datalink_querier_load_data_vot_exception(mock_datalink_querier, overwri
 
 def test_datalink_querier_load_data_vot(mock_datalink_querier):
     result_dict = mock_datalink_querier.load_data(ids=[5937083312263887616], data_release='Gaia DR3',
-                                                  data_structure='INDIVIDUAL',
+                                                  data_structure='DATAMODEL_STANDARD',
                                                   retrieval_type="ALL",
                                                   linking_parameter='SOURCE_ID', valid_data=False,
                                                   avoid_datatype_check=False,
@@ -964,7 +964,7 @@ def test_datalink_querier_load_data_vot(mock_datalink_querier):
 
 def test_datalink_querier_load_data_ecsv(mock_datalink_querier_ecsv):
     result_dict = mock_datalink_querier_ecsv.load_data(ids=[5937083312263887616], data_release='Gaia DR3',
-                                                       data_structure='INDIVIDUAL',
+                                                       data_structure='DATAMODEL_STANDARD',
                                                        retrieval_type="ALL",
                                                        linking_parameter='SOURCE_ID', valid_data=False,
                                                        avoid_datatype_check=False,
@@ -1005,7 +1005,7 @@ def test_datalink_querier_load_data_ecsv(mock_datalink_querier_ecsv):
 
 def test_datalink_querier_load_data_csv(mock_datalink_querier_csv):
     result_dict = mock_datalink_querier_csv.load_data(ids=[5937083312263887616], data_release='Gaia DR3',
-                                                      data_structure='INDIVIDUAL',
+                                                      data_structure='DATAMODEL_STANDARD',
                                                       retrieval_type="ALL",
                                                       linking_parameter='SOURCE_ID', valid_data=False,
                                                       avoid_datatype_check=False,
@@ -1047,7 +1047,7 @@ def test_datalink_querier_load_data_csv(mock_datalink_querier_csv):
 @pytest.mark.filterwarnings("ignore:")
 def test_datalink_querier_load_data_fits(mock_datalink_querier_fits):
     result_dict = mock_datalink_querier_fits.load_data(ids=[5937083312263887616], data_release='Gaia DR3',
-                                                       data_structure='INDIVIDUAL',
+                                                       data_structure='DATAMODEL_STANDARD',
                                                        retrieval_type="ALL",
                                                        linking_parameter='SOURCE_ID', valid_data=False,
                                                        avoid_datatype_check=False,
@@ -1105,7 +1105,7 @@ def test_load_data_vot(monkeypatch, tmp_path, tmp_path_factory, patch_datetime_n
             "ID": "1,2,3,4",
             "FORMAT": "votable",
             "RETRIEVAL_TYPE": "epoch_photometry",
-            "DATA_STRUCTURE": "INDIVIDUAL",
+            "DATA_STRUCTURE": "DATAMODEL_STANDARD",
             "USE_ZIP_ALWAYS": "true"}
         assert str(path) == output_file
         assert verbose is True
@@ -1148,7 +1148,7 @@ def test_load_data_fits(monkeypatch, tmp_path, tmp_path_factory, patch_datetime_
             "ID": "1,2,3,4",
             "FORMAT": "fits",
             "RETRIEVAL_TYPE": "epoch_photometry",
-            "DATA_STRUCTURE": "INDIVIDUAL",
+            "DATA_STRUCTURE": "DATAMODEL_STANDARD",
             "USE_ZIP_ALWAYS": "true"}
         assert str(path) == output_file
         assert verbose is True
@@ -1186,7 +1186,7 @@ def test_load_data_csv(monkeypatch, tmp_path, tmp_path_factory, patch_datetime_n
             "ID": "1,2,3,4",
             "FORMAT": "csv",
             "RETRIEVAL_TYPE": "epoch_photometry",
-            "DATA_STRUCTURE": "INDIVIDUAL",
+            "DATA_STRUCTURE": "DATAMODEL_STANDARD",
             "USE_ZIP_ALWAYS": "true"}
         assert str(path) == output_file
         assert verbose is True
@@ -1224,7 +1224,7 @@ def test_load_data_ecsv(monkeypatch, tmp_path, tmp_path_factory, patch_datetime_
             "ID": "1,2,3,4",
             "FORMAT": "ecsv",
             "RETRIEVAL_TYPE": "epoch_photometry",
-            "DATA_STRUCTURE": "INDIVIDUAL",
+            "DATA_STRUCTURE": "DATAMODEL_STANDARD",
             "USE_ZIP_ALWAYS": "true"}
         assert str(path) == output_file
         assert verbose is True
@@ -1262,7 +1262,7 @@ def test_load_data_linking_parameter(monkeypatch, tmp_path, patch_datetime_now):
             "ID": "1,2,3,4",
             "FORMAT": "votable",
             "RETRIEVAL_TYPE": "epoch_photometry",
-            "DATA_STRUCTURE": "INDIVIDUAL",
+            "DATA_STRUCTURE": "DATAMODEL_STANDARD",
             "USE_ZIP_ALWAYS": "true"}
         assert str(path) == output_file
         assert verbose is True
@@ -1310,7 +1310,7 @@ def test_load_data_linking_parameter_with_values(monkeypatch, tmp_path, linking_
             "ID": "1,2,3,4",
             "FORMAT": "votable",
             "RETRIEVAL_TYPE": "epoch_photometry",
-            "DATA_STRUCTURE": "INDIVIDUAL",
+            "DATA_STRUCTURE": "DATAMODEL_STANDARD",
             "LINKING_PARAMETER": linking_param,
             "USE_ZIP_ALWAYS": "true", }
         assert output_file == str(Path(os.getcwd(), datalink_output))

--- a/docs/gaia/gaia.rst
+++ b/docs/gaia/gaia.rst
@@ -909,7 +909,7 @@ The following example shows how to retrieve the DataLink products associated wit
 .. doctest-remote-data::
 
   >>> retrieval_type = 'ALL'          # Options are: 'EPOCH_PHOTOMETRY', 'MCMC_GSPPHOT', 'MCMC_MSC', 'XP_SAMPLED', 'XP_CONTINUOUS', 'RVS', 'ALL'
-  >>> data_structure = 'INDIVIDUAL'     # Options are: 'INDIVIDUAL' or 'RAW'
+  >>> data_structure = 'DATAMODEL_STANDARD'     # Options are: 'DATAMODEL_STANDARD' or 'DATAMODEL_GAIA'
   >>> data_release   = 'Gaia DR3'     # Options are: 'Gaia DR3' (default), 'Gaia DR2'
   >>> datalink = Gaia.load_data(ids=[2263166706630078848, 2263178457660566784, 2268372099615724288],
   ...                           data_release=data_release, retrieval_type=retrieval_type, data_structure=data_structure)


### PR DESCRIPTION
Dear astroquery team,

We have opened this PR to propose a change to the set of values that can be passed to the `data_structure` parameter of the `load_data` method:

1. RAW --> DATAMODEL_GAIA
2. INDIVIDUAL --> DATAMODEL_STANDARD

In this case, we need to synchronize the merge of these changes so that access to the Gaia Archive through astroquery is not disrupted.

cc @esdc-esac-esa-int 
jira: GAIASA-3510