### PR TITLE
Update the content type to handle upcoming change in the backend datalink

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -126,6 +126,7 @@ heasarc
 - Include method to count the number of rows in a specified table. [#3549]
 - Fix ``query_region`` for catalog=None. It should fail early. [#3630]
 - Fix ``query_region`` when passing ``add_offset`` along with ``columns=None``. [#3630]
+- Generalize the ``content-type`` filter in ``locate_data`` in anticipation for backend datalink descriptor changes. [#3654]
 
 gaia
 ^^^^

--- a/astroquery/heasarc/core.py
+++ b/astroquery/heasarc/core.py
@@ -708,7 +708,7 @@ class HeasarcClass(BaseVOQuery, BaseQuery):
         # include rows that have directory links (i.e. data) and those
         # that report errors (usually means there are no data products)
         dl_result = dl_result[np.ma.mask_or(
-            dl_result['content_type'] == 'directory',
+            dl_result['content_type'].contains('directory'),
             dl_result['error_message'] != '',
             shrink=False
         )]


### PR DESCRIPTION
This is related to #3652.
The backend pushed a change that makes the datalink service more compliant with VO, but that broke `locate_data`. That change will be rolled back and will be implemented later. In preparation for that, this update prepares for that change.