### PR TITLE
Remove unquote method from completed UWS job XML

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -25,7 +25,6 @@ esa.emds.einsteinprobe
 - New module to access the ESA Einstein Probe Science Archive. [#3511]
 
 
-
 API changes
 -----------
 
@@ -146,6 +145,13 @@ ipac.irsa
   were typos; the API expects ``naifid``. Old ``obj_nafid`` keyword and
   ``"nafid_input"`` ``input_mode`` still work but emit
   ``AstropyDeprecationWarning``. [#3607]
+
+casda
+^^^^^
+
+- Preserve the percent-encoding of staged file URLs so that pre-signed S3
+  download URLs remain valid. Previously the URLs were unquoted, which corrupted
+  pre-signed URLs and could raise errors when parsed by ``urllib``. [#3636]
 
 
 mast

--- a/astroquery/casda/core.py
+++ b/astroquery/casda/core.py
@@ -280,7 +280,7 @@ class CasdaClass(QueryWithLogin):
         job_details = self._get_job_details_xml(job_url)
         fileurls = []
         for result in job_details.find("uws:results", self._uws_ns).findall("uws:result", self._uws_ns):
-            file_location = unquote(result.get("{http://www.w3.org/1999/xlink}href"))
+            file_location = result.get("{http://www.w3.org/1999/xlink}href")
             fileurls.append(file_location)
 
         return fileurls

--- a/astroquery/casda/tests/data/completed_job.xml
+++ b/astroquery/casda/tests/data/completed_job.xml
@@ -17,8 +17,9 @@
         </uws:parameter>
     </uws:parameters>
     <uws:results>
-        <uws:result id="cube-244.checksum" xlink:type="simple" xlink:href="http%3A%2F%2Fcasda.csiro.au%2Fdownload%2Fweb%2F111-000-111-000%2Faskap_img.fits.checksum" />
-        <uws:result id="cube-244" xlink:type="simple" xlink:href="http%3A%2F%2Fcasda.csiro.au%2Fdownload%2Fweb%2F111-000-111-000%2Faskap_img.fits" />
+        <uws:result id="cube-244.checksum" xlink:type="simple" xlink:href="http://casda.csiro.au/download/web/111-000-111-000/askap_img.fits.checksum" />
+        <uws:result id="cube-244" xlink:type="simple" xlink:href="http://casda.csiro.au/download/web/111-000-111-000/askap_img.fits" />
+        <uws:result id="cube-245" xlink:type="simple" xlink:href="https://ingest.pawsey.org.au/casda-prd-as201-03/sb85679/catalogues/selavy.components.xml?response-content-disposition=attachment%3B%20filename%3D%22selavy.components.xml%22&amp;X-Amz-Algorithm=AWS4-HMAC-SHA256&amp;X-Amz-Credential=abc123%2F20260722%2Fpawsey%2Fs3%2Faws4_request&amp;X-Amz-Signature=deadbeef1234567890" />
     </uws:results>
     <uws:errorSummary xsi:nil="true" />
 </uws:job>

--- a/astroquery/casda/tests/data/cutout_333.9092_-45.8418_0.5000.xml
+++ b/astroquery/casda/tests/data/cutout_333.9092_-45.8418_0.5000.xml
@@ -17,8 +17,8 @@
         </uws:parameter>
     </uws:parameters>
     <uws:results>
-        <uws:result id="cutout-1234-cube-244.checksum" xlink:type="simple" xlink:href="http%3A%2F%2Fcasda.csiro.au%2Fdownload%2Fweb%2F111-000-111-000%2Fcutout.fits.checksum" />
-        <uws:result id="cutout-1234-cube-244" xlink:type="simple" xlink:href="http%3A%2F%2Fcasda.csiro.au%2Fdownload%2Fweb%2F111-000-111-000%2Fcutout.fits" />
+        <uws:result id="cutout-1234-cube-244.checksum" xlink:type="simple" xlink:href="http://casda.csiro.au/download/web/111-000-111-000/cutout.fits.checksum" />
+        <uws:result id="cutout-1234-cube-244" xlink:type="simple" xlink:href="http://casda.csiro.au/download/web/111-000-111-000/cutout.fits" />
     </uws:results>
     <uws:errorSummary xsi:nil="true" />
 </uws:job>

--- a/astroquery/casda/tests/test_casda.py
+++ b/astroquery/casda/tests/test_casda.py
@@ -6,6 +6,7 @@ import pytest
 import requests
 import os
 import keyring
+from urllib.parse import urlparse
 
 from astropy.coordinates import SkyCoord
 import astropy.units as u
@@ -337,8 +338,25 @@ def test_stage_data(patch_get):
     casda.POLL_INTERVAL = 1
     with pytest.warns(W50, match="Invalid unit string 'pixels'"):
         urls = casda.stage_data(table, verbose=True)
+    presigned_url = ('https://ingest.pawsey.org.au/casda-prd-as201-03/sb85679/catalogues/selavy.components.xml?'
+                     'response-content-disposition=attachment%3B%20filename%3D%22selavy.components.xml%22'
+                     '&X-Amz-Algorithm=AWS4-HMAC-SHA256'
+                     '&X-Amz-Credential=abc123%2F20260722%2Fpawsey%2Fs3%2Faws4_request'
+                     '&X-Amz-Signature=deadbeef1234567890')
     assert urls == ['http://casda.csiro.au/download/web/111-000-111-000/askap_img.fits.checksum',
-                    'http://casda.csiro.au/download/web/111-000-111-000/askap_img.fits']
+                    'http://casda.csiro.au/download/web/111-000-111-000/askap_img.fits',
+                    presigned_url]
+
+    # The pre-signed S3 URL must keep its percent-encoding intact (it is part of the AWS signature)
+    # and must not contain characters that are illegal in a URL such as spaces, ';' or '"'.
+    assert '%3B' in presigned_url and '%20' in presigned_url and '%2F' in presigned_url
+    assert ' ' not in presigned_url
+    assert ';' not in presigned_url
+    assert '"' not in presigned_url
+    # urllib must be able to parse it without raising
+    parsed = urlparse(presigned_url)
+    assert parsed.scheme == 'https'
+    assert parsed.netloc == 'ingest.pawsey.org.au'
 
 
 def test_cutout(patch_get):


### PR DESCRIPTION
Hi Astroquery,

Recent changes to the underlying CASDA uws XML results in this unquote method not longer requiring being called. Tested locally against CASDA and resolves issues users are seeing

resolves #3637 