### PR TITLE
Fix the filtering for string content in masked array

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -126,8 +126,7 @@ heasarc
 - Include method to count the number of rows in a specified table. [#3549]
 - Fix ``query_region`` for catalog=None. It should fail early. [#3630]
 - Fix ``query_region`` when passing ``add_offset`` along with ``columns=None``. [#3630]
-- Generalize the ``content-type`` filter in ``locate_data`` in anticipation for backend datalink descriptor changes. [#3654]
-- Fix the bug introduced in #3654. [#3656]
+- Generalize the ``content-type`` filter in ``locate_data`` in anticipation for backend datalink descriptor changes. [#3656]
 
 gaia
 ^^^^

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -127,6 +127,7 @@ heasarc
 - Fix ``query_region`` for catalog=None. It should fail early. [#3630]
 - Fix ``query_region`` when passing ``add_offset`` along with ``columns=None``. [#3630]
 - Generalize the ``content-type`` filter in ``locate_data`` in anticipation for backend datalink descriptor changes. [#3654]
+- Fix the bug introduced in #3654. [#3656]
 
 gaia
 ^^^^

--- a/astroquery/heasarc/core.py
+++ b/astroquery/heasarc/core.py
@@ -708,7 +708,7 @@ class HeasarcClass(BaseVOQuery, BaseQuery):
         # include rows that have directory links (i.e. data) and those
         # that report errors (usually means there are no data products)
         dl_result = dl_result[np.ma.mask_or(
-            dl_result['content_type'].contains('directory'),
+            np.char.find(dl_result['content_type'].data.astype(str), "directory") >= 0,
             dl_result['error_message'] != '',
             shrink=False
         )]


### PR DESCRIPTION
The recent change from #3654 introduced a bug. The filtering does not work for masked arrays. It needs to happen on individual rows.