### PR TITLE
Fix two bugs in calling heasarc.query_region

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -124,8 +124,8 @@ heasarc
 - Add support for uploading tables when using TAP directly through ``query_tap``. [#3403]
 - Add automatic guessing for the data host in ``download_data``. [#3403]
 - Include method to count the number of rows in a specified table. [#3549]
-- Fix ``query_region`` for catalog=None. It should fail early. []
-- Fix ``query_region`` when passing ``add_offset`` along with ``columns=None``. []
+- Fix ``query_region`` for catalog=None. It should fail early. [#3630]
+- Fix ``query_region`` when passing ``add_offset`` along with ``columns=None``. [#3630]
 
 gaia
 ^^^^

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -124,6 +124,8 @@ heasarc
 - Add support for uploading tables when using TAP directly through ``query_tap``. [#3403]
 - Add automatic guessing for the data host in ``download_data``. [#3403]
 - Include method to count the number of rows in a specified table. [#3549]
+- Fix ``query_region`` for catalog=None. It should fail early. []
+- Fix ``query_region`` when passing ``add_offset`` along with ``columns=None``. []
 
 gaia
 ^^^^

--- a/astroquery/heasarc/core.py
+++ b/astroquery/heasarc/core.py
@@ -38,6 +38,11 @@ class HeasarcClass(BaseVOQuery, BaseQuery):
         self._tap = None
         self._datalink = None
         self._meta_info = None
+        self._catalog_msg = (
+            "catalog name is required! "
+            "Use 'xray' to search the master X-ray catalog. Or list catalogs by"
+            "calling :meth:`~astroquery.heasarc.HeasarcClass.list_catalogs`"
+        )
 
     @property
     def tap(self):
@@ -326,8 +331,7 @@ class HeasarcClass(BaseVOQuery, BaseQuery):
             commons.suppress_vo_warnings()
 
         if catalog is None:
-            raise InvalidQueryError("catalog name is required! Use 'xray' "
-                                    "to search the master X-ray catalog")
+            raise InvalidQueryError(self._catalog_msg)
 
         if where is None:
             where = ''
@@ -501,6 +505,9 @@ class HeasarcClass(BaseVOQuery, BaseQuery):
         # if we have column_filters and no position, assume all-sky search
         if position is None and column_filters is not None:
             spatial = 'all-sky'
+        
+        if catalog is None:
+            raise InvalidQueryError(self._catalog_msg)
 
         if spatial.lower() == 'all-sky':
             where = ''

--- a/astroquery/heasarc/core.py
+++ b/astroquery/heasarc/core.py
@@ -296,6 +296,7 @@ class HeasarcClass(BaseVOQuery, BaseQuery):
             query, language='ADQL', maxrec=maxrec, uploads=uploads)
 
     def _query_execute(self, catalog=None, where=None, *,
+                       offset_column=None,
                        get_query_payload=False, columns=None,
                        verbose=False, maxrec=None):
         """Queries some catalog using the HEASARC TAP server based on the
@@ -309,6 +310,9 @@ class HeasarcClass(BaseVOQuery, BaseQuery):
         where : str
             The WHERE condition to be used in the query. It must
             include the 'WHERE' keyword or be empty.
+        offset_column: str or None
+            If add_offset is True in query_regoni, this contains the
+            the string that addes that to the query.
         get_query_payload : bool, optional
             If `True` then returns the generated ADQL query as str.
             Defaults to `False`.
@@ -346,6 +350,9 @@ class HeasarcClass(BaseVOQuery, BaseQuery):
 
         if columns is None:
             columns = ', '.join(self._get_default_columns(catalog))
+        
+        if offset_column is not None:
+            columns += offset_column
 
         if '__row' not in columns and columns != '*':
             columns += ', __row'
@@ -506,8 +513,16 @@ class HeasarcClass(BaseVOQuery, BaseQuery):
         if position is None and column_filters is not None:
             spatial = 'all-sky'
         
+        # check for a valid catalog name
         if catalog is None:
             raise InvalidQueryError(self._catalog_msg)
+        
+        # add_offset is valid only with cone searches
+        if spatial != 'cone' and add_offset:
+            raise InvalidQueryError("add_offset is valid only spatial=='cone'")
+        
+        # to hold the offset columns, if needed
+        offset_column = None
 
         if spatial.lower() == 'all-sky':
             where = ''
@@ -550,8 +565,10 @@ class HeasarcClass(BaseVOQuery, BaseQuery):
                          f"'ICRS',{ra},{dec},{radius.to(u.deg).value}))=1")
                 # add search_offset for the case of cone
                 if add_offset:
-                    columns += (",DISTANCE(POINT('ICRS',ra,dec), "
-                                f"POINT('ICRS',{ra},{dec})) as search_offset")
+                    offset_column = (
+                        ",DISTANCE(POINT('ICRS',ra,dec), "
+                        f"POINT('ICRS',{ra},{dec})) as search_offset"
+                    )
             elif spatial.lower() == 'box':
                 if isinstance(width, str):
                     width = coordinates.Angle(width)
@@ -574,6 +591,7 @@ class HeasarcClass(BaseVOQuery, BaseQuery):
 
         table_or_query = self._query_execute(
             catalog=catalog, where=where,
+            offset_column=offset_column,
             get_query_payload=get_query_payload,
             columns=columns, verbose=verbose,
             maxrec=maxrec

--- a/astroquery/heasarc/core.py
+++ b/astroquery/heasarc/core.py
@@ -311,7 +311,7 @@ class HeasarcClass(BaseVOQuery, BaseQuery):
             The WHERE condition to be used in the query. It must
             include the 'WHERE' keyword or be empty.
         offset_column: str or None
-            If add_offset is True in query_regoni, this contains the
+            If add_offset is True in query_region, this contains the
             the string that addes that to the query.
         get_query_payload : bool, optional
             If `True` then returns the generated ADQL query as str.
@@ -350,7 +350,7 @@ class HeasarcClass(BaseVOQuery, BaseQuery):
 
         if columns is None:
             columns = ', '.join(self._get_default_columns(catalog))
-        
+
         if offset_column is not None:
             columns += offset_column
 
@@ -512,16 +512,16 @@ class HeasarcClass(BaseVOQuery, BaseQuery):
         # if we have column_filters and no position, assume all-sky search
         if position is None and column_filters is not None:
             spatial = 'all-sky'
-        
+
         # check for a valid catalog name
         if catalog is None:
             raise InvalidQueryError(self._catalog_msg)
-        
+
         # add_offset is valid only with cone searches
-        if spatial != 'cone' and add_offset:
+        if add_offset and spatial != 'cone':
             raise InvalidQueryError("add_offset is valid only spatial=='cone'")
-        
-        # to hold the offset columns, if needed
+
+        # to hold the offset column, if needed
         offset_column = None
 
         if spatial.lower() == 'all-sky':
@@ -927,7 +927,7 @@ class HeasarcClass(BaseVOQuery, BaseQuery):
         Users should be using `~self.download_data` instead
 
         """
-        if not os.path.exists('/FTP/'):
+        if not os.path.exists('/FTP/nusatr'):
             raise FileNotFoundError(
                 'No data archive found. This should be run on Sciserver '
                 'with the data drive mounted.'

--- a/astroquery/heasarc/tests/test_heasarc.py
+++ b/astroquery/heasarc/tests/test_heasarc.py
@@ -622,12 +622,16 @@ def test_download_data__sciserver():
 
 
 def test_download_data__outside_sciserver():
+    link = 'some-link'
     with pytest.raises(
-        FileNotFoundError,
-        match="No data archive found. This should be run on Sciserver",
+        ValueError,
+        match=(
+            f'No data found in {link}. '
+            'Make sure you are running this on Sciserver. '
+        ),
     ):
         Heasarc.download_data(
-            Table({"sciserver": ["some-link"]}), host="sciserver"
+            Table({"sciserver": [link]}), host="sciserver"
         )
 
 

--- a/astroquery/heasarc/tests/test_heasarc.py
+++ b/astroquery/heasarc/tests/test_heasarc.py
@@ -239,13 +239,11 @@ def test_no_catalog():
     with pytest.raises(InvalidQueryError):
         # OBJ_LIST[0] and radius added to avoid a remote call
         Heasarc.query_region(
-            OBJ_LIST[0], spatial="cone", columns="*", radius="2arcmin")
-
+            OBJ_LIST[0], catalog=None, spatial="cone")
 
 def test__query_execute_no_catalog():
     with pytest.raises(InvalidQueryError):
-        # OBJ_LIST[0] and radius added to avoid a remote call
-        Heasarc._query_execute(None)
+        Heasarc._query_execute(catalog=None)
 
 
 def test_parse_constraints_no_filter():

--- a/astroquery/heasarc/tests/test_heasarc.py
+++ b/astroquery/heasarc/tests/test_heasarc.py
@@ -241,6 +241,7 @@ def test_no_catalog():
         Heasarc.query_region(
             OBJ_LIST[0], catalog=None, spatial="cone")
 
+
 def test__query_execute_no_catalog():
     with pytest.raises(InvalidQueryError):
         Heasarc._query_execute(catalog=None)
@@ -620,16 +621,12 @@ def test_download_data__sciserver():
 
 
 def test_download_data__outside_sciserver():
-    link = 'some-link'
     with pytest.raises(
-        ValueError,
-        match=(
-            f'No data found in {link}. '
-            'Make sure you are running this on Sciserver. '
-        ),
+        FileNotFoundError,
+        match="No data archive found. This should be run on Sciserver",
     ):
         Heasarc.download_data(
-            Table({"sciserver": [link]}), host="sciserver"
+            Table({"sciserver": ["some-link"]}), host="sciserver"
         )
 
 
@@ -732,3 +729,17 @@ def test_s3_mock_directory(s3_mock):
 def test_row_count(mock_tap, mock_default_cols):
     cat = "name-1"
     assert Heasarc.count_rows(cat) == 3055
+
+
+def test_query_region_offset_with_no_column():
+    # use columns='*' to avoid remote call to obtain the default columns
+    query = Heasarc.query_region(
+        OBJ_LIST[0],
+        catalog="suzamaster",
+        spatial="cone",
+        radius="2arcmin",
+        columns='*',
+        get_query_payload=True,
+        add_offset=True,
+    )
+    assert ',DISTANCE(POINT(' in query

--- a/astroquery/heasarc/tests/test_heasarc_remote.py
+++ b/astroquery/heasarc/tests/test_heasarc_remote.py
@@ -268,6 +268,18 @@ class TestHeasarc:
         """
         cat = "suzamaster"
         assert Heasarc.count_rows(cat) == 3055
+    
+    def test_query_region_offset_with_no_column(self):
+        # use columns='*' to avoid remote call to obtain the default columns
+        query = Heasarc.query_region(
+            OBJ_LIST[0],
+            catalog="suzamaster",
+            spatial="cone",
+            radius="2arcmin",
+            columns=None,
+            get_query_payload=True,
+            add_offset=True,
+        )
 
 
 @pytest.mark.remote_data

--- a/astroquery/heasarc/tests/test_heasarc_remote.py
+++ b/astroquery/heasarc/tests/test_heasarc_remote.py
@@ -10,8 +10,6 @@ from astropy.coordinates import SkyCoord
 from astropy.utils.exceptions import AstropyDeprecationWarning
 from astroquery.exceptions import NoResultsWarning
 
-from pyvo.dal.exceptions import DALOverflowWarning
-
 from astroquery.heasarc import Heasarc
 
 
@@ -55,9 +53,6 @@ DEFAULT_COLS = [
         ],
     ],
 ]
-
-# The MAXREC related overflow message is different in pyvo 1.7+, remove workaround when we have it as a minimum
-overflow_message = r"Partial result set. Potential causes MAXREC|Result set limited by user- or server-supplied MAXREC"
 
 
 @pytest.mark.remote_data
@@ -156,12 +151,6 @@ class TestHeasarc:
         assert "rosmaster" in catalogs
         assert "rassmaster" in catalogs
 
-    def test_tap__maxrec(self):
-        query = "SELECT TOP 10 ra,dec FROM xray"
-        with pytest.warns(expected_warning=DALOverflowWarning, match=overflow_message):
-            result = Heasarc.query_tap(query=query, maxrec=5)
-        assert len(result) == 5
-        assert result.to_table().colnames == ["ra", "dec"]
 
     @pytest.mark.parametrize("tdefault", DEFAULT_COLS)
     def test__get_default_columns(self, tdefault):

--- a/astroquery/heasarc/tests/test_heasarc_remote.py
+++ b/astroquery/heasarc/tests/test_heasarc_remote.py
@@ -10,6 +10,10 @@ from astropy.coordinates import SkyCoord
 from astropy.utils.exceptions import AstropyDeprecationWarning
 from astroquery.exceptions import NoResultsWarning
 
+import importlib.metadata
+from packaging.version import Version
+from pyvo.dal.exceptions import DALOverflowWarning
+
 from astroquery.heasarc import Heasarc
 
 
@@ -53,6 +57,10 @@ DEFAULT_COLS = [
         ],
     ],
 ]
+
+# The MAXREC related overflow message is different in pyvo 1.7+, remove workaround when we have it as a minimum
+overflow_message = r"Partial result set. Potential causes MAXREC|Result set limited by user- or server-supplied MAXREC"
+pyvo_version = Version(importlib.metadata.version('pyvo'))
 
 
 @pytest.mark.remote_data
@@ -151,6 +159,13 @@ class TestHeasarc:
         assert "rosmaster" in catalogs
         assert "rassmaster" in catalogs
 
+    @pytest.mark.skipif(pyvo_version >= Version('1.7'), reason="pyvo >= 1.7")
+    def test_tap__maxrec(self):
+        query = "SELECT TOP 10 ra,dec FROM xray"
+        with pytest.warns(expected_warning=DALOverflowWarning, match=overflow_message):
+            result = Heasarc.query_tap(query=query, maxrec=5)
+        assert len(result) == 5
+        assert result.to_table().colnames == ["ra", "dec"]
 
     @pytest.mark.parametrize("tdefault", DEFAULT_COLS)
     def test__get_default_columns(self, tdefault):
@@ -268,18 +283,6 @@ class TestHeasarc:
         """
         cat = "suzamaster"
         assert Heasarc.count_rows(cat) == 3055
-    
-    def test_query_region_offset_with_no_column(self):
-        # use columns='*' to avoid remote call to obtain the default columns
-        query = Heasarc.query_region(
-            OBJ_LIST[0],
-            catalog="suzamaster",
-            spatial="cone",
-            radius="2arcmin",
-            columns=None,
-            get_query_payload=True,
-            add_offset=True,
-        )
 
 
 @pytest.mark.remote_data

--- a/astroquery/heasarc/tests/test_heasarc_remote.py
+++ b/astroquery/heasarc/tests/test_heasarc_remote.py
@@ -94,7 +94,7 @@ class TestHeasarc:
         assert isinstance(result, Table)
         assert len(result) == 3
         # assert all columns are returned
-        assert len(result.colnames) == 53
+        assert len(result.colnames) == 54
 
     def test_query_columns_radius(self):
         """

--- a/docs/heasarc/heasarc.rst
+++ b/docs/heasarc/heasarc.rst
@@ -107,8 +107,8 @@ To do a full sky search, use ``spatial='all-sky'``:
     >>> tab = Heasarc.query_region(catalog='chanmaster', spatial='all-sky',
     ...                            columns='name, obsid, ra, dec')
     >>> tab[:5].pprint()
-            name         obsid     ra       dec   
-                                  deg       deg   
+            name         obsid     ra       dec
+                                  deg       deg
     -------------------- ----- --------- ---------
              ESO005-G004 21421  91.42333 -86.63194
     1RXSJ200924.1-853911 10143 302.30417 -85.64633
@@ -122,7 +122,7 @@ The collection of available catalogs can be obtained by calling the `~astroquery
 method. In this example, we request the master catalogs only by passing ``master=True``.
 Master catalogs are catalogs that contain one entry per observation, as opposed to
 other catalogs that may record other information. There is typically one master catalog
-per mission. The ``master`` parameter is a boolean flag, which is ``False`` by default 
+per mission. The ``master`` parameter is a boolean flag, which is ``False`` by default
 (i.e. return all catalogs). `~astroquery.heasarc.HeasarcClass.list_catalogs` returns an
 `~astropy.table.Table` with two columns containing the names and description of the available
 catalogs.
@@ -227,12 +227,12 @@ the search defaults to an all-sky search.
     ...     catalog='chanmaster', column_filters={'exposure': ('>', '190000')}
     ... )
     >>> tab['name', 'obsid', 'ra', 'dec', 'exposure'][:3].pprint()
-        name      obsid     ra       dec    exposure
-                            deg       deg       s    
+          name      obsid     ra       dec    exposure
+                            deg       deg       s
     --------------- ----- --------- --------- --------
-       GW Transient 29852        --        --   300000
              Sgr A* 13842 266.41667 -29.00781   191760
-    IGR J17480-2446 30481 267.02013 -24.78024   200000
+    IGR J17480-2446 31425 267.02013 -24.78024   200000
+                M51 13814 202.50000  47.20000   192360
 
 Another example may be to search the ``xmmmaster`` for a observation in some time range:
 
@@ -244,11 +244,11 @@ Another example may be to search the ``xmmmaster`` for a observation in some tim
     ... )
     >>> tab['name', 'obsid', 'ra', 'dec', 'time', 'duration'][:3].pprint()
          name       obsid       ra       dec          time       duration
-                                deg       deg           d            s    
-    ------------- ---------- -------- --------- ---------------- --------
-        NGC 1316 0091770101 50.95833 -37.28333 52308.6872337963    60362
-        NGC 1316 0091770201 50.67296 -37.20928  52308.642974537     3462
-    Fei 16 offset 0154150101 28.64374  -6.86667 52305.2210416667    24619
+                               deg       deg           d            s
+     ------------- ---------- -------- --------- ---------------- --------
+          NGC 1316 0091770101 50.67296 -37.20928 52308.6835069444    55332
+          NGC 1316 0091770201 50.67296 -37.20928 52308.6421527778     3573
+     Fei 16 offset 0154150101 28.64375  -6.86667 52305.2201967593    24658
 
 To see the available columns that can be queried for a given catalog and their units,
 use `~astroquery.heasarc.HeasarcClass.list_columns` (see below).
@@ -312,7 +312,7 @@ returns the constructed ADQL query.
     >>> query = """SELECT ra,dec,name,obsid FROM xmmmaster
     ...            WHERE CONTAINS(POINT('ICRS',ra,dec),CIRCLE('ICRS',120.0,38.0,2.0))=1"""
     >>> tab = Heasarc.query_tap(query).to_table()
-    >>> tab[:10].pprint()
+    >>> tab[:10].pprint()  # doctest: +IGNORE_OUTPUT
         ra      dec            name           obsid
     deg      deg
     --------- -------- -------------------- ----------
@@ -330,12 +330,12 @@ returns the constructed ADQL query.
 Table Uploads
 -----------------
 You can also upload a table of positions to be queried. The table can be an
-`~astropy.table.Table` or a path to a file in VOtable format. The following example 
+`~astropy.table.Table` or a path to a file in VOtable format. The following example
 shows how to use the upload feature to do a cross-match between the
 ``chanmaster`` catalog and a list of known source positions:
 
 .. doctest-remote-data::
-    
+
     >>> from astroquery.heasarc import Heasarc
     >>> from astropy.table import Table
     >>> sample = Table({
@@ -349,21 +349,20 @@ shows how to use the upload feature to do a cross-match between the
     ... """
     >>> result = Heasarc.query_tap(query, uploads={'mytable': sample}).to_table()
     >>> result.pprint()
-        name        ra       dec    obsid
-                   deg       deg         
-    ----------- --------- --------- -----
-       NGC 4507 188.90250 -39.90928 12292
-       NGC 4507 188.90208 -39.90925  2150
-         HR4796 189.00417 -39.86950  7414
-    KUG0003+199   1.58134  20.20291 23709
-        Mrk 335   1.58142  20.20295 23292
-        Mrk 335   1.58142  20.20295 23297
-        Mrk 335   1.58142  20.20295 23298
-        Mrk 335   1.58142  20.20295 23299
-        Mrk 335   1.58142  20.20295 23300
-        Mrk 335   1.58142  20.20295 23301
-        Mrk 335   1.58142  20.20295 23302
-
+      cat_name    cat_ra   cat_dec  cat_obsid
+                   deg       deg
+    ----------- --------- --------- ---------
+       NGC 4507 188.90250 -39.90928     12292
+       NGC 4507 188.90208 -39.90925      2150
+         HR4796 189.00417 -39.86950      7414
+    KUG0003+199   1.58134  20.20291     23709
+        Mrk 335   1.58142  20.20295     23297
+        Mrk 335   1.58142  20.20295     23298
+        Mrk 335   1.58142  20.20295     23299
+        Mrk 335   1.58142  20.20295     23300
+        Mrk 335   1.58142  20.20295     23292
+        Mrk 335   1.58142  20.20295     23301
+        Mrk 335   1.58142  20.20295     23302
 
 Complex Regions
 ---------------
@@ -389,7 +388,7 @@ for ``'polygon'``. For ``'all-sky'``:
 
     >>> Heasarc.query_region(pos, spatial='all-sky', catalog='csc', maxrec=None)
 
-though you may find that maxrec has a hard limit of 1e5 regardless of how you set it. 
+though you may find that maxrec has a hard limit of 1e5 regardless of how you set it.
 
 In this case one can do instead:
 
@@ -431,7 +430,7 @@ method. Here, for instance, we fetch the number of rows in the Suzaku 'master' o
 
     >>> from astroquery.heasarc import Heasarc
     >>> Heasarc.count_rows('suzamaster')
-    np.int64(3055)
+    3055
 
 Reference/API
 =============


### PR DESCRIPTION
This is fixes two issues:

- `Heasarc.query_region(position, catalog=None)`: This used to fail but the recent addition of `_query_execute` has pushed the failure down. This fix make the failure happen earlier.

- Passing `add_offset=True` to `Heasarc.query_region` fails when `columns=None`. This was also caused by the recent addition of `_query_execute`

Tests were added for both cases.

Other minor changes:
- remove the `test_tap__maxrec` test. Recent changes in pyvo make it irrelevant.
- Style fixes using flake8