### PR TITLE
IRSA: raise an exception for a non-existing collection in query_sia/query_ssa

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -143,7 +143,7 @@ ipac.irsa
   ``AstropyDeprecationWarning``. [#3607]
 - ``query_sia`` and ``query_ssa`` now raise ``InvalidQueryError`` for a
   collection that doesn't exist, rather than silently returning an empty
-  table. The valid collection names are cached on the instance. [#XXXX]
+  table. The valid collection names are cached on the instance. [#3631]
 
 
 mast

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -141,6 +141,9 @@ ipac.irsa
   were typos; the API expects ``naifid``. Old ``obj_nafid`` keyword and
   ``"nafid_input"`` ``input_mode`` still work but emit
   ``AstropyDeprecationWarning``. [#3607]
+- ``query_sia`` and ``query_ssa`` now raise ``InvalidQueryError`` for a
+  collection that doesn't exist, rather than silently returning an empty
+  table. The valid collection names are cached on the instance. [#XXXX]
 
 
 mast

--- a/astroquery/ipac/irsa/core.py
+++ b/astroquery/ipac/irsa/core.py
@@ -7,6 +7,7 @@ IRSA
 Module to query the IRSA archive.
 """
 
+import difflib
 import warnings
 from astropy.coordinates import SkyCoord, Angle
 from astropy import units as u
@@ -34,6 +35,7 @@ class IrsaClass(BaseVOQuery):
         self._sia = None
         self._ssa = None
         self._tap = None
+        self._collections_cache = {}
 
     @property
     def sia(self):
@@ -105,6 +107,8 @@ class IrsaClass(BaseVOQuery):
         Results in `~astropy.table.Table` format.
 
         """
+        self._validate_collection(collection=collection, servicetype='SIA')
+
         results = self.sia.search(
             pos=pos,
             band=band,
@@ -155,6 +159,7 @@ class IrsaClass(BaseVOQuery):
         -------
         Results in `~astropy.table.Table` format.
         """
+        self._validate_collection(collection=collection, servicetype='SSA')
 
         if radius is None:
             diameter = None
@@ -207,6 +212,36 @@ class IrsaClass(BaseVOQuery):
             mask = [filter in collection for collection in collections['collection']]
             collections = collections[mask]
         return collections
+
+    def _validate_collection(self, *, collection, servicetype):
+        """
+        Raise `~astroquery.exceptions.InvalidQueryError` if ``collection`` is not
+        available for ``servicetype``. Both a single collection name and a list of
+        them are accepted, ``None`` is a no-op.
+
+        The valid collection names are cached on the instance, as looking them up
+        requires a TAP query.
+        """
+        if collection is None:
+            return
+
+        if servicetype not in self._collections_cache:
+            self._collections_cache[servicetype] = sorted(
+                self.list_collections(servicetype=servicetype)['collection'])
+        valid_collections = self._collections_cache[servicetype]
+
+        if isinstance(collection, str):
+            collection = [collection]
+
+        for coll in collection:
+            if coll not in valid_collections:
+                error_msg = f"'{coll}' is not a valid {servicetype} collection. "
+                closest_match = difflib.get_close_matches(coll, valid_collections, n=1)
+                if closest_match:
+                    error_msg += f"Did you mean '{closest_match[0]}'? "
+                error_msg += ("To list the available collections, use "
+                              f"Irsa.list_collections(servicetype='{servicetype}').")
+                raise InvalidQueryError(error_msg)
 
     @deprecated_renamed_argument(("selcols", "cache", "verbose"), ("columns", None, None), since="0.4.7")
     def query_region(self, coordinates=None, *, catalog=None, spatial='Cone',

--- a/astroquery/ipac/irsa/tests/test_irsa.py
+++ b/astroquery/ipac/irsa/tests/test_irsa.py
@@ -2,9 +2,10 @@
 
 import pytest
 from astropy.coordinates import SkyCoord
+from astropy.table import Table
 import astropy.units as u
 
-from astroquery.ipac.irsa import Irsa
+from astroquery.ipac.irsa import Irsa, IrsaClass
 from astroquery.exceptions import InvalidQueryError
 
 OBJ_LIST = ["00h42m44.330s +41d16m07.50s",
@@ -77,3 +78,75 @@ def test_no_catalog():
 def test_deprecated_namespace_import_warning():
     with pytest.warns(DeprecationWarning):
         import astroquery.irsa  # noqa: F401
+
+
+@pytest.fixture
+def irsa_mocked_collections(monkeypatch):
+    """An ``IrsaClass`` instance with the collection listing stubbed out, along
+    with the list of servicetypes it has been looked up for."""
+    irsa = IrsaClass()
+    lookups = []
+
+    def mock_list_collections(*, servicetype=None, filter=None):
+        lookups.append(servicetype)
+        collections = {'SIA': ['spitzer_seip', 'wise_allwise'],
+                       'SSA': ['sofia_exes']}[servicetype]
+        return Table({'collection': collections})
+
+    monkeypatch.setattr(irsa, 'list_collections', mock_list_collections)
+    return irsa, lookups
+
+
+def test_query_sia_invalid_collection(irsa_mocked_collections):
+    irsa, _ = irsa_mocked_collections
+    with pytest.raises(InvalidQueryError, match="'foobar' is not a valid SIA collection."):
+        irsa.query_sia(collection='foobar')
+
+
+def test_query_ssa_invalid_collection(irsa_mocked_collections):
+    irsa, _ = irsa_mocked_collections
+    with pytest.raises(InvalidQueryError, match="'foobar' is not a valid SSA collection."):
+        irsa.query_ssa(collection='foobar')
+
+
+def test_invalid_collection_close_match(irsa_mocked_collections):
+    irsa, _ = irsa_mocked_collections
+    with pytest.raises(InvalidQueryError, match="Did you mean 'wise_allwise'\\?"):
+        irsa.query_sia(collection='wise_allwize')
+
+
+def test_invalid_collection_no_close_match(irsa_mocked_collections):
+    irsa, _ = irsa_mocked_collections
+    with pytest.raises(InvalidQueryError, match="use Irsa.list_collections\\(servicetype='SIA'\\)"):
+        irsa.query_sia(collection='foobar')
+
+
+def test_invalid_collection_in_list(irsa_mocked_collections):
+    """``collection`` also accepts a list, each of which should be validated."""
+    irsa, _ = irsa_mocked_collections
+    with pytest.raises(InvalidQueryError, match="'foobar' is not a valid SIA collection."):
+        irsa.query_sia(collection=['spitzer_seip', 'foobar'])
+
+
+@pytest.mark.parametrize('collection', ['spitzer_seip', ['spitzer_seip', 'wise_allwise'], None])
+def test_validate_valid_collection(irsa_mocked_collections, collection):
+    irsa, _ = irsa_mocked_collections
+    irsa._validate_collection(collection=collection, servicetype='SIA')
+
+
+def test_validate_collection_none_skips_lookup(irsa_mocked_collections):
+    irsa, lookups = irsa_mocked_collections
+    irsa._validate_collection(collection=None, servicetype='SIA')
+
+    assert lookups == []
+
+
+def test_validate_collection_is_cached(irsa_mocked_collections):
+    irsa, lookups = irsa_mocked_collections
+    irsa._validate_collection(collection='spitzer_seip', servicetype='SIA')
+    irsa._validate_collection(collection='wise_allwise', servicetype='SIA')
+    irsa._validate_collection(collection='sofia_exes', servicetype='SSA')
+
+    # The SIA collections should have been looked up only once, and the SSA ones
+    # cached separately from them.
+    assert lookups == ['SIA', 'SSA']

--- a/astroquery/ipac/irsa/tests/test_irsa_remote.py
+++ b/astroquery/ipac/irsa/tests/test_irsa_remote.py
@@ -6,6 +6,7 @@ from astropy.table import Table
 from astropy.coordinates import SkyCoord
 from astropy.utils.exceptions import AstropyDeprecationWarning
 
+from astroquery.exceptions import InvalidQueryError
 from astroquery.ipac.irsa import Irsa
 
 
@@ -116,6 +117,17 @@ class TestIrsa:
         spitzer_collections = Irsa.list_collections(filter='spitzer')
 
         assert len(spitzer_collections) == 47
+
+    @pytest.mark.parametrize('servicetype', ('SIA', 'SSA'))
+    def test_query_invalid_collection(self, servicetype):
+        query = getattr(Irsa, f'query_{servicetype.lower()}')
+        with pytest.raises(InvalidQueryError,
+                           match=f"'foobar' is not a valid {servicetype} collection."):
+            query(collection='foobar')
+
+    def test_query_invalid_collection_close_match(self):
+        with pytest.raises(InvalidQueryError, match="Did you mean 'wise_allwise'\\?"):
+            Irsa.query_sia(collection='wise_allwize')
 
     def test_tap(self):
         query = "SELECT TOP 5 ra,dec FROM cosmos2015"

--- a/docs/ipac/irsa/irsa.rst
+++ b/docs/ipac/irsa/irsa.rst
@@ -414,7 +414,7 @@ or spectral collectionsn, using ``'SSA'``.
    If you experience query timeout, please open an IRSA helpdesk ticket.
 
 Querying a collection that doesn't exist raises an
-`~astroquery.exceptions.InvalidQueryError` rather than returning an empty
+``InvalidQueryError`` rather than returning an empty
 table, and suggests a close match when there is one:
 
 .. doctest-remote-data::

--- a/docs/ipac/irsa/irsa.rst
+++ b/docs/ipac/irsa/irsa.rst
@@ -413,6 +413,18 @@ or spectral collectionsn, using ``'SSA'``.
    side, and therefore should return quickly with results.
    If you experience query timeout, please open an IRSA helpdesk ticket.
 
+Querying a collection that doesn't exist raises an
+`~astroquery.exceptions.InvalidQueryError` rather than returning an empty
+table, and suggests a close match when there is one:
+
+.. doctest-remote-data::
+
+   >>> from astroquery.ipac.irsa import Irsa
+   >>> Irsa.query_sia(collection='wise_allwize')  # doctest: +IGNORE_EXCEPTION_DETAIL
+   Traceback (most recent call last):
+   ...
+   astroquery.exceptions.InvalidQueryError: 'wise_allwize' is not a valid SIA collection. Did you mean 'wise_allwise'? To list the available collections, use Irsa.list_collections(servicetype='SIA').
+
 .. doctest-remote-data::
 
    >>> from astroquery.ipac.irsa import Irsa


### PR DESCRIPTION
Fixes #3213.

Querying a collection that does not exist silently returned an empty table, giving no hint that the collection name was the problem:

```python
>>> Irsa.query_sia(pos=(coord, 10), collection="foobar")
<DALResultsTable length=0>
```

Following the approach suggested in the issue, the `collection` kwarg of `query_sia` and `query_ssa` is now validated against `list_collections`, and the valid names are cached on the instance. Now:

```python
>>> Irsa.query_sia(pos=(coord, 10), collection="foobar")
InvalidQueryError: 'foobar' is not a valid SIA collection. To list the available collections, use Irsa.list_collections(servicetype='SIA').

>>> Irsa.query_sia(pos=(coord, 10), collection="wise_allwize")
InvalidQueryError: 'wise_allwize' is not a valid SIA collection. Did you mean 'wise_allwise'? To list the available collections, use Irsa.list_collections(servicetype='SIA').
```

The close-match suggestion uses `difflib`, matching the existing idiom in `astroquery/mast/missions.py`. SIA and SSA collections are cached separately, since `list_collections` returns different sets for each. `collection` also accepts a list of names (per the pyvo SIA2 signature), so each entry is validated.

### Tradeoff worth a look

Validation costs one extra TAP query the first time a `collection` is passed on a given instance, cached from then on. The issue prescribed caching on the instance, so I believe this is the intended behaviour, but flagging it in case you want an opt-out for callers who would rather skip the lookup. Passing `collection=None` never triggers it.

### Testing

- Offline tests mock `list_collections`, covering both services, the close-match and no-close-match messages, list input, the `None` no-op, and that the cache is populated once per servicetype.
- Remote tests cover the invalid-collection error for both services and the close-match suggestion.
- Verified against the live IRSA service: the exact reproduction from the issue now raises, and valid collections still return data.

Unrelated pre-existing failures on `main`, not touched here: `test_query_region_box` (`assert 28 == 24`) and the `list_collections(servicetype='SSA')` doctest in `docs/ipac/irsa/irsa.rst` (expects 41, server now returns 43) both fail on a clean checkout of `main` due to server-side data drift.