### PR TITLE
Added explicit Fornax datalinks and download support to the Heasarc submodule

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -110,6 +110,7 @@ heasarc
 - Add support for uploading tables when using TAP directly through ``query_tap``. [#3403]
 - Add automatic guessing for the data host in ``download_data``. [#3403]
 - Include method to count the number of rows in a specified table. [#3549]
+- Add 'fornax' column to the datalinks tables produced by ``locate_data``, and support for copying from Fornax to the ``download_data`` function. [#3633]
 
 gaia
 ^^^^
@@ -334,7 +335,7 @@ heasarc
   if there are no data associated with that row rather than filtering it
   out. [#3275]
 
-- ``locate_data`` changed to use POST request instead of GET to accomodate
+- ``locate_data`` changed to use POST request instead of GET to accommodate
   large requests. [#3356]
 
 - Preserve size of mask when all values are False in ``locate_data``. [#3411]

--- a/astroquery/heasarc/core.py
+++ b/astroquery/heasarc/core.py
@@ -796,7 +796,7 @@ class HeasarcClass(BaseVOQuery, BaseQuery):
 
     def download_data(self, links, *, host=None, location='.'):
         """Download data products in links with a choice of getting the
-        data from either the heasarc server, sciserver, or the cloud in AWS.
+        data from either the HEASARC FTP server, SciServer, Fornax, or the cloud in AWS.
 
 
         Parameters
@@ -844,17 +844,22 @@ class HeasarcClass(BaseVOQuery, BaseQuery):
 
         if host == 'heasarc':
 
-            log.info('Downloading data from the HEASARC ...')
+            log.info('Downloading data from the HEASARC FTP ...')
             self._download_heasarc(links, location)
 
         elif host == 'sciserver':
 
-            log.info('Copying data on Sciserver ...')
-            self._copy_sciserver(links, location)
+            log.info('Copying data on SciServer ...')
+            self._copy_locally_mounted(links, location)
+
+        elif host == 'fornax':
+
+            log.info('Copying data on Fornax ...')
+            self._copy_locally_mounted(links, location)
 
         elif host == 'aws':
 
-            log.info('Downloading data AWS S3 ...')
+            log.info('Downloading data from the HEASARC AWS S3 ...')
             self._download_s3(links, location)
 
     def _download_heasarc(self, links, location='.'):
@@ -869,7 +874,7 @@ class HeasarcClass(BaseVOQuery, BaseQuery):
             The result from locate_data
         location : str
             local folder where the downloaded file will be saved.
-            Default is current working directory
+            Default is the current working directory
 
         """
         # The limit comes from the size of the string in the POST request
@@ -914,29 +919,51 @@ class HeasarcClass(BaseVOQuery, BaseQuery):
                 'An error occurred when downloading the data. Retry again.'
             )
 
-    def _copy_sciserver(self, links, location='.'):
-        """Copy data from the local archive on sciserver
+    @staticmethod
+    def _copy_locally_mounted(links, location, host):
+        """Copy data from a locally mounted HEASARC, either on SciServer or Fornax.
 
         Do not call directly.
-        Users should be using `~self.download_data` instead
+        Users should be calling `~self.download_data` instead.
 
+        Parameters
+        ----------
+        links : `astropy.table.Table`
+            The result from locate_data
+        location : str
+            local folder where the downloaded file will be saved.
+            Default is the current working directory
+        host : str
+            Name of the host system. Either 'sciserver' or 'fornax'.
         """
-        if not os.path.exists('/FTP/'):
+        # Check that the input host is valid for this method.
+        valid_hosts = {"fornax": "Fornax", "sciserver": "SciServer"}
+        if host not in valid_hosts:
+            raise ValueError(
+                f'`host` must be either "sciserver" or "fornax".')
+
+        # Check that data are mounted where we expect them to be for SciServer
+        #  and Fornax
+        if ((host == 'sciserver' and not os.path.exists('/FTP/')) or
+                (host == 'fornax' and not os.path.exists('/archive-data/nasa-heasarc/'))):
+
             raise FileNotFoundError(
-                'No data archive found. This should be run on Sciserver '
+                f'No data archive found. This should be run on {valid_hosts[host]}'
                 'with the data drive mounted.'
             )
 
-        # make sure the output folder exits
+        # If we've got to this point, we are going to be able to copy some data, so
+        #  we make sure that the user-specified 'download' output location exists
         os.makedirs(location, exist_ok=True)
 
-        for link in links['sciserver']:
+        # Now we iterate through the data links and copy the data
+        for link in links[host]:
             link = str(link)
-            log.info(f'Copying to {link} from the data drive ...')
+            log.info(f'Copying {link} from the data drive ...')
             if not os.path.exists(link):
                 raise ValueError(
                     f'No data found in {link}. '
-                    'Make sure you are running this on Sciserver. '
+                    f'Make sure you are running this on {valid_hosts[host]}. '
                     'If you think data is missing, please contact the '
                     'Heasarc Help desk'
                 )

--- a/astroquery/heasarc/core.py
+++ b/astroquery/heasarc/core.py
@@ -949,7 +949,7 @@ class HeasarcClass(BaseVOQuery, BaseQuery):
 
             raise FileNotFoundError(
                 f'No data archive found. This should be run on {valid_hosts[host]}'
-                'with the data drive mounted.'
+                 'with the data drive mounted.'
             )
 
         # If we've got to this point, we are going to be able to copy some data, so

--- a/astroquery/heasarc/core.py
+++ b/astroquery/heasarc/core.py
@@ -785,6 +785,10 @@ class HeasarcClass(BaseVOQuery, BaseQuery):
             # we are on idies, so we can use sciserver
             return 'sciserver'
 
+        # Check for the mounted S3 bucket and the current Fornax build version
+        if os.path.exists("/opt/build-fornax-jupyter") and os.path.exists('/archive-data/nasa-heasarc/'):
+            return 'fornax'
+
         for var in ['AWS_REGION', 'AWS_DEFAULT_REGION', 'AWS_ROLE_ARN']:
             if var in os.environ:
                 return 'aws'

--- a/astroquery/heasarc/core.py
+++ b/astroquery/heasarc/core.py
@@ -689,16 +689,27 @@ class HeasarcClass(BaseVOQuery, BaseQuery):
         )]
         dl_result = dl_result[['ID', 'access_url', 'content_length', 'error_message']]
 
-        # add sciserver and s3 columns
-        newcol = [
+        # add sciserver, s3, and Fornax columns
+        # Construct SciServer paths
+        sci_new_col = [
             f"/FTP/{row.split('FTP/')[1]}".replace('//', '/')
             if 'FTP' in row else ''
             for row in dl_result['access_url']
         ]
-        dl_result.add_column(newcol, name='sciserver', index=2)
-        newcol = [f"s3://{self.S3_BUCKET}/{row[5:]}" if row != '' else ''
+        dl_result.add_column(sci_new_col, name='sciserver', index=2)
+
+        # Construct S3 URIs
+        s3_new_col = [f"s3://{self.S3_BUCKET}/{row[5:]}" if row != '' else ''
                   for row in dl_result['sciserver']]
-        dl_result.add_column(newcol, name='aws', index=3)
+        dl_result.add_column(s3_new_col, name='aws', index=3)
+
+        # Construct Fornax paths (very similar to SciServer)
+        fornax_new_col = [
+            f"/archive-data/nasa-heasarc/{row.split('FTP/')[1]}".replace('//', '/')
+            if 'FTP' in row else ''
+            for row in dl_result['access_url']
+        ]
+        dl_result.add_column(fornax_new_col, name='fornax', index=2)
 
         return dl_result
 

--- a/astroquery/heasarc/core.py
+++ b/astroquery/heasarc/core.py
@@ -850,12 +850,12 @@ class HeasarcClass(BaseVOQuery, BaseQuery):
         elif host == 'sciserver':
 
             log.info('Copying data on SciServer ...')
-            self._copy_locally_mounted(links, location)
+            self._copy_locally_mounted(links, location, host)
 
         elif host == 'fornax':
 
             log.info('Copying data on Fornax ...')
-            self._copy_locally_mounted(links, location)
+            self._copy_locally_mounted(links, location, host)
 
         elif host == 'aws':
 

--- a/astroquery/heasarc/core.py
+++ b/astroquery/heasarc/core.py
@@ -700,7 +700,7 @@ class HeasarcClass(BaseVOQuery, BaseQuery):
 
         # Construct S3 URIs
         s3_new_col = [f"s3://{self.S3_BUCKET}/{row[5:]}" if row != '' else ''
-                  for row in dl_result['sciserver']]
+                      for row in dl_result['sciserver']]
         dl_result.add_column(s3_new_col, name='aws', index=3)
 
         # Construct Fornax paths (very similar to SciServer)
@@ -939,17 +939,16 @@ class HeasarcClass(BaseVOQuery, BaseQuery):
         # Check that the input host is valid for this method.
         valid_hosts = {"fornax": "Fornax", "sciserver": "SciServer"}
         if host not in valid_hosts:
-            raise ValueError(
-                f'`host` must be either "sciserver" or "fornax".')
+            raise ValueError('`host` must be either "sciserver" or "fornax".')
 
         # Check that data are mounted where we expect them to be for SciServer
         #  and Fornax
-        if ((host == 'sciserver' and not os.path.exists('/FTP/')) or
-                (host == 'fornax' and not os.path.exists('/archive-data/nasa-heasarc/'))):
+        if ((host == 'sciserver' and not os.path.exists('/FTP/'))
+                or (host == 'fornax' and not os.path.exists('/archive-data/nasa-heasarc/'))):
 
             raise FileNotFoundError(
-                f'No data archive found. This should be run on {valid_hosts[host]}'
-                 'with the data drive mounted.'
+                f'No data archive found. This should be run on {valid_hosts[host]} '
+                f'with the data drive mounted.'
             )
 
         # If we've got to this point, we are going to be able to copy some data, so

--- a/astroquery/heasarc/core.py
+++ b/astroquery/heasarc/core.py
@@ -754,12 +754,13 @@ class HeasarcClass(BaseVOQuery, BaseQuery):
 
         self.s3_client = self.s3_resource.meta.client
 
-    def _guess_host(self, host):
+    @staticmethod
+    def _guess_host(host):
         """Guess the host to use for downloading data
 
         Parameters
         ----------
-        host : str
+        host : str or None
             The host provided by the user
 
         Returns
@@ -768,11 +769,12 @@ class HeasarcClass(BaseVOQuery, BaseQuery):
             The guessed host
 
         """
-        if host in ['heasarc', 'sciserver', 'aws']:
+        all_hosts = ['heasarc', 'sciserver', 'aws', 'fornax']
+        if host in all_hosts:
             return host
         elif host is not None:
             raise ValueError(
-                'host has to be one of heasarc, sciserver, aws or None')
+                f'`host` must be one of the following; {"/".join(all_hosts)}/None.')
 
         # host is None, so we guess
         if (
@@ -798,24 +800,26 @@ class HeasarcClass(BaseVOQuery, BaseQuery):
         links : `astropy.table.Table` or `astropy.table.Row`
             A table (or row) of data links, typically the result of locate_data.
         host : str or None
-            The data host. The options are: None (default), heasarc, sciserver, aws.
+            The data host. The options are: None (default), heasarc, sciserver, aws, and fornax.
             If None, the host is guessed based on the environment.
             If host == 'sciserver', data is copied from the local mounted
             data drive.
             If host == 'aws', data is downloaded from Amazon S3 Open
             Data Repository.
+            If host == 'fornax', the data is copied from the mounted HEASARC
+            S3 bucket.
         location : str
             local folder where the downloaded file will be saved.
-            Default is current working directory
+            Default is the current working directory
 
-        Note that ff you are downloading large datasets (more 10 10GB),
-        from the main heasarc server, it is recommended that you split
-        it up, so that if the downloaded is interrupted, you do not need
+        Note that if you are downloading large datasets (more than 10GB),
+        from the HEASARC FTP server, it is recommended that you split
+        the download up so that if it is interrupted, you do not need
         to start again.
         """
 
         if len(links) == 0:
-            raise ValueError('Input links table is empty')
+            raise ValueError('Input links table is empty.')
 
         if isinstance(links, Row):
             links = links.table[[links.index]]

--- a/astroquery/heasarc/tests/test_heasarc.py
+++ b/astroquery/heasarc/tests/test_heasarc.py
@@ -563,7 +563,7 @@ def test__guess_host_default():
     assert Heasarc._guess_host(host=None) == 'heasarc'
 
 
-@pytest.mark.parametrize("host", ["heasarc", "sciserver", "aws"])
+@pytest.mark.parametrize("host", ["heasarc", "sciserver", "aws", "fornax"])
 def test__guess_host_know(host):
     # Use a new HeasarcClass object
     assert Heasarc._guess_host(host=host) == host
@@ -588,12 +588,12 @@ def test_download_data__empty():
 
 def test_download_data__wronghost():
     with pytest.raises(
-        ValueError, match="host has to be one of heasarc, sciserver, aws"
+        ValueError, match="`host` must be one of the following; heasarc/sciserver/aws/fornax/None."
     ):
         Heasarc.download_data(Table({"id": [1]}), host="nohost")
 
 
-@pytest.mark.parametrize("host", ["heasarc", "sciserver", "aws"])
+@pytest.mark.parametrize("host", ["heasarc", "sciserver", "aws", "fornax"])
 def test_download_data__missingcolumn(host):
     host_col = "access_url" if host == "heasarc" else host
     with pytest.raises(
@@ -603,7 +603,8 @@ def test_download_data__missingcolumn(host):
         Heasarc.download_data(Table({"id": [1]}), host=host)
 
 
-def test_download_data__sciserver():
+@pytest.mark.parametrize("host", ["sciserver", "fornax"])
+def test_download_data__local_mount(host):
     with tempfile.TemporaryDirectory() as tmpdir:
         datadir = f'{tmpdir}/data'
         downloaddir = f'{tmpdir}/download'
@@ -611,11 +612,11 @@ def test_download_data__sciserver():
         with open(f'{datadir}/file.txt', 'w') as fp:
             fp.write('data')
         # include both a file and a directory
-        tab = Table({'sciserver': [f'{tmpdir}/data/file.txt', f'{tmpdir}/data']})
+        tab = Table({host: [f'{tmpdir}/data/file.txt', f'{tmpdir}/data']})
         # The patch is to avoid the test that we are on sciserver
         with patch('os.path.exists') as exists:
             exists.return_value = True
-            Heasarc.download_data(tab, host="sciserver", location=downloaddir)
+            Heasarc.download_data(tab, host=host, location=downloaddir)
         assert os.path.exists(f'{downloaddir}/file.txt')
         assert os.path.exists(f'{downloaddir}/data')
         assert os.path.exists(f'{downloaddir}/data/file.txt')
@@ -624,10 +625,20 @@ def test_download_data__sciserver():
 def test_download_data__outside_sciserver():
     with pytest.raises(
         FileNotFoundError,
-        match="No data archive found. This should be run on Sciserver",
+        match="No data archive found. This should be run on SciServer with the data drive mounted.",
     ):
         Heasarc.download_data(
             Table({"sciserver": ["some-link"]}), host="sciserver"
+        )
+
+
+def test_download_data__outside_fornax():
+    with pytest.raises(
+        FileNotFoundError,
+        match="No data archive found. This should be run on Fornax with the data drive mounted.",
+    ):
+        Heasarc.download_data(
+            Table({"fornax": ["some-link"]}), host="fornax"
         )
 
 


### PR DESCRIPTION
# Changes

- A new constructed column, "fornax", is now included in the datalinks table returned by Heasarc.locate_data. This is almost identical in function to the "sciserver" column currently included in the return.
- Updated the Heasarc.download_data method, as well as several internal methods called by it, to support 'fornax' as an input to the `host` argument. This means that data can be copied from the Fornax mount of the HEASARC S3 bucket.
- Updated the _guess_host method to be able to detect when the module is running on Fornax.
- Altered the tests to account for the new 'fornax' host.