### PR TITLE
Fix docstring parameter names that do not match the signatures

### DIFF
--- a/astroquery/ipac/irsa/core.py
+++ b/astroquery/ipac/irsa/core.py
@@ -139,7 +139,7 @@ class IrsaClass(BaseVOQuery):
         pos : `~astropy.coordinates.SkyCoord` class or sequence of two floats
             the position of the center of the circular search region.
             assuming icrs decimal degrees if unit is not specified.
-        raidus : `~astropy.units.Quantity` class or scalar float
+        radius : `~astropy.units.Quantity` class or scalar float
             the radius of the circular region around pos in which to search.
             assuming icrs decimal degrees if unit is not specified.
         band : `~astropy.units.Quantity` class or sequence of two floats

--- a/astroquery/ipac/irsa/irsa_dust/utils.py
+++ b/astroquery/ipac/irsa/irsa_dust/utils.py
@@ -78,7 +78,7 @@ def find_result_node(desc, xml_tree):
 
     Parameters
     -----
-    xmlTree : `xml.etree.ElementTree`
+    xml_tree : `xml.etree.ElementTree`
         the xml tree to search for the <result> node
     desc : string
         the text contained in the desc node

--- a/astroquery/ipac/ned/core.py
+++ b/astroquery/ipac/ned/core.py
@@ -503,7 +503,7 @@ class NedClass(BaseQuery):
         html_in : str
             source from which the urls are to be extracted
 
-        format : str, optional
+        file_format : str, optional
             Format of spectra to return. Defaults to 'fits'.
             Other options available: 'author-ascii', 'NED-ascii', 'VO-table'.
 

--- a/astroquery/linelists/cdms/core.py
+++ b/astroquery/linelists/cdms/core.py
@@ -617,7 +617,7 @@ class Lookuptable(dict):
 
         Parameters
         ----------
-        s : str
+        st : str
             String to compile as a regular expression
             Can be entered non-specific for broader results
             ('H2O' yields 'H2O' but will also yield 'HCCCH2OD')

--- a/astroquery/mast/services.py
+++ b/astroquery/mast/services.py
@@ -249,7 +249,7 @@ class ServiceAPI(BaseQuery):
 
         Parameters
         ----------
-        responses : `~requests.Response`
+        response : `~requests.Response`
             The restponse from a self._request call.
         verbose : bool
             (presently does nothing - there is no output with verbose set to

--- a/astroquery/mast/utils.py
+++ b/astroquery/mast/utils.py
@@ -530,7 +530,7 @@ def parse_numeric_product_filter(vals):
 
     Parameters
     ----------
-    val : str or list of str
+    vals : str or list of str
         The filter value(s). Each entry can be:
         - A single number (e.g., "100")
         - A range in the form "start..end" (e.g., "100..200")


### PR DESCRIPTION
### Description

Six `Parameters` entries name an argument the function does not take. Each was read against its signature before changing.

| Where | Documented | Actual |
|---|---|---|
| `astroquery/ipac/irsa/core.py:142` `query_ssa` | `raidus` | `radius` — a typo; the description below it already says "the radius of the circular region" |
| `astroquery/ipac/irsa/irsa_dust/utils.py:80` `find_result_node` | `xmlTree` | `xml_tree` |
| `astroquery/ipac/ned/core.py:506` `_extract_image_urls` | `format` | `file_format` |
| `astroquery/linelists/cdms/core.py:619` `CDMSClass.find` | `s` | `st` (the summary line above still reads "regex match to string s") |
| `astroquery/mast/services.py:252` `_parse_result` | `responses` | `response` |
| `astroquery/mast/utils.py:533` `parse_numeric_product_filter` | `val` | `vals` |

`raidus` is the one users would actually hit: it is a public method, so the rendered docs offer a keyword that raises `TypeError` if copied.

Docstrings only — no signature, call site, or behaviour is touched.

### Not included

The same sweep raised twenty more of this kind, spread across `cadc`, `cosmosim`, `esa/hubble`, `esa/iso`, `esa/xmm_newton`, `mocserver`, `vizier`, `wfau` and others. I kept this PR to the six that are unambiguous single-name mismatches rather than opening one that touches nine subpackages at once. Happy to send the rest, split per subpackage if you prefer.

Two I deliberately left alone:

- `astroquery/template_module/core.py` documents `verbose` and `any_other_param` that the template's own signature does not have — but that file is the worked example for new modules, so the placeholders read as intentional.
- `astroquery/esa/utils/utils.py:505` `__create_adql_criteria` documents `query_criteria` against a `filters` parameter; that one looked like it might be a genuine rename in progress rather than a stale tag, and I did not want to guess.
